### PR TITLE
Add flag forcing non-GUI JVM to exit after test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/ApacheJMeter.jar
+build
+lib

--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -832,8 +832,15 @@ beanshell.server.file=../extras/startup.bsh
 #jmeterengine.remote.system.exit=false
 
 # Whether to call System.exit(1) on failure to stop threads in non-GUI mode.
+# This only takes effect if the test was explictly requested to stop.
 # If this is disabled, it may be necessary to kill the JVM externally
 #jmeterengine.stopfail.system.exit=true
+
+# Whether to force call System.exit(0) at end of test in non-GUI mode, even if
+# there were no failures and the test was not explicitly asked to stop.
+# Without this, the JVM may never exit if there are other threads spawned by
+# the test which never exit.
+#jmeterengine.force.system.exit=false
 
 # How long to pause (in ms) in the daemon thread before reporting that the JVM has failed to exit.
 # If the value is <= 0, the JMeter does not start the daemon thread 

--- a/src/core/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -86,6 +86,9 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
     /** Whether to call System.exit(1) if threads won't stop */
     private static final boolean SYSTEM_EXIT_ON_STOP_FAIL = JMeterUtils.getPropDefault("jmeterengine.stopfail.system.exit", true);
     
+    /** Whether to call System.exit(0) unconditionally at end of non-GUI test */
+    private static final boolean SYSTEM_EXIT_FORCED = JMeterUtils.getPropDefault("jmeterengine.force.system.exit", false);
+
     /** Flag to show whether test is running. Set to false to stop creating more threads. */
     private volatile boolean running = false;
 
@@ -435,6 +438,11 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         }
 
         notifyTestListenersOfEnd(testListeners);
+
+        if (JMeter.isNonGUI() && SYSTEM_EXIT_FORCED) {
+            log.info("Forced JVM shutdown requested at end of test");
+            System.exit(0);
+        }
     }
 
     /**


### PR DESCRIPTION
This is useful for cases when JMeter is run by an automated system
(such as CI builds) and tests start threads that prevent the JVM
from cleanly shutting down. The existing property to do a full JVM
shutdown (jmeterengine.stopfail.system.exit) only executes when the
test is explicitly asked to stop. We needed to unconditionally insure
the JVM is terminated when the test was finished, even if the tests
themselves did things which left the JVM in a state where JMeter could
not cleanly exit in non-GUI mode.

The new flag is "jmeterengine.force.system.exit" and defaults to
"false".
