### PR TITLE
Use typed methods such as setInt, setDouble, setDate ... for prepared statement

### DIFF
--- a/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -31,9 +31,29 @@ import org.apache.log.Logger;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
-import java.sql.*;
+import java.math.BigDecimal;
+import java.sql.CallableStatement;
+import java.sql.Connection;
 import java.sql.Date;
-import java.util.*;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -333,13 +353,20 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
         case Types.INTEGER:
             pstmt.setInt(index, Integer.parseInt(argument));
             break;
-        case Types.DOUBLE:
         case Types.DECIMAL:
+        case Types.NUMERIC:
+            pstmt.setBigDecimal(index, new BigDecimal(argument));
+            break;
+        case Types.DOUBLE:
+        case Types.FLOAT:
             pstmt.setDouble(index, Double.parseDouble(argument));
             break;
+        case Types.CHAR:
+        case Types.LONGVARCHAR:
         case Types.VARCHAR:
             pstmt.setString(index, argument);
             break;
+        case Types.BIT:
         case Types.BOOLEAN:
             pstmt.setBoolean(index, Boolean.parseBoolean(argument));
             break;
@@ -349,14 +376,25 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
         case Types.DATE:
             pstmt.setDate(index, Date.valueOf(argument));
             break;
-        case Types.FLOAT:
+        case Types.REAL:
             pstmt.setFloat(index, Float.parseFloat(argument));
+            break;
+        case Types.TINYINT:
+            pstmt.setByte(index, Byte.parseByte(argument));
+            break;
+        case Types.SMALLINT:
+            pstmt.setShort(index, Short.parseShort(argument));
             break;
         case Types.TIMESTAMP:
             pstmt.setTimestamp(index, Timestamp.valueOf(argument));
             break;
         case Types.TIME:
             pstmt.setTime(index, Time.valueOf(argument));
+            break;
+        case Types.BINARY:
+        case Types.VARBINARY:
+        case Types.LONGVARBINARY:
+            pstmt.setBytes(index, argument.getBytes());
             break;
         case Types.NULL:
             pstmt.setNull(index, targetSqlType);

--- a/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -18,23 +18,12 @@
 
 package org.apache.jmeter.protocol.jdbc;
 
-import org.apache.commons.collections.map.LRUMap;
-import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jmeter.save.CSVSaveService;
-import org.apache.jmeter.testelement.AbstractTestElement;
-import org.apache.jmeter.testelement.TestStateListener;
-import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -44,17 +33,23 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.collections.map.LRUMap;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.save.CSVSaveService;
+import org.apache.jmeter.testelement.AbstractTestElement;
+import org.apache.jmeter.testelement.TestStateListener;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
 
 /**
  * A base class for all JDBC test elements handling the basics of a SQL request.

--- a/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -18,24 +18,6 @@
 
 package org.apache.jmeter.protocol.jdbc;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.commons.collections.map.LRUMap;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.save.CSVSaveService;
@@ -45,6 +27,14 @@ import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.sql.*;
+import java.sql.Date;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A base class for all JDBC test elements handling the basics of a SQL request.
@@ -321,7 +311,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
                     if (argument.equals(NULL_MARKER)){
                         pstmt.setNull(i+1, targetSqlType);
                     } else {
-                        pstmt.setObject(i+1, argument, targetSqlType);
+                        setArgument(pstmt, argument, targetSqlType, i+1);
                     }
                 }
                 if (OUT.equalsIgnoreCase(inputOutput)||INOUT.equalsIgnoreCase(inputOutput)) {
@@ -336,6 +326,44 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
             }
         }
         return outputs;
+    }
+
+    private void setArgument(PreparedStatement pstmt, String argument, int targetSqlType, int index) throws SQLException {
+        switch (targetSqlType) {
+        case Types.INTEGER:
+            pstmt.setInt(index, Integer.parseInt(argument));
+            break;
+        case Types.DOUBLE:
+        case Types.DECIMAL:
+            pstmt.setDouble(index, Double.parseDouble(argument));
+            break;
+        case Types.VARCHAR:
+            pstmt.setString(index, argument);
+            break;
+        case Types.BOOLEAN:
+            pstmt.setBoolean(index, Boolean.parseBoolean(argument));
+            break;
+        case Types.BIGINT:
+            pstmt.setLong(index, Long.parseLong(argument));
+            break;
+        case Types.DATE:
+            pstmt.setDate(index, Date.valueOf(argument));
+            break;
+        case Types.FLOAT:
+            pstmt.setFloat(index, Float.parseFloat(argument));
+            break;
+        case Types.TIMESTAMP:
+            pstmt.setTimestamp(index, Timestamp.valueOf(argument));
+            break;
+        case Types.TIME:
+            pstmt.setTime(index, Time.valueOf(argument));
+            break;
+        case Types.NULL:
+            pstmt.setNull(index, targetSqlType);
+            break;
+        default:
+            pstmt.setObject(index, argument, targetSqlType);
+        }
     }
 
 


### PR DESCRIPTION
Use typed methods such as `setInt`, `setDouble`, `setDate` ... for prepared statement.

It moves parsing from the driver to Jmeter, but it allows to compare more easily two drivers / databases. 
Moreover it makes benchmark closer to reality, in fact for performance reasons we try to avoid calls to setObject as the driver as to cast/parse String parameters.
