### PR TITLE
Bug 58673 Module Controller : when the target element is disabled the default jtree icons are displayed

### DIFF
--- a/src/components/org/apache/jmeter/control/gui/ModuleControllerGui.java
+++ b/src/components/org/apache/jmeter/control/gui/ModuleControllerGui.java
@@ -420,6 +420,13 @@ public class ModuleControllerGui extends AbstractControllerGui implements Action
                         setDisabledIcon(icon);
                     }
                 }
+                else if (!enabled) { // i.e. no disabled icon found
+                    // Must therefore set the enabled icon so there is at least some  icon
+                    icon = node.getIcon();
+                    if (icon != null) {
+                        setIcon(icon);
+                    }
+                }
             }
             return this;
         }


### PR DESCRIPTION
Use the same logic as the main jmeter tree
