### PR TITLE
Bug 58689 : Add shortcuts to expand / collapse a part of the tree

### DIFF
--- a/src/core/org/apache/jmeter/gui/action/ActionNames.java
+++ b/src/core/org/apache/jmeter/gui/action/ActionNames.java
@@ -21,8 +21,6 @@ package org.apache.jmeter.gui.action;
 /*
  * Collect all the action names together in one place.
  * This helps to ensure that there are no duplicates
- *
- *
  */
 public final class ActionNames {
 
@@ -62,7 +60,7 @@ public final class ActionNames {
     public static final String MERGE            = "merge"; // $NON-NLS-1$
     public static final String OPEN             = "open"; // $NON-NLS-1$
     public static final String OPEN_RECENT      = "open_recent"; // $NON-NLS-1$
-    public static final String TEMPLATES      = "templates"; // $NON-NLS-1$
+    public static final String TEMPLATES        = "templates"; // $NON-NLS-1$
     public static final String PASTE            = "Paste"; // $NON-NLS-1$
     public static final String REMOTE_EXIT      = "remote_exit"; // $NON-NLS-1$
     public static final String REMOTE_EXIT_ALL  = "remote_exit_all"; // $NON-NLS-1$
@@ -87,10 +85,10 @@ public final class ActionNames {
     public static final String SUB_TREE_MERGED  = "sub_tree_merged"; // $NON-NLS-1$
     public static final String SUB_TREE_SAVED   = "sub_tree_saved"; // $NON-NLS-1$
     public static final String TOGGLE           = "toggle"; // $NON-NLS-1$ enable/disable
-    public static final String TOOLBAR           = "toolbar"; // $NON-NLS-1$
+    public static final String TOOLBAR          = "toolbar"; // $NON-NLS-1$
     public static final String WHAT_CLASS       = "what_class"; // $NON-NLS-1$
     public static final String SEARCH_TREE      = "search_tree"; // $NON-NLS-1$
-    public static final String SEARCH_RESET      = "search_reset"; // $NON-NLS-1$
+    public static final String SEARCH_RESET     = "search_reset"; // $NON-NLS-1$
     public static final String MOVE_UP          = "move_up"; // $NON-NLS-1$
     public static final String MOVE_DOWN        = "move_down"; // $NON-NLS-1$
     public static final String MOVE_LEFT        = "move_left"; // $NON-NLS-1$
@@ -98,9 +96,9 @@ public final class ActionNames {
     public static final String UNDO             = "undo"; // $NON-NLS-1$
     public static final String REDO             = "redo"; // $NON-NLS-1$
     public static final String QUICK_COMPONENT  = "quick_component"; // $NON-NLS-1$
+    public static final String COLLAPSE         = "collapse"; // $NON-NLS-1$
+    public static final String EXPAND           = "expand"; // $NON-NLS-1$
 
     // Prevent instantiation
-    private ActionNames(){
-
-    }
+    private ActionNames() {}
 }

--- a/src/core/org/apache/jmeter/gui/action/CollapseExpand.java
+++ b/src/core/org/apache/jmeter/gui/action/CollapseExpand.java
@@ -40,13 +40,13 @@ public class CollapseExpand implements Command {
     }
 
     /**
-     * Constructor for the Close object.
+     * Constructor for the CollapseExpand object.
      */
     public CollapseExpand() {
     }
 
     /**
-     * Gets the ActionNames attribute of the Close object.
+     * Gets the ActionNames attribute of the CollapseExpand object.
      *
      * @return the ActionNames value
      */
@@ -66,14 +66,14 @@ public class CollapseExpand implements Command {
         boolean collapse=ActionNames.COLLAPSE_ALL.equals(e.getActionCommand());
         GuiPackage guiInstance = GuiPackage.getInstance();
         JTree jTree = guiInstance.getMainFrame().getTree();
-        if (collapse){
+        if (collapse) {
             for (int i = jTree.getRowCount() - 1; i >= 0; i--) {
-                 jTree.collapseRow(i);
+                jTree.collapseRow(i);
             }
             return;
         }
-       for(int i = 0; i < jTree.getRowCount(); i++) {
-               jTree.expandRow(i);
-       }
+        for(int i = 0; i < jTree.getRowCount(); i++) {
+            jTree.expandRow(i);
+        }
     }
 }

--- a/src/core/org/apache/jmeter/gui/action/CollapseExpandTreeBranch.java
+++ b/src/core/org/apache/jmeter/gui/action/CollapseExpandTreeBranch.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.jmeter.gui.action;
+
+import java.awt.event.ActionEvent;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.swing.JTree;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+
+import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.tree.JMeterTreeListener;
+import org.apache.jmeter.gui.tree.JMeterTreeNode;
+
+/**
+ * Processes the collapse and expand of a tree branch
+ */
+public class CollapseExpandTreeBranch extends AbstractAction {
+    private static final Set<String> commands = new HashSet<>();
+
+    static {
+        commands.add(ActionNames.COLLAPSE);
+        commands.add(ActionNames.EXPAND);
+    }
+
+    /**
+     * Constructor
+     */
+    public CollapseExpandTreeBranch() {}
+
+    /**
+     * Gets the ActionNames attribute of the CollapseExpandTreeBranch object.
+     *
+     * @return the ActionNames value
+     */
+    @Override
+    public Set<String> getActionNames() {
+        return commands;
+    }
+
+    /**
+     * This method performs the actual command processing.
+     *
+     * @param e the generic UI action event
+     */
+    @Override
+    public void doAction(ActionEvent e) {
+        JMeterTreeListener treeListener = GuiPackage.getInstance().getTreeListener();
+
+        JTree jTree = GuiPackage.getInstance().getMainFrame().getTree();
+        JMeterTreeNode[] selectedNodes = treeListener.getSelectedNodes();
+        for (JMeterTreeNode currentNode : selectedNodes) {
+            if(!currentNode.isLeaf()) {
+                TreeNode[] nodes = GuiPackage.getInstance().getTreeModel().getPathToRoot(currentNode);
+                TreePath path = new TreePath(nodes);
+                boolean collapse = ActionNames.COLLAPSE.equals(e.getActionCommand());
+                
+                expandCollapseNode(jTree, path, collapse);
+            }
+        }
+    }
+    
+    private void expandCollapseNode(JTree jTree, TreePath parent, boolean collapse) {
+        TreeNode node = (TreeNode) parent.getLastPathComponent();
+        if (node.isLeaf()) {
+            return;
+        }
+        
+        Enumeration children = node.children();
+        while(children.hasMoreElements()) {
+            TreeNode child = (TreeNode) children.nextElement();
+            TreePath path = parent.pathByAddingChild(child);
+            expandCollapseNode(jTree, path, collapse);
+        }
+        
+        if(collapse) {
+            jTree.collapsePath(parent);
+        }
+        else {
+            jTree.expandPath(parent);
+        }
+    }
+}

--- a/src/core/org/apache/jmeter/gui/action/KeyStrokes.java
+++ b/src/core/org/apache/jmeter/gui/action/KeyStrokes.java
@@ -74,6 +74,8 @@ public final class KeyStrokes {
     public static final KeyStroke ALT_DOWN_ARROW    = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, InputEvent.ALT_DOWN_MASK);
     public static final KeyStroke ALT_LEFT_ARROW    = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, InputEvent.ALT_DOWN_MASK);
     public static final KeyStroke ALT_RIGHT_ARROW   = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, InputEvent.ALT_DOWN_MASK);
+    public static final KeyStroke SHIFT_LEFT_ARROW  = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, InputEvent.SHIFT_DOWN_MASK);
+    public static final KeyStroke SHIFT_RIGHT_ARROW = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, InputEvent.SHIFT_DOWN_MASK);
     
     // component hotkeys
     public static final KeyStroke CTRL_0   = KeyStroke.getKeyStroke(KeyEvent.VK_0, CONTROL_MASK);
@@ -86,6 +88,7 @@ public final class KeyStrokes {
     public static final KeyStroke CTRL_7   = KeyStroke.getKeyStroke(KeyEvent.VK_7, CONTROL_MASK);
     public static final KeyStroke CTRL_8   = KeyStroke.getKeyStroke(KeyEvent.VK_8, CONTROL_MASK);
     public static final KeyStroke CTRL_9   = KeyStroke.getKeyStroke(KeyEvent.VK_9, CONTROL_MASK);
+
 
     /**
      * Check if an event matches the KeyStroke definition.

--- a/src/core/org/apache/jmeter/gui/tree/JMeterTreeListener.java
+++ b/src/core/org/apache/jmeter/gui/tree/JMeterTreeListener.java
@@ -219,6 +219,10 @@ public class JMeterTreeListener implements TreeSelectionListener, MouseListener,
             actionName = ActionNames.MOVE_LEFT;
         } else if (KeyStrokes.matches(e, KeyStrokes.ALT_RIGHT_ARROW)) {
             actionName = ActionNames.MOVE_RIGHT;
+        } else if (KeyStrokes.matches(e, KeyStrokes.SHIFT_LEFT_ARROW)) {
+            actionName = ActionNames.COLLAPSE;
+        } else if (KeyStrokes.matches(e, KeyStrokes.SHIFT_RIGHT_ARROW)) {
+            actionName = ActionNames.EXPAND;
         } 
         
         if (actionName != null) {


### PR DESCRIPTION
before it was possible to collapse / expand the entire tree not a part
of it.
With this new action you can expand / collapse all the nodes under the
current selected one

it's mapped to shift + left arrow and shift + right arrow
