### PR TITLE
Bug 58726 - Remove the jmeterthread.startearlier parameter

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1030,12 +1030,6 @@ beanshell.server.file=../extras/startup.bsh
 # If you want to use Nashorn on JDK8, set this property to false
 #javascript.use_rhino=true
 
-# (2.0.3) JMeterThread behaviour has been changed to set the started flag before
-# the controllers are initialised. This is so controllers can access variables earlier. 
-# In case this causes problems, the previous behaviour can be restored by uncommenting
-# the following line.
-#jmeterthread.startearlier=false
-
 # (2.2.1) JMeterThread behaviour has changed so that PostProcessors are run in forward order
 # (as they appear in the test plan) rather than reverse order as previously.
 # Uncomment the following line to revert to the original behaviour

--- a/src/core/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/org/apache/jmeter/threads/JMeterThread.java
@@ -226,18 +226,10 @@ public class JMeterThread implements Runnable, Interruptible {
      * See below for reason for this change. Just in case this causes problems,
      * allow the change to be backed out
      */
-    private static final boolean startEarlier =
-        JMeterUtils.getPropDefault("jmeterthread.startearlier", true); // $NON-NLS-1$
-
     private static final boolean reversePostProcessors =
-        JMeterUtils.getPropDefault("jmeterthread.reversePostProcessors",false); // $NON-NLS-1$
+        JMeterUtils.getPropDefault("jmeterthread.reversePostProcessors", false); // $NON-NLS-1$
 
     static {
-        if (startEarlier) {
-            log.info("jmeterthread.startearlier=true (see jmeter.properties)");
-        } else {
-            log.info("jmeterthread.startearlier=false (see jmeter.properties)");
-        }
         if (reversePostProcessors) {
             log.info("Running PostProcessors in reverse order");
         } else {
@@ -551,15 +543,12 @@ public class JMeterThread implements Runnable, Interruptible {
          * them to access the running values of functions and variables (however
          * it does not seem to help with the listeners)
          */
-        if (startEarlier) {
-            threadContext.setSamplingStarted(true);
-        }
+        threadContext.setSamplingStarted(true);
+        
         controller.initialize();
         IterationListener iterationListener = new IterationListener();
         controller.addIterationListener(iterationListener);
-        if (!startEarlier) {
-            threadContext.setSamplingStarted(true);
-        }
+
         threadStarted();
         return iterationListener;
     }


### PR DESCRIPTION
this parameter was added 11 years ago (rev 325222) as a way to revert to
a previous behaviour if a problem was found.

Extract of jmeter.properties
# In case this causes problems, the previous behaviour can be restored

by uncommenting the following line.

We're now 11 years later and no pb were found, it's time to remove that
parameter
