### PR TITLE
bug 58811 : When pasting arguments between http samplers the column "Encode" and "Include Equals" are lost.

### DIFF
--- a/src/core/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -485,14 +485,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
             for (String clipboardLine : clipboardLines) {
                 String[] clipboardCols = clipboardLine.split("\t");
                 if (clipboardCols.length > 0) {
-                    Argument argument = makeNewArgument();
-                    argument.setName(clipboardCols[0]);
-                    if (clipboardCols.length > 1) {
-                        argument.setValue(clipboardCols[1]);
-                        if (clipboardCols.length > 2) {
-                            argument.setDescription(clipboardCols[2]);
-                        }
-                    }
+                    Argument argument = createArgumentFromClipboard(clipboardCols);
                     tableModel.addRow(argument);
                 }
             }
@@ -513,6 +506,18 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
                     "Could not add retrieve " + DataFlavor.stringFlavor.getHumanPresentableName()
                             + " from clipboard" + ufe.getLocalizedMessage(), "Error", JOptionPane.ERROR_MESSAGE);
         }
+    }
+
+    protected Argument createArgumentFromClipboard(String[] clipboardCols) {
+        Argument argument = makeNewArgument();
+        argument.setName(clipboardCols[0]);
+        if (clipboardCols.length > 1) {
+            argument.setValue(clipboardCols[1]);
+            if (clipboardCols.length > 2) {
+                argument.setDescription(clipboardCols[2]);
+            }
+        }
+        return argument;
     }
 
     /**

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
@@ -22,6 +22,8 @@ import java.util.Iterator;
 
 import javax.swing.JTable;
 
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
@@ -135,4 +137,29 @@ public class HTTPArgumentsPanel extends ArgumentsPanel {
         return arg.getMetaData() == null || arg.getMetaData().equals("=")
                 || (arg.getValue() != null && arg.getValue().length() > 0);
     }
+
+    @Override
+    protected Argument createArgumentFromClipboard(String[] clipboardCols) {
+        HTTPArgument argument = makeNewArgument();
+        argument.setName(clipboardCols[0]);
+        if (clipboardCols.length > 1) {
+            argument.setValue(clipboardCols[1]);
+            
+            if (clipboardCols.length > 2) {
+                
+                // default to false if the string is not a boolean
+                argument.setAlwaysEncoded(Boolean.parseBoolean(clipboardCols[2]));
+                
+                if (clipboardCols.length > 3) {
+                    Boolean useEqual = BooleanUtils.toBooleanObject(clipboardCols[3]);
+                    // default to true if the string is not a boolean
+                    argument.setUseEquals(useEqual!=null?useEqual.booleanValue():true);
+                }
+            }
+        }
+        
+        return argument;
+    }
+    
+    
 }


### PR DESCRIPTION
That's bad !
