### PR TITLE
Bug 56554 : the script cache key is now automatically generated.

### DIFF
--- a/src/core/org/apache/jmeter/util/ScriptingBeanInfoSupport.java
+++ b/src/core/org/apache/jmeter/util/ScriptingBeanInfoSupport.java
@@ -35,7 +35,7 @@ public abstract class ScriptingBeanInfoSupport extends BeanInfoSupport {
         this(beanClass, languageTags, null);
     }
 
-    protected ScriptingBeanInfoSupport(Class<? extends TestBean> beanClass, String[] LANGUAGE_TAGS, ResourceBundle rb) {
+    protected ScriptingBeanInfoSupport(Class<? extends TestBean> beanClass, String[] languageTags, ResourceBundle rb) {
         super(beanClass);
         PropertyDescriptor p;
 
@@ -45,7 +45,7 @@ public abstract class ScriptingBeanInfoSupport extends BeanInfoSupport {
         if (rb != null) {
             p.setValue(RESOURCE_BUNDLE, rb);
         }
-        p.setValue(TAGS, LANGUAGE_TAGS);
+        p.setValue(TAGS, languageTags);
 
         createPropertyGroup("scriptingLanguage", // $NON-NLS-1$
                 new String[] { "scriptLanguage" }); // $NON-NLS-1$
@@ -65,38 +65,6 @@ public abstract class ScriptingBeanInfoSupport extends BeanInfoSupport {
         createPropertyGroup("filenameGroup",  // $NON-NLS-1$
                 new String[] { "filename" }); // $NON-NLS-1$
 
-        /*
-         * If we are creating a JSR223 element, add the cache key property.
-         * 
-         * Note that this cannot be done in the JSR223BeanInfoSupport class
-         * because that causes problems with the group; its properties are
-         * not always set up before they are needed. This cause various
-         * issues with the GUI:
-         * - wrong field attributes (should not allow null)
-         * - sometimes GUI is completely mangled
-         * - field appears at start rather than at end.
-         * - the following warning is logged:
-         * jmeter.testbeans.gui.GenericTestBeanCustomizer: 
-         * org.apache.jmeter.util.JSR223TestElement#cacheKey does not appear to have been configured
-         * 
-         * Adding the group here solves these issues, and it's also
-         * possible to add the key just before the script panel
-         * to which it relates.
-         * 
-         * It's not yet clear why this should be, but it looks as though
-         * createPropertyGroup does not work properly if it is called from
-         * any subclasses of this class.
-         * 
-         */
-        if (JSR223TestElement.class.isAssignableFrom(beanClass) ) {
-            p = property("cacheKey"); // $NON-NLS-1$
-            p.setValue(NOT_UNDEFINED, Boolean.TRUE);
-            p.setValue(DEFAULT, ""); // $NON-NLS-1$
-    
-            createPropertyGroup("cacheKey_group", // $NON-NLS-1$
-                new String[] { "cacheKey" }); // $NON-NLS-1$
-        }
-
         p = property("script"); // $NON-NLS-1$
         p.setValue(NOT_UNDEFINED, Boolean.TRUE);
         p.setValue(DEFAULT, ""); // $NON-NLS-1$
@@ -104,6 +72,17 @@ public abstract class ScriptingBeanInfoSupport extends BeanInfoSupport {
 
         createPropertyGroup("scripting", // $NON-NLS-1$
                 new String[] { "script" }); // $NON-NLS-1$
+        
+        // the cache key property was kept in the JSR223TestElement 
+        //  for compatibility with jmeter <= 2.13
+        // but it should be removed in a future version
+        // mark the property as 'hidden' to remove it from the gui
+        if (JSR223TestElement.class.isAssignableFrom(beanClass) ) {
+            p = property("cacheKey");
+            if(p != null) {
+                p.setHidden(true);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
The md5 of the script content is used.
The previous cacheKey property is still there for compatibility but can
not be modified or viewed in the gui.
Note that with this change, a Compilable script will always be cached,
it was not the case with the previous version if the user set the
cacheKey property to an empty value.
Documentation _was not_ updated.
