### PR TITLE
Bug 58860 : automatic variable generation in http parameter

### DIFF
--- a/src/core/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -672,7 +672,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
     /**
      * Initialize the components and layout of this component.
      */
-    private void init() {
+    protected void init() {
         JPanel p = this;
 
         if (standalone) {

--- a/src/core/org/apache/jmeter/resources/messages.properties
+++ b/src/core/org/apache/jmeter/resources/messages.properties
@@ -1167,6 +1167,7 @@ tr=Turkish
 transaction_controller_include_timers=Include duration of timer and pre-post processors in generated sample
 transaction_controller_parent=Generate parent sample
 transaction_controller_title=Transaction Controller
+transform_into_variable=Replace values with variables
 unbind=Thread Unbind
 undo=Undo
 unescape_html_string=String to unescape

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
@@ -18,11 +18,16 @@
 
 package org.apache.jmeter.protocol.http.gui;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.util.Iterator;
 
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -160,6 +165,41 @@ public class HTTPArgumentsPanel extends ArgumentsPanel {
         
         return argument;
     }
+
+    @Override
+    protected void init() {
+        super.init();
+        
+        // register the right click menu
+        JTable table = getTable();
+        final JPopupMenu popupMenu = new JPopupMenu();
+        JMenuItem variabilizeItem = new JMenuItem(JMeterUtils.getResString("transform_into_variable"));
+        variabilizeItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                transformNameIntoVariable();
+            }
+        });
+        popupMenu.add(variabilizeItem);
+        table.setComponentPopupMenu(popupMenu);
+    }
     
+    /** 
+     * replace the argument value of the selection with a variable 
+     * the variable name is derived from the parameter name 
+     */
+    private void transformNameIntoVariable() {
+        int[] rowsSelected = getTable().getSelectedRows();
+        for (int i = 0; i < rowsSelected.length; i++) {
+            String name = (String) tableModel.getValueAt(rowsSelected[i], 0);
+            if(StringUtils.isNotBlank(name)) {
+                name = name.trim();
+                name = name.replaceAll("\\$", "_");
+                name = name.replaceAll("\\{", "_");
+                name = name.replaceAll("\\}", "_");
+                tableModel.setValueAt("${"+name+"}", rowsSelected[i], 1);                
+            }
+        }
+    }
     
 }


### PR DESCRIPTION
in the http panel, the right click on a row selection 
give the ability to automatically replace the variables values of the selected rows by a
variable.
the variable name is derived from the parameter name 
eg myparam1 -> ${myparam1}

Right click menu :
<img width="963" alt="replace-value" src="https://cloud.githubusercontent.com/assets/5681005/12324756/40891b4a-bac5-11e5-856e-19044c874515.png">

After replacement :
<img width="796" alt="after" src="https://cloud.githubusercontent.com/assets/5681005/12324770/5a5174be-bac5-11e5-85a9-93c20e72d692.png">
