### PR TITLE
Bug 58865 : allow empty default value in the regex extractor

### DIFF
--- a/src/components/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/org/apache/jmeter/extractor/RegexExtractor.java
@@ -78,6 +78,8 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
     private static final String MATCH_NUMBER = "RegexExtractor.match_number"; // $NON-NLS-1$
 
     private static final String DEFAULT = "RegexExtractor.default"; // $NON-NLS-1$
+    
+    private static final String DEFAULT_EMPTY_VALUE = "RegexExtractor.default_empty_value"; // $NON-NLS-1$
 
     private static final String TEMPLATE = "RegexExtractor.template"; // $NON-NLS-1$
 
@@ -109,9 +111,10 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         int matchNumber = getMatchNumber();
 
         final String defaultValue = getDefaultValue();
-        if (defaultValue.length() > 0){// Only replace default if it is provided
+        if (defaultValue.length() > 0 || isEmptyDefaultValue()) {// Only replace default if it is provided or empty default value is explicitly requested
             vars.put(refName, defaultValue);
         }
+        
         Perl5Matcher matcher = JMeterUtils.getMatcher();
         String regex = getRegex();
         Pattern pattern = null;
@@ -439,6 +442,10 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
     public void setDefaultValue(String defaultValue) {
         setProperty(DEFAULT, defaultValue);
     }
+    
+    public void setDefaultEmptyValue(boolean defaultEmptyValue) {
+        setProperty(DEFAULT_EMPTY_VALUE, defaultEmptyValue);
+    }
 
     /**
      * Get the default value for the variable, which should be used, if no
@@ -448,6 +455,10 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
      */
     public String getDefaultValue() {
         return getPropertyAsString(DEFAULT);
+    }
+    
+    public boolean isEmptyDefaultValue() {
+        return getPropertyAsBoolean(DEFAULT_EMPTY_VALUE);
     }
 
     public void setTemplate(String template) {

--- a/src/components/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
+++ b/src/components/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
@@ -21,11 +21,14 @@ package org.apache.jmeter.extractor.gui;
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.ButtonGroup;
+import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
@@ -70,6 +73,8 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
     private JRadioButton useMessage;
 
     private ButtonGroup group;
+    
+    private JCheckBox emptyDefaultValue;
 
     public RegexExtractorGui() {
         super();
@@ -98,6 +103,7 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
             regexField.setText(re.getRegex());
             templateField.setText(re.getTemplate());
             defaultField.setText(re.getDefaultValue());
+            emptyDefaultValue.setSelected(re.isEmptyDefaultValue());
             matchNumberField.setText(re.getMatchNumberAsString());
             refNameField.setText(re.getRefName());
         }
@@ -129,6 +135,7 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
             regex.setRegex(regexField.getText());
             regex.setTemplate(templateField.getText());
             regex.setDefaultValue(defaultField.getText());
+            regex.setDefaultEmptyValue(emptyDefaultValue.isSelected());
             regex.setMatchNumber(matchNumberField.getText());
         }
     }
@@ -145,6 +152,7 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
         regexField.setText(""); //$NON-NLS-1$
         templateField.setText(""); //$NON-NLS-1$
         defaultField.setText(""); //$NON-NLS-1$
+        emptyDefaultValue.setSelected(false);
         refNameField.setText(""); //$NON-NLS-1$
         matchNumberField.setText(""); //$NON-NLS-1$
     }
@@ -211,7 +219,6 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
     private JPanel makeParameterPanel() {
         regexField = new JLabeledTextField(JMeterUtils.getResString("regex_field")); //$NON-NLS-1$
         templateField = new JLabeledTextField(JMeterUtils.getResString("template_field")); //$NON-NLS-1$
-        defaultField = new JLabeledTextField(JMeterUtils.getResString("default_value_field")); //$NON-NLS-1$
         refNameField = new JLabeledTextField(JMeterUtils.getResString("ref_name_field")); //$NON-NLS-1$
         matchNumberField = new JLabeledTextField(JMeterUtils.getResString("match_num_field")); //$NON-NLS-1$
 
@@ -227,7 +234,31 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
         addField(panel, matchNumberField, gbc);
         resetContraints(gbc);
         gbc.weighty = 1;
-        addField(panel, defaultField, gbc);
+        
+        
+        defaultField = new JLabeledTextField(JMeterUtils.getResString("default_value_field")); //$NON-NLS-1$
+        List<JComponent> item = defaultField.getComponentList();
+        panel.add(item.get(0), gbc.clone());
+        JPanel p = new JPanel(new BorderLayout());
+        p.add(item.get(1), BorderLayout.WEST);
+        emptyDefaultValue = new JCheckBox(JMeterUtils.getResString("assertion_regex_empty_default_value"));
+        emptyDefaultValue.addItemListener(new ItemListener() {
+            
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if(emptyDefaultValue.isSelected()) {
+                    defaultField.setText("");
+                }
+                defaultField.setEnabled(!emptyDefaultValue.isSelected());
+            }
+        });
+        
+        p.add(emptyDefaultValue, BorderLayout.CENTER);
+        gbc.gridx++;
+        gbc.weightx = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        panel.add(p, gbc.clone());
+        
         return panel;
     }
 

--- a/src/core/org/apache/jmeter/resources/messages.properties
+++ b/src/core/org/apache/jmeter/resources/messages.properties
@@ -112,6 +112,7 @@ assertion_network_size=Full Response
 assertion_not=Not
 assertion_pattern_match_rules=Pattern Matching Rules
 assertion_patterns_to_test=Patterns to Test
+assertion_regex_empty_default_value=Empty default value
 assertion_resp_field=Response Field to Test
 assertion_resp_size_field=Response Size Field to Test
 assertion_substring=Substring

--- a/test/src/org/apache/jmeter/extractor/TestRegexExtractor.java
+++ b/test/src/org/apache/jmeter/extractor/TestRegexExtractor.java
@@ -65,6 +65,24 @@ public class TestRegexExtractor extends TestCase {
             jmctx.setPreviousResult(result);
         }
 
+        public void testEmptyDefaultVariable() throws Exception {
+            extractor.setRegex("<value name=\"positioncount\">(.+?)</value>");
+            extractor.setTemplate("$1$");
+            extractor.setMatchNumber(1);
+            extractor.setDefaultEmptyValue(true);
+            extractor.process();
+            assertEquals("", vars.get("regVal"));
+        }
+        
+        public void testNotEmptyDefaultVariable() throws Exception {
+            extractor.setRegex("<value name=\"positioncount\">(.+?)</value>");
+            extractor.setTemplate("$1$");
+            extractor.setMatchNumber(1);
+            extractor.setDefaultEmptyValue(false);
+            extractor.process();
+            assertNull(vars.get("regVal"));
+        }
+        
         public void testVariableExtraction0() throws Exception {
             extractor.setRegex("<(value) field=\"");
             extractor.setTemplate("$1$");


### PR DESCRIPTION
Example
with the following regex for the variable myvar
<input name="baulpismuth" type="text" value="(.+?)" 
and a http argument as
baulpismuth = ${myvar}

and the given html
<input name="baulpismuth" type="text" >
the browser will send baulpismuth=

but jmeter will send baulpismuth=${myvar}
as no match will be found and it's not possible to define an empty
default value

this PR add a checkbox (I love checkbox) to let the user choose an empty default value
