### PR TITLE
Bug 58897 : DO NOT MERGE AS THIS !!!

### DIFF
--- a/test/src/org/apache/jmeter/junit/JMeterTest.java
+++ b/test/src/org/apache/jmeter/junit/JMeterTest.java
@@ -596,7 +596,17 @@ public class JMeterTest extends JMeterTestCase {
                 } catch (HeadlessException e) {
                     caught = e;
                     System.out.println("o.a.j.junit.JMeterTest Error creating "+n+" "+e.toString());
-                } catch (Exception e) {
+                } 
+                catch(ExceptionInInitializerError eiie) {
+                    caught = eiie;
+                    if(caught.getCause() instanceof HeadlessException) {
+                        System.out.println("o.a.j.junit.JMeterTest Error creating "+n+" "+eiie.toString());
+                    }
+                    else {
+                        throw new Exception("Error creating " + n, eiie);
+                    }
+                }
+                catch (Exception e) {
                     caught = e;
                     if (e instanceof RemoteException) { // not thrown, so need to check here
                         System.out.println("o.a.j.junit.JMeterTest WARN: " + "Error creating " + n + " " + e.toString());


### PR DESCRIPTION
Some code added a few years ago silently disabled a _lot_ of tests : 
when run in headless mode (apache build bot ?) a HeadlessException is
thrown but wrapped in an ExceptionInInitializerError
this error stop the JmeterTest suite and the following tests are
disabled
- suiteSerializableElements
- suiteTestElements
- suiteBeanComponents
- new JMeterTest("createFunctionSet"));
- suiteFunctions
- new JMeterTest("checkGuiSet"));
- new JMeterTest("checkFunctionSet"));  
- new JMeterTest("resetLocale")

this patch will re-enable those tests but some of them fail
Those tests need to be reviewed by a jmeter ninja or an archaeologist
