### PR TITLE
Bug 58897 : Step 5 misc clean up

### DIFF
--- a/src/functions/org/apache/jmeter/functions/EvalFunction.java
+++ b/src/functions/org/apache/jmeter/functions/EvalFunction.java
@@ -18,8 +18,6 @@
 
 package org.apache.jmeter.functions;
 
-// @see PackageTest for unit tests
-
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/functions/org/apache/jmeter/functions/EvalVarFunction.java
+++ b/src/functions/org/apache/jmeter/functions/EvalVarFunction.java
@@ -18,8 +18,6 @@
 
 package org.apache.jmeter.functions;
 
-// @see PackageTest for unit tests
-
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;

--- a/test/src/org/apache/jmeter/assertions/SizeAssertionTest.java
+++ b/test/src/org/apache/jmeter/assertions/SizeAssertionTest.java
@@ -162,9 +162,6 @@ public class SizeAssertionTest extends JMeterTestCase{
 // TODO - need a lot more tests
       
       private void assertPassed() throws Exception{
-         // if (null != result.getFailureMessage()){
-              //System.out.println(result.getFailureMessage());// debug
-          //}
           assertNull("Failure message should be null",result.getFailureMessage());
           assertFalse(result.isError());
           assertFalse(result.isFailure());        
@@ -172,10 +169,8 @@ public class SizeAssertionTest extends JMeterTestCase{
       
       private void assertFailed() throws Exception{
           assertNotNull("Failure message should not be null",result.getFailureMessage());
-          //System.out.println(result.getFailureMessage());
           assertFalse("Should not be: Response was null","Response was null".equals(result.getFailureMessage()));
           assertFalse(result.isError());
           assertTrue(result.isFailure());     
-          
       }
 }

--- a/test/src/org/apache/jmeter/assertions/XMLSchemaAssertionTest.java
+++ b/test/src/org/apache/jmeter/assertions/XMLSchemaAssertionTest.java
@@ -35,8 +35,6 @@ import org.apache.jmeter.threads.JMeterVariables;
 import org.junit.Before;
 import org.junit.Test;
 
-//import org.apache.jorphan.logging.LoggingManager;
-
 public class XMLSchemaAssertionTest extends JMeterTestCase {
 
     private XMLSchemaAssertion assertion;
@@ -56,7 +54,6 @@ public class XMLSchemaAssertionTest extends JMeterTestCase {
         JMeterVariables vars = new JMeterVariables();
         jmctx.setVariables(vars);
         jmctx.setPreviousResult(result);
-        // LoggingManager.setPriority("DEBUG","jmeter");
     }
 
     private ByteArrayOutputStream readBA(String name) throws IOException {

--- a/test/src/org/apache/jmeter/assertions/XPathAssertionTest.java
+++ b/test/src/org/apache/jmeter/assertions/XPathAssertionTest.java
@@ -59,7 +59,6 @@ public class XPathAssertionTest extends JMeterTestCase {
         vars = new JMeterVariables();
         jmctx.setVariables(vars);
         jmctx.setPreviousResult(result);
-        //testLog.setPriority(org.apache.log.Priority.DEBUG);
     }
 
     private void setAlternateResponseData(){

--- a/test/src/org/apache/jmeter/engine/util/TestValueReplacer.java
+++ b/test/src/org/apache/jmeter/engine/util/TestValueReplacer.java
@@ -117,7 +117,6 @@ public class TestValueReplacer extends JMeterTestCase {
             TestElement element = new ConfigTestElement();
             element.setProperty(new StringProperty("domain", "${server}"));
             replacer.replaceValues(element);
-            //log.debug("domain property = " + element.getProperty("domain"));
             element.setRunningVersion(true);
             assertEquals("jakarta.apache.org", element.getPropertyAsString("domain"));
         }
@@ -130,7 +129,6 @@ public class TestValueReplacer extends JMeterTestCase {
             String input = "\\${server} \\ \\\\ \\\\\\ \\, ";
             element.setProperty(new StringProperty("domain", input));
             replacer.replaceValues(element);
-            //log.debug("domain property = " + element.getProperty("domain"));
             element.setRunningVersion(true);
             assertEquals(input, element.getPropertyAsString("domain"));
         }
@@ -150,7 +148,6 @@ public class TestValueReplacer extends JMeterTestCase {
             String input = "${server} \\ \\\\ \\\\\\ \\, ";
             element.setProperty(new StringProperty("domain", input));
             replacer.replaceValues(element);
-            //log.debug("domain property = " + element.getProperty("domain"));
             element.setRunningVersion(true);
             assertEquals("jakarta.apache.org \\ \\ \\\\ , ", element.getPropertyAsString("domain"));
         }

--- a/test/src/org/apache/jmeter/functions/EvalFunctionTest.java
+++ b/test/src/org/apache/jmeter/functions/EvalFunctionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.apache.jmeter.functions;
+
+import java.util.Collection;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.apache.jmeter.functions.FunctionTestHelper.makeParams;
+
+public class EvalFunctionTest extends JMeterTestCase {
+
+    private JMeterContext jmctx = null;
+    private JMeterVariables vars = null;
+    
+    @Before
+    public void setUp() {
+        jmctx = JMeterContextService.getContext();
+        jmctx.setVariables(new JMeterVariables());
+        vars = jmctx.getVariables();
+    }
+    
+    @Test
+    public void evalTest1() throws Exception {
+        EvalFunction eval = new EvalFunction();
+        vars.put("query","select ${column} from ${table}");
+        vars.put("column","name");
+        vars.put("table","customers");
+        Collection<CompoundVariable> parms;
+        String s;
+        
+        parms = makeParams("${query}",null,null);
+        eval.setParameters(parms);
+        s = eval.execute(null,null);
+        assertEquals("select name from customers",s);
+        
+    }
+
+    @Test
+    public void evalTest2() throws Exception {
+        EvalVarFunction evalVar = new EvalVarFunction();
+        vars.put("query","select ${column} from ${table}");
+        vars.put("column","name");
+        vars.put("table","customers");
+        Collection<CompoundVariable> parms;
+        String s;
+        
+        parms = makeParams("query",null,null);
+        evalVar.setParameters(parms);
+        s = evalVar.execute(null,null);
+        assertEquals("select name from customers",s);
+    }
+}

--- a/test/src/org/apache/jmeter/functions/FunctionTestHelper.java
+++ b/test/src/org/apache/jmeter/functions/FunctionTestHelper.java
@@ -16,22 +16,26 @@
  * 
  */
 
-package org.apache.jmeter.gui.action;
+package org.apache.jmeter.functions;
 
-import junit.framework.TestCase;
+import java.util.Collection;
+import java.util.LinkedList;
 
-public class PackageTest extends TestCase {
+import org.apache.jmeter.engine.util.CompoundVariable;
 
-    public PackageTest(String arg0) {
-        super(arg0);
+public class FunctionTestHelper {
+
+    public static Collection<CompoundVariable> makeParams(String p1, String p2, String p3) {
+        Collection<CompoundVariable> parms = new LinkedList<>();
+        if (p1 != null) {
+            parms.add(new CompoundVariable(p1));
+        }
+        if (p2 != null) {
+            parms.add(new CompoundVariable(p2));
+        }
+        if (p3 != null) {
+            parms.add(new CompoundVariable(p3));
+        }
+        return parms;
     }
-
-    //TODO add tests for SaveGraphics
-    public void testSaveGraphics() throws Exception {
-    }
-    
-    //TODO add tests for ReportSaveGraphics
-    public void testReportSaveGraphics() throws Exception {
-    }
-    
 }

--- a/test/src/org/apache/jmeter/functions/PackageTest.java
+++ b/test/src/org/apache/jmeter/functions/PackageTest.java
@@ -26,6 +26,8 @@
  */
 package org.apache.jmeter.functions;
 
+import static org.apache.jmeter.functions.FunctionTestHelper.makeParams;
+
 import java.io.FileNotFoundException;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -38,7 +40,6 @@ import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.logging.LoggingManager;
-import org.apache.jorphan.util.JMeterStopThreadException;
 import org.apache.log.Logger;
 
 import junit.extensions.ActiveTestSuite;
@@ -75,25 +76,6 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         return cr;
     }
 
-    // Create the StringFromFile function and set its parameters.
-    private static StringFromFile SFFParams(String p1, String p2, String p3, String p4) throws Exception {
-        StringFromFile sff = new StringFromFile();
-        Collection<CompoundVariable> parms = new LinkedList<>();
-        if (p1 != null) {
-            parms.add(new CompoundVariable(p1));
-        }
-        if (p2 != null) {
-            parms.add(new CompoundVariable(p2));
-        }
-        if (p3 != null) {
-            parms.add(new CompoundVariable(p3));
-        }
-        if (p4 != null) {
-            parms.add(new CompoundVariable(p4));
-        }
-        sff.setParameters(parms);
-        return sff;
-    }
 
     // Create the SplitFile function and set its parameters.
     private static SplitFunction splitParams(String p1, String p2, String p3) throws Exception {
@@ -117,24 +99,12 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         return bsh;
     }
 
-    private static Collection<CompoundVariable> makeParams(String p1, String p2, String p3) {
-        Collection<CompoundVariable> parms = new LinkedList<>();
-        if (p1 != null) {
-            parms.add(new CompoundVariable(p1));
-        }
-        if (p2 != null) {
-            parms.add(new CompoundVariable(p2));
-        }
-        if (p3 != null) {
-            parms.add(new CompoundVariable(p3));
-        }
-        return parms;
-    }
+    
 
     public static Test suite() throws Exception {
         TestSuite allsuites = new TestSuite("Function PackageTest");
 
-        if (!BeanShellInterpreter.isInterpreterPresent()){
+        if (!BeanShellInterpreter.isInterpreterPresent()) {
             final String msg = "BeanShell jar not present, tests ignored";
             log.warn(msg);
         } else {
@@ -160,14 +130,6 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         par.addTest(new PackageTest("CSVThread2"));
         allsuites.addTest(par);
 
-        TestSuite sff = new TestSuite("StringFromFile");
-        sff.addTest(new PackageTest("SFFTest1"));
-        sff.addTest(new PackageTest("SFFTest2"));
-        sff.addTest(new PackageTest("SFFTest3"));
-        sff.addTest(new PackageTest("SFFTest4"));
-        sff.addTest(new PackageTest("SFFTest5"));
-        allsuites.addTest(sff);
-
         TestSuite split = new TestSuite("SplitFunction");
         split.addTest(new PackageTest("splitTest1"));
         allsuites.addTest(split);
@@ -184,10 +146,6 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
 
         allsuites.addTest(xpath);
         
-        TestSuite random = new TestSuite("Random");
-        random.addTest(new PackageTest("randomTest1"));
-        allsuites.addTest(random);
-
         allsuites.addTest(new PackageTest("XPathSetup1"));
         TestSuite par2 = new ActiveTestSuite("ParallelXPath1");
         par2.addTest(new PackageTest("XPathThread1"));
@@ -199,19 +157,6 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         par3.addTest(new PackageTest("XPathThread1"));
         par3.addTest(new PackageTest("XPathThread2"));
         allsuites.addTest(par3);
-
-        TestSuite variable = new TestSuite("Variable");
-        variable.addTest(new PackageTest("variableTest1"));
-        allsuites.addTest(variable);
-        
-        TestSuite eval = new TestSuite("Eval");
-        eval.addTest(new PackageTest("evalTest1"));
-        eval.addTest(new PackageTest("evalTest2"));
-        allsuites.addTest(eval);
-
-        TestSuite intSum = new TestSuite("Sums");
-        intSum.addTest(new PackageTest("sumTest"));
-        allsuites.addTest(intSum);
 
         return allsuites;
     }
@@ -377,88 +322,9 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         assertEquals("c", vars.get("VAR5_3"));
         assertEquals("?", vars.get("VAR5_4"));
         assertNull(vars.get("VAR5_5"));
-
-}
-
-    public void SFFTest1() throws Exception {
-        StringFromFile sff1 = SFFParams("testfiles/SFFTest#'.'txt", "", "1", "3");
-        assertEquals("uno", sff1.execute());
-        assertEquals("dos", sff1.execute());
-        assertEquals("tres", sff1.execute());
-        assertEquals("cuatro", sff1.execute());
-        assertEquals("cinco", sff1.execute());
-        assertEquals("one", sff1.execute());
-        assertEquals("two", sff1.execute());
-        sff1.execute();
-        sff1.execute();
-        assertEquals("five", sff1.execute());
-        assertEquals("eins", sff1.execute());
-        sff1.execute();
-        sff1.execute();
-        sff1.execute();
-        assertEquals("fuenf", sff1.execute());
-        try {
-            sff1.execute();
-            fail("Should have thrown JMeterStopThreadException");
-        } catch (JMeterStopThreadException e) {
-            // expected
-        }
     }
 
-    public void SFFTest2() throws Exception {
-        StringFromFile sff = SFFParams("testfiles/SFFTest1.txt", "", null, null);
-        assertEquals("uno", sff.execute());
-        assertEquals("dos", sff.execute());
-        assertEquals("tres", sff.execute());
-        assertEquals("cuatro", sff.execute());
-        assertEquals("cinco", sff.execute());
-        assertEquals("uno", sff.execute()); // Restarts
-        assertEquals("dos", sff.execute());
-        assertEquals("tres", sff.execute());
-        assertEquals("cuatro", sff.execute());
-        assertEquals("cinco", sff.execute());
-    }
-
-    public void SFFTest3() throws Exception {
-        StringFromFile sff = SFFParams("testfiles/SFFTest1.txt", "", "", "");
-        assertEquals("uno", sff.execute());
-        assertEquals("dos", sff.execute());
-        assertEquals("tres", sff.execute());
-        assertEquals("cuatro", sff.execute());
-        assertEquals("cinco", sff.execute());
-        assertEquals("uno", sff.execute()); // Restarts
-        assertEquals("dos", sff.execute());
-        assertEquals("tres", sff.execute());
-        assertEquals("cuatro", sff.execute());
-        assertEquals("cinco", sff.execute());
-    }
-
-    public void SFFTest4() throws Exception {
-        StringFromFile sff = SFFParams("xxtestfiles/SFFTest1.txt", "", "", "");
-        assertEquals(StringFromFile.ERR_IND, sff.execute());
-        assertEquals(StringFromFile.ERR_IND, sff.execute());
-    }
-
-    // Test that only loops twice
-    public void SFFTest5() throws Exception {
-        StringFromFile sff = SFFParams("testfiles/SFFTest1.txt", "", "", "2");
-        assertEquals("uno", sff.execute());
-        assertEquals("dos", sff.execute());
-        assertEquals("tres", sff.execute());
-        assertEquals("cuatro", sff.execute());
-        assertEquals("cinco", sff.execute());
-        assertEquals("uno", sff.execute());
-        assertEquals("dos", sff.execute());
-        assertEquals("tres", sff.execute());
-        assertEquals("cuatro", sff.execute());
-        assertEquals("cinco", sff.execute());
-        try {
-            sff.execute();
-            fail("Should have thrown JMeterStopThreadException");
-        } catch (JMeterStopThreadException e) {
-            // expected
-        }
-    }
+   
 
     // Function objects to be tested
     private static CSVRead cr1, cr2, cr3, cr4, cr5, cr6;
@@ -696,7 +562,6 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
     public void XPathtestrowNum() throws Exception {
         XPathFileContainer f = new XPathFileContainer("../build.xml", "/project/target/@name");
         assertNotNull(f);
-        // assertEquals("Expected 4 lines",4,f.size());
 
         int myRow = f.nextRow();
         assertEquals(0, myRow);
@@ -709,15 +574,6 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         myRow = f.nextRow();
         assertEquals(2, myRow);
         assertEquals(3, f.getNextRow());
-
-        // myRow = f.nextRow();
-        // assertEquals(3,myRow);
-        // assertEquals(0,f.getNextRow());
-
-        // myRow = f.nextRow();
-        // assertEquals(0,myRow);
-        // assertEquals(1,f.getNextRow());
-
     }
 
     public void XPathtestColumns() throws Exception {
@@ -830,153 +686,5 @@ public class PackageTest extends JMeterTestCaseJUnit3 {
         xp.setParameters(parms);
         return xp;        
     }
-    
 
-    
-    public void randomTest1() throws Exception {
-        Random r = new Random();
-        Collection<CompoundVariable> parms = makeParams("0","10000000000","VAR");
-        r.setParameters(parms);
-        String s = 
-            r.execute(null,null);
-        long l = Long.parseLong(s);
-        assertTrue(l>=0 && l<=10000000000L);
-        
-        
-        parms = makeParams("1","1","VAR");
-        r.setParameters(parms);
-        s = 
-            r.execute(null,null);
-        l = Long.parseLong(s);
-        assertTrue(l==1);
-
-    }
-
-    public void variableTest1() throws Exception {
-        Variable r = new Variable();
-        vars.put("A_1","a1");
-        vars.put("A_2","a2");
-        vars.put("one","1");
-        vars.put("two","2");
-        vars.put("V","A");
-        Collection<CompoundVariable> parms;
-        String s;
-        
-        parms = makeParams("V",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("A",s);
-        
-        parms = makeParams("X",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("X",s);
-        
-        parms = makeParams("A${X}",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("A${X}",s);
-        
-        parms = makeParams("A_1",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("a1",s);
-        
-        parms = makeParams("A_2",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("a2",s);
-        
-        parms = makeParams("A_${two}",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("a2",s);
-        
-        parms = makeParams("${V}_${one}",null,null);
-        r.setParameters(parms);
-        s = r.execute(null,null);
-        assertEquals("a1",s);
-    }        
-
-    public void evalTest1() throws Exception {
-        EvalFunction eval = new EvalFunction();
-        vars.put("query","select ${column} from ${table}");
-        vars.put("column","name");
-        vars.put("table","customers");
-        Collection<CompoundVariable> parms;
-        String s;
-        
-        parms = makeParams("${query}",null,null);
-        eval.setParameters(parms);
-        s = eval.execute(null,null);
-        assertEquals("select name from customers",s);
-        
-    }
-
-    public void evalTest2() throws Exception {
-        EvalVarFunction evalVar = new EvalVarFunction();
-        vars.put("query","select ${column} from ${table}");
-        vars.put("column","name");
-        vars.put("table","customers");
-        Collection<CompoundVariable> parms;
-        String s;
-        
-        parms = makeParams("query",null,null);
-        evalVar.setParameters(parms);
-        s = evalVar.execute(null,null);
-        assertEquals("select name from customers",s);
-    }
-    
-    public void sumTest() throws Exception {
-        String maxIntVal = Integer.toString(Integer.MAX_VALUE);
-        String minIntVal = Integer.toString(Integer.MIN_VALUE);
-
-        { // prevent accidental use of is below
-        IntSum is = new IntSum();
-        checkInvalidParameterCounts(is,2);
-        checkSum(is,"3", new String[]{"1","2"});
-        checkSumNoVar(is,"3", new String[]{"1","2"});
-        checkSum(is,"1", new String[]{"-1","1","1","1","-2","1"});
-        checkSumNoVar(is,"1", new String[]{"-1","1","1","1","-2","1"});
-        checkSumNoVar(is,"-1", new String[]{"-1","1","1","1","-2","-1"});
-        checkSum(is,maxIntVal, new String[]{maxIntVal,"0"});
-        checkSum(is,minIntVal, new String[]{maxIntVal,"1"}); // wrap-round check
-        }
-
-        LongSum ls = new LongSum();
-        checkInvalidParameterCounts(ls,2);
-        checkSum(ls,"3", new String[]{"1","2"});
-        checkSum(ls,"1", new String[]{"-1","1","1","1","-1","0"});
-        checkSumNoVar(ls,"3", new String[]{"1","2"});
-        checkSumNoVar(ls,"1", new String[]{"-1","1","1","1","-1","0"});
-        checkSumNoVar(ls,"0", new String[]{"-1","1","1","1","-1","-1"});
-        String maxIntVal_1 = Long.toString(1+(long)Integer.MAX_VALUE);
-        checkSum(ls,maxIntVal, new String[]{maxIntVal,"0"});
-        checkSum(ls,maxIntVal_1, new String[]{maxIntVal,"1"}); // no wrap-round check
-        String maxLongVal = Long.toString(Long.MAX_VALUE);
-        String minLongVal = Long.toString(Long.MIN_VALUE);
-        checkSum(ls,maxLongVal, new String[]{maxLongVal,"0"});
-        checkSum(ls,minLongVal, new String[]{maxLongVal,"1"}); // wrap-round check
-    }
-    
-    // Perform a sum and check the results
-    private void checkSum(AbstractFunction func, String value, String [] addends)  throws Exception {
-        Collection<CompoundVariable> parms = new LinkedList<>();
-        for (int i=0; i< addends.length; i++){
-            parms.add(new CompoundVariable(addends[i]));
-        }
-        parms.add(new CompoundVariable("Result"));
-        func.setParameters(parms);
-        assertEquals(value,func.execute(null,null));
-        assertEquals(value,vars.getObject("Result"));       
-    }
-    // Perform a sum and check the results
-    private void checkSumNoVar(AbstractFunction func, String value, String [] addends)  throws Exception {
-        Collection<CompoundVariable> parms = new LinkedList<>();
-        for (int i=0; i< addends.length; i++){
-            parms.add(new CompoundVariable(addends[i]));
-        }
-        func.setParameters(parms);
-        assertEquals(value,func.execute(null,null));
-    }
 }

--- a/test/src/org/apache/jmeter/functions/RandomFunctionTest.java
+++ b/test/src/org/apache/jmeter/functions/RandomFunctionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.apache.jmeter.functions;
+
+import static org.apache.jmeter.functions.FunctionTestHelper.makeParams;
+
+import java.util.Collection;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class RandomFunctionTest extends JMeterTestCase {
+
+    @Test
+    public void randomTest1() throws Exception {
+        Random r = new Random();
+        Collection<CompoundVariable> parms = makeParams("0","10000000000","VAR");
+        r.setParameters(parms);
+        String s = r.execute(null,null);
+        long l = Long.parseLong(s);
+        assertTrue(l>=0 && l<=10000000000L);
+        
+        parms = makeParams("1","1","VAR");
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        l = Long.parseLong(s);
+        assertEquals(1, l);
+    }
+}

--- a/test/src/org/apache/jmeter/functions/StringFromFileFunctionTest.java
+++ b/test/src/org/apache/jmeter/functions/StringFromFileFunctionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.apache.jmeter.functions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jorphan.util.JMeterStopThreadException;
+import org.junit.Test;
+
+public class StringFromFileFunctionTest extends JMeterTestCase {
+
+    @Test
+    public void SFFTest1() throws Exception {
+        StringFromFile sff1 = SFFParams("testfiles/SFFTest#'.'txt", "", "1", "3");
+        assertEquals("uno", sff1.execute());
+        assertEquals("dos", sff1.execute());
+        assertEquals("tres", sff1.execute());
+        assertEquals("cuatro", sff1.execute());
+        assertEquals("cinco", sff1.execute());
+        assertEquals("one", sff1.execute());
+        assertEquals("two", sff1.execute());
+        sff1.execute();
+        sff1.execute();
+        assertEquals("five", sff1.execute());
+        assertEquals("eins", sff1.execute());
+        sff1.execute();
+        sff1.execute();
+        sff1.execute();
+        assertEquals("fuenf", sff1.execute());
+        try {
+            sff1.execute();
+            fail("Should have thrown JMeterStopThreadException");
+        } catch (JMeterStopThreadException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void SFFTest2() throws Exception {
+        StringFromFile sff = SFFParams("testfiles/SFFTest1.txt", "", null, null);
+        assertEquals("uno", sff.execute());
+        assertEquals("dos", sff.execute());
+        assertEquals("tres", sff.execute());
+        assertEquals("cuatro", sff.execute());
+        assertEquals("cinco", sff.execute());
+        assertEquals("uno", sff.execute()); // Restarts
+        assertEquals("dos", sff.execute());
+        assertEquals("tres", sff.execute());
+        assertEquals("cuatro", sff.execute());
+        assertEquals("cinco", sff.execute());
+    }
+
+    @Test
+    public void SFFTest3() throws Exception {
+        StringFromFile sff = SFFParams("testfiles/SFFTest1.txt", "", "", "");
+        assertEquals("uno", sff.execute());
+        assertEquals("dos", sff.execute());
+        assertEquals("tres", sff.execute());
+        assertEquals("cuatro", sff.execute());
+        assertEquals("cinco", sff.execute());
+        assertEquals("uno", sff.execute()); // Restarts
+        assertEquals("dos", sff.execute());
+        assertEquals("tres", sff.execute());
+        assertEquals("cuatro", sff.execute());
+        assertEquals("cinco", sff.execute());
+    }
+
+    @Test
+    public void SFFTest4() throws Exception {
+        StringFromFile sff = SFFParams("xxtestfiles/SFFTest1.txt", "", "", "");
+        assertEquals(StringFromFile.ERR_IND, sff.execute());
+        assertEquals(StringFromFile.ERR_IND, sff.execute());
+    }
+
+    // Test that only loops twice
+    @Test
+    public void SFFTest5() throws Exception {
+        StringFromFile sff = SFFParams("testfiles/SFFTest1.txt", "", "", "2");
+        assertEquals("uno", sff.execute());
+        assertEquals("dos", sff.execute());
+        assertEquals("tres", sff.execute());
+        assertEquals("cuatro", sff.execute());
+        assertEquals("cinco", sff.execute());
+        assertEquals("uno", sff.execute());
+        assertEquals("dos", sff.execute());
+        assertEquals("tres", sff.execute());
+        assertEquals("cuatro", sff.execute());
+        assertEquals("cinco", sff.execute());
+        try {
+            sff.execute();
+            fail("Should have thrown JMeterStopThreadException");
+        } catch (JMeterStopThreadException e) {
+            // expected
+        }
+    }
+    
+    // Create the StringFromFile function and set its parameters.
+    private static StringFromFile SFFParams(String p1, String p2, String p3, String p4) throws Exception {
+        StringFromFile sff = new StringFromFile();
+        Collection<CompoundVariable> parms = new LinkedList<>();
+        if (p1 != null) {
+            parms.add(new CompoundVariable(p1));
+        }
+        if (p2 != null) {
+            parms.add(new CompoundVariable(p2));
+        }
+        if (p3 != null) {
+            parms.add(new CompoundVariable(p3));
+        }
+        if (p4 != null) {
+            parms.add(new CompoundVariable(p4));
+        }
+        sff.setParameters(parms);
+        return sff;
+    }
+}

--- a/test/src/org/apache/jmeter/functions/SumFunctionTest.java
+++ b/test/src/org/apache/jmeter/functions/SumFunctionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.apache.jmeter.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SumFunctionTest extends JMeterTestCase {
+
+    private JMeterContext jmctx = null;
+    private JMeterVariables vars = null;
+    
+    @Before
+    public void setUp() {
+        jmctx = JMeterContextService.getContext();
+        jmctx.setVariables(new JMeterVariables());
+        vars = jmctx.getVariables();
+    }
+    
+    @Test
+    public void sumTest() throws Exception {
+        String maxIntVal = Integer.toString(Integer.MAX_VALUE);
+        String minIntVal = Integer.toString(Integer.MIN_VALUE);
+
+        { // prevent accidental use of is below
+            IntSum is = new IntSum();
+            checkInvalidParameterCounts(is, 2);
+            checkSum(is,"3", new String[]{"1","2"});
+            checkSumNoVar(is,"3", new String[]{"1","2"});
+            checkSum(is,"1", new String[]{"-1","1","1","1","-2","1"});
+            checkSumNoVar(is,"1", new String[]{"-1","1","1","1","-2","1"});
+            checkSumNoVar(is,"-1", new String[]{"-1","1","1","1","-2","-1"});
+            checkSum(is,maxIntVal, new String[]{maxIntVal,"0"});
+            checkSum(is,minIntVal, new String[]{maxIntVal,"1"}); // wrap-round check
+        }
+
+        LongSum ls = new LongSum();
+        checkInvalidParameterCounts(ls, 2);
+        checkSum(ls,"3", new String[]{"1","2"});
+        checkSum(ls,"1", new String[]{"-1","1","1","1","-1","0"});
+        checkSumNoVar(ls,"3", new String[]{"1","2"});
+        checkSumNoVar(ls,"1", new String[]{"-1","1","1","1","-1","0"});
+        checkSumNoVar(ls,"0", new String[]{"-1","1","1","1","-1","-1"});
+        String maxIntVal_1 = Long.toString(1+(long)Integer.MAX_VALUE);
+        checkSum(ls,maxIntVal, new String[]{maxIntVal,"0"});
+        checkSum(ls,maxIntVal_1, new String[]{maxIntVal,"1"}); // no wrap-round check
+        String maxLongVal = Long.toString(Long.MAX_VALUE);
+        String minLongVal = Long.toString(Long.MIN_VALUE);
+        checkSum(ls,maxLongVal, new String[]{maxLongVal,"0"});
+        checkSum(ls,minLongVal, new String[]{maxLongVal,"1"}); // wrap-round check
+    }
+    
+    // Perform a sum and check the results
+    private void checkSum(AbstractFunction func, String value, String [] addends)  throws Exception {
+        Collection<CompoundVariable> parms = new LinkedList<>();
+        for (int i=0; i< addends.length; i++){
+            parms.add(new CompoundVariable(addends[i]));
+        }
+        parms.add(new CompoundVariable("Result"));
+        func.setParameters(parms);
+        assertEquals(value, func.execute(null,null));
+        assertEquals(value, vars.getObject("Result"));       
+    }
+    
+    // Perform a sum and check the results
+    private void checkSumNoVar(AbstractFunction func, String value, String [] addends)  throws Exception {
+        Collection<CompoundVariable> parms = new LinkedList<>();
+        for (int i=0; i< addends.length; i++){
+            parms.add(new CompoundVariable(addends[i]));
+        }
+        func.setParameters(parms);
+        assertEquals(value,func.execute(null,null));
+    }
+}

--- a/test/src/org/apache/jmeter/functions/VariableTest.java
+++ b/test/src/org/apache/jmeter/functions/VariableTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.apache.jmeter.functions;
+
+import static org.apache.jmeter.functions.FunctionTestHelper.makeParams;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.junit.Before;
+import org.junit.Test;
+
+public class VariableTest extends JMeterTestCase {
+
+    private JMeterContext jmctx = null;
+    private JMeterVariables vars = null;
+    
+    @Before
+    public void setUp() {
+        jmctx = JMeterContextService.getContext();
+        jmctx.setVariables(new JMeterVariables());
+        vars = jmctx.getVariables();
+    }
+    
+    @Test
+    public void variableTest1() throws Exception {
+        Variable r = new Variable();
+        vars.put("A_1","a1");
+        vars.put("A_2","a2");
+        vars.put("one","1");
+        vars.put("two","2");
+        vars.put("V","A");
+        Collection<CompoundVariable> parms;
+        String s;
+        
+        parms = makeParams("V",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("A",s);
+        
+        parms = makeParams("X",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("X",s);
+        
+        parms = makeParams("A${X}",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("A${X}",s);
+        
+        parms = makeParams("A_1",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("a1",s);
+        
+        parms = makeParams("A_2",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("a2",s);
+        
+        parms = makeParams("A_${two}",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("a2",s);
+        
+        parms = makeParams("${V}_${one}",null,null);
+        r.setParameters(parms);
+        s = r.execute(null,null);
+        assertEquals("a1",s);
+    }
+}

--- a/test/src/org/apache/jmeter/gui/action/TestLoad.java
+++ b/test/src/org/apache/jmeter/gui/action/TestLoad.java
@@ -70,18 +70,17 @@ public class TestLoad extends JMeterTestCaseJUnit3 {
     }
 
     public static TestSuite suite(){
-        TestSuite suite=new TestSuite("Load Test");
-        //suite.addTest(new TestLoad("checkGuiPackage"));
-        scanFiles(suite,testfiledir);
-        scanFiles(suite,demofiledir);
+        TestSuite suite = new TestSuite("Load Test");
+        scanFiles(suite, testfiledir);
+        scanFiles(suite, demofiledir);
         return suite;
     }
 
     private static void scanFiles(TestSuite suite, File parent) {
-        File testFiles[]=parent.listFiles(jmxFilter);
         String dir = parent.getName();
-        for (int i=0; i<testFiles.length; i++){
-            suite.addTest(new TestLoad("checkTestFile",testFiles[i],dir));
+        File[] testFiles = parent.listFiles(jmxFilter);
+        for (File file : testFiles) {
+            suite.addTest(new TestLoad("checkTestFile", file, dir));
         }
     }
     

--- a/test/src/org/apache/jmeter/protocol/http/modifier/TestURLRewritingModifier.java
+++ b/test/src/org/apache/jmeter/protocol/http/modifier/TestURLRewritingModifier.java
@@ -203,7 +203,6 @@ public class TestURLRewritingModifier extends JMeterTestCase {
             context.setCurrentSampler(sampler);
             context.setPreviousResult(response);
             mod.process();
-            // Arguments args = sampler.getArguments();
             assertEquals("index.html;%24sid%24KQNq3AAADQZoEQAxlkX8uQV5bjqVBPbT", sampler.getPath());
         }
 

--- a/test/src/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/test/src/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -122,9 +122,6 @@ public class TestHTMLParser extends JMeterTestCaseJUnit3 {
                 this.userAgent = userAgent;
             }
 
-//            private TestData(String f, String b, String s) {
-//                this(f, b, s, null);
-//            }
         }
         
         private static final String DEFAULT_JMETER_PARSER = 

--- a/test/src/org/apache/jmeter/protocol/http/sampler/PackageTest.java
+++ b/test/src/org/apache/jmeter/protocol/http/sampler/PackageTest.java
@@ -21,9 +21,9 @@
  */
 package org.apache.jmeter.protocol.http.sampler;
 
-import java.awt.HeadlessException;
+import static org.junit.Assert.assertEquals;
 
-import junit.framework.TestCase;
+import java.awt.GraphicsEnvironment;
 
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.ConfigTestElement;
@@ -32,22 +32,21 @@ import org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
+import org.junit.Test;
 
-public class PackageTest extends TestCase {
+public class PackageTest {
     private static final Logger log = LoggingManager.getLoggerForClass();
 
-    public PackageTest(String arg0) {
-        super(arg0);
-    }
-
+    @Test
     public void testConfiguring() throws Exception {
-        try {
-            HTTPSamplerBase sampler = (HTTPSamplerBase) new HttpTestSampleGui().createTestElement();
-            configure(sampler);
-        } catch (HeadlessException e) {
-            System.out.println("o.a.j.junit.JMeterTest Error running testConfiguring due to Headless mode, "+e.toString());
-            log.warn("o.a.j.junit.JMeterTest Error running testConfiguring due to Headless mode, "+e.toString());
+        if(GraphicsEnvironment.isHeadless()) {
+            System.out.println("Skipping test:"+getClass().getName()+"#testConfiguring"+", cannot run in Headless mode");
+            log.warn("Skipping test:"+getClass().getName()+"#testConfiguring"+", cannot run in Headless mode");
+            return;
         }
+        
+        HTTPSamplerBase sampler = (HTTPSamplerBase) new HttpTestSampleGui().createTestElement();
+        configure(sampler);
     }
 
     private void configure(HTTPSamplerBase sampler) throws Exception {

--- a/test/src/org/apache/jmeter/testbeans/gui/PackageTest.java
+++ b/test/src/org/apache/jmeter/testbeans/gui/PackageTest.java
@@ -35,7 +35,6 @@ import org.apache.jorphan.reflect.ClassFinder;
 import org.apache.log.Logger;
 
 import junit.framework.Test;
-// import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 /*
@@ -50,9 +49,7 @@ import junit.framework.TestSuite;
 public final class PackageTest extends JMeterTestCaseJUnit3 {
     private static final Logger log = LoggingManager.getLoggerForClass();
 
-    // ResourceBundle i18nEdit=
-    // ResourceBundle.getBundle("org.apache.jmeter.resources.i18nedit");
-    private static final Locale defaultLocale = new Locale("en",""); // i18nEdit.getString("locale.default");
+    private static final Locale defaultLocale = new Locale("en","");
 
     private final ResourceBundle defaultBundle;
 
@@ -81,7 +78,7 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
     @Override
     public void setUp() {
         if (testLocale == null) {
-            return;// errorDetected()
+            return;
         }
         JMeterUtils.setLocale(testLocale);
         Introspector.flushFromCaches(testBeanClass);
@@ -106,7 +103,7 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
     public void runTest() throws Throwable {
         if (testLocale == null) {
             super.runTest();
-            return;// errorDetected()
+            return;
         }
         if (bundle == defaultBundle) {
             checkAllNecessaryKeysPresent();
@@ -155,7 +152,6 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
             String name = descriptors[i].getName();
 
             bundle.getString(name + ".displayName");
-            // bundle.getString(name+".shortDescription"); NOT MANDATORY
 
             String group = (String) descriptors[i].getValue(GenericTestBeanCustomizer.GROUP);
             if (group != null) {
@@ -179,8 +175,7 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
                         GenericTestBeanCustomizer.RESOURCE_BUNDLE);
             } catch (IntrospectionException e) {
                 log.error("Can't get beanInfo for " + testBeanClass.getName(), e);
-                throw new Error(e.toString(), e); // Programming error. Don't
-                                                // continue.
+                throw new Error(e.toString(), e); // Programming error. Don't continue.
             }
 
             if (defaultBundle == null) {
@@ -190,15 +185,14 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
                 }
                 errorDetected=true;
                 log.error("No default bundle found for " + className + " using " + defaultLocale.toString());
-                //throw new Error("No default bundle for class " + className);
                 continue;
             }
 
             suite.addTest(new PackageTest(testBeanClass, defaultLocale, defaultBundle));
 
-            String [] languages = JMeterMenuBar.getLanguages();
-            for (int i=0; i < languages.length; i++){
-                final String[] language = languages[i].split("_");
+            String[] languages = JMeterMenuBar.getLanguages();
+            for (String lang : languages) {
+                final String[] language = lang.split("_");
                 if (language.length == 1){
                     suite.addTest(new PackageTest(testBeanClass, new Locale(language[0]), defaultBundle));                                    
                 } else if (language.length == 2){

--- a/test/src/org/apache/jmeter/testbeans/gui/TestBooleanPropertyEditor.java
+++ b/test/src/org/apache/jmeter/testbeans/gui/TestBooleanPropertyEditor.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
+
 import org.junit.Test;
 
 /**
@@ -29,7 +30,7 @@ import org.junit.Test;
  *
  * Also checks that BooleanPropertyEditor behaves in the same way.
  */
-public class TestBooleanPropertyEditor extends junit.framework.TestCase {
+public class TestBooleanPropertyEditor {
  
     /*
      * N.B.

--- a/test/src/org/apache/jmeter/testbeans/gui/TestComboStringEditor.java
+++ b/test/src/org/apache/jmeter/testbeans/gui/TestComboStringEditor.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
-public class TestComboStringEditor extends junit.framework.TestCase {
+public class TestComboStringEditor {
 
         private void testSetGet(ComboStringEditor e, Object value) throws Exception {
             e.setValue(value);


### PR DESCRIPTION
remove empty test
remove commented code
split some tests
explicitly disable org.apache.jmeter.protocol.http.sampler.PackageTest when in headless mode
