### PR TITLE
Change the default port for the Proxy recorder to 8888 from 8080

### DIFF
--- a/docs/usermanual/component_reference.html
+++ b/docs/usermanual/component_reference.html
@@ -6255,7 +6255,7 @@ Both Chrome and Internet Explorer use the same trust store for certificates.
         Parameters
         <a class="sectionlink" href="#HTTP(S)_Test_Script_Recorder_parms1" title="Link to here">&para;</a></h3><div class="property title"><div class="name title">Attribute</div><div class="description title">Description</div><div class="required title">Required</div></div>
         <div class="property"><div class="name req-false">Name</div><div class="description req-false">Descriptive name for this element that is shown in the tree.</div><div class="required req-false">No</div></div>
-        <div class="property"><div class="name req-true">Port</div><div class="description req-true">The port that the HTTP(S) Test Script Recorder listens to.  8080 is the default, but you can change it.</div><div class="required req-true">Yes</div></div>
+        <div class="property"><div class="name req-true">Port</div><div class="description req-true">The port that the HTTP(S) Test Script Recorder listens to.  8888 is the default, but you can change it.</div><div class="required req-true">Yes</div></div>
         <div class="property"><div class="name req-false">HTTPS Domains</div><div class="description req-false">List of domain (or host) names for HTTPS. Use this to pre-generate certificates for all servers you wish to record.
         <br>
         For example, *.apache.org,*.incubator.apache.org

--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -121,7 +121,7 @@ public class ProxyControl extends GenericController {
 
     private static final String AUTH_MANAGER = AuthManager.class.getName();
 
-    public static final int DEFAULT_PORT = 8080;
+    public static final int DEFAULT_PORT = 8888;
 
     // and as a string
     public static final String DEFAULT_PORT_S =

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6401,7 +6401,7 @@ Both Chrome and Internet Explorer use the same trust store for certificates.
 
 <properties>
         <property name="Name" required="No">Descriptive name for this element that is shown in the tree.</property>
-        <property name="Port" required="Yes">The port that the HTTP(S) Test Script Recorder listens to.  <code>8080</code> is the default, but you can change it.</property>
+        <property name="Port" required="Yes">The port that the HTTP(S) Test Script Recorder listens to.  <code>8888</code> is the default, but you can change it.</property>
         <property name="HTTPS Domains" required="No">List of domain (or host) names for HTTPS. Use this to pre-generate certificates for all servers you wish to record.
         <br/>
         For example, <code>*.example.com,*.subdomain.example.com</code>


### PR DESCRIPTION
Now it's the same as the template recording

8888 is better than 8080 because 8080 is used for a lot of other tools 
like Tomcat

Bug 59006 

Antonio
