### PR TITLE
Minimum height for TableEditor widget

### DIFF
--- a/src/core/org/apache/jmeter/testbeans/gui/TableEditor.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/TableEditor.java
@@ -107,6 +107,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
     {
         JPanel p = new JPanel(new BorderLayout());
         JScrollPane scroller = new JScrollPane(table);
+        scroller.setMinimumSize(new Dimension(100, 70));
         scroller.setPreferredSize(scroller.getMinimumSize());
         p.add(scroller,BorderLayout.CENTER);
         JPanel south = new JPanel();


### PR DESCRIPTION
BugzillaId #58870: Set a minimum height for TableEditor widget when the element screen, that contains a such widgget, has its size is reduced, not to reduce the widget's height only to its headers row height
