### PR TITLE
Bug 59037 - Drop HtmlParserHTMLParser and dependencies on htmlparser …

### DIFF
--- a/README
+++ b/README
@@ -149,17 +149,6 @@
   LICENSE
   NOTICE
 
-  This project includes HTMLParser.
-  For detailed information about HTMLParser, the project is
-  hosted on Sourceforge at http://htmlparser.sourceforge.net/
-
-  The developers of Apache JMeter are grateful to the developers
-  of HTMLParser for re-releasing htmlparser under CPL V1.0.
-
-  HTMLParser was originally created by Somik Raha in 2000.
-  Derrick Oswald is the current lead developer and was kind
-  enough to assist JMeter.
-
 
 Cryptographic Software Notice
 -----------------------------


### PR DESCRIPTION
…and htmllexer

remove mention of htmlparser from README
