### PR TITLE
Bug 59034 - Parallel downloads connection management is not realistic

### DIFF
--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -184,7 +184,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * 1 HttpClient instance per combination of (HttpClient,HttpClientKey)
      */
     private static final ThreadLocal<Map<HttpClientKey, HttpClient>> HTTPCLIENTS_CACHE_PER_THREAD_AND_HTTPCLIENTKEY = 
-        new ThreadLocal<Map<HttpClientKey, HttpClient>>(){
+        new InheritableThreadLocal<Map<HttpClientKey, HttpClient>>(){
         @Override
         protected Map<HttpClientKey, HttpClient> initialValue() {
             return new HashMap<>();

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1964,7 +1964,6 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         @Override
         public AsynSamplerResultHolder call() {
             JMeterContextService.replaceContext(jmeterContextOfParentThread);
-            ((CleanerThread) Thread.currentThread()).registerSamplerForEndNotification(sampler);
             HTTPSampleResult httpSampleResult = sampler.sample(url, method, areFollowingRedirect, depth);
             if(sampler.getCookieManager() != null) {
                 CollectionProperty cookies = sampler.getCookieManager().getCookies();

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/MeasuringConnectionManager.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/MeasuringConnectionManager.java
@@ -55,6 +55,8 @@ public class MeasuringConnectionManager extends PoolingClientConnectionManager {
 
     public MeasuringConnectionManager(SchemeRegistry schemeRegistry, DnsResolver resolver) {
         super(schemeRegistry, resolver);
+        // FIXME Make this depend on HttpRequest configuration
+        setDefaultMaxPerRoute(10);
     }
 
     @Override


### PR DESCRIPTION
Draft of a patch making parallel downloads more realistic by sharing the HttpClient instance between Main browser thread and threads used to download embedded resources.
This will allow Keep Alive and connection reuse accross downloads.

Please be aware that patch would not work if PR 132 for Bug 52073 was applied as the Thread Pool in the fix is shared among all threads while for now there is 1 pool per Virtual User Thread.

If the PR 132 was applied, a solution would be for example to:
- Create a Session Manager that generate a zone per virtual user (with UUID)
- The current HTTPCLIENTS_CACHE_PER_THREAD_AND_HTTPCLIENTKEY would be available per the virtual user key
- This would make it sharing possible without switching to InheritableThreadLocal

I benchmarked current patch vs current trunk (5 minutes test / 15 threads):

Before:
summary = 499819 in 00:05:07 = 1627.8/s Avg:    14 Min:     0 Max: 11821 Err:    26 (0.01%)

After:
summary = 1177289 in 00:05:07 = 3834.1/s Avg:     4 Min:     0 Max:  2172 Err:    38 (0.00%)

As you can see:
- Throughput is 135% higher
- Response times are also much more realistic
- Compared to bench mentionned in Bug 58950, there is no more huge ephemeral ports consumption and no more CPU pause during the test

Feedback very welcome
