### PR TITLE
Bug 59067 JMeter fail to iterate over SimpleController after an assertion error.

### DIFF
--- a/src/core/org/apache/jmeter/control/TransactionController.java
+++ b/src/core/org/apache/jmeter/control/TransactionController.java
@@ -283,7 +283,6 @@ public class TransactionController extends GenericController implements SampleLi
             // update them with SubSamplerResult
             if(subSampler instanceof TransactionSampler) {
                 TransactionSampler tc = (TransactionSampler) subSampler;
-                tc.getTransactionController().triggerEndOfLoop();
                 transactionSampler.addSubSamplerResult(tc.getTransactionResult());
             }
             transactionSampler.setTransactionDone();


### PR DESCRIPTION
Please review carefully as it may break the world...

The controller does not restart at the first sampler
The pb is that in JMeterThread#triggerEndOfLoopOnParentControllers the
Sampler used is not always the "real" one, but it can be a
TransactionSampler, if there are some other controllers
(Simplecontroller) between this TransactionSampler and the http sampler,
triggerEndOfLoop will not be called for those controllers.

the idea behind the patch is to always do the tree traversal from the
real sampler.
