### PR TITLE
Bug 59082 : remove the "TestCompiler.useStaticSet" parameter 

### DIFF
--- a/src/core/org/apache/jmeter/control/GenericController.java
+++ b/src/core/org/apache/jmeter/control/GenericController.java
@@ -31,7 +31,6 @@ import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jmeter.threads.TestCompiler;
 import org.apache.jmeter.threads.TestCompilerHelper;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
@@ -57,8 +56,7 @@ public class GenericController extends AbstractTestElement implements Controller
     private transient LinkedList<LoopIterationListener> iterationListeners = new LinkedList<>();
 
     // Only create the map if it is required
-    private transient ConcurrentMap<TestElement, Object> children = 
-            TestCompiler.IS_USE_STATIC_SET ? null : new ConcurrentHashMap<TestElement, Object>();
+    private transient ConcurrentMap<TestElement, Object> children = new ConcurrentHashMap<TestElement, Object>();
 
     private static final Object DUMMY = new Object();
 
@@ -422,7 +420,7 @@ public class GenericController extends AbstractTestElement implements Controller
     
     protected Object readResolve(){
         iterationListeners = new LinkedList<>();
-        children = TestCompiler.IS_USE_STATIC_SET ? null : new ConcurrentHashMap<TestElement, Object>();
+        children = new ConcurrentHashMap<TestElement, Object>();
         subControllersAndSamplers = new ArrayList<>();
 
         return this;

--- a/src/core/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -46,8 +46,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
     private static final long serialVersionUID = 240L;
 
     // Only create the map if it is required
-    private transient final ConcurrentMap<TestElement, Object> children = 
-            TestCompiler.IS_USE_STATIC_SET ? null : new ConcurrentHashMap<TestElement, Object>();
+    private transient final ConcurrentMap<TestElement, Object> children = new ConcurrentHashMap<TestElement, Object>();
 
     private static final Object DUMMY = new Object();
 

--- a/src/core/org/apache/jmeter/threads/TestCompiler.java
+++ b/src/core/org/apache/jmeter/threads/TestCompiler.java
@@ -41,7 +41,6 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.timers.Timer;
-import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.collections.HashTreeTraverser;
 import org.apache.jorphan.logging.LoggingManager;
@@ -58,17 +57,9 @@ public class TestCompiler implements HashTreeTraverser {
 
     private static final Logger LOG = LoggingManager.getLoggerForClass();
 
-    /**
-     * Set this property {@value} to true to revert to using a shared static set.
-     */
-    private static final String USE_STATIC_SET = "TestCompiler.useStaticSet";
-    
-    /**
-     * The default value - {@value} - assumed for {@link #USE_STATIC_SET}. 
-     */
-    private static final boolean USE_STATIC_SET_DEFAULT = false;
-
-    public static final boolean IS_USE_STATIC_SET = JMeterUtils.getPropDefault(USE_STATIC_SET, USE_STATIC_SET_DEFAULT);
+    /** @deprecated since 3.0 will be removed in the next version 3.1 */
+    @Deprecated
+    public static final boolean IS_USE_STATIC_SET = false;
 
     /**
      * This set keeps track of which ObjectPairs have been seen.
@@ -158,7 +149,7 @@ public class TestCompiler implements HashTreeTraverser {
             boolean duplicate = false;
             // Bug 53750: this condition used to be in ObjectPair#addTestElements()
             if (parent instanceof Controller && (child instanceof Sampler || child instanceof Controller)) {
-                if (!IS_USE_STATIC_SET && parent instanceof TestCompilerHelper) {
+                if (parent instanceof TestCompilerHelper) {
                     TestCompilerHelper te = (TestCompilerHelper) parent;
                     duplicate = !te.addTestElementOnce(child);
                 } else { // this is only possible for 3rd party controllers by default


### PR DESCRIPTION
remove the "TestCompiler.useStaticSet" parameter that was added 3.5 years ago as a way to revert to a previous behavior if something was wrong.
The world did not collapse, the parameter is not needed anymore.
TestCompiler#IS_USE_STATIC_SET was kept for compatibility. it will be removed in the next version.
