### PR TITLE
Bug 59118 - Add comment in recorded thik time by proxy recorder

### DIFF
--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -931,6 +931,7 @@ public class ProxyControl extends GenericController {
                 TestElement template = templateNode.getTestElement();
                 if (template instanceof Timer) {
                     TestElement timer = (TestElement) template.clone();
+                    timer.setComment("Recorded think time: "+Long.toString(deltaT)+"ms");//TODO ARRRROOOO
                     try {
                         replacer.undoReverseReplace(timer);
                         model.addComponent(timer, node);


### PR DESCRIPTION
Hi,

To complete my previous PR about adding a new template "recording with
think time" I have made a new PR.

This PR add a comment in the recorded timer like "Recorded think time:
XXXms"

It will allow to:
   differentiate recorded timer from other
   have the original think time duration

Antonio
