### PR TITLE
PR for BUG 59116 without tab

### DIFF
--- a/src/core/org/apache/jmeter/resources/messages.properties
+++ b/src/core/org/apache/jmeter/resources/messages.properties
@@ -767,6 +767,7 @@ proxy_domains_dynamic_mode_tooltip=List of domain names for HTTPS url, ex. jmete
 proxy_domains_dynamic_mode_tooltip_java6=To activate this field, use a Java 7+ runtime environment
 proxy_general_settings=Global Settings
 proxy_headers=Capture HTTP Headers
+proxy_prefix_http_sampler_name=Prefix\:
 proxy_regex=Regex matching
 proxy_sampler_settings=HTTP Sampler settings
 proxy_sampler_type=Type\:

--- a/src/core/org/apache/jmeter/resources/messages_fr.properties
+++ b/src/core/org/apache/jmeter/resources/messages_fr.properties
@@ -752,6 +752,7 @@ proxy_domains_dynamic_mode_tooltip=Liste de noms de domaine pour les url HTTPS, 
 proxy_domains_dynamic_mode_tooltip_java6=Pour activer ce champ, utiliser un environnement d'ex\u00E9cution Java 7+
 proxy_general_settings=Param\u00E8tres g\u00E9n\u00E9raux
 proxy_headers=Capturer les ent\u00EAtes HTTP
+proxy_prefix_http_sampler_name=Prefix \:
 proxy_regex=Correspondance des variables par regex ?
 proxy_sampler_settings=Param\u00E8tres Echantillon HTTP
 proxy_sampler_type=Type \:

--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -151,6 +151,8 @@ public class ProxyControl extends GenericController {
     private static final String USE_KEEPALIVE = "ProxyControlGui.use_keepalive"; // $NON-NLS-1$
 
     private static final String SAMPLER_DOWNLOAD_IMAGES = "ProxyControlGui.sampler_download_images"; // $NON-NLS-1$
+    
+    private static final String PREFIX_HTTP_SAMPLER_NAME = "ProxyControlGui.proxy_prefix_http_sampler_name"; // $NON-NLS-1$
 
     private static final String REGEX_MATCH = "ProxyControlGui.regex_match"; // $NON-NLS-1$
 
@@ -358,6 +360,10 @@ public class ProxyControl extends GenericController {
         setProperty(new BooleanProperty(SAMPLER_DOWNLOAD_IMAGES, b));
     }
 
+    public void setPrefixHTTPSampleName(String prefixHTTPSampleName) {
+        setProperty(PREFIX_HTTP_SAMPLER_NAME, prefixHTTPSampleName);
+    }
+
     public void setNotifyChildSamplerListenerOfFilteredSamplers(boolean b) {
         notifyChildSamplerListenersOfFilteredSamples = b;
         setProperty(new BooleanProperty(NOTIFY_CHILD_SAMPLER_LISTENERS_FILTERED, b));
@@ -438,6 +444,10 @@ public class ProxyControl extends GenericController {
 
     public boolean getSamplerDownloadImages() {
         return getPropertyAsBoolean(SAMPLER_DOWNLOAD_IMAGES, false);
+    }
+
+    public String getPrefixHTTPSampleName() {
+        return getPropertyAsString(PREFIX_HTTP_SAMPLER_NAME);
     }
 
     public boolean getNotifyChildSamplerListenerOfFilteredSamplers() {
@@ -569,6 +579,7 @@ public class ProxyControl extends GenericController {
                 sampler.setFollowRedirects(samplerFollowRedirects);
                 sampler.setUseKeepAlive(useKeepAlive);
                 sampler.setImageParser(samplerDownloadImages);
+                sampler.setName(getPrefixHTTPSampleName() + sampler.getName());
 
                 Authorization authorization = createAuthorization(subConfigs, sampler);
                 if (authorization != null) {

--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -151,6 +151,11 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
     private JCheckBox samplerDownloadImages;
 
     /**
+     * Add a prefix to HTTP sample name recorded
+     */
+    private JTextField prefixHTTPSampleName;
+
+    /**
      * Regular expression to include results based on content type
      */
     private JTextField contentTypeInclude;
@@ -209,6 +214,8 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
     private static final String ADD_TO_EXCLUDE_FROM_CLIPBOARD = "exclude_clipboard"; // $NON-NLS-1$
 
     private static final String ADD_SUGGESTED_EXCLUDES = "exclude_suggested";
+    
+    private static final String PREFIX_HTTP_SAMPLER_NAME = "proxy_prefix_http_sampler_name"; // $NON-NLS-1$
     //- action names
 
     // Resource names for column headers
@@ -263,6 +270,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
             model.setSamplerFollowRedirects(samplerFollowRedirects.isSelected());
             model.setUseKeepAlive(useKeepAlive.isSelected());
             model.setSamplerDownloadImages(samplerDownloadImages.isSelected());
+            model.setPrefixHTTPSampleName(prefixHTTPSampleName.getText());
             model.setNotifyChildSamplerListenerOfFilteredSamplers(notifyChildSamplerListenerOfFilteredSamplersCB.isSelected());
             model.setRegexMatch(regexMatch.isSelected());
             model.setContentTypeInclude(contentTypeInclude.getText());
@@ -323,6 +331,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         samplerFollowRedirects.setSelected(model.getSamplerFollowRedirects());
         useKeepAlive.setSelected(model.getUseKeepalive());
         samplerDownloadImages.setSelected(model.getSamplerDownloadImages());
+        prefixHTTPSampleName.setText(model.getPrefixHTTPSampleName());
         notifyChildSamplerListenerOfFilteredSamplersCB.setSelected(model.getNotifyChildSamplerListenerOfFilteredSamplers());
         regexMatch.setSelected(model.getRegexMatch());
         contentTypeInclude.setText(model.getContentTypeInclude());
@@ -739,11 +748,20 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         samplerDownloadImages.addActionListener(this);
         samplerDownloadImages.setActionCommand(ENABLE_RESTART);
 
+        prefixHTTPSampleName = new JTextField(4);
+        prefixHTTPSampleName.addKeyListener(this);
+        prefixHTTPSampleName.setName(PREFIX_HTTP_SAMPLER_NAME);
+        prefixHTTPSampleName.setActionCommand(ENABLE_RESTART);
+        JLabel labelPrefix = new JLabel(JMeterUtils.getResString("proxy_prefix_http_sampler_name")); // $NON-NLS-1$
+        labelPrefix.setLabelFor(prefixHTTPSampleName);
+        
         HorizontalPanel panel = new HorizontalPanel();
         panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("proxy_sampler_settings"))); // $NON-NLS-1$
         panel.add(label2);
         panel.add(samplerTypeName);
+        panel.add(labelPrefix);
+        panel.add(prefixHTTPSampleName);
         panel.add(samplerRedirectAutomatically);
         panel.add(samplerFollowRedirects);
         panel.add(useKeepAlive);


### PR DESCRIPTION
Hi,

I have add a new option in proxy recorder to add a prefix in sampler name recorded by the proxy.

It allow to be more productive (less work to rename samplers after a recording) and complete the regex in backend listener I have add previously

This new PR fix the tab

Antonio
