### PR TITLE
Force JSONPATH to always return list of Object

### DIFF
--- a/src/components/org/apache/jmeter/extractor/json/jsonpath/JSONManager.java
+++ b/src/components/org/apache/jmeter/extractor/json/jsonpath/JSONManager.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
 
 /**
  * Handles the extractions
@@ -59,9 +61,10 @@ public class JSONManager {
      * @return List of String extracted data
      * @throws ParseException
      */
-    public List<String> extractWithJsonPath(String jsonString, String jsonPath)
+    public List<Object> extractWithJsonPath(String jsonString, String jsonPath)
             throws ParseException {
         JsonPath jsonPathParser = getJsonPath(jsonPath);
-        return jsonPathParser.read(jsonString);
+        Configuration cfg = Configuration.defaultConfiguration().addOptions(Option.ALWAYS_RETURN_LIST);
+        return jsonPathParser.read(jsonString, cfg);
     }
 }

--- a/src/components/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
+++ b/src/components/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
@@ -104,7 +104,7 @@ public class JSONPostProcessor extends AbstractScopedTestElement implements Seri
                     vars.put(currentRefName, defaultValues[i]);
                 } else {
 
-                    List<String> extractedValues = localMatcher.get()
+                    List<Object> extractedValues = localMatcher.get()
                             .extractWithJsonPath(jsonResponse, currentJsonPath);
                     // if no values extracted, default value added
                     if (extractedValues.isEmpty()) {
@@ -125,8 +125,8 @@ public class JSONPostProcessor extends AbstractScopedTestElement implements Seri
                                         new StringBuilder(getComputeConcatenation()
                                                 ? extractedValues.size() * 20
                                                 : 1);
-                                for (String stringExtracted : extractedValues) {
-                                    vars.put(currentRefName + "_" + index, stringExtracted);
+                                for (Object stringExtracted : extractedValues) {
+                                    vars.put(currentRefName + "_" + index, "" + stringExtracted);
                                     if (getComputeConcatenation()) {
                                         concat.append(stringExtracted)
                                                 .append(JSONPostProcessor.JSON_CONCATENATION_SEPARATOR);
@@ -140,7 +140,7 @@ public class JSONPostProcessor extends AbstractScopedTestElement implements Seri
                             } else if (matchNumber == 0) {
                                 // Random extraction
                                 int matchSize = extractedValues.size();
-                                vars.put(currentRefName, extractedValues.get(JMeterUtils.getRandomInt(matchSize)));
+                                vars.put(currentRefName, "" + extractedValues.get(JMeterUtils.getRandomInt(matchSize)));
                             } else {
                                 // extract at position
                                 if (matchNumber > extractedValues.size()) {
@@ -152,14 +152,14 @@ public class JSONPostProcessor extends AbstractScopedTestElement implements Seri
                                     }
                                     vars.put(currentRefName, defaultValues[i]);
                                 } else {
-                                    vars.put(currentRefName, extractedValues.get(matchNumber - 1));
+                                    vars.put(currentRefName, "" + extractedValues.get(matchNumber - 1));
                                 }
                             }
                         } else {
                             // else just one value extracted
-                            vars.put(currentRefName, extractedValues.get(0));
+                            vars.put(currentRefName, "" + extractedValues.get(0));
                             if (matchNumber < 0 && getComputeConcatenation()) {
-                                vars.put(currentRefName + ALL_SUFFIX, extractedValues.get(0));
+                                vars.put(currentRefName + ALL_SUFFIX, "" + extractedValues.get(0));
                             }
                         }
                         vars.put(currentRefName + REF_MATCH_NR, Integer.toString(extractedValues.size()));

--- a/src/components/org/apache/jmeter/extractor/json/render/RenderAsJsonRenderer.java
+++ b/src/components/org/apache/jmeter/extractor/json/render/RenderAsJsonRenderer.java
@@ -119,14 +119,14 @@ public class RenderAsJsonRenderer implements ResultRenderer, ActionListener {
 
     private String process(String textToParse) {
         try {
-            List<String> matchStrings = extractWithJSonPath(textToParse, jsonPathExpressionField.getText());
+            List<Object> matchStrings = extractWithJSonPath(textToParse, jsonPathExpressionField.getText());
             if (matchStrings.size() == 0) {
                 return "NO MATCH"; //$NON-NLS-1$
             } else {
                 StringBuilder builder = new StringBuilder();
                 int i = 0;
-                for (String text : matchStrings) {
-                    builder.append("Result[").append(i++).append("]=").append(text).append("\n"); //$NON-NLS-1$ $NON-NLS-2$ $NON-NLS-3$
+                for (Object text : matchStrings) {
+                    builder.append("Result[").append(i++).append("]=").append("" + text).append("\n"); //$NON-NLS-1$ $NON-NLS-2$ $NON-NLS-3$
                 }
 
                 return builder.toString();
@@ -136,7 +136,7 @@ public class RenderAsJsonRenderer implements ResultRenderer, ActionListener {
         }
     }
     
-    private List<String> extractWithJSonPath(String textToParse, String expression) throws ParseException {
+    private List<Object> extractWithJSonPath(String textToParse, String expression) throws ParseException {
         JSONManager jsonManager = new JSONManager();
         return jsonManager.extractWithJsonPath(textToParse, expression);
     }


### PR DESCRIPTION
When the JSONPATH expression retrieve only one value, an exeption was thrown ( Unable to cast String type to List type by example)
Add the Option.ALWAYS_RETURN_LIST force JSONPATH to always return a list.
To avoid problem of cast, the list type is set to Object.
