### PR TITLE
Bug59207_ChangeColorErrorsOrFatalsLabel.setToolTipTextTranslationErro…

### DIFF
--- a/src/core/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/org/apache/jmeter/gui/MainFrame.java
@@ -19,6 +19,7 @@
 package org.apache.jmeter.gui;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
@@ -844,6 +845,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
                 SwingUtilities.invokeLater(new Runnable() {
                     @Override
                     public void run() {
+                        errorsOrFatalsLabel.setForeground(Color.red);
                         errorsOrFatalsLabel.setText(Integer.toString(newValue));
                     }
                 });
@@ -856,6 +858,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
             SwingUtilities.invokeLater(new Runnable() {
                 @Override
                 public void run() {
+                    errorsOrFatalsLabel.setForeground(Color.black);
                     errorsOrFatalsLabel.setText(Integer.toString(errorOrFatal.get()));
                 }
             });


### PR DESCRIPTION
Hi,

I think it will be great to change the color font of errorsOrFatalsLabel
to red when a error occur

Like that it will have more visibility and help the user when an error
occur (like in my previous PR
https://bz.apache.org/bugzilla/show_bug.cgi?id=59153)

Antonio
