### PR TITLE
Bug 59281 testTimeDurationGUI

### DIFF
--- a/src/core/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/org/apache/jmeter/gui/MainFrame.java
@@ -214,7 +214,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
 
         testTimeDuration = new JLabel("00:00:00"); //$NON-NLS-1$
         testTimeDuration.setToolTipText(JMeterUtils.getResString("duration_tooltip")); //$NON-NLS-1$
-        testTimeDuration.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.LOWERED));
+
 
         totalThreads = new JLabel("0"); // $NON-NLS-1$
         totalThreads.setToolTipText(JMeterUtils.getResString("total_threads_tooltip")); // $NON-NLS-1$


### PR DESCRIPTION
Hi,

There is a border in testTimeDuration.
It's not well integrated with the GUI of JMeter

I propose to remove the border

Antonio
