### PR TITLE
Bug59293_AddAvgInAxisToLatenciesOverTimeReport

### DIFF
--- a/bin/report-template/content/js/graph.js.fmkr
+++ b/bin/report-template/content/js/graph.js.fmkr
@@ -791,7 +791,7 @@ var latenciesOverTimeInfos = {
                     axisLabelPadding: 20,
                 },
                 yaxis: {
-                    axisLabel: "Response latencies in ms",
+                    axisLabel: "Average response latencies in ms",
                     axisLabelUseCanvas: true,
                     axisLabelFontSizePixels: 12,
                     axisLabelFontFamily: 'Verdana, Arial',


### PR DESCRIPTION
Hi,

Not enough info in Axis to Latencies over Time graph in report

I propose to add average

Antonio
