### PR TITLE
Bug59291_FixDuplicateLineIngenerating-dashboardDocumentation

### DIFF
--- a/xdocs/usermanual/generating-dashboard.xml
+++ b/xdocs/usermanual/generating-dashboard.xml
@@ -423,7 +423,7 @@ jmeter.reportgenerator.apdex_tolerated_threshold=3000
 # This will override the value set through -o command line option
 # jmeter.reportgenerator.exporter.html.property.output_dir=/tmp/test-report
 
-# Indicates which graph series are filtered (regular expression)
+
 # Indicates which graph series are filtered (regular expression)
 # In the below example we filter on Sample1 and Sample2
 # Note that the end of the pattern should always include (-success|-failure)? 


### PR DESCRIPTION
Hi,

There is a typo in generating-dashboard.html

I have remove the duplicate line (# Indicates which graph series are
filtered (regular expression)) in generating-dashboard.xml

This new PR fix problem I have in my editor to have a better PR

Antonio
