### PR TITLE
Bug59303_NewDefaultResponseTimeDistributionGranularity

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1202,7 +1202,7 @@ jmeter.reportgenerator.graph.responseTimePercentiles.title=Response Time Percent
 # Response Time Distribution graph definition
 jmeter.reportgenerator.graph.responseTimeDistribution.classname=org.apache.jmeter.report.processor.graph.impl.ResponseTimeDistributionGraphConsumer
 jmeter.reportgenerator.graph.responseTimeDistribution.title=Response Time Distribution
-jmeter.reportgenerator.graph.responseTimeDistribution.property.set_granularity=1000
+jmeter.reportgenerator.graph.responseTimeDistribution.property.set_granularity=500
 
 # Active Threads Over Time graph definition
 jmeter.reportgenerator.graph.activeThreadsOverTime.classname=org.apache.jmeter.report.processor.graph.impl.ActiveThreadsGraphConsumer


### PR DESCRIPTION
Hi,

By default the response time distribution granularity in HTML report is
1000ms

jmeter.reportgenerator.graph.responseTimeDistribution.property.set_granularity=1000

I think is too high

I propose to have a lower value like 500ms

Antonio
