### PR TITLE
Bug59305DefaultReportHTMLStatisticsColumnSort

### DIFF
--- a/bin/report-template/content/js/dashboard.js.fmkr
+++ b/bin/report-template/content/js/dashboard.js.fmkr
@@ -154,7 +154,7 @@ $(document).ready(function() {
                 break;
         }
         return item;
-    }, [[3, 1]], 0);
+    }, [[0, 0]], 0);
 
     // Create error table
     createTable($("#errorsTable"), ${errorsSummary!"{}"}, function(index, item){


### PR DESCRIPTION
Hi,

By default in HTML report statistics, it's the column Error% which is
sorted

I think it's better to sort the table with label column

Antonio
