### PR TITLE
Bug59320 generic gui tooltipsv2

### DIFF
--- a/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -650,7 +650,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
         // if the displayName is the empty string, leave it like that.
         JLabel label = new JLabel(text);
         label.setHorizontalAlignment(SwingConstants.TRAILING);
-        text = propertyToolTipMessage.format(new Object[] { desc.getShortDescription() });
+        text = desc.getShortDescription();
         label.setToolTipText(text);
 
         return label;

--- a/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -650,7 +650,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
         // if the displayName is the empty string, leave it like that.
         JLabel label = new JLabel(text);
         label.setHorizontalAlignment(SwingConstants.TRAILING);
-        text = propertyToolTipMessage.format(new Object[] { desc.getName(), desc.getShortDescription() });
+        text = propertyToolTipMessage.format(new Object[] { desc.getShortDescription() });
         label.setToolTipText(text);
 
         return label;


### PR DESCRIPTION
Hi,

When you use GenericTestBeanCustomizer to create your GUI, the tooltip
in French and Enflish have not the same form (in english we have a line
breack and not in French)
The second problem is that the tooltip contain desc.getName +
desc.getShortDescription

Or desc.getName is not translated and, in my opinion, useless

My proposition is to remove desc.getName from the tooltip

Antonio
