### PR TITLE
Bug 59345 - SMTPSampler connection leak

### DIFF
--- a/src/protocol/mail/org/apache/jmeter/protocol/smtp/sampler/protocol/SendMailCommand.java
+++ b/src/protocol/mail/org/apache/jmeter/protocol/smtp/sampler/protocol/SendMailCommand.java
@@ -302,16 +302,18 @@ public class SendMailCommand {
         } else {
             tr.connect();
         }
+        
+        try {
+            tr.sendMessage(message, message.getAllRecipients());
 
-        tr.sendMessage(message, message.getAllRecipients());
-
-        if (listener != null /*synchronousMode==true*/) {
-            listener.attend(); // listener cannot be null here
+            if (listener != null /*synchronousMode==true*/) {
+                listener.attend(); // listener cannot be null here
+            }
+        } finally {
+            tr.close();
+            logger.debug("transport closed");
         }
-
-        tr.close();
-        logger.debug("transport closed");
-
+        
         logger.debug("message sent");
         return;
     }


### PR DESCRIPTION
Move trasport closing command into finally block in order to avoid SMTP connection leak when sending email fails. 
