### PR TITLE
Bug59350_WritingLogFileTo

### DIFF
--- a/src/jorphan/org/apache/jorphan/logging/LoggingManager.java
+++ b/src/jorphan/org/apache/jorphan/logging/LoggingManager.java
@@ -180,7 +180,7 @@ public final class LoggingManager {
         isWriterSystemOut = false;
         try {
             File logFileAsFile = new File(logFile);
-            System.out.println("Writing log file to:"+logFileAsFile.getAbsolutePath());
+            System.out.println("Writing log file to: "+logFileAsFile.getAbsolutePath());
             wt = new FileWriter(logFile);
         } catch (Exception e) {
             System.out.println(propName + "=" + logFile + " " + e.toString());


### PR DESCRIPTION
Hi,

When JMeter start it's display a message like:
Writing log file to:C:\Util\apache-jmeter-3.0\bin\jmeter.log

I propose to add a space after to:

Antonio
