### PR TITLE
Bug59351_BetterErrorMessageInIncludeControllerForFileNotFound

### DIFF
--- a/src/components/org/apache/jmeter/control/IncludeController.java
+++ b/src/components/org/apache/jmeter/control/IncludeController.java
@@ -121,8 +121,9 @@ public class IncludeController extends GenericController implements ReplaceableC
         final String includePath = getIncludePath();
         HashTree tree = null;
         if (includePath != null && includePath.length() > 0) {
+            String fileName=prefix+includePath;
             try {
-                String fileName=prefix+includePath;
+                
                 File file = new File(fileName);
                 final String absolutePath = file.getAbsolutePath();
                 log.info("loadIncludedElements -- try to load included module: "+absolutePath);
@@ -130,10 +131,10 @@ public class IncludeController extends GenericController implements ReplaceableC
                     log.info("loadIncludedElements -failed for: "+absolutePath);
                     file = new File(FileServer.getFileServer().getBaseDir(), includePath);
                     log.info("loadIncludedElements -Attempting to read it from: " + file.getAbsolutePath());
-                    if(!file.exists()){
+                    if(!file.canRead() || !file.isFile()){
                         log.error("loadIncludedElements -failed for: " + file.getAbsolutePath());
-                        throw new IOException("loadIncludedElements -failed for: " + absolutePath +
-                                " and " + file.getAbsolutePath());
+                        throw new IOException("Include Controller \""+ this.getName()+"\" can't load \"" + fileName +
+                                "\" - see log for details" );
                     }
                 }
                 
@@ -152,7 +153,7 @@ public class IncludeController extends GenericController implements ReplaceableC
                 JMeterUtils.reportErrorToUser(msg);
             } catch (FileNotFoundException ex) {
                 String msg = ex.getMessage();
-                JMeterUtils.reportErrorToUser(msg);
+                JMeterUtils.reportErrorToUser("File \""+ fileName + "\" not found for Include Controller \""+ this.getName()+"\"");
                 log.warn(msg);
             } catch (Exception ex) {
                 String msg = ex.getMessage();


### PR DESCRIPTION
Hi,

When JMeter try to load a file which don't exist in InludeController we
have this log

2016/04/18 22:22:12 INFO  - jmeter.services.FileServer: Set new
base='C:\Util\0_JMX' 
2016/04/18 22:22:13 INFO  - jmeter.control.IncludeController:
loadIncludedElements -- try to load included module:
C:\Util\apache-jmeter-3.0\bin\  C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 INFO  - jmeter.control.IncludeController:
loadIncludedElements -failed for: C:\Util\apache-jmeter-3.0\bin\
C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 INFO  - jmeter.control.IncludeController:
loadIncludedElements -Attempting to read it from: C:\Util\0_JMX\
C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 ERROR - jmeter.control.IncludeController:
loadIncludedElements -failed for: C:\Util\0_JMX\
C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 INFO  - jmeter.control.IncludeController:
loadIncludedElements -- try to load included module:
C:\Util\apache-jmeter-3.0\bin\  C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 INFO  - jmeter.control.IncludeController:
loadIncludedElements -failed for: C:\Util\apache-jmeter-3.0\bin\
C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 INFO  - jmeter.control.IncludeController:
loadIncludedElements -Attempting to read it from: C:\Util\0_JMX\
C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:22:13 ERROR - jmeter.control.IncludeController:
loadIncludedElements -failed for: C:\Util\0_JMX\
C:\Util\0_JMX\IncludeSRCFragment.jmx 
2016/04/18 22:34:12 WARN  - jmeter.control.IncludeController: Unexpected
error java.io.IOException: loadIncludedElements -failed for:
C:\Util\apache-jmeter-3.0\bin\  C:\Util\0_JMX\IncludeSRCFragment.jmx and
C:\Util\0_JMX\  C:\Util\0_JMX\IncludeSRCFragment.jmx
    at
org.apache.jmeter.control.IncludeController.loadIncludedElements(IncludeController.java:135)
    at
org.apache.jmeter.control.IncludeController.resolveReplacementSubTree(IncludeController.java:111)
    at
org.apache.jmeter.control.IncludeController.clone(IncludeController.java:64)
    at org.apache.jmeter.gui.action.CheckDirty.addNode(CheckDirty.java:162)

and a popup box with useless message to user (see attached screenshot)

I propose to have a more usefull log and error message.

Ant to check that the file can be read

Antonio
