### PR TITLE
Measure Time to First byte in JDBCSampler

### DIFF
--- a/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -147,7 +147,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
     /**
      * Execute the test element.
      * 
-     * @param conn a {@link SampleResult} in case the test should sample; <code>null</code> if only execution is requested
+     * @param conn a {@link Connection}
      * @return the result of the execute command
      * @throws SQLException if a database error occurs
      * @throws UnsupportedEncodingException when the result can not be converted to the required charset
@@ -155,9 +155,16 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
      * @throws UnsupportedOperationException if the user provided incorrect query type 
      */
     protected byte[] execute(Connection conn) throws SQLException, IOException, UnsupportedOperationException {
+        return execute(conn,  new SampleResult());
+    }
+
+    /**
+     * Use the sample given as argument to set time to first byte in the "latency" field of the SampleResult.
+     */
+    protected byte[] execute(Connection conn, SampleResult sample) throws SQLException, IOException {
         log.debug("executing jdbc");
         Statement stmt = null;
-        
+
         try {
             // Based on query return value, get results
             String _queryType = getQueryType();
@@ -167,6 +174,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
                 ResultSet rs = null;
                 try {
                     rs = stmt.executeQuery(getQuery());
+                    sample.latencyEnd();
                     return getStringFromResultSet(rs).getBytes(ENCODING);
                 } finally {
                     close(rs);
@@ -177,12 +185,14 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
                 // A CallableStatement can return more than 1 ResultSets
                 // plus a number of update counts.
                 boolean hasResultSet = cstmt.execute();
+                sample.latencyEnd();
                 String sb = resultSetsToString(cstmt,hasResultSet, out);
                 return sb.getBytes(ENCODING);
             } else if (UPDATE.equals(_queryType)) {
                 stmt = conn.createStatement();
                 stmt.setQueryTimeout(getIntegerQueryTimeout());
                 stmt.executeUpdate(getQuery());
+                sample.latencyEnd();
                 int updateCount = stmt.getUpdateCount();
                 String results = updateCount + " updates";
                 return results.getBytes(ENCODING);
@@ -192,6 +202,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
                 ResultSet rs = null;
                 try {
                     rs = pstmt.executeQuery();
+                    sample.latencyEnd();
                     return getStringFromResultSet(rs).getBytes(ENCODING);
                 } finally {
                     close(rs);
@@ -200,19 +211,24 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
                 PreparedStatement pstmt = getPreparedStatement(conn);
                 setArguments(pstmt);
                 pstmt.executeUpdate();
+                sample.latencyEnd();
                 String sb = resultSetsToString(pstmt,false,null);
                 return sb.getBytes(ENCODING);
             } else if (ROLLBACK.equals(_queryType)){
                 conn.rollback();
+                sample.latencyEnd();
                 return ROLLBACK.getBytes(ENCODING);
             } else if (COMMIT.equals(_queryType)){
                 conn.commit();
+                sample.latencyEnd();
                 return COMMIT.getBytes(ENCODING);
             } else if (AUTOCOMMIT_FALSE.equals(_queryType)){
                 conn.setAutoCommit(false);
+                sample.latencyEnd();
                 return AUTOCOMMIT_FALSE.getBytes(ENCODING);
             } else if (AUTOCOMMIT_TRUE.equals(_queryType)){
                 conn.setAutoCommit(true);
+                sample.latencyEnd();
                 return AUTOCOMMIT_TRUE.getBytes(ENCODING);
             } else { // User provided incorrect query type
                 throw new UnsupportedOperationException("Unexpected query type: "+_queryType);

--- a/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -150,7 +150,6 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
      * @param conn a {@link Connection}
      * @return the result of the execute command
      * @throws SQLException if a database error occurs
-     * @throws UnsupportedEncodingException when the result can not be converted to the required charset
      * @throws IOException when I/O error occurs
      * @throws UnsupportedOperationException if the user provided incorrect query type 
      */
@@ -159,9 +158,17 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
     }
 
     /**
+     * Execute the test element.
      * Use the sample given as argument to set time to first byte in the "latency" field of the SampleResult.
+     *
+     * @param conn a {@link Connection}
+     * @param sample a {@link SampleResult} to save the latency
+     * @return the result of the execute command
+     * @throws SQLException if a database error occurs
+     * @throws IOException when I/O error occurs
+     * @throws UnsupportedOperationException if the user provided incorrect query type
      */
-    protected byte[] execute(Connection conn, SampleResult sample) throws SQLException, IOException {
+    protected byte[] execute(Connection conn, SampleResult sample) throws SQLException, IOException, UnsupportedOperationException {
         log.debug("executing jdbc");
         Statement stmt = null;
 

--- a/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
+++ b/src/protocol/jdbc/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
@@ -83,11 +83,10 @@ public class JDBCSampler extends AbstractJDBCTestElement implements Sampler, Tes
             try {
                 conn = DataSourceElement.getConnection(getDataSource());
             } finally {
-                // FIXME: there is separate connect time field now
-                res.latencyEnd(); // use latency to measure connection time
+                res.connectEnd();
             }
             res.setResponseHeaders(conn.toString());
-            res.setResponseData(execute(conn));
+            res.setResponseData(execute(conn, res));
         } catch (SQLException ex) {
             final String errCode = Integer.toString(ex.getErrorCode());
             res.setResponseMessage(ex.toString());


### PR DESCRIPTION
Hello,

I use JMeter to measure performance of a database. When executing queries returning a lot of rows, the time taken by JMeter to read the ResultSet and storing the result in a StringBuilder then calling toString() might be bigger than the execution time on the server.

In order to easily understand what's taking time for slow queries, I thought it might be interesting to use "Latency" and "Connect Time" of the SampleResult to show two informations:
- **Connect time**: time needed to establish the connection (previously it was in the Latency)
- **Latency**: time taken to get the first ResultSet (TTFB) (or whatever if it's a statement returning something else)

What do you think of that change?

Regards,
Thomas
