### PR TITLE
Bug 59882 : JMeter memory allocations reduction

### DIFF
--- a/src/core/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -187,6 +187,15 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
         }
         return prop;
     }
+    
+    /**
+     * Null property are wrapped in a {@link NullProperty}
+     * for internal use only
+     * @since 3.1
+     */
+    private JMeterProperty getRawProperty(String key) {
+        return propMap.get(key);
+    }
 
     @Override
     public void traverse(TestElementTraverser traverser) {
@@ -230,8 +239,8 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
 
     @Override
     public int getPropertyAsInt(String key, int defaultValue) {
-        JMeterProperty jmp = getProperty(key);
-        return jmp instanceof NullProperty ? defaultValue : jmp.getIntValue();
+        JMeterProperty jmp = getRawProperty(key);
+        return jmp == null || jmp instanceof NullProperty ? defaultValue : jmp.getIntValue();
     }
 
     @Override
@@ -241,8 +250,8 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
 
     @Override
     public boolean getPropertyAsBoolean(String key, boolean defaultVal) {
-        JMeterProperty jmp = getProperty(key);
-        return jmp instanceof NullProperty ? defaultVal : jmp.getBooleanValue();
+        JMeterProperty jmp = getRawProperty(key);
+        return jmp == null || jmp instanceof NullProperty ? defaultVal : jmp.getBooleanValue();
     }
 
     @Override
@@ -257,8 +266,8 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
 
     @Override
     public long getPropertyAsLong(String key, long defaultValue) {
-        JMeterProperty jmp = getProperty(key);
-        return jmp instanceof NullProperty ? defaultValue : jmp.getLongValue();
+        JMeterProperty jmp = getRawProperty(key);
+        return jmp == null || jmp instanceof NullProperty ? defaultValue : jmp.getLongValue();
     }
 
     @Override
@@ -273,8 +282,8 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
 
     @Override
     public String getPropertyAsString(String key, String defaultValue) {
-        JMeterProperty jmp = getProperty(key);
-        return jmp instanceof NullProperty ? defaultValue : jmp.getStringValue();
+        JMeterProperty jmp = getRawProperty(key);
+        return jmp == null || jmp instanceof NullProperty ? defaultValue : jmp.getStringValue();
     }
 
     /**

--- a/src/core/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/org/apache/jmeter/threads/JMeterThread.java
@@ -457,16 +457,20 @@ public class JMeterThread implements Runnable, Interruptible {
 
         // Perform the actual sample
         currentSampler = sampler;
-        for(SampleMonitor monitor : sampleMonitors) {
-            monitor.sampleStarting(sampler);
+        if(!sampleMonitors.isEmpty()) {
+            for(SampleMonitor monitor : sampleMonitors) {
+                monitor.sampleStarting(sampler);
+            }
         }
         SampleResult result = null;
         try {
             result = sampler.sample(null); // TODO: remove this useless Entry parameter
         } finally {
-            for(SampleMonitor monitor : sampleMonitors) {
-                monitor.sampleEnded(sampler);
-            }            
+            if(sampleMonitors.isEmpty()) {
+                for(SampleMonitor monitor : sampleMonitors) {
+                    monitor.sampleEnded(sampler);
+                }
+            }
         }
         currentSampler = null;
 

--- a/src/jorphan/org/apache/jorphan/util/JOrphanUtils.java
+++ b/src/jorphan/org/apache/jorphan/util/JOrphanUtils.java
@@ -262,15 +262,22 @@ public final class JOrphanUtils {
      * @return the output string
      */
     public static String replaceAllChars(String source, char search, String replace) {
+        int indexOf = source.indexOf(search);
+        if(indexOf == -1) {
+            return source;
+        }
+        
+        int offset = 0;
         char[] chars = source.toCharArray();
         StringBuilder sb = new StringBuilder(source.length()+20);
-        for(char c : chars){
-            if (c == search){
-                sb.append(replace);
-            } else {
-                sb.append(c);
-            }
+        while(indexOf != -1) {
+            sb.append(chars, offset, indexOf-offset);
+            sb.append(replace);
+            offset = indexOf +1;
+            indexOf = source.indexOf(search, offset);
         }
+        sb.append(chars, offset, chars.length- offset);
+        
         return sb.toString();
     }
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -749,7 +749,8 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
         HttpClientKey key = new HttpClientKey(url, useProxy, proxyHost, proxyPort, proxyUser, proxyPass);
         
         HttpClient httpClient = null;
-        if(this.testElement.isConcurrentDwn()) {
+        boolean concurrentDwn = this.testElement.isConcurrentDwn();
+        if(concurrentDwn) {
             httpClient = (HttpClient) JMeterContextService.getContext().getSamplerContext().get(HTTPCLIENT_TOKEN);
         }
         
@@ -784,7 +785,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
             // Modern browsers use more connections per host than the current httpclient default (2)
             // when using parallel download the httpclient and connection manager are shared by the downloads threads
             // to be realistic JMeter must set an higher value to DefaultMaxPerRoute
-            if(this.testElement.isConcurrentDwn()) {
+            if(concurrentDwn) {
                 try {
                     int maxConcurrentDownloads = Integer.parseInt(this.testElement.getConcurrentPool());
                     connManager.setDefaultMaxPerRoute(Math.max(maxConcurrentDownloads, connManager.getDefaultMaxPerRoute()));                
@@ -843,7 +844,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
             }
         }
 
-        if(this.testElement.isConcurrentDwn()) {
+        if(concurrentDwn) {
             JMeterContextService.getContext().getSamplerContext().put(HTTPCLIENT_TOKEN, httpClient);
         }
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -1084,7 +1084,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
     private String getConnectionHeaders(HttpRequest method) {
         if(method != null) {
             // Get all the request headers
-            StringBuilder hdrs = new StringBuilder(100);
+            StringBuilder hdrs = new StringBuilder(150);
             Header[] requestHeaders = method.getAllHeaders();
             for (Header requestHeader : requestHeaders) {
                 // Exclude the COOKIE header, since cookie is reported separately in the sample

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -1218,7 +1218,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
                 }
                 bos.flush();
                 // We get the posted bytes using the encoding used to create it
-                postedBody.append(new String(bos.toByteArray(),
+                postedBody.append(bos.toString(
                         contentEncoding == null ? "US-ASCII" // $NON-NLS-1$ this is the default used by HttpClient
                         : contentEncoding));
                 bos.close();
@@ -1341,11 +1341,8 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
                         post.getEntity().writeTo(bos);
                         bos.flush();
                         // We get the posted bytes using the encoding used to create it
-                        if (contentEncoding != null) {
-                            postedBody.append(new String(bos.toByteArray(), contentEncoding));
-                        } else {
-                            postedBody.append(new String(bos.toByteArray(), SampleResult.DEFAULT_HTTP_ENCODING));
-                        }
+                        postedBody.append(bos.toString(contentEncoding != null?contentEncoding:SampleResult.DEFAULT_HTTP_ENCODING));
+                        
                         bos.close();
                     }  else {
                         postedBody.append("<RequestEntity was not repeatable, cannot view what was sent>");

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1600,7 +1600,9 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     protected HTTPSampleResult resultProcessing(boolean areFollowingRedirect, int frameDepth, HTTPSampleResult res) {
         boolean wasRedirected = false;
         if (!areFollowingRedirect && res.isRedirect()) {
-            log.debug("Location set to - " + res.getRedirectLocation());
+            if(log.isDebugEnabled()) {
+                log.debug("Location set to - " + res.getRedirectLocation());
+            }
 
             if (getFollowRedirects()) {
                 res = followRedirects(res, frameDepth);

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.protocol.http.sampler;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
@@ -56,6 +57,7 @@ import org.apache.jmeter.protocol.http.parser.LinkExtractorParseException;
 import org.apache.jmeter.protocol.http.parser.LinkExtractorParser;
 import org.apache.jmeter.protocol.http.sampler.ResourcesDownloader.AsynSamplerResultHolder;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
+import org.apache.jmeter.protocol.http.util.DirectAccessByteArrayOutputStream;
 import org.apache.jmeter.protocol.http.util.EncoderCache;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -1751,12 +1753,15 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @throws IOException if reading the result fails
      */
     public byte[] readResponse(SampleResult sampleResult, InputStream in, int length) throws IOException {
+        
+        OutputStream w = null;
         try {
             byte[] readBuffer = new byte[8192]; // 8kB is the (max) size to have the latency ('the first packet')
             int bufferSize = 32;// Enough for MD5
 
             MessageDigest md = null;
             boolean asMD5 = useMD5();
+            boolean knownResponseLength = length > 0;// may also happen if long value > int.max
             if (asMD5) {
                 try {
                     md = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
@@ -1765,13 +1770,14 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                     asMD5 = false;
                 }
             } else {
-                if (length <= 0) {// may also happen if long value > int.max
+                if (!knownResponseLength) {
                     bufferSize = 4 * 1024;
                 } else {
                     bufferSize = length;
                 }
             }
-            ByteArrayOutputStream w = new ByteArrayOutputStream(bufferSize);
+            
+            
             int bytesRead = 0;
             int totalBytes = 0;
             boolean first = true;
@@ -1779,29 +1785,54 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 if (first) {
                     sampleResult.latencyEnd();
                     first = false;
+                    if(!asMD5) {
+                        if(knownResponseLength) {
+                            w = new DirectAccessByteArrayOutputStream(bufferSize);
+                        }
+                        else {
+                            w = new org.apache.commons.io.output.ByteArrayOutputStream(bufferSize);
+                        }
+                    }
                 }
-                if (asMD5 && md != null) {
+                
+                if (asMD5) {
                     md.update(readBuffer, 0, bytesRead);
                     totalBytes += bytesRead;
                 } else {
                     w.write(readBuffer, 0, bytesRead);
                 }
             }
+            
             if (first) { // Bug 46838 - if there was no data, still need to set latency
                 sampleResult.latencyEnd();
+                return new byte[0];
             }
-            in.close();
-            w.flush();
-            if (asMD5 && md != null) {
+            
+            if (asMD5) {
                 byte[] md5Result = md.digest();
-                w.write(JOrphanUtils.baToHexBytes(md5Result));
                 sampleResult.setBytes(totalBytes);
+                return JOrphanUtils.baToHexBytes(md5Result);
             }
-            w.close();
-            return w.toByteArray();
+            
+            return toByteArray(w);
         } finally {
             IOUtils.closeQuietly(in);
+            IOUtils.closeQuietly(w);
         }
+    }
+
+    private byte[] toByteArray(OutputStream w) {
+        if(w instanceof DirectAccessByteArrayOutputStream) {
+            return ((DirectAccessByteArrayOutputStream) w).toByteArray();
+        }
+        
+        if(w instanceof org.apache.commons.io.output.ByteArrayOutputStream) {
+            return ((org.apache.commons.io.output.ByteArrayOutputStream) w).toByteArray();
+        }
+        
+        log.warn("Unknown stream type " + w.getClass());
+        
+        return null;
     }
 
     /**

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -998,13 +998,20 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @return the QueryString value
      */
     public String getQueryString(String contentEncoding) {
+        
+        CollectionProperty arguments = getArguments().getArguments();
+        if(arguments.size() == 0) {
+            return "";
+        }
+        
         // Check if the sampler has a specified content encoding
         if (JOrphanUtils.isBlank(contentEncoding)) {
             // We use the encoding which should be used according to the HTTP spec, which is UTF-8
             contentEncoding = EncoderCache.URL_ARGUMENT_ENCODING;
         }
-        StringBuilder buf = new StringBuilder();
-        PropertyIterator iter = getArguments().iterator();
+        
+        StringBuilder buf = new StringBuilder(arguments.size() * 15);
+        PropertyIterator iter = arguments.iterator();
         boolean first = true;
         while (iter.hasNext()) {
             HTTPArgument item = null;

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1610,7 +1610,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 wasRedirected = true;
             }
         }
-        if (isImageParser() && (SampleResult.TEXT).equals(res.getDataType()) && res.isSuccessful()) {
+        
+        if (res.isSuccessful() && SampleResult.TEXT.equals(res.getDataType()) && isImageParser() ) {
             if (frameDepth > MAX_FRAME_DEPTH) {
                 HTTPSampleResult errSubResult = new HTTPSampleResult(res);
                 errSubResult.removeSubResults();

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -684,9 +684,13 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @return port number or UNSPECIFIED_PORT (== 0)
      */
     public int getPortIfSpecified() {
-        String port_s = getPropertyAsString(PORT, UNSPECIFIED_PORT_AS_STRING);
+        String portAsString = getPropertyAsString(PORT);
+        if(portAsString == null || portAsString.isEmpty()) {
+            return UNSPECIFIED_PORT;
+        }
+        
         try {
-            return Integer.parseInt(port_s.trim());
+            return Integer.parseInt(portAsString.trim());
         } catch (NumberFormatException e) {
             return UNSPECIFIED_PORT;
         }

--- a/src/protocol/http/org/apache/jmeter/protocol/http/util/ConversionUtils.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/util/ConversionUtils.java
@@ -48,6 +48,8 @@ public class ConversionUtils {
     private static final String DOTDOT = ".."; // $NON-NLS-1$
     private static final String SLASH = "/"; // $NON-NLS-1$
     private static final String COLONSLASHSLASH = "://"; // $NON-NLS-1$
+    
+    private static final Pattern MAKE_RELATIVE_PATTERN = Pattern.compile("^/((?:\\.\\./)+)"); // $NON-NLS-1$
 
     /**
      * Extract the encoding (charset) from the Content-Type, e.g.
@@ -111,8 +113,8 @@ public class ConversionUtils {
         }
         String path = initial.getPath();
         // Match /../[../] etc.
-        Pattern p = Pattern.compile("^/((?:\\.\\./)+)"); // $NON-NLS-1$
-        Matcher m = p.matcher(path);
+        
+        Matcher m = MAKE_RELATIVE_PATTERN.matcher(path);
         if (m.lookingAt()){
             String prefix = m.group(1); // get ../ or ../../ etc.
             if (location.startsWith(prefix)){

--- a/src/protocol/http/org/apache/jmeter/protocol/http/util/DirectAccessByteArrayOutputStream.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/util/DirectAccessByteArrayOutputStream.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jmeter.protocol.http.util;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+/**
+ * this is a non thread-safe specialization of java {@link ByteArrayOutputStream}
+ * it returns the internal buffer if its size match the byte count
+ * 
+ * @since 3.1
+ */
+public class DirectAccessByteArrayOutputStream extends ByteArrayOutputStream {
+
+    public DirectAccessByteArrayOutputStream(int initialSize) {
+        super(initialSize);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        // no need to copy the buffer if it has the right size
+        // avoid an unneeded memory allocation
+        if(this.count == this.buf.length) {
+            return this.buf;
+        }
+        
+        return Arrays.copyOf(buf, count);
+    }
+    
+}

--- a/test/src/org/apache/jorphan/util/TestJorphanUtils.java
+++ b/test/src/org/apache/jorphan/util/TestJorphanUtils.java
@@ -287,7 +287,7 @@ public class TestJorphanUtils {
 
     @Test
     public void testSplitSSSNone() {
-        String out[];
+        String[] out;
         out = JOrphanUtils.split("", "," ,"x");
         assertEquals(0, out.length);
 
@@ -298,14 +298,13 @@ public class TestJorphanUtils {
 
     @Test
     public void testreplaceAllChars(){
-        assertEquals(JOrphanUtils.replaceAllChars("",' ', "+"),"");
-        String in,out;
-        in="source";
-        assertEquals(JOrphanUtils.replaceAllChars(in,' ', "+"),in);
-        out="so+rce";
-        assertEquals(JOrphanUtils.replaceAllChars(in,'u', "+"),out);
-        in="A B  C "; out="A+B++C+";
-        assertEquals(JOrphanUtils.replaceAllChars(in,' ', "+"),out);
+        assertEquals("", JOrphanUtils.replaceAllChars("",' ', "+"));
+        assertEquals("source", JOrphanUtils.replaceAllChars("source",' ', "+"));
+        assertEquals("so+rce", JOrphanUtils.replaceAllChars("source",'u', "+"));
+        assertEquals("+so+urc+", JOrphanUtils.replaceAllChars("esoeurce",'e', "+"));
+        assertEquals("AZAZsoAZurcAZ", JOrphanUtils.replaceAllChars("eesoeurce",'e', "AZ"));
+        assertEquals("A+B++C+", JOrphanUtils.replaceAllChars("A B  C ",' ', "+"));
+        assertEquals("A%20B%20%20C%20", JOrphanUtils.replaceAllChars("A B  C ",' ', "%20"));
     }
     
     @Test


### PR DESCRIPTION
I've been profiling jmeter memory allocation under different conditions
the PR linked to this bug gives substantial improvements.

Gain really depends on the test but in the worst case (compressed content, no embedded resources) it's about 15% less allocations (in bytes)
When not compressed (no embedded resources) and if content-length is sent by the server my test gives 30% reduction in bytes allocated
As always YMMV but this PR is always a win in all my different tests.

Reduction in memory allocated comes from
Better usage of ByteArrayOutputStream  by
- directly accessing the buffer instead of copying it
- or by using the commons-lang implementation which avoid copying memory around when extending the buffer
- or by creating the string directly from the buffer instead of a temporary copy

Avoid unneeded string concatenation due to missing log.isDebugEnabled()
if possible use httpclient CharArrayBuffer to avoid memory allocations
Do not create unneeded silent exceptions
Do not allocate 2 empty iterators on each call to executeSamplePackage
- LinkedList.iterator() is a stinky monkey. Also see HTTPCORE-361

Set better default size to StringBuilder buffers
improve JOrphanUtils#replaceAllChars : provides a fast path which does not allocate memory
etc..

**Remark** : 
When using ssl, jsse is a major source of unneeded allocation !!!!  (sun.security.ssl.SSLContextImpl#getDefaultCipherSuiteList(boolean))
https://bugs.openjdk.java.net/browse/JDK-8133070 should improve the situation (I did not test it)
the title of the bug is misleading as it's also about an internal cache beeing cleared on each method call.
