### PR TITLE
Bug 59885 Optimize css parsing for embedded resources download

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -997,6 +997,9 @@ beanshell.server.file=../extras/startup.bsh
 # ORO PatternCacheLRU size
 #oro.patterncache.size=1000
 
+# CSS parser LRU cache size
+#css.parser.cache.size=400
+
 #TestBeanGui
 #
 #propertyEditorSearchPath=null


### PR DESCRIPTION
the css parser is essential to test real world applications with
embedded resources download.
But it's heavy on cpu and memory allocations.

this commit add a lru cache which saves the url extracted from the css
file.
the key of the cache is the md5 of the css file.

the cache is not enabled by default (but should probably be)
To activate it, a value > 0 must be set for the key
'css.parser.cache.size' in the jmeter config file
