### PR TITLE
fixed garbled label in report dashboard 

### DIFF
--- a/src/core/org/apache/jmeter/report/core/CsvSampleReader.java
+++ b/src/core/org/apache/jmeter/report/core/CsvSampleReader.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.save.CSVSaveService;
@@ -45,8 +46,6 @@ public class CsvSampleReader implements Closeable{
 
     private static final Logger LOG = LoggingManager.getLoggerForClass();
     private static final int BUF_SIZE = 10000;
-
-    private static final String CHARSET = "ISO8859-1";
 
     private static final char DEFAULT_SEPARATOR =
             JMeterUtils.getPropDefault("jmeter.save.saveservice.default_delimiter", ",").charAt(0); //$NON-NLS-1$ //$NON-NLS-2$
@@ -101,8 +100,8 @@ public class CsvSampleReader implements Closeable{
         this.file = inputFile;
         try {
             this.reader = new BufferedReader(new InputStreamReader(
-                    new FileInputStream(file), CHARSET), BUF_SIZE);
-        } catch (FileNotFoundException | UnsupportedEncodingException ex) {
+                    new FileInputStream(file), StandardCharsets.UTF_8), BUF_SIZE);
+        } catch (FileNotFoundException ex) {
             throw new SampleException("Could not create file reader !", ex);
         }
         if (metadata == null) {

--- a/test/src/org/apache/jmeter/report/core/dashboard/DashboardGeneratorTest.java
+++ b/test/src/org/apache/jmeter/report/core/dashboard/DashboardGeneratorTest.java
@@ -1,7 +1,0 @@
-package org.apache.jmeter.report.core.dashboard;
-
-/**
- * Created by hzyiwei on 2016/8/4.
- */
-public class DashboardGeneratorTest {
-}

--- a/test/src/org/apache/jmeter/report/core/dashboard/DashboardGeneratorTest.java
+++ b/test/src/org/apache/jmeter/report/core/dashboard/DashboardGeneratorTest.java
@@ -1,0 +1,7 @@
+package org.apache.jmeter.report.core.dashboard;
+
+/**
+ * Created by hzyiwei on 2016/8/4.
+ */
+public class DashboardGeneratorTest {
+}


### PR DESCRIPTION
When there are some Chinese characters in the label, the content is all messed up. I change the BufferedReader to UTF-8 encoding. Now it works fine.
