### PR TITLE
Bug59945_DefaultGroovyEngineToJSR223ElementsV2

### DIFF
--- a/src/core/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/org/apache/jmeter/util/JSR223TestElement.java
@@ -90,8 +90,9 @@ public abstract class JSR223TestElement extends ScriptingTestElement
     protected ScriptEngine getScriptEngine() throws ScriptException {
         String lang = getScriptLanguage();
         
-        if (lang.isEmpty()) {
-            lang = defaultScriptLanguage;
+        if (StringUtils.isEmpty(lang)) {
+            lang = DEFAULT_SCRIPT_LANGUAGE;
+            setScriptLanguage(lang);
             log.warn("Script language has not been chosen on the UI: "+getName()+", the script will be interpreted as a groovy script");
         }
 

--- a/src/core/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/org/apache/jmeter/util/JSR223TestElement.java
@@ -93,7 +93,6 @@ public abstract class JSR223TestElement extends ScriptingTestElement
         if (StringUtils.isEmpty(lang)) {
             lang = DEFAULT_SCRIPT_LANGUAGE;
             setScriptLanguage(lang);
-            log.warn("Script language has not been chosen on the UI: "+getName()+", the script will be interpreted as a groovy script");
         }
 
         ScriptEngine scriptEngine = getInstance().getEngineByName(lang);

--- a/src/core/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/org/apache/jmeter/util/JSR223TestElement.java
@@ -92,7 +92,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
         
         if (lang.isEmpty()) {
             lang = defaultScriptLanguage;
-            log.warn("Script language has not been chosen on the UI, the script will be interpreted as a groovy script");
+            log.warn("Script language has not been chosen on the UI: "+getName()+", the script will be interpreted as a groovy script");
         }
 
         ScriptEngine scriptEngine = getInstance().getEngineByName(lang);

--- a/src/core/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/org/apache/jmeter/util/JSR223TestElement.java
@@ -66,6 +66,8 @@ public abstract class JSR223TestElement extends ScriptingTestElement
     }
     
     private static final long serialVersionUID = 233L;
+    
+    private static final Logger log = LoggingManager.getLoggerForClass();
 
     /** If not empty then script in ScriptText will be compiled and cached */
     private String cacheKey = "";
@@ -86,11 +88,16 @@ public abstract class JSR223TestElement extends ScriptingTestElement
     }
 
     protected ScriptEngine getScriptEngine() throws ScriptException {
-        final String lang = getScriptLanguage();
+        String lang = getScriptLanguage();
+        
+        if (lang.isEmpty()) {
+            lang = defaultScriptLanguage;
+            log.warn("Script language has not been chosen on the UI, the script will be interpreted as a groovy script");
+        }
 
         ScriptEngine scriptEngine = getInstance().getEngineByName(lang);
         if (scriptEngine == null) {
-            throw new ScriptException("Cannot find engine named: '"+lang+"', ensure you set language field in JSR223 Test Element:"+getName());
+            throw new ScriptException("Cannot find engine named: '"+lang+"', ensure you set language field in JSR223 Test Element: "+getName());
         }
 
         return scriptEngine;

--- a/src/core/org/apache/jmeter/util/ScriptingTestElement.java
+++ b/src/core/org/apache/jmeter/util/ScriptingTestElement.java
@@ -37,7 +37,7 @@ public abstract class ScriptingTestElement extends AbstractTestElement {
 
     protected String scriptLanguage = ""; // BSF/JSR223 language to use
     
-    protected String defaultScriptLanguage = "groovy"; // if no language is chosen in GUI
+    protected final static String defaultScriptLanguage = "groovy"; // if no language is chosen in GUI
     //-- For TestBean implementations only
 
     public ScriptingTestElement() {

--- a/src/core/org/apache/jmeter/util/ScriptingTestElement.java
+++ b/src/core/org/apache/jmeter/util/ScriptingTestElement.java
@@ -37,7 +37,7 @@ public abstract class ScriptingTestElement extends AbstractTestElement {
 
     protected String scriptLanguage = ""; // BSF/JSR223 language to use
     
-    protected final static String defaultScriptLanguage = "groovy"; // if no language is chosen in GUI
+    protected final static String DEFAULT_SCRIPT_LANGUAGE = "groovy"; // if no language is chosen in GUI
     //-- For TestBean implementations only
 
     public ScriptingTestElement() {

--- a/src/core/org/apache/jmeter/util/ScriptingTestElement.java
+++ b/src/core/org/apache/jmeter/util/ScriptingTestElement.java
@@ -36,6 +36,8 @@ public abstract class ScriptingTestElement extends AbstractTestElement {
     private String script = ""; // script (if file not provided)
 
     protected String scriptLanguage = ""; // BSF/JSR223 language to use
+    
+    protected String defaultScriptLanguage = "groovy"; // if no language is chosen in GUI
     //-- For TestBean implementations only
 
     public ScriptingTestElement() {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -117,6 +117,7 @@ Summary
 <ul>
     <li><bug>59803</bug>Use <code>isValid()</code> method from jdbc driver, if no validationQuery
     is given in JDBC Connection Configuration.</li>
+    <li><bug>59945</bug>For all JSR223 elements, if script language has not been chosen on the UI, the script will be interpreted as a groovy script.</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
Hi,

If the script language has not been chosen on the GUI, I propose to add
a WARN message into the log to inform that the script will be
interpreted as a groovy script

It's avoid message like "ERROR -
jmeter.protocol.java.sampler.JSR223Sampler: Problem in JSR223 script
Echantillon JSR223, message:javax.script.ScriptException: Cannot find
engine named: '', ensure you set language field in JSR223 Test
Element:Echantillon JSR223" and allow to execute the  script

Antonio
