### PR TITLE
Adds API to create JMeter threads on the fly

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -555,7 +555,7 @@
         JMeter version
         This is overridden for formal releases.
     -->
-    <property name="jmeter.version" value="3.1-SNAPSHOT"/>
+    <property name="jmeter.version" value="3.1"/>
     <!-- Remember to change "docversion" below if necessary -->
     <condition property="implementation.version"
           value="${jmeter.version} r${svn.revision}" else="${jmeter.version}.${DSTAMP}">

--- a/src/core/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -251,6 +251,8 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
 
     public abstract void start(int groupCount, ListenerNotifier notifier, ListedHashTree threadGroupTree, StandardJMeterEngine engine);
 
+    public abstract void addNewThread(int delay, StandardJMeterEngine engine);
+
     public abstract boolean verifyThreadsStopped();
 
     public abstract void waitThreadsStopped();

--- a/src/core/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -251,7 +251,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
 
     public abstract void start(int groupCount, ListenerNotifier notifier, ListedHashTree threadGroupTree, StandardJMeterEngine engine);
 
-    public abstract void addNewThread(int delay, StandardJMeterEngine engine);
+    public abstract JMeterThread addNewThread(int delay, StandardJMeterEngine engine);
 
     public abstract boolean verifyThreadsStopped();
 

--- a/src/core/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/org/apache/jmeter/threads/JMeterThread.java
@@ -51,6 +51,7 @@ import org.apache.jmeter.timers.Timer;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.collections.HashTreeTraverser;
+import org.apache.jorphan.collections.ListedHashTree;
 import org.apache.jorphan.collections.SearchByClass;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.util.JMeterStopTestException;
@@ -976,6 +977,14 @@ public class JMeterThread implements Runnable, Interruptible {
 
     public void setThreadGroup(AbstractThreadGroup group) {
         this.threadGroup = group;
+    }
+
+    public ListedHashTree getTestTree() {
+        return (ListedHashTree) testTree;
+    }
+
+    public ListenerNotifier getNotifier() {
+        return notifier;
     }
 
 }

--- a/src/core/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/org/apache/jmeter/threads/ThreadGroup.java
@@ -90,7 +90,7 @@ public class ThreadGroup extends AbstractThreadGroup {
      */
     private volatile boolean running = false;
 
-    private int numGroup;
+    private int groupNumber;
 
     /**
      * Are we using delayed startup?
@@ -280,15 +280,15 @@ public class ThreadGroup extends AbstractThreadGroup {
     }
 
     @Override
-    public void start(int groupCount, ListenerNotifier notifier, ListedHashTree threadGroupTree, StandardJMeterEngine engine) {
+    public void start(int groupNum, ListenerNotifier notifier, ListedHashTree threadGroupTree, StandardJMeterEngine engine) {
         running = true;
-        numGroup = groupCount;
+        groupNumber = groupNum;
         int numThreads = getNumThreads();
         int rampUpPeriodInSeconds = getRampUp();
         float perThreadDelayInMillis = ((float) (rampUpPeriodInSeconds * 1000) / (float) getNumThreads());
 
         delayedStartup = isDelayedStartup(); // Fetch once; needs to stay constant
-        log.info("Starting thread group number " + numGroup
+        log.info("Starting thread group number " + groupNumber
                 + " threads " + numThreads
                 + " ramp-up " + rampUpPeriodInSeconds
                 + " perThread " + perThreadDelayInMillis
@@ -305,7 +305,7 @@ public class ThreadGroup extends AbstractThreadGroup {
                 startNewThread(notifier, threadGroupTree, engine, threadNum, context, now, (int)(threadNum * perThreadDelayInMillis));
             }
         }
-        log.info("Started thread group number "+numGroup);
+        log.info("Started thread group number "+groupNumber);
     }
 
     /**
@@ -330,7 +330,7 @@ public class ThreadGroup extends AbstractThreadGroup {
         jmeterThread.setThreadNum(i);
         jmeterThread.setThreadGroup(this);
         jmeterThread.setInitialContext(context);
-        final String threadName = groupName + " " + (numGroup) + "-" + (i + 1);
+        final String threadName = groupName + " " + (groupNumber) + "-" + (i + 1);
         jmeterThread.setThreadName(threadName);
         jmeterThread.setEngine(engine);
         jmeterThread.setOnErrorStopTest(onErrorStopTest);
@@ -370,7 +370,7 @@ public class ThreadGroup extends AbstractThreadGroup {
             setNumThreads( numThread + 1 );
         }
         JMeterContextService.addTotalThreads( 1 );
-        log.info("Started new thread in group " + numGroup );
+        log.info("Started new thread in group " + groupNumber );
         return newJmThread;
     }
 

--- a/src/core/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/org/apache/jmeter/threads/ThreadGroup.java
@@ -340,7 +340,7 @@ public class ThreadGroup extends AbstractThreadGroup {
         return jmeterThread;
     }
 
-    private void startNewThread(ListenerNotifier notifier, ListedHashTree threadGroupTree, StandardJMeterEngine engine,
+    private JMeterThread startNewThread(ListenerNotifier notifier, ListedHashTree threadGroupTree, StandardJMeterEngine engine,
             int threadNum, final JMeterContext context, long now, int delay) {
         JMeterThread jmThread = makeThread(notifier, threadGroupTree, engine, threadNum, context);
         scheduleThread(jmThread, now); // set start and end time
@@ -348,10 +348,11 @@ public class ThreadGroup extends AbstractThreadGroup {
         Thread newThread = new Thread(jmThread, jmThread.getThreadName());
         registerStartedThread(jmThread, newThread);
         newThread.start();
+        return jmThread;
     }
 
     @Override
-    public void addNewThread(int delay, StandardJMeterEngine engine) {
+    public JMeterThread addNewThread(int delay, StandardJMeterEngine engine) {
 
         long now = System.currentTimeMillis();
 
@@ -362,13 +363,15 @@ public class ThreadGroup extends AbstractThreadGroup {
         ListedHashTree threadGroupTree = anyThread.getTestTree();
 
         JMeterContext context = JMeterContextService.getContext();
+        JMeterThread newJmThread;
         synchronized (addThreadLock) {
             int numThread =  getNumThreads();
-            startNewThread(notifier, threadGroupTree, engine, numThread, context, now, delay);
+            newJmThread = startNewThread(notifier, threadGroupTree, engine, numThread, context, now, delay);
             setNumThreads( numThread + 1 );
         }
         JMeterContextService.addTotalThreads( 1 );
         log.info("Started new thread in group " + numGroup );
+        return newJmThread;
     }
 
     /**


### PR DESCRIPTION
Adds a method in a thread group to add new threads dynamically.

Feature can be use to adjust thread count:

- in case of low load
- dynamic scenarii
- ...

To prevent code duplication, thread "make"/register/start has been moved to a new method, and a field has been added to track group number.