### PR TITLE
Allow table sorting

### DIFF
--- a/src/components/org/apache/jmeter/assertions/gui/AssertionGui.java
+++ b/src/components/org/apache/jmeter/assertions/gui/AssertionGui.java
@@ -385,7 +385,7 @@ public class AssertionGui extends AbstractAssertionGui {
     private JPanel createStringPanel() {
         tableModel = new PowerTableModel(new String[] { COL_RESOURCE_NAME }, new Class[] { String.class });
         stringTable = new JTable(tableModel);
-        stringTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(stringTable);
         stringTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         JMeterUtils.applyHiDPI(stringTable);
 

--- a/src/components/org/apache/jmeter/modifiers/gui/UserParametersGui.java
+++ b/src/components/org/apache/jmeter/modifiers/gui/UserParametersGui.java
@@ -161,21 +161,24 @@ public class UserParametersGui extends AbstractPreProcessorGui {
 
         initTableModel();
         paramTable.setModel(tableModel);
-        HeaderAsPropertyRenderer defaultRenderer = new HeaderAsPropertyRenderer(){
-            private static final long serialVersionUID = 240L;
+        TableCellRenderer defaultHeaderRenderer = paramTable.getTableHeader().getDefaultRenderer();
+        if (!(defaultHeaderRenderer instanceof HeaderAsPropertyRenderer)) {
+            HeaderAsPropertyRenderer defaultRenderer = new HeaderAsPropertyRenderer(defaultHeaderRenderer) {
+                private static final long serialVersionUID = 240L;
 
-            @Override
-            protected String getText(Object value, int row, int column) {
-                if (column >= 1){ // Don't process the NAME column
-                    String val = value.toString();
-                    if (val.startsWith(USER_COL_RESOURCE+UNDERSCORE)){
-                        return JMeterUtils.getResString(USER_COL_RESOURCE)+val.substring(val.indexOf(UNDERSCORE));
+                @Override
+                protected String getText(Object value, int row, int column) {
+                    if (column >= 1){ // Don't process the NAME column
+                        String val = value.toString();
+                        if (val.startsWith(USER_COL_RESOURCE+UNDERSCORE)){
+                            return JMeterUtils.getResString(USER_COL_RESOURCE)+val.substring(val.indexOf(UNDERSCORE));
+                        }
                     }
+                    return super.getText(value, row, column);
                 }
-                return super.getText(value, row, column);
-            }
-        };
-        paramTable.getTableHeader().setDefaultRenderer(defaultRenderer);
+            };
+            paramTable.getTableHeader().setDefaultRenderer(defaultRenderer);
+        }
         perIterationCheck.setSelected(false);
     }
 

--- a/src/components/org/apache/jmeter/visualizers/PropertyControlGui.java
+++ b/src/components/org/apache/jmeter/visualizers/PropertyControlGui.java
@@ -155,7 +155,7 @@ public class PropertyControlGui extends AbstractConfigGui implements
     private Component makeMainPanel() {
         initializeTableModel();
         table = new JTable(tableModel);
-        table.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(table);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         JMeterUtils.applyHiDPI(table);
         return makeScrollPane(table);

--- a/src/components/org/apache/jmeter/visualizers/SamplerResultTab.java
+++ b/src/components/org/apache/jmeter/visualizers/SamplerResultTab.java
@@ -420,8 +420,7 @@ public abstract class SamplerResultTab implements ResultRenderer {
         tableResHeaders.setToolTipText(JMeterUtils.getResString("textbox_tooltip_cell")); // $NON-NLS-1$
         tableResHeaders.addMouseListener(new TextBoxDoubleClick(tableResHeaders));
         setFirstColumnPreferredSize(tableResHeaders);
-        tableResHeaders.getTableHeader().setDefaultRenderer(
-                new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(tableResHeaders);
         RendererUtils.applyRenderers(tableResHeaders, RENDERERS_HEADERS);
 
         // Set up the 3rd table 
@@ -430,8 +429,7 @@ public abstract class SamplerResultTab implements ResultRenderer {
         tableResFields.setToolTipText(JMeterUtils.getResString("textbox_tooltip_cell")); // $NON-NLS-1$
         tableResFields.addMouseListener(new TextBoxDoubleClick(tableResFields));
         setFirstColumnPreferredSize(tableResFields);
-        tableResFields.getTableHeader().setDefaultRenderer(
-                new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(tableResFields);
         RendererUtils.applyRenderers(tableResFields, RENDERERS_FIELDS);
 
         // Prepare the Results tabbed pane

--- a/src/components/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -469,7 +469,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         myJTable = new JTable(model);
         JMeterUtils.applyHiDPI(myJTable);
         // Fix centering of titles
-        myJTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer(getColumnsMsgParameters()));
+        HeaderAsPropertyRenderer.install(myJTable, getColumnsMsgParameters());
         myJTable.setPreferredScrollableViewportSize(new Dimension(500, 70));
         RendererUtils.applyRenderers(myJTable, getRenderers());
         myScrollPane = new JScrollPane(myJTable);

--- a/src/components/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -319,8 +319,8 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
                 new Functor("getSentKBPerSecond") },            //$NON-NLS-1$
                 new Functor[] { null, null, null, null, null, null, null, null, null, null, null, null, null },
                 new Class[] { String.class, Long.class, Long.class, Long.class, Long.class, 
-                            Long.class, Long.class, Long.class, Long.class, String.class, 
-                            String.class, String.class, String.class});
+                            Long.class, Long.class, Long.class, Long.class, Double.class,
+                            Double.class, Double.class, Double.class});
     }
 
     // Column formats

--- a/src/components/org/apache/jmeter/visualizers/StatVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/StatVisualizer.java
@@ -48,6 +48,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.ObjectTableModel;
+import org.apache.jorphan.gui.ObjectTableSorter;
 import org.apache.jorphan.gui.RendererUtils;
 
 /**
@@ -172,6 +173,7 @@ public class StatVisualizer extends AbstractVisualizer implements Clearable, Act
         mainPanel.add(makeTitlePanel());
 
         myJTable = new JTable(model);
+        myJTable.setRowSorter(new ObjectTableSorter(model).fixLastRow());
         JMeterUtils.applyHiDPI(myJTable);
         HeaderAsPropertyRenderer.install(myJTable, StatGraphVisualizer.getColumnsMsgParameters());
         myJTable.setPreferredScrollableViewportSize(new Dimension(500, 70));

--- a/src/components/org/apache/jmeter/visualizers/StatVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/StatVisualizer.java
@@ -173,7 +173,7 @@ public class StatVisualizer extends AbstractVisualizer implements Clearable, Act
 
         myJTable = new JTable(model);
         JMeterUtils.applyHiDPI(myJTable);
-        myJTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer(StatGraphVisualizer.getColumnsMsgParameters()));
+        HeaderAsPropertyRenderer.install(myJTable, StatGraphVisualizer.getColumnsMsgParameters());
         myJTable.setPreferredScrollableViewportSize(new Dimension(500, 70));
         RendererUtils.applyRenderers(myJTable, StatGraphVisualizer.getRenderers());
         myScrollPane = new JScrollPane(myJTable);

--- a/src/components/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/org/apache/jmeter/visualizers/SummaryReport.java
@@ -240,7 +240,7 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
 
         myJTable = new JTable(model);
         JMeterUtils.applyHiDPI(myJTable);
-        myJTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(myJTable);
         myJTable.setPreferredScrollableViewportSize(new Dimension(500, 70));
         RendererUtils.applyRenderers(myJTable, RENDERERS);
         myScrollPane = new JScrollPane(myJTable);

--- a/src/components/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/org/apache/jmeter/visualizers/SummaryReport.java
@@ -53,6 +53,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.gui.ObjectTableModel;
+import org.apache.jorphan.gui.ObjectTableSorter;
 import org.apache.jorphan.gui.RateRenderer;
 import org.apache.jorphan.gui.RendererUtils;
 import org.apache.jorphan.reflect.Functor;
@@ -158,8 +159,8 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
                     new Functor("getAvgPageBytes"),       //$NON-NLS-1$
                 },
                 new Functor[] { null, null, null, null, null, null, null, null , null, null, null },
-                new Class[] { String.class, Long.class, Long.class, Long.class, Long.class,
-                              String.class, String.class, String.class, String.class, String.class, String.class });
+                new Class[] { String.class, Integer.class, Long.class, Long.class, Long.class,
+                              Double.class, Double.class, Double.class, Double.class, Double.class, Double.class });
         clearData();
         init();
     }
@@ -239,6 +240,7 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
         mainPanel.add(makeTitlePanel());
 
         myJTable = new JTable(model);
+        myJTable.setRowSorter(new ObjectTableSorter(model).fixLastRow());
         JMeterUtils.applyHiDPI(myJTable);
         HeaderAsPropertyRenderer.install(myJTable);
         myJTable.setPreferredScrollableViewportSize(new Dimension(500, 70));

--- a/src/components/org/apache/jmeter/visualizers/TableVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/TableVisualizer.java
@@ -185,10 +185,10 @@ public class TableVisualizer extends AbstractVisualizer implements Clearable {
                     calc.addSample(res);
                     int count = calc.getCount();
                     TableSample newS = new TableSample(
-                            count, 
-                            res.getSampleCount(), 
-                            res.getStartTime(), 
-                            res.getThreadName(), 
+                            count,
+                            res.getSampleCount(),
+                            res.getStartTime(),
+                            res.getThreadName(),
                             res.getSampleLabel(),
                             res.getTime(),
                             res.isSuccessful(),
@@ -239,7 +239,7 @@ public class TableVisualizer extends AbstractVisualizer implements Clearable {
         // Set up the table itself
         table = new JTable(model);
         JMeterUtils.applyHiDPI(table);
-        table.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(table);
         RendererUtils.applyRenderers(table, RENDERERS);
 
         tableScrollPanel = new JScrollPane(table);

--- a/src/components/org/apache/jmeter/visualizers/TableVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/TableVisualizer.java
@@ -23,6 +23,7 @@ import java.awt.Color;
 import java.awt.FlowLayout;
 import java.text.Format;
 import java.text.SimpleDateFormat;
+import java.util.Comparator;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -45,6 +46,7 @@ import org.apache.jmeter.util.Calculator;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.ObjectTableModel;
+import org.apache.jorphan.gui.ObjectTableSorter;
 import org.apache.jorphan.gui.RendererUtils;
 import org.apache.jorphan.gui.RightAlignRenderer;
 import org.apache.jorphan.gui.layout.VerticalLayout;
@@ -238,6 +240,7 @@ public class TableVisualizer extends AbstractVisualizer implements Clearable {
 
         // Set up the table itself
         table = new JTable(model);
+        table.setRowSorter(new ObjectTableSorter(model).setValueComparator(5, Comparator.nullsFirst(SampleSucessComparator.INSTANCE)));
         JMeterUtils.applyHiDPI(table);
         HeaderAsPropertyRenderer.install(table);
         RendererUtils.applyRenderers(table, RENDERERS);
@@ -321,6 +324,24 @@ public class TableVisualizer extends AbstractVisualizer implements Clearable {
         // Add the main panel and the graph
         this.add(mainPanel, BorderLayout.NORTH);
         this.add(tablePanel, BorderLayout.CENTER);
+    }
+
+    public static enum SampleSucessComparator implements Comparator<ImageIcon> {
+        INSTANCE;
+
+        @Override
+        public int compare(ImageIcon o1, ImageIcon o2) {
+            if (o1 == o2) {
+                return 0;
+            }
+            if (o1 == imageSuccess) {
+                return -1;
+            }
+            if (o1 == imageFailure) {
+                return 1;
+            }
+            throw new IllegalArgumentException("Only success and failure images can be compared");
+        }
     }
 
     public static class SampleSuccessFunctor extends Functor {

--- a/src/core/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -616,7 +616,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
     private Component makeMainPanel() {
         initializeTableModel();
         table = new JTable(tableModel);
-        table.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(table);
         table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         if (this.background != null) {
             table.setBackground(this.background);

--- a/src/core/org/apache/jmeter/config/gui/SimpleConfigGui.java
+++ b/src/core/org/apache/jmeter/config/gui/SimpleConfigGui.java
@@ -202,7 +202,7 @@ public class SimpleConfigGui extends AbstractConfigGui implements ActionListener
 
         table = new JTable(tableModel);
         JMeterUtils.applyHiDPI(table);
-        table.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(table);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         return makeScrollPane(table);
     }

--- a/src/core/org/apache/jmeter/gui/util/HeaderAsPropertyRenderer.java
+++ b/src/core/org/apache/jmeter/gui/util/HeaderAsPropertyRenderer.java
@@ -19,54 +19,52 @@
 package org.apache.jmeter.gui.util;
 
 import java.awt.Component;
+import java.io.Serializable;
 import java.text.MessageFormat;
 
 import javax.swing.JTable;
-import javax.swing.SwingConstants;
-import javax.swing.UIManager;
-import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
 
 import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * Renders items in a JTable by converting from resource names.
  */
-public class HeaderAsPropertyRenderer extends DefaultTableCellRenderer {
+public class HeaderAsPropertyRenderer implements TableCellRenderer, Serializable {
 
     private static final long serialVersionUID = 240L;
     private Object[][] columnsMsgParameters;
 
-    /**
-     * 
-     */
-    public HeaderAsPropertyRenderer() {
-        this(null);
+    private TableCellRenderer delegate;
+
+    public static void install(JTable table) {
+        install(table, null);
     }
-    
+
+    public static void install(JTable table, Object[][] columnsMsgParameters) {
+        TableCellRenderer defaultRenderer = table.getTableHeader().getDefaultRenderer();
+        if (!(defaultRenderer instanceof HeaderAsPropertyRenderer)) {
+            HeaderAsPropertyRenderer newRenderer = new HeaderAsPropertyRenderer(defaultRenderer, columnsMsgParameters);
+            table.getTableHeader().setDefaultRenderer(newRenderer);
+        }
+    }
+
     /**
      * @param columnsMsgParameters Optional parameters of i18n keys
      */
-    public HeaderAsPropertyRenderer(Object[][] columnsMsgParameters) {
-        super();
+    public HeaderAsPropertyRenderer(TableCellRenderer renderer, Object[][] columnsMsgParameters) {
+        this(renderer);
         this.columnsMsgParameters = columnsMsgParameters;
+    }
+
+    public HeaderAsPropertyRenderer(TableCellRenderer renderer) {
+        this.delegate = renderer;
     }
 
     @Override
     public Component getTableCellRendererComponent(JTable table, Object value,
             boolean isSelected, boolean hasFocus, int row, int column) {
-        if (table != null) {
-            JTableHeader header = table.getTableHeader();
-            if (header != null){
-                setForeground(header.getForeground());
-                setBackground(header.getBackground());
-                setFont(header.getFont());
-            }
-            setText(getText(value, row, column));
-            setBorder(UIManager.getBorder("TableHeader.cellBorder"));
-            setHorizontalAlignment(SwingConstants.CENTER);
-        }
-        return this;
+        return delegate.getTableCellRendererComponent(table, getText(value, row, column), isSelected, hasFocus, row, column);
     }
 
     /**

--- a/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
+++ b/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
@@ -49,7 +49,7 @@ public class ObjectTableModel extends DefaultTableModel {
     private transient ArrayList<Functor> writeFunctors = new ArrayList<>();
 
     private transient Class<?> objectClass = null; // if provided
-    
+
     private transient boolean cellEditable = true;
 
     /**
@@ -66,7 +66,7 @@ public class ObjectTableModel extends DefaultTableModel {
         this(headers, readFunctors, writeFunctors, editorClasses);
         this.objectClass=_objClass;
     }
-    
+
     /**
      * The ObjectTableModel is a TableModel whose rows are objects;
      * columns are defined as Functors on the object.
@@ -78,7 +78,7 @@ public class ObjectTableModel extends DefaultTableModel {
      * @param editorClasses - class for each column
      * @param cellEditable - if cell must editable (false to allow double click on cell)
      */
-    public ObjectTableModel(String[] headers, Class<?> _objClass, Functor[] readFunctors, 
+    public ObjectTableModel(String[] headers, Class<?> _objClass, Functor[] readFunctors,
             Functor[] writeFunctors, Class<?>[] editorClasses, boolean cellEditable) {
         this(headers, readFunctors, writeFunctors, editorClasses);
         this.objectClass=_objClass;
@@ -289,7 +289,7 @@ public class ObjectTableModel extends DefaultTableModel {
         return status;
     }
 
-    public Object getObjectList() { // used by TableEditor
+    public List<Object> getObjectList() { // used by TableEditor
         return objects;
     }
 

--- a/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
+++ b/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.swing.event.TableModelEvent;
 import javax.swing.table.DefaultTableModel;
 
 import org.apache.jorphan.logging.LoggingManager;
@@ -134,9 +133,8 @@ public class ObjectTableModel extends DefaultTableModel {
     }
 
     public void clearData() {
-        int size = getRowCount();
         objects.clear();
-        super.fireTableRowsDeleted(0, size);
+        super.fireTableDataChanged();
     }
 
     public void addRow(Object value) {
@@ -149,12 +147,12 @@ public class ObjectTableModel extends DefaultTableModel {
             }
         }
         objects.add(value);
-        super.fireTableRowsInserted(objects.size() - 1, objects.size());
+        super.fireTableRowsInserted(objects.size() - 1, objects.size() - 1);
     }
 
     public void insertRow(Object value, int index) {
         objects.add(index, value);
-        super.fireTableRowsInserted(index, index + 1);
+        super.fireTableRowsInserted(index, index);
     }
 
     /** {@inheritDoc} */
@@ -202,12 +200,11 @@ public class ObjectTableModel extends DefaultTableModel {
     /** {@inheritDoc} */
     @Override
     public void moveRow(int start, int end, int to) {
-        List<Object> subList = new ArrayList<>(objects.subList(start, end));
-        for (int x = end - 1; x >= start; x--) {
-            objects.remove(x);
-        }
-        objects.addAll(to, subList);
-        super.fireTableChanged(new TableModelEvent(this));
+        List<Object> subList = objects.subList(start, end);
+        List<Object> backup  = new ArrayList<>(subList);
+        subList.clear();
+        objects.addAll(to, backup);
+        super.fireTableDataChanged();
     }
 
     /** {@inheritDoc} */

--- a/src/jorphan/org/apache/jorphan/gui/ObjectTableSorter.java
+++ b/src/jorphan/org/apache/jorphan/gui/ObjectTableSorter.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui;
+
+import static java.lang.String.format;
+
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
+
+public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
+
+    /**
+     * View row with model mapping. All data relates to model.
+     */
+    public class Row {
+        private int index;
+
+        protected Row(int index) {
+            this.index = index;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public Object getValue() {
+            return getModel().getObjectList().get(getIndex());
+        }
+
+        public Object getValueAt(int column) {
+            return getModel().getValueAt(getIndex(), column);
+        }
+    }
+
+    protected class PreserveLastRowComparator implements Comparator<Row> {
+        @Override
+        public int compare(Row o1, Row o2) {
+            int lastIndex = model.getRowCount() - 1;
+            if (o1.getIndex() >= lastIndex || o2.getIndex() >= lastIndex) {
+                return o1.getIndex() - o2.getIndex();
+            }
+            return 0;
+        }
+    }
+
+    private ObjectTableModel model;
+    private SortKey sortkey;
+
+    private Comparator<Row> comparator  = null;
+    private ArrayList<Row>  viewToModel = new ArrayList<>();
+    private int[]           modelToView = new int[0];
+
+    private Comparator<Row>  primaryComparator = null;
+    private Comparator<?>[]  valueComparators;
+    private Comparator<Row>  fallbackComparator;
+
+    public ObjectTableSorter(ObjectTableModel model) {
+        this.model = model;
+
+        this.valueComparators = new Comparator<?>[this.model.getColumnCount()];
+        IntStream.range(0, this.valueComparators.length).forEach(i -> this.setValueComparator(i, null));
+
+        setFallbackComparator(null);
+    }
+
+    /**
+     * Comparator used prior to sorted columns.
+     */
+    public Comparator<Row> getPrimaryComparator() {
+        return primaryComparator;
+    }
+
+    /**
+     * Comparator used on sorted columns.
+     */
+    public Comparator<?> getValueComparator(int column) {
+        return valueComparators[column];
+    }
+
+    /**
+     * Comparator if all sorted columns matches. Defaults to model index comparison.
+     */
+    public Comparator<Row> getFallbackComparator() {
+        return fallbackComparator;
+    }
+
+    /**
+     * Comparator used prior to sorted columns.
+     * @return <code>this</code>
+     */
+    public ObjectTableSorter setPrimaryComparator(Comparator<Row> primaryComparator) {
+      invalidate();
+      this.primaryComparator = primaryComparator;
+      return this;
+    }
+
+    /**
+     * Sets {@link #getPrimaryComparator() primary comparator} to one that don't sort last row.
+     * @return <code>this</code>
+     */
+    public ObjectTableSorter fixLastRow() {
+        return setPrimaryComparator(new PreserveLastRowComparator());
+    }
+
+    /**
+     * Assign comparator to given column, if <code>null</code> a {@link #getDefaultComparator(int) default one} is used instead.
+     * @param column Model column index.
+     * @param comparator Column value comparator.
+     * @return <code>this</code>
+     */
+    public ObjectTableSorter setValueComparator(int column, Comparator<?> comparator) {
+        invalidate();
+        if (comparator == null) {
+            comparator = getDefaultComparator(column);
+        }
+        valueComparators[column] = comparator;
+        return this;
+    }
+
+    /**
+     * Builds a default comparator based on model column class. {@link Collator#getInstance()} for {@link String},
+     * {@link Comparator#naturalOrder() natural order} for {@link Comparable}, no sort support for others.
+     * @param column Model column index.
+     */
+    protected Comparator<?> getDefaultComparator(int column) {
+        Class<?> columnClass = model.getColumnClass(column);
+        if (columnClass == null) {
+            return null;
+        }
+        if (columnClass == String.class) {
+            return Comparator.nullsFirst(Collator.getInstance());
+        }
+        if (Comparable.class.isAssignableFrom(columnClass)) {
+            return Comparator.nullsFirst(Comparator.naturalOrder());
+        }
+        return null;
+    }
+
+    /**
+     * Sets a fallback comparator (defaults to model index comparison) if none {@link #getPrimaryComparator() primary}, neither {@link #getValueComparator(int) column value comparators} can make differences between two rows.
+     * @return <code>this</code>
+     */
+    public ObjectTableSorter setFallbackComparator(Comparator<Row> comparator) {
+        invalidate();
+        if (comparator == null) {
+            comparator = Comparator.comparingInt(Row::getIndex);
+        }
+        fallbackComparator = comparator;
+        return this;
+    }
+
+    @Override
+    public ObjectTableModel getModel() {
+        return model;
+    }
+
+    @Override
+    public void toggleSortOrder(int column) {
+        SortKey newSortKey;
+        if (isSortable(column)) {
+            SortOrder newOrder = sortkey == null || sortkey.getColumn() != column
+                    || sortkey.getSortOrder() != SortOrder.ASCENDING ? SortOrder.ASCENDING : SortOrder.DESCENDING;
+            newSortKey = new SortKey(column, newOrder);
+        } else {
+            newSortKey = null;
+        }
+        setSortKey(newSortKey);
+    }
+
+    @Override
+    public int convertRowIndexToModel(int index) {
+        if (!isSorted()) {
+            return index;
+        }
+        validate();
+        return viewToModel.get(index).getIndex();
+    }
+
+    @Override
+    public int convertRowIndexToView(int index) {
+        if (!isSorted()) {
+            return index;
+        }
+        validate();
+        return modelToView[index];
+    }
+
+    @Override
+    public void setSortKeys(List<? extends SortKey> keys) {
+        switch (keys.size()) {
+            case 0:
+                setSortKey(null);
+                break;
+            case 1:
+                setSortKey(keys.get(0));
+                break;
+            default:
+                throw new IllegalArgumentException("Only one column can be sorted");
+        }
+    }
+
+    public void setSortKey(SortKey sortkey) {
+        if (Objects.equals(this.sortkey, sortkey)) {
+            return;
+        }
+
+        invalidate();
+        if (sortkey != null) {
+            int column = sortkey.getColumn();
+            Comparator<?> comparator = valueComparators[column];
+            if (comparator == null) {
+                throw new IllegalArgumentException(format("Can't sort column %s, it is mapped to type %s and this one have no natural order. So an explicit one must be specified", column, model.getColumnClass(column)));
+            }
+        }
+        this.sortkey    = sortkey;
+        this.comparator = null;
+    }
+
+    @Override
+    public List<? extends SortKey> getSortKeys() {
+        return isSorted() ? Collections.singletonList(sortkey) : Collections.emptyList();
+    }
+
+    @Override
+    public int getViewRowCount() {
+        return getModelRowCount();
+    }
+
+    @Override
+    public int getModelRowCount() {
+        return model.getRowCount();
+    }
+
+    @Override
+    public void modelStructureChanged() {
+        setSortKey(null);
+    }
+
+    @Override
+    public void allRowsChanged() {
+        invalidate();
+    }
+
+    @Override
+    public void rowsInserted(int firstRow, int endRow) {
+        rowsChanged(firstRow, endRow, false, true);
+    }
+
+    @Override
+    public void rowsDeleted(int firstRow, int endRow) {
+        rowsChanged(firstRow, endRow, true, false);
+    }
+
+    @Override
+    public void rowsUpdated(int firstRow, int endRow) {
+        rowsChanged(firstRow, endRow, true, true);
+    }
+
+    protected void rowsChanged(int firstRow, int endRow, boolean deleted, boolean inserted) {
+        invalidate();
+    }
+
+    @Override
+    public void rowsUpdated(int firstRow, int endRow, int column) {
+        if (isSorted(column)) {
+            rowsUpdated(firstRow, endRow);
+        }
+    }
+
+    protected boolean isSortable(int column) {
+        return getValueComparator(column) != null;
+    }
+
+    protected boolean isSorted(int column) {
+        return isSorted() && sortkey.getColumn() == column && sortkey.getSortOrder() != SortOrder.UNSORTED;
+    }
+
+    protected boolean isSorted() {
+        return sortkey != null;
+    }
+
+    protected void invalidate() {
+      viewToModel.clear();
+      modelToView = new int[0];
+    }
+
+    protected void validate() {
+      if (isSorted() && viewToModel.isEmpty()) {
+          sort();
+      }
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    protected Comparator<Row> getComparatorFromSortKey(SortKey sortkey) {
+        Comparator comparator = getValueComparator(sortkey.getColumn());
+        if (sortkey.getSortOrder() == SortOrder.DESCENDING) {
+            comparator = comparator.reversed();
+        }
+        Function<Row,Object> getValueAt = (Row row) -> row.getValueAt(sortkey.getColumn());
+        return Comparator.comparing(getValueAt, comparator);
+    }
+
+    protected void sort() {
+        if (comparator == null) {
+            comparator = Stream.concat(
+                    Stream.concat(
+                            getPrimaryComparator() != null ? Stream.of(getPrimaryComparator()) : Stream.<Comparator<Row>>empty(),
+                            getSortKeys().stream().filter(sk -> sk != null && sk.getSortOrder() != SortOrder.UNSORTED).map(this::getComparatorFromSortKey)
+                    ),
+                    Stream.of(getFallbackComparator())
+            ).reduce(comparator, (result, current) -> result != null ? result.thenComparing(current) : current);
+        }
+
+        viewToModel.clear();
+        viewToModel.ensureCapacity(model.getRowCount());
+        IntStream.range(0, model.getRowCount()).mapToObj(i -> new Row(i)).forEach(viewToModel::add);
+        Collections.sort(viewToModel, comparator);
+
+        updateModelToView();
+    }
+
+    protected void updateModelToView() {
+        modelToView = new int[viewToModel.size()];
+        IntStream.range(0, viewToModel.size()).forEach(viewIndex -> modelToView[viewToModel.get(viewIndex).getIndex()] = viewIndex);
+    }
+}

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/AuthPanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/AuthPanel.java
@@ -265,7 +265,7 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
         // create the JTable that holds auth per row
         authTable = new JTable(tableModel);
         JMeterUtils.applyHiDPI(authTable);
-        authTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(authTable);
         authTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         authTable.setPreferredScrollableViewportSize(new Dimension(100, 70));
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/CookiePanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/CookiePanel.java
@@ -378,7 +378,7 @@ public class CookiePanel extends AbstractConfigGui implements ActionListener {
         // create the JTable that holds one cookie per row
         cookieTable = new JTable(tableModel);
         JMeterUtils.applyHiDPI(cookieTable);
-        cookieTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(cookieTable);
         cookieTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         cookieTable.setPreferredScrollableViewportSize(new Dimension(100, 70));
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/HTTPFileArgsPanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/HTTPFileArgsPanel.java
@@ -310,7 +310,7 @@ public class HTTPFileArgsPanel extends JPanel implements ActionListener {
         initializeTableModel();
         table = new JTable(tableModel);
         JMeterUtils.applyHiDPI(table);
-        table.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(table);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         return makeScrollPane(table);
     }

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
@@ -272,7 +272,7 @@ public class HeaderPanel extends AbstractConfigGui implements ActionListener
         // create the JTable that holds header per row
         headerTable = new JTable(tableModel);
         JMeterUtils.applyHiDPI(headerTable);
-        headerTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(headerTable);
         headerTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         headerTable.setPreferredScrollableViewportSize(new Dimension(100, 70));
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -864,7 +864,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         includeModel = new PowerTableModel(new String[] { INCLUDE_COL }, new Class[] { String.class });
         includeTable = new JTable(includeModel);
         JMeterUtils.applyHiDPI(includeTable);
-        includeTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(includeTable);
         includeTable.setPreferredScrollableViewportSize(new Dimension(100, 30));
 
         JPanel panel = new JPanel(new BorderLayout());
@@ -881,7 +881,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         excludeModel = new PowerTableModel(new String[] { EXCLUDE_COL }, new Class[] { String.class });
         excludeTable = new JTable(excludeModel);
         JMeterUtils.applyHiDPI(excludeTable);
-        excludeTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(excludeTable);
         excludeTable.setPreferredScrollableViewportSize(new Dimension(100, 30));
 
         JPanel panel = new JPanel(new BorderLayout());

--- a/src/protocol/http/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -382,7 +382,7 @@ public class RequestViewHTTP implements RequestView {
         tableParams.addMouseListener(new TextBoxDoubleClick(tableParams));
         TableColumn column = tableParams.getColumnModel().getColumn(0);
         column.setPreferredWidth(160);
-        tableParams.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(tableParams);
         RendererUtils.applyRenderers(tableParams, RENDERERS_PARAMS);
 
         // Set up the 3rd table 
@@ -391,8 +391,7 @@ public class RequestViewHTTP implements RequestView {
         tableHeaders.setToolTipText(JMeterUtils.getResString("textbox_tooltip_cell")); // $NON-NLS-1$
         tableHeaders.addMouseListener(new TextBoxDoubleClick(tableHeaders));
         setFirstColumnPreferredAndMaxWidth(tableHeaders);
-        tableHeaders.getTableHeader().setDefaultRenderer(
-                new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(tableHeaders);
         RendererUtils.applyRenderers(tableHeaders, RENDERERS_HEADERS);
 
         // Create the split pane

--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
@@ -186,7 +186,7 @@ public class JMSPropertiesPanel extends JPanel implements ActionListener {
         // create the JTable that holds JMSProperty per row
         jmsPropertiesTable = new JTable(tableModel);
         JMeterUtils.applyHiDPI(jmsPropertiesTable);
-        jmsPropertiesTable.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(jmsPropertiesTable);
         jmsPropertiesTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         jmsPropertiesTable.setPreferredScrollableViewportSize(new Dimension(100, 70));
 

--- a/src/protocol/ldap/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
+++ b/src/protocol/ldap/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
@@ -287,7 +287,7 @@ public class LDAPArgumentsPanel extends AbstractConfigGui implements ActionListe
         initializeTableModel();
         table = new JTable(tableModel);
         JMeterUtils.applyHiDPI(table);
-        table.getTableHeader().setDefaultRenderer(new HeaderAsPropertyRenderer());
+        HeaderAsPropertyRenderer.install(table);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         return makeScrollPane(table);
     }

--- a/test/src/org/apache/jorphan/gui/ObjectTableModelTest.java
+++ b/test/src/org/apache/jorphan/gui/ObjectTableModelTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui;
+
+import static java.lang.String.format;
+import static java.util.stream.IntStream.range;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import javax.swing.event.TableModelEvent;
+
+import org.apache.jorphan.reflect.Functor;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ObjectTableModelTest {
+
+    public static class Dummy {
+        String a;
+        String b;
+        String c;
+
+        Dummy(String a, String b, String c) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+
+        public String getA() {
+            return a;
+        }
+
+        public String getB() {
+            return b;
+        }
+
+        public String getC() {
+            return c;
+        }
+    }
+
+    ObjectTableModel model;
+    TableModelEventBacker events;
+
+    @Before
+    public void init() {
+        String[] headers = { "a", "b", "c" };
+        Functor[] readFunctors = Arrays.stream(headers).map(name -> "get" + name.toUpperCase()).map(Functor::new).toArray(n -> new Functor[n]);
+        Functor[] writeFunctors = new Functor[headers.length];
+        Class<?>[] editorClasses = new Class<?>[headers.length];
+        Arrays.fill(editorClasses, String.class);
+        model = new ObjectTableModel(headers, readFunctors, writeFunctors, editorClasses);
+        events = new TableModelEventBacker();
+    }
+
+    @Test
+    public void checkAddRow() {
+        model.addTableModelListener(events);
+
+        assertModel();
+
+        model.addRow(new Dummy("1", "1", "1"));
+        assertModel("1");
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.INSERT)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(0)
+                    .lastRow(0)
+        );
+
+        model.addRow(new Dummy("2", "1", "1"));
+        assertModel("1", "2");
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.INSERT)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(1)
+                    .lastRow(1)
+        );
+    }
+
+    @Test
+    public void checkClear() {
+        // Arrange
+        for (int i = 0; i < 5; i++) {
+            model.addRow(new Dummy("" + i, "" + i%2, "" + i%3));
+        }
+        assertModelRanges(range(0,5));
+
+        // Act
+        model.addTableModelListener(events);
+        model.clearData();
+
+        // Assert
+        assertModelRanges();
+
+
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.UPDATE)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(0)
+                    .lastRow(Integer.MAX_VALUE)
+        );
+    }
+
+    @Test
+    public void checkInsertRow() {
+        assertModel();
+        model.addRow(new Dummy("3", "1", "1"));
+        assertModel("3");
+        model.addTableModelListener(events);
+
+        model.insertRow(new Dummy("1", "1", "1"), 0);
+        assertModel("1", "3");
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.INSERT)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(0)
+                    .lastRow(0)
+       );
+
+       model.insertRow(new Dummy("2", "1", "1"), 1);
+       assertModel("1", "2", "3");
+       events.assertEvents(
+               events.assertEvent()
+                   .source(model)
+                   .type(TableModelEvent.INSERT)
+                   .column(TableModelEvent.ALL_COLUMNS)
+                   .firstRow(1)
+                   .lastRow(1)
+      );
+
+
+    }
+
+    @Test
+    public void checkMoveRow_from_5_11_to_0() {
+        // Arrange
+        for (int i = 0; i < 20; i++) {
+            model.addRow(new Dummy("" + i, "" + i%2, "" + i%3));
+        }
+        assertModelRanges(range(0, 20));
+
+        // Act
+        model.addTableModelListener(events);
+        model.moveRow(5, 11, 0);
+
+        // Assert
+        assertModelRanges(range(5, 11), range(0, 5), range(11, 20));
+
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.UPDATE)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(0)
+                    .lastRow(Integer.MAX_VALUE)
+        );
+    }
+
+    @Test
+    public void checkMoveRow_from_0_6_to_0() {
+        // Arrange
+        for (int i = 0; i < 20; i++) {
+            model.addRow(new Dummy("" + i, "" + i%2, "" + i%3));
+        }
+        assertModelRanges(range(0, 20));
+
+        // Act
+        model.addTableModelListener(events);
+        model.moveRow(0, 6, 0);
+
+        // Assert
+        assertModelRanges(range(0, 20));
+
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.UPDATE)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(0)
+                    .lastRow(Integer.MAX_VALUE)
+        );
+    }
+
+    @Test
+    public void checkMoveRow_from_0_6_to_10() {
+        // Arrange
+        for (int i = 0; i < 20; i++) {
+            model.addRow(new Dummy("" + i, "" + i%2, "" + i%3));
+        }
+        assertModelRanges(range(0, 20));
+
+        // Act
+        model.addTableModelListener(events);
+        model.moveRow(0, 6, 10);
+
+        // Assert
+        assertModelRanges(range(6, 16), range(0, 6), range(16, 20));
+
+        events.assertEvents(
+                events.assertEvent()
+                    .source(model)
+                    .type(TableModelEvent.UPDATE)
+                    .column(TableModelEvent.ALL_COLUMNS)
+                    .firstRow(0)
+                    .lastRow(Integer.MAX_VALUE)
+        );
+    }
+
+    private void assertModelRanges(IntStream... ranges) {
+        IntStream ints = IntStream.empty();
+        for (IntStream range : ranges) {
+            ints = IntStream.concat(ints, range);
+        }
+        assertModel(ints.mapToObj(i -> "" + i).toArray(n -> new String[n]));
+    }
+
+    private void assertModel(String... as) {
+        assertEquals("model row count", as.length, model.getRowCount());
+
+        for (int row = 0; row < as.length; row++) {
+            assertEquals(format("model[%d,0]", row), as[row], model.getValueAt(row, 0));
+        }
+    }
+
+}

--- a/test/src/org/apache/jorphan/gui/ObjectTableSorterTest.java
+++ b/test/src/org/apache/jorphan/gui/ObjectTableSorterTest.java
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.swing.RowSorter.SortKey;
+import javax.swing.SortOrder;
+
+import org.apache.jorphan.reflect.Functor;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.junit.rules.ExpectedException;
+
+public class ObjectTableSorterTest {
+    ObjectTableModel  model;
+    ObjectTableSorter sorter;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    @Rule
+    public ErrorCollector errorCollector = new ErrorCollector();
+
+    @Before
+    public void createModelAndSorter() {
+        String[] headers         = { "key", "value", "object" };
+        Functor[] readFunctors   = { new Functor("getKey"), new Functor("getValue"), new Functor("getValue") };
+        Functor[] writeFunctors  = { null, null, null };
+        Class<?>[] editorClasses = { String.class, Integer.class, Object.class };
+        model                    = new ObjectTableModel(headers, readFunctors, writeFunctors, editorClasses);
+        sorter                   = new ObjectTableSorter(model);
+        List<Entry<String,Integer>> data = asList(b2(), a3(), d4(), c1());
+        data.forEach(model::addRow);
+    }
+
+    @Test
+    public void noSorting() {
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(b2(), a3(), d4(), c1());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void sortKeyAscending() {
+        sorter.setSortKey(new SortKey(0, SortOrder.ASCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(a3(), b2(), c1(), d4());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void sortKeyDescending() {
+        sorter.setSortKey(new SortKey(0, SortOrder.DESCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(d4(), c1(), b2(), a3());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void sortValueAscending() {
+        sorter.setSortKey(new SortKey(1, SortOrder.ASCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(c1(), b2(), a3(), d4());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void sortValueDescending() {
+        sorter.setSortKey(new SortKey(1, SortOrder.DESCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(d4(), a3(), b2(), c1());
+        assertRowOrderAndIndexes(expected);
+    }
+
+
+    @Test
+    public void fixLastRowWithAscendingKey() {
+        sorter.fixLastRow().setSortKey(new SortKey(0, SortOrder.ASCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(a3(), b2(), d4(), c1());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void fixLastRowWithDescendingKey() {
+        sorter.fixLastRow().setSortKey(new SortKey(0, SortOrder.DESCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(d4(), b2(), a3(), c1());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void fixLastRowWithAscendingValue() {
+        sorter.fixLastRow().setSortKey(new SortKey(1, SortOrder.ASCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(b2(), a3(), d4(), c1());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void fixLastRowWithDescendingValue() {
+        sorter.fixLastRow().setSortKey(new SortKey(1, SortOrder.DESCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(d4(), a3(), b2(), c1());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void customKeyOrder() {
+        HashMap<String, Integer> customKeyOrder = asList("a", "c", "b", "d").stream().reduce(new HashMap<String,Integer>(), (map,key) -> { map.put(key, map.size()); return map; }, (a,b) -> a);
+        Comparator<String> customKeyComparator = (a,b) -> customKeyOrder.get(a).compareTo(customKeyOrder.get(b));
+        sorter.setValueComparator(0, customKeyComparator).setSortKey(new SortKey(0, SortOrder.ASCENDING));
+        List<SimpleImmutableEntry<String, Integer>> expected = asList(a3(), c1(), b2(), d4());
+        assertRowOrderAndIndexes(expected);
+    }
+
+    @Test
+    public void getDefaultComparatorForNullClass() {
+        ObjectTableModel model = new ObjectTableModel(new String[] { "null" }, new Functor[] { null }, new Functor[] { null }, new Class<?>[] { null });
+        ObjectTableSorter sorter = new ObjectTableSorter(model);
+
+        assertThat(sorter.getValueComparator(0), is(nullValue()));
+    }
+
+    @Test
+    public void getDefaultComparatorForStringClass() {
+        ObjectTableModel model = new ObjectTableModel(new String[] { "string" }, new Functor[] { null }, new Functor[] { null }, new Class<?>[] { String.class });
+        ObjectTableSorter sorter = new ObjectTableSorter(model);
+
+        assertThat(sorter.getValueComparator(0), is(CoreMatchers.notNullValue()));
+    }
+
+    @Test
+    public void getDefaultComparatorForIntegerClass() {
+        ObjectTableModel model = new ObjectTableModel(new String[] { "integer" }, new Functor[] { null }, new Functor[] { null }, new Class<?>[] { Integer.class });
+        ObjectTableSorter sorter = new ObjectTableSorter(model);
+
+        assertThat(sorter.getValueComparator(0), is(CoreMatchers.notNullValue()));
+    }
+
+    @Test
+    public void getDefaultComparatorForObjectClass() {
+        ObjectTableModel model = new ObjectTableModel(new String[] { "integer" }, new Functor[] { null }, new Functor[] { null }, new Class<?>[] { Object.class });
+        ObjectTableSorter sorter = new ObjectTableSorter(model);
+
+        assertThat(sorter.getValueComparator(0), is(nullValue()));
+    }
+
+    @Test
+    public void toggleSortOrder_none() {
+        assertSame(emptyList(), sorter.getSortKeys());
+    }
+
+    @Test
+    public void toggleSortOrder_0() {
+        sorter.toggleSortOrder(0);
+        assertEquals(singletonList(new SortKey(0, SortOrder.ASCENDING)), sorter.getSortKeys());
+    }
+
+    @Test
+    public void toggleSortOrder_0_1() {
+        sorter.toggleSortOrder(0);
+        sorter.toggleSortOrder(1);
+        assertEquals(singletonList(new SortKey(1, SortOrder.ASCENDING)), sorter.getSortKeys());
+    }
+
+    @Test
+    public void toggleSortOrder_0_0() {
+        sorter.toggleSortOrder(0);
+        sorter.toggleSortOrder(0);
+        assertEquals(singletonList(new SortKey(0, SortOrder.DESCENDING)), sorter.getSortKeys());
+    }
+
+    @Test
+    public void toggleSortOrder_0_0_0() {
+        sorter.toggleSortOrder(0);
+        sorter.toggleSortOrder(0);
+        sorter.toggleSortOrder(0);
+        assertEquals(singletonList(new SortKey(0, SortOrder.ASCENDING)), sorter.getSortKeys());
+    }
+
+    @Test
+    public void toggleSortOrder_2() {
+        sorter.toggleSortOrder(2);
+        assertSame(emptyList(), sorter.getSortKeys());
+    }
+
+    @Test
+    public void toggleSortOrder_0_2() {
+        sorter.toggleSortOrder(0);
+        sorter.toggleSortOrder(2);
+        assertSame(emptyList(), sorter.getSortKeys());
+    }
+
+    @Test
+    public void setSortKeys_none() {
+        sorter.setSortKeys(new ArrayList<>());
+        assertSame(Collections.emptyList(), sorter.getSortKeys());
+    }
+
+    @Test
+    public void setSortKeys_withSortedThenUnsorted() {
+        sorter.setSortKeys(singletonList(new SortKey(0, SortOrder.ASCENDING)));
+        sorter.setSortKeys(new ArrayList<>());
+        assertSame(Collections.emptyList(), sorter.getSortKeys());
+    }
+
+    @Test
+    public void setSortKeys_single() {
+        List<SortKey> keys = singletonList(new SortKey(0, SortOrder.ASCENDING));
+        sorter.setSortKeys(keys);
+        assertThat(sorter.getSortKeys(), allOf(  is(not(sameInstance(keys))),  is(equalTo(keys)) ));
+    }
+
+    @Test
+    public void setSortKeys_many() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        sorter.setSortKeys(asList(new SortKey(0, SortOrder.ASCENDING), new SortKey(1, SortOrder.ASCENDING)));
+    }
+
+    @Test
+    public void setSortKeys_invalidColumn() {
+        expectedException.expect(IllegalArgumentException.class);
+
+        sorter.setSortKeys(Collections.singletonList(new SortKey(2, SortOrder.ASCENDING)));
+    }
+
+
+    @SuppressWarnings("unchecked")
+    protected List<Entry<String,Integer>> actual() {
+        return IntStream
+                .range(0, sorter.getViewRowCount())
+                .map(sorter::convertRowIndexToModel)
+                .mapToObj(modelIndex -> (Entry<String,Integer>) sorter.getModel().getObjectList().get(modelIndex))
+                .collect(Collectors.toList())
+                ;
+    }
+
+    protected SimpleImmutableEntry<String, Integer> d4() {
+        return new AbstractMap.SimpleImmutableEntry<>("d",  4);
+    }
+
+    protected SimpleImmutableEntry<String, Integer> c1() {
+        return new AbstractMap.SimpleImmutableEntry<>("c",  1);
+    }
+
+    protected SimpleImmutableEntry<String, Integer> b2() {
+        return new AbstractMap.SimpleImmutableEntry<>("b",  2);
+    }
+
+    protected SimpleImmutableEntry<String, Integer> a3() {
+        return new AbstractMap.SimpleImmutableEntry<>("a",  3);
+    }
+
+    protected void assertRowOrderAndIndexes(List<SimpleImmutableEntry<String, Integer>> expected) {
+        assertEquals(expected, actual());
+        assertRowIndexes();
+    }
+
+    protected void assertRowIndexes() {
+        IntStream
+            .range(0, sorter.getViewRowCount())
+            .forEach(viewIndex -> {
+                int modelIndex = sorter.convertRowIndexToModel(viewIndex);
+                errorCollector.checkThat(format("view(%d) model(%d)", viewIndex, modelIndex),
+                        sorter.convertRowIndexToView(modelIndex),
+                        CoreMatchers.equalTo(viewIndex));
+            });
+
+    }
+}

--- a/test/src/org/apache/jorphan/gui/TableModelEventBacker.java
+++ b/test/src/org/apache/jorphan/gui/TableModelEventBacker.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.ObjIntConsumer;
+import java.util.function.ToIntFunction;
+
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
+
+public class TableModelEventBacker implements TableModelListener {
+
+    public class EventAssertion {
+        private List<ObjIntConsumer<TableModelEvent>> assertions = new ArrayList<>();
+
+        public EventAssertion add(ObjIntConsumer<TableModelEvent> assertion) {
+            assertions.add(assertion);
+            return this;
+        }
+
+        public EventAssertion addInt(String name, int expected, ToIntFunction<TableModelEvent> f) {
+            return add((e,i) -> assertEquals(format("%s[%d]", name, i), expected, f.applyAsInt(e)));
+        }
+
+        public EventAssertion source(Object expected) {
+            return add((e,i) -> assertSame(format("source[%d]",i), expected, e.getSource()));
+        }
+
+        public EventAssertion type(int expected) {
+            return addInt("type", expected, TableModelEvent::getType);
+        }
+
+        public EventAssertion column(int expected) {
+            return addInt("column", expected, TableModelEvent::getColumn);
+        }
+
+        public EventAssertion firstRow(int expected) {
+            return addInt("firstRow", expected, TableModelEvent::getFirstRow);
+        }
+
+        public EventAssertion lastRow(int expected) {
+            return addInt("lastRow", expected, TableModelEvent::getLastRow);
+        }
+
+        protected void assertEvent(TableModelEvent e, int i) {
+            assertions.forEach(a -> a.accept(e, i));
+        }
+    }
+
+    private Deque<TableModelEvent> events = new LinkedList<>();
+
+    @Override
+    public void tableChanged(TableModelEvent e) {
+        events.add(e);
+    }
+
+    public Deque<TableModelEvent> getEvents() {
+        return events;
+    }
+
+    public EventAssertion assertEvent() {
+        return new EventAssertion();
+    }
+
+    public void assertEvents(EventAssertion... assertions) {
+        assertEquals("event count", assertions.length, events.size());
+
+        int i = 0;
+        for (TableModelEvent event : events) {
+            assertions[i].assertEvent(event, i++);
+        }
+
+        events.clear();
+    }
+
+
+}


### PR DESCRIPTION
It is a PR about [Bugzilla ID 52962](https://bz.apache.org/bugzilla/show_bug.cgi?id=52962)

PR is cut into many commits for each required step for full implementation. Final commit enables sorting for aggregate report, view results in table and summary report.

Any table relying on `ObjectTableModel` must be supported.