### PR TITLE
Feature/bz60564 (1)

### DIFF
--- a/src/protocol/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
@@ -44,9 +44,9 @@ import org.apache.jmeter.protocol.java.sampler.JavaSamplerClient;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.reflect.ClassFinder;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The <code>JavaConfigGui</code> class provides the user interface for the
@@ -57,7 +57,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ActionListener {
     private static final long serialVersionUID = 240L;
 
     /** Logging */
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JavaConfigGui.class);
 
     /** A combo box allowing the user to choose a test class. */
     private JComboBox<String> classnameCombo;

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/AbstractJavaSamplerClient.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/AbstractJavaSamplerClient.java
@@ -19,8 +19,9 @@
 package org.apache.jmeter.protocol.java.sampler;
 
 import org.apache.jmeter.config.Arguments;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * An abstract implementation of the JavaSamplerClient interface. This
@@ -52,7 +53,7 @@ import org.apache.log.Logger;
  */
 public abstract class AbstractJavaSamplerClient implements JavaSamplerClient {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AbstractJavaSamplerClient.class);
 
     /* Implements JavaSamplerClient.setupTest(JavaSamplerContext) */
     @Override

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BSFSampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BSFSampler.java
@@ -37,8 +37,8 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.BSFTestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A sampler which understands BSF
@@ -51,7 +51,7 @@ public class BSFSampler extends BSFTestElement implements Sampler, TestBean, Con
 
     private static final long serialVersionUID = 240L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(BSFSampler.class);
 
     public BSFSampler() {
         super();

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
@@ -31,9 +31,9 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.BeanShellTestElement;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.util.JMeterException;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A sampler which understands BeanShell
@@ -44,7 +44,7 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
             Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));
     
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(BeanShellSampler.class);
 
     private static final long serialVersionUID = 3;
 

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -35,8 +35,8 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JSR223TestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampler, TestBean, ConfigMergabilityIndicator {
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
@@ -44,7 +44,7 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
 
     private static final long serialVersionUID = 234L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JSR223Sampler.class);
 
     @Override
     public SampleResult sample(Entry entry) {

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JavaSampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JavaSampler.java
@@ -34,8 +34,8 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.property.TestElementProperty;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A sampler for executing custom Java code in each sample. See
@@ -45,7 +45,7 @@ import org.apache.log.Logger;
  */
 public class JavaSampler extends AbstractSampler implements TestStateListener, Interruptible {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JavaSampler.class);
 
     private static final long serialVersionUID = 232L; // Remember to change this when the class changes ...
 

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JavaSamplerContext.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JavaSamplerContext.java
@@ -22,8 +22,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.jmeter.config.Arguments;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JavaSamplerContext is used to provide context information to a
@@ -46,7 +46,7 @@ public class JavaSamplerContext {
      */
 
     /** Logging */
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JavaSamplerContext.class);
 
     /**
      * Map containing the initialization parameters for the JavaSamplerClient.

--- a/src/protocol/java/org/apache/jmeter/protocol/java/test/JavaTest.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/test/JavaTest.java
@@ -28,8 +28,8 @@ import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.Interruptible;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The <code>JavaTest</code> class is a simple sampler which is intended for
@@ -70,7 +70,7 @@ import org.apache.log.Logger;
 
 public class JavaTest extends AbstractJavaSamplerClient implements Serializable, Interruptible {
 
-    private static final Logger LOG = LoggingManager.getLoggerForClass();
+    private static final Logger LOG = LoggerFactory.getLogger(JavaTest.class);
 
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/java/org/apache/jmeter/protocol/java/test/SleepTest.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/test/SleepTest.java
@@ -27,8 +27,8 @@ import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.Interruptible;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The <code>SleepTest</code> class is a simple example class for a JMeter
@@ -50,7 +50,7 @@ import org.apache.log.Logger;
  */
 public class SleepTest extends AbstractJavaSamplerClient implements Serializable, Interruptible {
 
-    private static final Logger LOG = LoggingManager.getLoggerForClass();
+    private static final Logger LOG = LoggerFactory.getLogger(SleepTest.class);
 
     private static final long serialVersionUID = 240L;
 

--- a/src/slf4j-logkit/org/apache/jmeter/logging/LogkitLoggerFactory.java
+++ b/src/slf4j-logkit/org/apache/jmeter/logging/LogkitLoggerFactory.java
@@ -30,6 +30,9 @@ import org.slf4j.Logger;
  * @since 3.0
  */
 public class LogkitLoggerFactory implements ILoggerFactory {
+
+    private static final String PACKAGE_PREFIX = "org.apache."; //$NON_NLS-1$
+
     // key: name (String), value: a Log4jLogger;
     private final Map<String, Logger> loggerMap;
 
@@ -58,12 +61,25 @@ public class LogkitLoggerFactory implements ILoggerFactory {
                 if (name.equalsIgnoreCase(Logger.ROOT_LOGGER_NAME)) {
                     logkitLogger = Hierarchy.getDefaultHierarchy().getRootLogger();
                 } else {
-                    logkitLogger = Hierarchy.getDefaultHierarchy().getLoggerFor(name);
+                    logkitLogger = Hierarchy.getDefaultHierarchy().getLoggerFor(removePrefix(name));
                 }
                 slf4jLogger = new LogkitLoggerAdapter(logkitLogger);
                 loggerMap.put(name, slf4jLogger);
             }
         }
         return slf4jLogger;
+    }
+
+    /**
+     * Removes the standard prefix, i.e. "org.apache.".
+     *
+     * @param name from which to remove the prefix
+     * @return the name with the prefix removed
+     */
+    private static String removePrefix(String name){
+        if (name.startsWith(PACKAGE_PREFIX)) { // remove the package prefix
+            name = name.substring(PACKAGE_PREFIX.length());
+        }
+        return name;
     }
 }


### PR DESCRIPTION
This is the first pull request for https://bz.apache.org/bugzilla/show_bug.cgi?id=60564.
This PR contains only slf4j migration in ```protocol/java``` component for easier review/merging.

The minor change in ```LogkitLoggerFactory.java``` in this PR is necessary for the following reasons:
- ```LoggingManager``` always removes the package prefix, ```org.apache.```, in the logger category name, while ```LogkitLoggerFactory.java``` hasn't used the same category name pattern, but used FQCN so far.
- Because of this difference, after replacing logs with slf4j logger, the ```BatchTestLocal``` test should always fail because it keeps ```INFO``` level log lines in ```bin/BatchTestLocal.log``` even if ```bin/testfiles/jmeter-batch.properties``` contains ```log_level.jmeter=WARN```. This is caused by the fact that slf4j logger uses FQCN logger category name and so it uses the default INFO log level instead of the overridden WARN level in ```bin/testfiles/jmeter-batch.properties```.

I also have a doubt in keeping a logger cache in ```LogkitLoggerFactory```, but that's out of scope. The factory can be removed in the end or revisited later anyway with a new bz ticket.

Please take a review.