### PR TITLE
BZ60590

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1290,6 +1290,9 @@ system.properties=system.properties
 # Number of threads to use to validate a Thread Group
 #testplan_validation.nb_threads_per_thread_group=1
 
+# Ignore BackendListener when validating the thread group of plan
+#testplan_validation.ignore_backends=true
+
 # Ignore timers when validating the thread group of plan
 #testplan_validation.ignore_timers=true
 

--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1293,9 +1293,6 @@ system.properties=system.properties
 # Ignore timers when validating the thread group of plan
 #testplan_validation.ignore_timers=true
 
-# Ignore BackendListener when validating the thread group of plan
-#testplan_validation.ignore_backend=true
-
 # Number of iterations to use to validate a Thread Group
 #testplan_validation.number_iterations=1
 

--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1293,6 +1293,9 @@ system.properties=system.properties
 # Ignore timers when validating the thread group of plan
 #testplan_validation.ignore_timers=true
 
+# Ignore BackendListener when validating the thread group of plan
+#testplan_validation.ignore_backend=true
+
 # Number of iterations to use to validate a Thread Group
 #testplan_validation.number_iterations=1
 

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
@@ -48,7 +48,7 @@ import org.apache.log.Logger;
  * @since 2.13
  */
 public class BackendListener extends AbstractTestElement
-    implements Serializable, SampleListener, TestStateListener, NoThreadClone, Remoteable  {
+    implements Backend, Serializable, SampleListener, TestStateListener, NoThreadClone, Remoteable  {
 
     /**
      * 

--- a/src/components/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -301,8 +301,8 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
                         .fieldToStringValue(application) + "\"");
 
         scheduler = Executors.newScheduledThreadPool(MAX_POOL_SIZE);
-        // Start scheduler and put the pooling ( 5 seconds by default )
-        this.timerHandle = scheduler.scheduleAtFixedRate(this, SEND_INTERVAL, SEND_INTERVAL, TimeUnit.SECONDS);
+        // Start immediately the scheduler and put the pooling ( 5 seconds by default )
+        this.timerHandle = scheduler.scheduleAtFixedRate(this, 0, SEND_INTERVAL, TimeUnit.SECONDS);
 
     }
 

--- a/src/components/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -96,6 +96,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
     private Map<String, Float> koPercentiles;
     private Map<String, Float> allPercentiles;
     private String testTitle;
+    private String testTags;
     // Name of the application tested
     private String application = "";
 
@@ -264,6 +265,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         measurement = AbstractInfluxdbMetricsSender
                 .tagToStringValue(context.getParameter("measurement", DEFAULT_MEASUREMENT));
         testTitle = context.getParameter("testTitle", "Test");
+        testTags = AbstractInfluxdbMetricsSender.tagToStringValue(context.getParameter("eventTags", "TestTags"));
         String percentilesAsString = context.getParameter("percentiles", "");
         String[] percentilesStringArray = percentilesAsString.split(SEPARATOR);
         okPercentiles = new HashMap<>(percentilesStringArray.length);
@@ -291,14 +293,16 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         influxdbMetricsManager.setup(influxdbUrl);
         samplersToFilter = Pattern.compile(samplersRegex);
 
-        // Annotation of the start of the run ( usefull with Grafana )
-        // Never double or single quotes in influxdb except for string field
-        // see : https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_reference/#quoting-special-characters-and-additional-naming-guidelines
-        influxdbMetricsManager.addMetric(EVENTS_FOR_ANNOTATION, TAG_APPLICATION + application + ",title=ApacheJMeter", 
+        /* Annotation of the start of the run ( usefull with Grafana )
+        * Grafana will let you send HTML in the “Text” such as a link to the release notes
+        * Tags are separated by spaces in grafana
+        * Tags is put as InfluxdbTag for better query performance on it
+        * Never double or single quotes in influxdb except for string field
+        * see : https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_reference/#quoting-special-characters-and-additional-naming-guidelines
+        */
+        influxdbMetricsManager.addMetric(EVENTS_FOR_ANNOTATION, TAG_APPLICATION + application + ",title=ApacheJMeter,tags="+ testTags, 
                         "text=\"" +  AbstractInfluxdbMetricsSender
-                        .fieldToStringValue(testTitle + " started") + "\"" 
-                        + ",tags=\"" + AbstractInfluxdbMetricsSender
-                        .fieldToStringValue(application) + "\"");
+                        .fieldToStringValue(testTitle + " started") + "\"" );
 
         scheduler = Executors.newScheduledThreadPool(MAX_POOL_SIZE);
         // Start immediately the scheduler and put the pooling ( 5 seconds by default )
@@ -335,14 +339,17 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
             LOGGER.error("Error waiting for end of scheduler");
             Thread.currentThread().interrupt();
         }
-        // Annotation of the end of the run ( usefull with Grafana )
-        // Never double or single quotes in influxdb except for string field
-        // see : https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_reference/#quoting-special-characters-and-additional-naming-guidelines
-        influxdbMetricsManager.addMetric(EVENTS_FOR_ANNOTATION, TAG_APPLICATION + application + ",title=ApacheJMeter", 
-                "text=\"" +  AbstractInfluxdbMetricsSender
-                .fieldToStringValue(testTitle + " ended") + "\""
-                + ",tags=\"" + AbstractInfluxdbMetricsSender
-                .fieldToStringValue(application) + "\"");
+        
+        /* Annotation of the end of the run ( usefull with Grafana )
+        * Grafana will let you send HTML in the “Text” such as a link to the release notes
+        * Tags are separated by spaces in grafana
+        * Tags is put as InfluxdbTag for better query performance on it
+        * Never double or single quotes in influxdb except for string field
+        * see : https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_reference/#quoting-special-characters-and-additional-naming-guidelines
+        */
+        influxdbMetricsManager.addMetric(EVENTS_FOR_ANNOTATION, TAG_APPLICATION + application + ",title=ApacheJMeter,tags="+ testTags, 
+                        "text=\"" +  AbstractInfluxdbMetricsSender
+                        .fieldToStringValue(testTitle + " ended") + "\"" );
 
 
         
@@ -365,6 +372,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         arguments.addArgument("samplersRegex", ".*");
         arguments.addArgument("percentiles", "99,95,90");
         arguments.addArgument("testTitle", "Test name");
+        arguments.addArgument("eventTags", "TagName");
         return arguments;
     }
 }

--- a/src/core/org/apache/jmeter/gui/action/validation/TreeClonerForValidation.java
+++ b/src/core/org/apache/jmeter/gui/action/validation/TreeClonerForValidation.java
@@ -24,7 +24,6 @@ import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.threads.ThreadGroup;
 import org.apache.jmeter.timers.Timer;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jmeter.visualizers.backend.BackendListener;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 
@@ -44,11 +43,6 @@ public class TreeClonerForValidation extends TreeCloner {
      * Ignore or not timers during a Thread Group validation
      */
     protected static final boolean VALIDATION_IGNORE_TIMERS = JMeterUtils.getPropDefault("testplan_validation.ignore_timers", true); //$NON-NLS-1$
-    
-    /**
-     * Ignore or not BackendListener during a Thread Group validation
-     */
-    protected static final boolean VALIDATION_IGNORE_BACKENDS = JMeterUtils.getPropDefault("testplan_validation.ignore_backends", true); //$NON-NLS-1$
 
     /**
      * Number of iterations to run during a Thread Group validation
@@ -76,8 +70,8 @@ public class TreeClonerForValidation extends TreeCloner {
      */
     @Override
     protected Object addNodeToTree(Object node) {
-        if( (VALIDATION_IGNORE_TIMERS && node instanceof Timer) || (VALIDATION_IGNORE_BACKENDS && node instanceof BackendListener) ) {
-            return node; // don't add timer or BackendListener node
+        if(VALIDATION_IGNORE_TIMERS && node instanceof Timer) {
+            return node; // don't add the timer
         } else {
             Object clonedNode = super.addNodeToTree(node);
             if(clonedNode instanceof org.apache.jmeter.threads.ThreadGroup) {

--- a/src/core/org/apache/jmeter/gui/action/validation/TreeClonerForValidation.java
+++ b/src/core/org/apache/jmeter/gui/action/validation/TreeClonerForValidation.java
@@ -24,6 +24,7 @@ import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.threads.ThreadGroup;
 import org.apache.jmeter.timers.Timer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.visualizers.backend.BackendListener;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 
@@ -43,6 +44,11 @@ public class TreeClonerForValidation extends TreeCloner {
      * Ignore or not timers during a Thread Group validation
      */
     protected static final boolean VALIDATION_IGNORE_TIMERS = JMeterUtils.getPropDefault("testplan_validation.ignore_timers", true); //$NON-NLS-1$
+    
+    /**
+     * Ignore or not BackendListener during a Thread Group validation
+     */
+    protected static final boolean VALIDATION_IGNORE_BACKENDS = JMeterUtils.getPropDefault("testplan_validation.ignore_backends", true); //$NON-NLS-1$
 
     /**
      * Number of iterations to run during a Thread Group validation
@@ -70,8 +76,8 @@ public class TreeClonerForValidation extends TreeCloner {
      */
     @Override
     protected Object addNodeToTree(Object node) {
-        if(VALIDATION_IGNORE_TIMERS && node instanceof Timer) {
-            return node; // don't add the timer
+        if( (VALIDATION_IGNORE_TIMERS && node instanceof Timer) || (VALIDATION_IGNORE_BACKENDS && node instanceof BackendListener) ) {
+            return node; // don't add timer or BackendListener node
         } else {
             Object clonedNode = super.addNodeToTree(node);
             if(clonedNode instanceof org.apache.jmeter.threads.ThreadGroup) {

--- a/src/core/org/apache/jmeter/gui/action/validation/TreeClonerForValidation.java
+++ b/src/core/org/apache/jmeter/gui/action/validation/TreeClonerForValidation.java
@@ -24,6 +24,7 @@ import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.threads.ThreadGroup;
 import org.apache.jmeter.timers.Timer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.visualizers.backend.Backend;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 
@@ -39,10 +40,16 @@ public class TreeClonerForValidation extends TreeCloner {
      * Number of Threads to configure when running a Thread Group during a validation
      */
     protected static final int VALIDATION_NUMBER_OF_THREADS = JMeterUtils.getPropDefault("testplan_validation.nb_threads_per_thread_group", 1); //$NON-NLS-1$
+    
     /**
      * Ignore or not timers during a Thread Group validation
      */
     protected static final boolean VALIDATION_IGNORE_TIMERS = JMeterUtils.getPropDefault("testplan_validation.ignore_timers", true); //$NON-NLS-1$
+    
+    /**
+     * Ignore or not Backend during a Thread Group validation
+     */
+    protected static final boolean VALIDATION_IGNORE_BACKENDS = JMeterUtils.getPropDefault("testplan_validation.ignore_backends", true); //$NON-NLS-1$
 
     /**
      * Number of iterations to run during a Thread Group validation
@@ -70,8 +77,8 @@ public class TreeClonerForValidation extends TreeCloner {
      */
     @Override
     protected Object addNodeToTree(Object node) {
-        if(VALIDATION_IGNORE_TIMERS && node instanceof Timer) {
-            return node; // don't add the timer
+        if((VALIDATION_IGNORE_TIMERS && node instanceof Timer) || (VALIDATION_IGNORE_BACKENDS && node instanceof Backend)) {
+            return node; // don't add timer or backend
         } else {
             Object clonedNode = super.addNodeToTree(node);
             if(clonedNode instanceof org.apache.jmeter.threads.ThreadGroup) {

--- a/src/core/org/apache/jmeter/visualizers/backend/Backend.java
+++ b/src/core/org/apache/jmeter/visualizers/backend/Backend.java
@@ -1,0 +1,7 @@
+package org.apache.jmeter.visualizers.backend;
+
+import java.io.Serializable;
+
+public interface Backend extends Serializable {
+
+}


### PR DESCRIPTION
This PR has 3 new changes for the Backend Listener : 

- Start the scheduler for the InfluxdbListener immediately to send start annotation even if the test take less than 5 sec.
- Add a new parameter in the Influxdb Backend to put tags. ( i.e  Tags are separated by spaces in grafana )
Tags is put as Influxdb Tag for better query performance on it
- Add new option in jmeter.properties to ignore BackendListener when validating the thread group of plan