### PR TITLE
Clear querystring args on each call to setPath

### DIFF
--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -443,7 +443,9 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     /**
      * Sets the PATH property; if the request is a GET or DELETE (and the path
      * does not start with http[s]://) it also calls {@link #parseArguments(String, String)}
-     * to extract and store any query arguments.
+     * to extract and store any query arguments, clearing any previously stored query
+     * arguments in the process. This method should always be called before any calls to
+     * {@link #addArgument(String, String)} and related functions.
      *
      * @param path
      *            The new Path value
@@ -457,6 +459,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             int index = path.indexOf(QRY_PFX);
             if (index > -1) {
                 setProperty(PATH, path.substring(0, index));
+                // Zero out the arguments, so we don't include query strings from previous calls
+                getArguments().clear();
                 // Parse the arguments in querystring, assuming specified encoding for values
                 parseArguments(path.substring(index + 1), contentEncoding);
             } else {

--- a/test/src/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplers.java
+++ b/test/src/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplers.java
@@ -160,10 +160,10 @@ public class TestHTTPSamplers {
             HTTPSamplerBase config = new HTTPNullSampler();
             config.setProtocol("http");
             config.setMethod(HTTPConstants.GET);
-            config.addArgument("param1", "value1");
             config.setPath("/index.html?p1=p2");
+            config.addArgument("param1", "value1");
             config.setDomain("192.168.0.1");
-            assertEquals("http://192.168.0.1/index.html?param1=value1&p1=p2", config.getUrl().toString());
+            assertEquals("http://192.168.0.1/index.html?p1=p2&param1=value1", config.getUrl().toString());
         }
 
         @Test
@@ -259,7 +259,26 @@ public class TestHTTPSamplers {
             config.setDomain("192.168.0.1");
             assertEquals("http://192.168.0.1/index.html", config.getUrl().toString());
         }
-        
+
+        @Test
+        public void testClearGetArgumentsOnSetPath() throws Exception {
+            HTTPSamplerBase config = new HTTPNullSampler();
+            config.setProtocol("http");
+            config.setMethod(HTTPConstants.GET);
+            config.setPath("/first.html?p1=v1");
+            config.addArgument("param2", "value2");
+            config.setDomain("192.168.0.1");
+            assertEquals("http://192.168.0.1/first.html?p1=v1&param2=value2", config.getUrl().toString());
+            config.setPath("/second.html?p3=v3");
+            config.addArgument("param4", "value4");
+            assertEquals("http://192.168.0.1/second.html?p3=v3&param4=value4", config.getUrl().toString());
+            // WARNING!! This WILL NOT be added to the querystring arguments
+            config.addArgument("param5", "value5");
+            config.setPath("/third.html?p6=v6");
+            assertEquals("http://192.168.0.1/third.html?p6=v6", config.getUrl().toString());
+        }
+
+
         @Test
         public void testFileList(){
             HTTPSamplerBase config = new HTTPNullSampler();


### PR DESCRIPTION
I use the `HTTPSamplerBase` class as a base class for an HTTP sampler class. I recently found a bug with the way handling of query strings is implemented. Specifically, each call to `setPath()` on the sampler adds the query string arguments to the current set of query string arguments. That means calling `setPath()` multiple times accumulates all the query string arguments.

From the source code:
```java
    // src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java:453
    public void setPath(String path, String contentEncoding) {
        boolean fullUrl = path.startsWith(HTTP_PREFIX) || path.startsWith(HTTPS_PREFIX);
        boolean getOrDelete = HTTPConstants.GET.equals(getMethod()) || HTTPConstants.DELETE.equals(getMethod());
        if (!fullUrl && getOrDelete) {
            int index = path.indexOf(QRY_PFX);
            if (index > -1) {
                setProperty(PATH, path.substring(0, index));
                // Parse the arguments in querystring, assuming specified encoding for values
                parseArguments(path.substring(index + 1), contentEncoding);
            } else {
                setProperty(PATH, path);
            }
        } else {
            setProperty(PATH, path);
        }
    }
```

As you can see, if there's a query string, it calls {{parseArguments}} to set the query string. That function just adds every argument to the sampler's arguments, whether it exists or not:
```java
    // src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java:1090
    public void parseArguments(String queryString, String contentEncoding) {
        String[] args = JOrphanUtils.split(queryString, QRY_SEP);
        final boolean isDebug = log.isDebugEnabled();
        for (String arg : args) {
            if (isDebug) {
                log.debug("Arg: " + arg);
            }
            // need to handle four cases:
            // - string contains name=value
            // - string contains name=
            // - string contains name
            // - empty string

            String metaData; // records the existence of an equal sign
            String name;
            String value;
            int length = arg.length();
            int endOfNameIndex = arg.indexOf(ARG_VAL_SEP);
            if (endOfNameIndex != -1) {// is there a separator?
                // case of name=value, name=
                metaData = ARG_VAL_SEP;
                name = arg.substring(0, endOfNameIndex);
                value = arg.substring(endOfNameIndex + 1, length);
            } else {
                metaData = "";
                name = arg;
                value = "";
            }
            if (name.length() > 0) {
                if (isDebug) {
                    log.debug("Name: " + name + " Value: " + value + " Metadata: " + metaData);
                }
                // If we know the encoding, we can decode the argument value,
                // to make it easier to read for the user
                if (!StringUtils.isEmpty(contentEncoding)) {
                    addEncodedArgument(name, value, metaData, contentEncoding);
                } else {
                    // If we do not know the encoding, we just use the encoded value
                    // The browser has already done the encoding, so save the values as is
                    addNonEncodedArgument(name, value, metaData);
                }
            }
        }
    }
```

My solution is very simple -- just clear the arguments before the call to `parseArguments`:
```java
    // src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java:453
    public void setPath(String path, String contentEncoding) {
        boolean fullUrl = path.startsWith(HTTP_PREFIX) || path.startsWith(HTTPS_PREFIX);
        boolean getOrDelete = HTTPConstants.GET.equals(getMethod()) || HTTPConstants.DELETE.equals(getMethod());
        if (!fullUrl && getOrDelete) {
            int index = path.indexOf(QRY_PFX);
            if (index > -1) {
                setProperty(PATH, path.substring(0, index));
                // Zero out the arguments, so we don't include query strings from previous calls
                getArguments().clear();
                // Parse the arguments in querystring, assuming specified encoding for values
                parseArguments(path.substring(index + 1), contentEncoding);
            } else {
                setProperty(PATH, path);
            }
        } else {
            setProperty(PATH, path);
        }
    }
```