### PR TITLE
Bug 60564 - Migrating LogKit to SLF4J - components (1), functions, protocol, test

### DIFF
--- a/src/components/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jorphan.logging.LoggingManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,9 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractBackendListenerClient implements BackendListenerClient {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractBackendListenerClient.class);
+
+    private static final org.apache.log.Logger oldLogger = LoggingManager.getLoggerForClass();
+
     private UserMetric userMetrics = new UserMetric();
     
     private ConcurrentHashMap<String, SamplerMetric> metricsPerSampler = new ConcurrentHashMap<>();
@@ -89,8 +93,20 @@ public abstract class AbstractBackendListenerClient implements BackendListenerCl
      * As this class is designed to be subclassed this is useful.
      *
      * @return a Logger instance which can be used for logging
+     * @deprecated Will be removed in 3.3, use {@link AbstractBackendListenerClient#getNewLogger()} 
      */
-    protected Logger getLogger() {
+    @Deprecated
+    protected org.apache.log.Logger getLogger() {
+        return oldLogger;
+    }
+
+    /**
+     * Get a Logger instance which can be used by subclasses to log information.
+     * As this class is designed to be subclassed this is useful.
+     *
+     * @return {@link Logger}  instance which can be used for logging
+     */
+    protected Logger getNewLogger() {
         return log;
     }
 

--- a/src/functions/org/apache/jmeter/functions/LogFunction.java
+++ b/src/functions/org/apache/jmeter/functions/LogFunction.java
@@ -26,9 +26,9 @@ import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
-import org.apache.log.Priority;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * <p>
@@ -47,7 +47,7 @@ import org.apache.log.Priority;
  * @since 2.2
  */
 public class LogFunction extends AbstractFunction {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LogFunction.class);
 
     private static final List<String> desc = new LinkedList<>();
 
@@ -133,31 +133,44 @@ public class LogFunction extends AbstractFunction {
     }
 
     // Routine to perform the output (also used by __logn() function)
-    static synchronized void logDetails(Logger l, String s, String prio, Throwable t, String c) {
-        if (prio.equalsIgnoreCase("OUT")) //$NON-NLS-1
-        {
-            printDetails(System.out, s, t, c);
-        } else if (prio.equalsIgnoreCase("ERR")) //$NON-NLS-1
-        {
-            printDetails(System.err, s, t, c);
+    static synchronized void logDetails(Logger logger, String stringToLog, String priorityString, Throwable throwable,
+            String comment) {
+        String prio = priorityString.trim().toUpperCase();
+
+        if ("OUT".equals(prio)) {//$NON-NLS-1
+            printDetails(System.out, stringToLog, throwable, comment);
+        } else if ("ERR".equals(prio)) {//$NON-NLS-1
+            printDetails(System.err, stringToLog, throwable, comment);
         } else {
-            // N.B. if the string is not recognised, DEBUG is assumed
-            Priority p = Priority.getPriorityForName(prio.trim());
-            if (log.isPriorityEnabled(p)) {// Thread method is potentially expensive
-                String tn = Thread.currentThread().getName();
-                StringBuilder sb = new StringBuilder(40);
-                sb.append(tn);
-                if (c.length()>0){
-                    sb.append(' ');
-                    sb.append(c);
-                } else {
-                    sb.append(DEFAULT_SEPARATOR);
-                }
-                sb.append(s);
-                log.log(p, sb.toString(), t);
+            // N.B. if the string is not recognized, DEBUG is assumed
+            Level prioLevel;
+            try {
+                prioLevel = Level.valueOf(prio);
+            } catch (IllegalArgumentException ignored) {
+                prioLevel = Level.DEBUG;
+            }
+
+            final String threadName = Thread.currentThread().getName();
+            final String separator = (comment.isEmpty()) ? DEFAULT_SEPARATOR : comment;
+
+            switch (prioLevel) {
+            case ERROR:
+                logger.error("{} {} {}", threadName, separator, stringToLog, throwable);
+                break;
+            case WARN:
+                logger.warn("{} {} {}", threadName, separator, stringToLog, throwable);
+                break;
+            case INFO:
+                logger.info("{} {} {}", threadName, separator, stringToLog, throwable);
+                break;
+            case DEBUG:
+                logger.debug("{} {} {}", threadName, separator, stringToLog, throwable);
+                break;
+            case TRACE:
+                logger.trace("{} {} {}", threadName, separator, stringToLog, throwable);
+                break;
             }
         }
-
     }
 
     /** {@inheritDoc} */

--- a/src/functions/org/apache/jmeter/functions/LogFunction2.java
+++ b/src/functions/org/apache/jmeter/functions/LogFunction2.java
@@ -26,8 +26,8 @@ import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -45,7 +45,7 @@ import org.apache.log.Logger;
  * @since 2.2
  */
 public class LogFunction2 extends AbstractFunction {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(LogFunction2.class);
 
     private static final List<String> desc = new LinkedList<>();
 

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/AbstractJavaSamplerClient.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/AbstractJavaSamplerClient.java
@@ -20,7 +20,7 @@ package org.apache.jmeter.protocol.java.sampler;
 
 import org.apache.jmeter.config.Arguments;
 import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -51,9 +51,9 @@ import org.slf4j.LoggerFactory;
  *
  */
 public abstract class AbstractJavaSamplerClient implements JavaSamplerClient {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(AbstractJavaSamplerClient.class);
+    private static final Logger log = LoggerFactory.getLogger(AbstractJavaSamplerClient.class);
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final org.apache.log.Logger oldLogger = LoggingManager.getLoggerForClass();
 
     /* Implements JavaSamplerClient.setupTest(JavaSamplerContext) */
     @Override
@@ -82,18 +82,18 @@ public abstract class AbstractJavaSamplerClient implements JavaSamplerClient {
      * @deprecated Will be removed in 3.3, use {@link AbstractJavaSamplerClient#getNewLogger()} 
      */
     @Deprecated
-    protected Logger getLogger() {
-        return log;
+    protected org.apache.log.Logger getLogger() {
+        return oldLogger;
     }
-    
+
     /**
      * Get a Logger instance which can be used by subclasses to log information.
      * This is the same Logger which is used by the base JavaSampler classes
      * (jmeter.protocol.java).
      *
-     * @return {@link org.slf4j.Logger}  instance which can be used for logging
+     * @return {@link Logger}  instance which can be used for logging
      */
-    protected org.slf4j.Logger getNewLogger() {
-        return logger;
+    protected Logger getNewLogger() {
+        return log;
     }
 }

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BSFSampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BSFSampler.java
@@ -37,8 +37,8 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.BSFTestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A sampler which understands BSF
@@ -49,9 +49,9 @@ public class BSFSampler extends BSFTestElement implements Sampler, TestBean, Con
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
             Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));
 
-    private static final long serialVersionUID = 240L;
+    private static final long serialVersionUID = 241L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(BSFSampler.class);
 
     public BSFSampler() {
         super();
@@ -63,7 +63,7 @@ public class BSFSampler extends BSFTestElement implements Sampler, TestBean, Con
         final String label = getName();
         final String request = getScript();
         final String fileName = getFilename();
-        log.debug(label + " " + fileName);
+        log.debug("{} {}", label, fileName);
         SampleResult res = new SampleResult();
         res.setSampleLabel(label);
         

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
@@ -31,9 +31,9 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.BeanShellTestElement;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.util.JMeterException;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A sampler which understands BeanShell
@@ -44,9 +44,9 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
             Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));
     
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(BeanShellSampler.class);
 
-    private static final long serialVersionUID = 3;
+    private static final long serialVersionUID = 4;
 
     public static final String FILENAME = "BeanShellSampler.filename"; //$NON-NLS-1$
 
@@ -88,7 +88,6 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
     @Override
     public SampleResult sample(Entry e)// Entry tends to be ignored ...
     {
-        // log.info(getLabel()+" "+getFilename());
         SampleResult res = new SampleResult();
         boolean isSuccessful = false;
         res.setSampleLabel(getName());
@@ -142,13 +141,15 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
          */
         // but we do trap this error to make tests work better
         catch (NoClassDefFoundError ex) {
-            log.error("BeanShell Jar missing? " + ex.toString());
+            log.error("BeanShell Jar missing? {}", ex.toString());
             res.setResponseCode("501");//$NON-NLS-1$
             res.setResponseMessage(ex.toString());
             res.setStopThread(true); // No point continuing
         } catch (Exception ex) // Mainly for bsh.EvalError
         {
-            log.warn(ex.toString());
+            if (log.isWarnEnabled()) {
+                log.warn("Exception executing script. {}", ex.toString());
+            }
             res.setResponseCode("500");//$NON-NLS-1$
             res.setResponseMessage(ex.toString());
         } finally {
@@ -169,7 +170,9 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
             try {
                 savedBsh.evalNoLog("interrupt()"); // $NON-NLS-1$
             } catch (JMeterException ignored) {
-                log.debug(getClass().getName() + " : " + ignored.getLocalizedMessage()); // $NON-NLS-1$
+                if (log.isDebugEnabled()) {
+                    log.debug("{} : {}", getClass(), ignored.getLocalizedMessage()); // $NON-NLS-1$
+                }
             }
             return true;
         }

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -35,16 +35,16 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JSR223TestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampler, TestBean, ConfigMergabilityIndicator {
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
             Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));
 
-    private static final long serialVersionUID = 234L;
+    private static final long serialVersionUID = 235L;
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JSR223Sampler.class);
 
     @Override
     public SampleResult sample(Entry entry) {
@@ -71,7 +71,7 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
                 result.setResponseData(ret.toString(), null);
             }
         } catch (IOException | ScriptException e) {
-            log.error("Problem in JSR223 script "+getName()+", message:"+e, e);
+            log.error("Problem in JSR223 script {}, message: {}", getName(), e, e);
             result.setSuccessful(false);
             result.setResponseCode("500"); // $NON-NLS-1$
             result.setResponseMessage(e.toString());

--- a/test/src/org/apache/jmeter/assertions/XPathAssertionTest.java
+++ b/test/src/org/apache/jmeter/assertions/XPathAssertionTest.java
@@ -32,13 +32,13 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XPathAssertionTest extends JMeterTestCase {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(XPathAssertionTest.class);
 
     private XPathAssertion assertion;
 
@@ -92,8 +92,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionOK() throws Exception {
         assertion.setXPathString("/");
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertFalse("Should not be a failure", res.isFailure());
     }
@@ -102,8 +102,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionFail() throws Exception {
         assertion.setXPathString("//x");
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertTrue("Should be a failure",res.isFailure());
     }
@@ -112,8 +112,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionPath1() throws Exception {
         assertion.setXPathString("//*[code=1]");
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertFalse("Should not be a failure",res.isFailure());
     }
@@ -122,8 +122,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionPath2() throws Exception {
         assertion.setXPathString("//*[code=2]"); // Not present
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertTrue("Should be a failure",res.isFailure());
     }
@@ -132,8 +132,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionBool1() throws Exception {
         assertion.setXPathString("count(//error)=2");
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertFalse("Should not be a failure",res.isFailure());
     }
@@ -142,8 +142,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionBool2() throws Exception {
         assertion.setXPathString("count(//*[code=1])=1");
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertFalse("Should not be a failure",res.isFailure());
     }
@@ -152,18 +152,18 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionBool3() throws Exception {
         assertion.setXPathString("count(//error)=1"); // wrong
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
-        assertTrue("Should be a failure",res.isFailure());
+        assertTrue("Should be a failure", res.isFailure());
     }
 
     @Test
     public void testAssertionBool4() throws Exception {
         assertion.setXPathString("count(//*[code=2])=1"); //Wrong
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertTrue("Should be a failure",res.isFailure());
     }
@@ -172,8 +172,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionNumber() throws Exception {
         assertion.setXPathString("count(//error)");// not yet handled
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertTrue("Should be a failure",res.isFailure());
     }
@@ -183,8 +183,8 @@ public class XPathAssertionTest extends JMeterTestCase {
         // result.setResponseData - not set
         result = new SampleResult();
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertEquals(AssertionResult.RESPONSE_WAS_NULL, res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertTrue("Should be a failure",res.isFailure());
@@ -194,8 +194,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionEmptyResult() throws Exception {
         result.setResponseData("", null);
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertEquals(AssertionResult.RESPONSE_WAS_NULL, res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
         assertTrue("Should be a failure",res.isFailure());
@@ -205,8 +205,8 @@ public class XPathAssertionTest extends JMeterTestCase {
     public void testAssertionBlankResult() throws Exception {
         result.setResponseData(" ", null);
         AssertionResult res = assertion.getResult(result);
-        testLog.debug("isError() " + res.isError() + " isFailure() " + res.isFailure());
-        testLog.debug("failure message: " + res.getFailureMessage());
+        testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
+        testLog.debug("failure message: {}", res.getFailureMessage());
         assertTrue(res.getFailureMessage().indexOf("Premature end of file") > 0);
         assertTrue("Should be an error",res.isError());
         assertFalse("Should not be a failure", res.isFailure());
@@ -225,7 +225,7 @@ public class XPathAssertionTest extends JMeterTestCase {
         assertion.setValidating(false);
         assertion.setTolerant(false);
         AssertionResult res = assertion.getResult(result);
-        log.debug("failureMessage: " + res.getFailureMessage());
+        log.debug("failureMessage: {}", res.getFailureMessage());
         assertTrue(res.isError());
         assertFalse(res.isFailure());
     }
@@ -235,8 +235,8 @@ public class XPathAssertionTest extends JMeterTestCase {
         setAlternateResponseData();
         assertion.setXPathString("//row/value[@field = 'alias']");
         AssertionResult res = assertion.getResult(jmctx.getPreviousResult());
-        log.debug(" res " + res.isError());
-        log.debug(" failure " + res.getFailureMessage());
+        log.debug(" res {}", res.isError());
+        log.debug(" failure {}", res.getFailureMessage());
         assertFalse(res.isError());
         assertFalse(res.isFailure());
     }
@@ -248,8 +248,8 @@ public class XPathAssertionTest extends JMeterTestCase {
         assertion.setNegated(true);
 
         AssertionResult res = assertion.getResult(jmctx.getPreviousResult());
-        log.debug(" res " + res.isError());
-        log.debug(" failure " + res.getFailureMessage());
+        log.debug(" res {}", res.isError());
+        log.debug(" failure {}", res.getFailureMessage());
         assertFalse(res.isError());
         assertFalse(res.isFailure());
     }
@@ -261,7 +261,7 @@ public class XPathAssertionTest extends JMeterTestCase {
         assertion.setNegated(false);
         assertion.setValidating(true);
         AssertionResult res = assertion.getResult(jmctx.getPreviousResult());
-        log.debug(res.getFailureMessage() + " error: " + res.isError() + " failure: " + res.isFailure());
+        log.debug("{} error: {} failure: {}", res.getFailureMessage(), res.isError(), res.isFailure());
         assertTrue(res.isError());
         assertFalse(res.isFailure());
     }
@@ -316,7 +316,7 @@ public class XPathAssertionTest extends JMeterTestCase {
         assertion.setXPathString("/");
         assertion.setValidating(true);
         AssertionResult res = assertion.getResult(result);
-        log.debug("failureMessage: " + res.getFailureMessage());
+        log.debug("failureMessage: {}", res.getFailureMessage());
         assertTrue(res.isError());
         assertFalse(res.isFailure());
     }
@@ -334,7 +334,7 @@ public class XPathAssertionTest extends JMeterTestCase {
         assertion.setValidating(true);
         assertion.setTolerant(true);
         AssertionResult res = assertion.getResult(result);
-        log.debug("failureMessage: " + res.getFailureMessage());
+        log.debug("failureMessage: {}", res.getFailureMessage());
         assertFalse(res.isFailure());
         assertFalse(res.isError());
     }

--- a/test/src/org/apache/jmeter/control/TestSwitchController.java
+++ b/test/src/org/apache/jmeter/control/TestSwitchController.java
@@ -37,10 +37,6 @@ import org.apache.jmeter.threads.JMeterVariables;
 import org.junit.Test;
 
 public class TestSwitchController extends JMeterTestCase {
-//      static {
-//           LoggingManager.setPriority("DEBUG","jmeter");
-//           LoggingManager.setTarget(new java.io.PrintWriter(System.out));
-//      }
 
         // Get next sample and its name
         private String nextName(GenericController c) {

--- a/test/src/org/apache/jmeter/control/TestWhileController.java
+++ b/test/src/org/apache/jmeter/control/TestWhileController.java
@@ -36,11 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestWhileController extends JMeterTestCase {
-//      static {
-//           LoggingManager.setPriority("DEBUG","jmeter");
-//           LoggingManager.setTarget(new java.io.PrintWriter(System.out));
-//      }
-
 
         private JMeterContext jmctx;
         private JMeterVariables jmvars;

--- a/test/src/org/apache/jmeter/engine/DistributedRunnerTest.java
+++ b/test/src/org/apache/jmeter/engine/DistributedRunnerTest.java
@@ -35,9 +35,9 @@ import java.util.Properties;
 
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DistributedRunnerTest {
 
@@ -137,7 +137,7 @@ public class DistributedRunnerTest {
     }
 
     private static class EmulatorEngine implements JMeterEngine {
-        private static final Logger log = LoggingManager.getLoggerForClass();
+        private static final Logger log = LoggerFactory.getLogger(EmulatorEngine.class);
         private String host;
 
         public EmulatorEngine() {
@@ -146,37 +146,37 @@ public class DistributedRunnerTest {
 
         @Override
         public void configure(HashTree testPlan) {
-            log.debug("Configuring " + host);
+            log.debug("Configuring {}", host);
         }
 
         @Override
         public void runTest() throws JMeterEngineException {
-            log.debug("Running " + host);
+            log.debug("Running {}", host);
         }
 
         @Override
         public void stopTest(boolean now) {
-            log.debug("Stopping " + host);
+            log.debug("Stopping {}", host);
         }
 
         @Override
         public void reset() {
-            log.debug("Resetting " + host);
+            log.debug("Resetting {}", host);
         }
 
         @Override
         public void setProperties(Properties p) {
-            log.debug("Set properties " + host);
+            log.debug("Set properties {}", host);
         }
 
         @Override
         public void exit() {
-            log.debug("Exiting " + host);
+            log.debug("Exiting {}", host);
         }
 
         @Override
         public boolean isActive() {
-            log.debug("Check if active " + host);
+            log.debug("Check if active {}", host);
             return false;
         }
 

--- a/test/src/org/apache/jmeter/functions/CSVReadFunctionTest.java
+++ b/test/src/org/apache/jmeter/functions/CSVReadFunctionTest.java
@@ -26,13 +26,13 @@ import java.util.LinkedList;
 
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.junit.JMeterTestCase;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CSVReadFunctionTest extends JMeterTestCase {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(CSVReadFunctionTest.class);
     
     // Create the CSVRead function and set its parameters.
     private static CSVRead setCSVReadParams(String p1, String p2) throws Exception {

--- a/test/src/org/apache/jmeter/functions/ComponentReferenceFunctionTest.java
+++ b/test/src/org/apache/jmeter/functions/ComponentReferenceFunctionTest.java
@@ -28,24 +28,24 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.junit.JMeterTest;
 import org.apache.jmeter.junit.JMeterTestCaseJUnit3;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
 public class ComponentReferenceFunctionTest extends JMeterTestCaseJUnit3 {
 
-    private static final Logger LOG = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ComponentReferenceFunctionTest.class);
     
     private static Map<String, Boolean> funcTitles;
     
@@ -134,7 +134,7 @@ public class ComponentReferenceFunctionTest extends JMeterTestCaseJUnit3 {
                 // No, not a work in progress ...
                 String s = "function.xml needs '" + title + "' entry for " + funcItem.getClass().getName();
                 if (!ct) {
-                    LOG.warn(s); // Record in log as well
+                    log.warn(s); // Record in log as well
                 }
                 assertTrue(s, ct);
             }

--- a/test/src/org/apache/jmeter/junit/JMeterTest.java
+++ b/test/src/org/apache/jmeter/junit/JMeterTest.java
@@ -44,9 +44,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.gui.ObsoleteGui;
 import org.apache.jmeter.gui.JMeterGUIComponent;
@@ -57,18 +54,21 @@ import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testbeans.gui.TestBeanGUI;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.reflect.ClassFinder;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
 public class JMeterTest extends JMeterTestCaseJUnit3 {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(JMeterTest.class);
 
     private static Map<String, Boolean> guiTitles;
 
@@ -339,7 +339,7 @@ public class JMeterTest extends JMeterTestCaseJUnit3 {
                 assertFalse("'" + label + "' should be in resource file for " + name, JMeterUtils.getResString(
                         label).startsWith(JMeterUtils.RES_KEY_PFX));
             } catch (UnsupportedOperationException uoe) {
-                log.warn("Class has not yet implemented getLabelResource " + name);
+                log.warn("Class has not yet implemented getLabelResource {}", name);
             }
         }
         checkElementAlias(guiItem);
@@ -366,7 +366,7 @@ public class JMeterTest extends JMeterTestCaseJUnit3 {
         if (!(guiItem instanceof UnsharedComponent)) {
             assertEquals("SHARED: Failed on " + name, "", el2.getPropertyAsString("NOT"));
         }
-        log.debug("Saving element: " + el.getClass());
+        log.debug("Saving element: {}", el.getClass());
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         SaveService.saveElement(el, bos);
         ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());

--- a/test/src/org/apache/jmeter/junit/JMeterTestCase.java
+++ b/test/src/org/apache/jmeter/junit/JMeterTestCase.java
@@ -26,12 +26,13 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Locale;
 import java.util.MissingResourceException;
+
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.functions.AbstractFunction;
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * Common setup for JUnit4 test cases
@@ -120,7 +121,7 @@ public abstract class JMeterTestCase {
         return file;
     }
 
-    protected static final Logger testLog = LoggingManager.getLoggerForClass();
+    protected static final Logger testLog = LoggerFactory.getLogger(JMeterTestCase.class);
 
     protected void checkInvalidParameterCounts(AbstractFunction func, int minimum)
             throws Exception {

--- a/test/src/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/test/src/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -36,13 +36,13 @@ import java.util.Vector;
 import org.apache.commons.io.IOUtils;
 import org.apache.jmeter.junit.JMeterTestCaseJUnit3;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import junit.framework.TestSuite;
 
 public class TestHTMLParser extends JMeterTestCaseJUnit3 {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(TestHTMLParser.class);
 
     private static final String DEFAULT_UA  = "Apache-HttpClient/4.2.6";
     private static final String UA_FF       = "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0";
@@ -372,7 +372,7 @@ public class TestHTMLParser extends JMeterTestCaseJUnit3 {
                 throws Exception {
             String parserName = p.getClass().getName().substring("org.apache.jmeter.protocol.http.parser.".length());
             String fname = file.substring(file.indexOf('/')+1);
-            log.debug("file   " + file);
+            log.debug("file   {}", file);
             File f = findTestFile(file);
             byte[] buffer = new byte[(int) f.length()];
             InputStream is = null;

--- a/test/src/org/apache/jmeter/protocol/http/sampler/PostWriterTest.java
+++ b/test/src/org/apache/jmeter/protocol/http/sampler/PostWriterTest.java
@@ -34,20 +34,21 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PostWriterTest {
 
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(PostWriterTest.class);
 
     private static final String UTF_8 = "UTF-8";
     private static final String HTTP_ENCODING = "ISO-8859-1";
@@ -219,13 +220,13 @@ public class PostWriterTest {
         
         String otherEncoding;
         final String fileEncoding = System.getProperty( "file.encoding");// $NON-NLS-1$
-        log.info("file.encoding: "+fileEncoding);
+        log.info("file.encoding: {}", fileEncoding);
         if (UTF_8.equalsIgnoreCase(fileEncoding) || "UTF8".equalsIgnoreCase(fileEncoding)){// $NON-NLS-1$
             otherEncoding="ISO-8859-1"; // $NON-NLS-1$
         } else {
             otherEncoding=UTF_8;
         }
-        log.info("Using other encoding: "+otherEncoding);
+        log.info("Using other encoding: {}", otherEncoding);
         establishConnection();
         sampler.setContentEncoding(otherEncoding);
         // File content is sent as binary, so the content encoding should not change the file data

--- a/test/src/org/apache/jmeter/testbeans/gui/PackageTest.java
+++ b/test/src/org/apache/jmeter/testbeans/gui/PackageTest.java
@@ -30,9 +30,9 @@ import org.apache.jmeter.junit.JMeterTestCaseJUnit3;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.reflect.ClassFinder;
-import org.apache.log.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -47,7 +47,7 @@ import junit.framework.TestSuite;
  * 
  */
 public final class PackageTest extends JMeterTestCaseJUnit3 {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(PackageTest.class);
 
     private static final Locale defaultLocale = new Locale("en","");
 
@@ -86,7 +86,7 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
             beanInfo = Introspector.getBeanInfo(testBeanClass);
             bundle = (ResourceBundle) beanInfo.getBeanDescriptor().getValue(GenericTestBeanCustomizer.RESOURCE_BUNDLE);
         } catch (IntrospectionException e) {
-            log.error("Can't get beanInfo for " + testBeanClass.getName(), e);
+            log.error("Can't get beanInfo for {}", testBeanClass, e);
             throw new Error(e.toString(), e); // Programming error. Don't continue.
         }
         if (bundle == null) {
@@ -174,17 +174,17 @@ public final class PackageTest extends JMeterTestCaseJUnit3 {
                 defaultBundle = (ResourceBundle) Introspector.getBeanInfo(testBeanClass).getBeanDescriptor().getValue(
                         GenericTestBeanCustomizer.RESOURCE_BUNDLE);
             } catch (IntrospectionException e) {
-                log.error("Can't get beanInfo for " + testBeanClass.getName(), e);
+                log.error("Can't get beanInfo for {}", testBeanClass, e);
                 throw new Error(e.toString(), e); // Programming error. Don't continue.
             }
 
             if (defaultBundle == null) {
                 if (className.startsWith("org.apache.jmeter.examples.")) {
-                    log.info("No default bundle found for " + className);
+                    log.info("No default bundle found for {}", className);
                     continue;
                 }
                 errorDetected=true;
-                log.error("No default bundle found for " + className + " using " + defaultLocale.toString());
+                log.error("No default bundle found for {} using {}", className, defaultLocale);
                 continue;
             }
 

--- a/test/src/org/apache/jmeter/timers/ConstantThroughputTimerTest.java
+++ b/test/src/org/apache/jmeter/timers/ConstantThroughputTimerTest.java
@@ -26,13 +26,13 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.TestJMeterContextService;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.ScriptingTestElement;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConstantThroughputTimerTest {
 
-    private static final Logger LOG = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(ConstantThroughputTimerTest.class);
 
     @Test
     public void testTimer1() throws Exception {
@@ -84,7 +84,7 @@ public class ConstantThroughputTimerTest {
     public void testTimerBSH() throws Exception {
         if (!BeanShellInterpreter.isInterpreterPresent()){
             final String msg = "BeanShell jar not present, test ignored";
-            LOG.warn(msg);
+            log.warn(msg);
             return;
         }
         BeanShellTimer timer = new BeanShellTimer();

--- a/test/src/org/apache/jorphan/collections/PackageTest.java
+++ b/test/src/org/apache/jorphan/collections/PackageTest.java
@@ -26,21 +26,22 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
-import org.apache.jorphan.logging.LoggingManager;
-import org.apache.log.Logger;
+
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PackageTest {
-        
+
+    private static Logger log = LoggerFactory.getLogger(PackageTest.class);
+
         @Test
         public void testAdd1() throws Exception {
-            Logger log = LoggingManager.getLoggerForClass();
             Collection<String> treePath = Arrays.asList(new String[] { "1", "2", "3", "4" });
             HashTree tree = new HashTree();
-            log.debug("treePath = " + treePath);
+            log.debug("treePath = {}", treePath);
             tree.add(treePath, "value");
-            log.debug("Now treePath = " + treePath);
-            log.debug(tree.toString());
+            log.debug("Now treePath = {}, tree = {}", treePath, tree);
             assertEquals(1, tree.list(treePath).size());
             assertEquals("value", tree.getArray(treePath)[0]);
         }

--- a/test/src/org/apache/jorphan/test/AllTests.java
+++ b/test/src/org/apache/jorphan/test/AllTests.java
@@ -20,9 +20,7 @@ package org.apache.jorphan.test;
 
 import java.awt.GraphicsEnvironment;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -30,18 +28,15 @@ import java.nio.charset.Charset;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Locale;
-import java.util.Properties;
 
 import javax.crypto.Cipher;
 
 import org.apache.jmeter.junit.categories.ExcludeCategoryFilter;
 import org.apache.jmeter.junit.categories.NeedGuiTests;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.logging.LoggingManager;
 import org.apache.jorphan.reflect.ClassFilter;
 import org.apache.jorphan.reflect.ClassFinder;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.log.Logger;
 import org.junit.internal.RealSystem;
 import org.junit.internal.TextListener;
 import org.junit.runner.Computer;
@@ -49,6 +44,8 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.notification.RunListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import junit.framework.TestCase;
 
@@ -107,7 +104,7 @@ import junit.framework.TestCase;
  * @see UnitTestManager
  */
 public final class AllTests {
-    private static final Logger log = LoggingManager.getLoggerForClass();
+    private static final Logger log = LoggerFactory.getLogger(AllTests.class);
 
     /**
      * Private constructor to prevent instantiation.
@@ -117,7 +114,7 @@ public final class AllTests {
 
     private static void logprop(String prop, boolean show) {
         String value = System.getProperty(prop);
-        log.info(prop + "=" + value);
+        log.info("{}={}", prop, value);
         if (show) {
             System.out.println(prop + "=" + value);
         }
@@ -148,30 +145,26 @@ public final class AllTests {
         String home = new File(System.getProperty("user.dir")).getParent();
         System.out.println("Setting JMeterHome: "+home);
         JMeterUtils.setJMeterHome(home);
-        initializeLogging(args);
         initializeManager(args);
 
-        String version = "JMeterVersion="+JMeterUtils.getJMeterVersion();
-        log.info(version);
-        System.out.println(version);
+        log.info("JMeterVersion={}", JMeterUtils.getJMeterVersion());
+        System.out.println("JMeterVersion=" + JMeterUtils.getJMeterVersion());
         logprop("java.version", true);
         logprop("java.vm.name");
         logprop("java.vendor");
         logprop("java.home", true);
         logprop("file.encoding", true);
         // Display actual encoding used (will differ if file.encoding is not recognised)
-        String msg = "default encoding="+Charset.defaultCharset();
-        System.out.println(msg);
-        log.info(msg);
+        System.out.println("default encoding="+Charset.defaultCharset());
+        log.info("default encoding={}", Charset.defaultCharset());
         logprop("user.home");
         logprop("user.dir", true);
         logprop("user.language");
         logprop("user.region");
         logprop("user.country");
         logprop("user.variant");
-        final String showLocale = "Locale="+Locale.getDefault().toString();
-        log.info(showLocale);
-        System.out.println(showLocale);
+        log.info("Locale={}", Locale.getDefault());
+        System.out.println("Locale=" + Locale.getDefault());
         logprop("os.name", true);
         logprop("os.version", true);
         logprop("os.arch");
@@ -239,29 +232,6 @@ public final class AllTests {
     }
 
     /**
-     * An overridable method that initializes the logging for the unit test run,
-     * using the properties file passed in as the second argument.
-     * 
-     * @param args arguments to get the logging setup information from
-     */
-    protected static void initializeLogging(String[] args) {
-        if (args.length >= 2) {
-            Properties props = new Properties();
-            InputStream inputStream = null;
-            try {
-                System.out.println("Setting up props using file: " + args[1]);
-                inputStream = new FileInputStream(args[1]);
-                props.load(inputStream);
-                LoggingManager.initializeLogging(props);
-            } catch (IOException e) {
-                System.out.println(e.getLocalizedMessage());
-            } finally {
-                JOrphanUtils.closeQuietly(inputStream);
-            }
-        }
-    }
-
-    /**
      * An overridable method that instantiates a UnitTestManager (if one
      * was specified in the command-line arguments), and hands it the name of
      * the properties file to use to configure the system.
@@ -320,7 +290,7 @@ public final class AllTests {
                 }
             } catch (UnsupportedClassVersionError | ClassNotFoundException
                     | NoClassDefFoundError e) {
-                log.debug(e.getLocalizedMessage());
+                log.debug("Exception while filtering class {}. {}", className, e.toString());
             }
 
             return isJunitTest;


### PR DESCRIPTION
Migrated old logger to slf4j logger in functions, protocols and test.
Also, applied the same backward compatibility pattern in AbstractBackendListenerClient (in components) as done in AbstractJavaSamplerClient by @pmouawad with slightly changing logger variable names. Preferred using 'log' for the new slf4j logger instance and named the old logger to 'oldLogger' since 'log' variable name for slf4j logger is use everywhere.