### PR TITLE
Bug 58506 - JMS Point-to-point sampler should offer an async using temp queue mode and prevent hangs by supporting a reply timeout

### DIFF
--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/ExtendedQueueRequestor.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/ExtendedQueueRequestor.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//
+// This source code implements specifications defined by the Java
+// Community Process. In order to remain compliant with the specification
+// DO NOT add / change / or delete method signatures!
+//
+
+package org.apache.jmeter.protocol.jms.sampler;
+
+import javax.jms.InvalidDestinationException;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueReceiver;
+import javax.jms.QueueSender;
+import javax.jms.QueueSession;
+import javax.jms.TemporaryQueue;
+
+/**
+ * @version $Rev: 467553 $ $Date: 2006-10-24 21:01:51 -0700 (Tue, 24 Oct 2006) $
+ */
+public class ExtendedQueueRequestor {
+    private QueueSession session;
+    private TemporaryQueue temporaryQueue;
+    private QueueSender sender;
+    private QueueReceiver receiver;
+
+    public ExtendedQueueRequestor(QueueSession session, Queue queue)
+        throws JMSException
+    {
+        super();
+
+        if(queue == null) {
+            throw new InvalidDestinationException("Invalid queue");
+        }
+        
+        setSession(session);
+        setTemporaryQueue(session.createTemporaryQueue());
+        setSender(session.createSender(queue));
+        setReceiver(session.createReceiver(getTemporaryQueue()));
+    }
+
+    public Message request(Message message) throws JMSException {
+        message.setJMSReplyTo(getTemporaryQueue());
+        getSender().send(message);
+        return getReceiver().receive();
+    }
+    
+    public Message request(Message message, long timeout) throws JMSException {
+      message.setJMSReplyTo(getTemporaryQueue());
+      getSender().send(message);
+      return getReceiver().receive(timeout);
+  }
+
+
+    public void close() throws JMSException {
+        getSession().close();
+        getTemporaryQueue().delete();
+    }
+
+    private void setReceiver(QueueReceiver receiver) {
+        this.receiver = receiver;
+    }
+
+    private QueueReceiver getReceiver() {
+        return receiver;
+    }
+
+    private void setSender(QueueSender sender) {
+        this.sender = sender;
+    }
+
+    private QueueSender getSender() {
+        return sender;
+    }
+
+    private void setSession(QueueSession session) {
+        this.session = session;
+    }
+
+    private QueueSession getSession() {
+        return session;
+    }
+
+    private void setTemporaryQueue(TemporaryQueue temporaryQueue) {
+        this.temporaryQueue = temporaryQueue;
+    }
+
+    private TemporaryQueue getTemporaryQueue() {
+        return temporaryQueue;
+    }
+}

--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/ExtendedTemporaryQueueExecutor.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/ExtendedTemporaryQueueExecutor.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.jmeter.protocol.jms.sampler;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueRequestor;
+import javax.jms.QueueSession;
+
+/**
+ * Request/reply executor with a temporary reply queue. <br>
+ * 
+ * Used by JMS Sampler (Point to Point)
+ */
+public class ExtendedTemporaryQueueExecutor implements QueueExecutor {
+    /** The sender and receiver. */
+    private final ExtendedQueueRequestor requestor;
+    
+    /** Timeout used for waiting on message. */
+    private final int timeout;
+
+    /**
+     * Constructor.
+     *
+     * @param session
+     *            the session to use to send the message
+     * @param destination
+     *            the queue to send the message on
+     * @throws JMSException
+     *             when internally used {@link QueueRequestor} can not be
+     *             constructed with <code>session</code> and
+     *             <code>destination</code>
+     */
+    public ExtendedTemporaryQueueExecutor(QueueSession session, Queue destination, int timeout) throws JMSException {
+        requestor = new ExtendedQueueRequestor(session, destination);
+        this.timeout = timeout;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Message sendAndReceive(Message request, 
+            int deliveryMode, 
+            int priority, 
+            long expiration) throws JMSException {
+        return requestor.request(request, timeout);
+    }
+}

--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -18,24 +18,6 @@
 
 package org.apache.jmeter.protocol.jms.sampler;
 
-import java.util.Date;
-import java.util.Hashtable;
-import java.util.Map;
-
-import javax.jms.DeliveryMode;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
-import javax.jms.QueueSender;
-import javax.jms.QueueSession;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.jms.Utils;
 import org.apache.jmeter.samplers.AbstractSampler;
@@ -47,6 +29,15 @@ import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jms.*;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Map;
+import java.lang.IllegalStateException;
 
 /**
  * This class implements the JMS Point-to-Point sampler
@@ -369,7 +360,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
             } else {
 
                 if (useTemporyQueue()) {
-                    executor = new TemporaryQueueExecutor(session, sendQueue);
+                    executor = new ExtendedTemporaryQueueExecutor(session, sendQueue, getTimeoutAsInt());
                 } else {
                     producer = session.createSender(sendQueue);
                     executor = new FixedQueueExecutor(producer, getTimeoutAsInt(), isUseReqMsgIdAsCorrelId());

--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -18,6 +18,24 @@
 
 package org.apache.jmeter.protocol.jms.sampler;
 
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.Map;
+
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueSender;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.jms.Utils;
 import org.apache.jmeter.samplers.AbstractSampler;
@@ -29,15 +47,6 @@ import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.jms.*;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import java.util.Date;
-import java.util.Hashtable;
-import java.util.Map;
-import java.lang.IllegalStateException;
 
 /**
  * This class implements the JMS Point-to-Point sampler


### PR DESCRIPTION
Bug 58506 - JMS Point-to-point sampler should offer an async using temp queue mode and prevent hangs by supporting a reply timeout.

Changed line 'executor = new ExtendedTemporaryQueueExecutor(session, sendQueue, getTimeoutAsInt());'
to accept timeout.