### PR TITLE
add apdex per sample (bugzilla #60112)

### DIFF
--- a/bin/reportgenerator.properties
+++ b/bin/reportgenerator.properties
@@ -38,6 +38,15 @@
 # Sets the tolerance threshold for the APDEX calculation (in milliseconds).
 #jmeter.reportgenerator.apdex_tolerated_threshold=1500
 
+# Sets satisfaction and tolerance threshold to specific samples.Use sample names or regular
+# expression. Format is : sample_name:satisfaction|tolerance[,;]
+# Notice the semicolon between sample name and values, the pipe between thresholds and the 
+# comma or semicolon at the end to separate different samples. Don't forget to escape after
+# comma or semicolon to span multiple lines. Ex : 
+#jmeter.reportgenerator.apdex_per_transaction=sample(\\d+):1000|2000,\
+#                                            samples12:3000|4000;\
+#                                            scenar01-12:5000|6000 
+
 # Regular Expression which Indicates which samples to keep for graphs and statistics generation.
 # Empty value means no filtering
 #jmeter.reportgenerator.sample_filter=

--- a/src/core/org/apache/jmeter/report/config/ReportGeneratorConfiguration.java
+++ b/src/core/org/apache/jmeter/report/config/ReportGeneratorConfiguration.java
@@ -71,6 +71,9 @@ public class ReportGeneratorConfiguration {
     private static final String REPORT_GENERATOR_KEY_APDEX_TOLERATED_THRESHOLD = REPORT_GENERATOR_KEY_PREFIX
             + KEY_DELIMITER + "apdex_tolerated_threshold";
     private static final Long REPORT_GENERATOR_KEY_APDEX_TOLERATED_THRESHOLD_DEFAULT = Long.valueOf(1500L);
+    
+    private static final String REPORT_GENERATOR_KEY_APDEX_PER_TRANSACTION = REPORT_GENERATOR_KEY_PREFIX
+            + KEY_DELIMITER + "apdex_per_transaction";
 
     // Exclude Transaction Controller from Top5 Errors by Sampler consumer
     private static final String REPORT_GENERATOR_KEY_EXCLUDE_TC_FROM_TOP5_ERRORS_BY_SAMPLER = REPORT_GENERATOR_KEY_PREFIX
@@ -275,6 +278,7 @@ public class ReportGeneratorConfiguration {
     private File tempDirectory;
     private long apdexSatisfiedThreshold;
     private long apdexToleratedThreshold;
+    private String apdexPerTransaction;
     private Pattern filteredSamplesPattern;
     private boolean ignoreTCFromTop5ErrorsBySampler;
     private Map<String, ExporterConfiguration> exportConfigurations = new HashMap<>();
@@ -356,7 +360,15 @@ public class ReportGeneratorConfiguration {
         this.apdexToleratedThreshold = apdexToleratedThreshold;
     }
 
-    /**
+    public String getApdexPerTransaction() {
+		return apdexPerTransaction;
+	}
+
+	public void setApdexPerTransaction(String apdexPerTransaction) {
+		this.apdexPerTransaction = apdexPerTransaction;
+	}
+
+	/**
      * Gets the export configurations.
      *
      * @return the export configurations
@@ -612,6 +624,11 @@ public class ReportGeneratorConfiguration {
                 REPORT_GENERATOR_KEY_APDEX_TOLERATED_THRESHOLD_DEFAULT,
                 long.class).longValue();
         configuration.setApdexToleratedThreshold(apdexToleratedThreshold);
+        
+        final String apdexPerTransaction = getOptionalProperty(props, 
+        		REPORT_GENERATOR_KEY_APDEX_PER_TRANSACTION, 
+        		String.class);
+        configuration.setApdexPerTransaction(apdexPerTransaction);
 
         final boolean ignoreTCFromTop5ErrorsBySampler = getRequiredProperty(
                 props, 

--- a/src/core/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -433,9 +433,22 @@ public class ReportGenerator {
         apdexSummaryConsumer.setThresholdSelector(sampleName -> {
                 ApdexThresholdsInfo info = new ApdexThresholdsInfo();
                 info.setSatisfiedThreshold(configuration
-                        .getApdexSatisfiedThreshold());
+                		.getApdexSatisfiedThreshold());
                 info.setToleratedThreshold(configuration
-                        .getApdexToleratedThreshold());
+                		.getApdexToleratedThreshold());
+                // see if the sample name is in the special cases targeted
+                // by property jmeter.reportgenerator.apdex_per_transaction
+                if (configuration.getApdexPerTransaction() != null) {
+                	Pattern regex = Pattern.compile(sampleName + ":(?<satisfied>\\d+)\\|(?<tolerated>\\d+)",
+                			Pattern.MULTILINE);
+                	Matcher matcher = regex.matcher(configuration.getApdexPerTransaction());
+                	if (matcher.find()) {
+                		Long satisfied = Long.valueOf(matcher.group("satisfied"));
+                		Long tolerated = Long.valueOf(matcher.group("tolerated"));
+                		info.setSatisfiedThreshold(satisfied);
+                		info.setToleratedThreshold(tolerated);
+                	}
+                }
                 return info;
         });
         return apdexSummaryConsumer;

--- a/test/resources/reportgenerator_test.properties
+++ b/test/resources/reportgenerator_test.properties
@@ -1,0 +1,144 @@
+################################################################################
+# Apache JMeter Property file for Report Generator
+################################################################################
+
+##   Licensed to the Apache Software Foundation (ASF) under one or more
+##   contributor license agreements.  See the NOTICE file distributed with
+##   this work for additional information regarding copyright ownership.
+##   The ASF licenses this file to You under the Apache License, Version 2.0
+##   (the "License"); you may not use this file except in compliance with
+##   the License.  You may obtain a copy of the License at
+## 
+##       http://www.apache.org/licenses/LICENSE-2.0
+## 
+##   Unless required by applicable law or agreed to in writing, software
+##   distributed under the License is distributed on an "AS IS" BASIS,
+##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+##   See the License for the specific language governing permissions and
+##   limitations under the License.
+
+################################################################################
+#
+#                      THIS FILE SHOULD NOT BE MODIFIED
+#
+# This avoids having to re-apply the modifications when upgrading JMeter
+# Instead only user.properties should be modified:
+# 1/ copy the property you want to modify to user.properties from here
+# 2/ Change its value there
+#
+################################################################################
+
+#---------------------------------------------------------------------------
+# Reporting configuration
+#---------------------------------------------------------------------------
+
+# Sets the satisfaction threshold for the APDEX calculation (in milliseconds).
+#jmeter.reportgenerator.apdex_satisfied_threshold=500
+
+# Sets the tolerance threshold for the APDEX calculation (in milliseconds).
+#jmeter.reportgenerator.apdex_tolerated_threshold=1500
+
+# Regular Expression which Indicates which samples to keep for graphs and statistics generation.
+# Empty value means no filtering
+#jmeter.reportgenerator.sample_filter=
+
+# Sets the temporary directory used by the generation process if it needs file I/O operations.
+#jmeter.reportgenerator.temp_dir=temp
+
+# Sets the size of the sliding window used by percentile evaluation.
+# Caution : higher value provides a better accuracy but needs more memory.
+#jmeter.reportgenerator.statistic_window = 200000
+
+# Configure this property to change the report title
+#jmeter.reportgenerator.report_title=Apache JMeter Dashboard
+
+# Defines the overall granularity for over time graphs
+jmeter.reportgenerator.overall_granularity=60000
+
+# Response Time Percentiles graph definition
+jmeter.reportgenerator.graph.responseTimePercentiles.classname=org.apache.jmeter.report.processor.graph.impl.ResponseTimePercentilesGraphConsumer
+jmeter.reportgenerator.graph.responseTimePercentiles.title=Response Time Percentiles
+
+# Response Time Distribution graph definition
+jmeter.reportgenerator.graph.responseTimeDistribution.classname=org.apache.jmeter.report.processor.graph.impl.ResponseTimeDistributionGraphConsumer
+jmeter.reportgenerator.graph.responseTimeDistribution.title=Response Time Distribution
+jmeter.reportgenerator.graph.responseTimeDistribution.property.set_granularity=500
+
+# Active Threads Over Time graph definition
+jmeter.reportgenerator.graph.activeThreadsOverTime.classname=org.apache.jmeter.report.processor.graph.impl.ActiveThreadsGraphConsumer
+jmeter.reportgenerator.graph.activeThreadsOverTime.title=Active Threads Over Time
+jmeter.reportgenerator.graph.activeThreadsOverTime.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Time VS Threads graph definition
+jmeter.reportgenerator.graph.timeVsThreads.classname=org.apache.jmeter.report.processor.graph.impl.TimeVSThreadGraphConsumer
+jmeter.reportgenerator.graph.timeVsThreads.title=Time VS Threads
+
+# Bytes Throughput Over Time graph definition
+jmeter.reportgenerator.graph.bytesThroughputOverTime.classname=org.apache.jmeter.report.processor.graph.impl.BytesThroughputGraphConsumer
+jmeter.reportgenerator.graph.bytesThroughputOverTime.title=Bytes Throughput Over Time
+jmeter.reportgenerator.graph.bytesThroughputOverTime.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Response Time Over Time graph definition
+jmeter.reportgenerator.graph.responseTimesOverTime.classname=org.apache.jmeter.report.processor.graph.impl.ResponseTimeOverTimeGraphConsumer
+jmeter.reportgenerator.graph.responseTimesOverTime.title=Response Time Over Time
+jmeter.reportgenerator.graph.responseTimesOverTime.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Latencies Over Time graph definition
+jmeter.reportgenerator.graph.latenciesOverTime.classname=org.apache.jmeter.report.processor.graph.impl.LatencyOverTimeGraphConsumer
+jmeter.reportgenerator.graph.latenciesOverTime.title=Latencies Over Time
+jmeter.reportgenerator.graph.latenciesOverTime.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Response Time Vs Request graph definition
+jmeter.reportgenerator.graph.responseTimeVsRequest.classname=org.apache.jmeter.report.processor.graph.impl.ResponseTimeVSRequestGraphConsumer
+jmeter.reportgenerator.graph.responseTimeVsRequest.title=Response Time Vs Request
+jmeter.reportgenerator.graph.responseTimeVsRequest.exclude_controllers=true
+jmeter.reportgenerator.graph.responseTimeVsRequest.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Latencies Vs Request graph definition
+jmeter.reportgenerator.graph.latencyVsRequest.classname=org.apache.jmeter.report.processor.graph.impl.LatencyVSRequestGraphConsumer
+jmeter.reportgenerator.graph.latencyVsRequest.title=Latencies Vs Request
+jmeter.reportgenerator.graph.latencyVsRequest.exclude_controllers=true
+jmeter.reportgenerator.graph.latencyVsRequest.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Hits Per Second graph definition
+jmeter.reportgenerator.graph.hitsPerSecond.classname=org.apache.jmeter.report.processor.graph.impl.HitsPerSecondGraphConsumer
+jmeter.reportgenerator.graph.hitsPerSecond.title=Hits Per Second
+jmeter.reportgenerator.graph.hitsPerSecond.exclude_controllers=true
+jmeter.reportgenerator.graph.hitsPerSecond.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Codes Per Second graph definition
+jmeter.reportgenerator.graph.codesPerSecond.classname=org.apache.jmeter.report.processor.graph.impl.CodesPerSecondGraphConsumer
+jmeter.reportgenerator.graph.codesPerSecond.title=Codes Per Second
+jmeter.reportgenerator.graph.codesPerSecond.exclude_controllers=true
+jmeter.reportgenerator.graph.codesPerSecond.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# Transactions Per Second graph definition
+jmeter.reportgenerator.graph.transactionsPerSecond.classname=org.apache.jmeter.report.processor.graph.impl.TransactionsPerSecondGraphConsumer
+jmeter.reportgenerator.graph.transactionsPerSecond.title=Transactions Per Second
+jmeter.reportgenerator.graph.transactionsPerSecond.property.set_granularity=${jmeter.reportgenerator.overall_granularity}
+
+# HTML Export
+jmeter.reportgenerator.exporter.html.classname=org.apache.jmeter.report.dashboard.HtmlTemplateExporter
+
+jmeter.reportgenerator.apdex_per_transaction=sample(\\d+):1000|2000,\
+                                            samples12:3000|4000;\
+                                            scenar01-12:5000|6000
+
+# Sets the source directory of templated files from which the html pages are generated.
+#jmeter.reportgenerator.exporter.html.property.template_dir=report-template
+
+# Sets the destination directory for generated html pages.
+# This will be overridden by the command line option -o 
+#jmeter.reportgenerator.exporter.html.property.output_dir=report-output
+
+# Regular Expression which Indicates which graph series are filtered in display
+# Empty value means no filtering
+#jmeter.reportgenerator.exporter.html.series_filter=
+
+# Indicates whether series filter apply only on sample series or to all series
+# setting this to false can lead to empty graphs if series_filter does not
+# contain required series
+#jmeter.reportgenerator.exporter.html.filters_only_sample_series=true
+
+# Indicates whether only controller samples are displayed on graphs that support it.
+#jmeter.reportgenerator.exporter.html.show_controllers_only=false

--- a/test/src/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
+++ b/test/src/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
@@ -16,10 +16,14 @@ import org.apache.jmeter.report.config.ReportGeneratorConfiguration;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.oro.text.regex.PatternMatcher;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jodd.props.Props;
 
 public class ApdexPerTransactionTest {
+	
+	private static final Logger log = LoggerFactory.getLogger(ApdexPerTransactionTest.class);
 	
 	// prop in the file mixes comma, semicolon and spans several lines.
 	// it also includes hardcoded sample names mixed with regexes 
@@ -87,7 +91,7 @@ public class ApdexPerTransactionTest {
         try (FileInputStream inStream = new FileInputStream(file)) {
             props.load(inStream);
         } catch (IOException e) {
-            System.err.println("Problem loading properties. " + e); // NOSONAR
+            log.error("Problem loading properties. " + e); // NOSONAR
         }
         return props;
     }

--- a/test/src/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
+++ b/test/src/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
@@ -1,0 +1,112 @@
+package org.apache.jmeter.report.dashboard;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.jmeter.report.config.ReportGeneratorConfiguration;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.oro.text.regex.PatternMatcher;
+import org.junit.Test;
+
+import jodd.props.Props;
+
+public class ApdexPerTransactionTest {
+	
+	// prop in the file mixes comma, semicolon and spans several lines.
+	// it also includes hardcoded sample names mixed with regexes 
+	private static final String apdexString = "sample(\\d+):1000|2000,samples12:3000|4000;scenar01-12:5000|6000";
+	
+	@Test
+	public void testgetApdexPerTransactionProperty() {
+		final Properties merged = new Properties();
+		final Props props = new Props();
+		final String REPORT_GENERATOR_KEY_PREFIX = "jmeter.reportgenerator";
+		final char KEY_DELIMITER = '.';
+		final String REPORT_GENERATOR_KEY_APDEX_PER_TRANSACTION = REPORT_GENERATOR_KEY_PREFIX
+	            + KEY_DELIMITER + "apdex_per_transaction";
+		
+		File rgp = new File("test/resources/", "reportgenerator_test.properties");
+		merged.putAll(loadProps(rgp));
+		props.load(merged);
+		final String apdexPerTransaction = getOptionalProperty(props, 
+        		REPORT_GENERATOR_KEY_APDEX_PER_TRANSACTION, 
+        		String.class);
+		assertEquals(apdexString, apdexPerTransaction);
+		
+	}
+	
+	@Test
+	public void testGetApdexPerTransactionParts() {
+		Map<String, Long[]> apdex = ReportGeneratorConfiguration.getApdexPerTransactionParts(apdexString);
+		assertNotNull("map should not be null", apdex);
+		assertEquals(3, apdex.size());
+		Set<String> keys = apdex.keySet();
+		assertTrue(keys.contains("samples12"));
+		assertTrue(keys.contains("scenar01-12"));
+		assertTrue(keys.contains("sample(\\d+)"));
+		assertArrayEquals(new Long[] {1000L,  2000L}, apdex.get("sample(\\d+)"));
+	}
+	
+	@Test
+	public void testSampleNameMatching() {
+		/* matching pairs : 
+		 * sample(\d+) sample2
+		 * sample(\d+) sample12
+		 * scenar01-12 scenar01-12
+		 * samples12 samples12
+		 * */
+		
+		String[] sampleNames = {"sample2","sample12", "scenar01-12", "samples12"};
+		
+		Map<String, Long[]> apdex = ReportGeneratorConfiguration.getApdexPerTransactionParts(apdexString);
+		for (String sampleName : sampleNames) {
+			boolean hasMatched = false;
+			for (Map.Entry<String, Long[]> entry : apdex.entrySet()) {
+				org.apache.oro.text.regex.Pattern regex = JMeterUtils.getPatternCache().getPattern(entry.getKey());
+    			PatternMatcher matcher = JMeterUtils.getMatcher();
+    			if(matcher.matches(sampleName, regex)) {
+    				hasMatched= true;
+    			}
+    		}
+			assertTrue(hasMatched);
+    	}
+		
+	}
+	
+	private static Properties loadProps(File file) {
+        final Properties props = new Properties();
+        try (FileInputStream inStream = new FileInputStream(file)) {
+            props.load(inStream);
+        } catch (IOException e) {
+            System.err.println("Problem loading properties. " + e); // NOSONAR
+        }
+        return props;
+    }
+	
+	private static String getOptionalProperty(Props props,
+            String key, Class clazz) {
+        String property = getProperty(props, key, null, clazz);
+        if (property != null) {
+        }
+        return property;
+    }
+	
+	private static String getProperty(Props props, String key,
+            String defaultValue, Class clazz)
+             {
+        String value = props.getValue(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
Add feature requested at 
https://bz.apache.org/bugzilla/show_bug.cgi?id=60112

So that apdex can be overriden per sample, everything that is not overriden will use defaults.

New sample reportgenerator.properties with new property `jmeter.reportgenerator.apdex_per_transaction`, is below.

In that example samples "scenar01-12" and "samples12" are hardcoded names and "sample(\\d+)" is a regex, so all samples that match the regex will have their apdex set by the specified values.
 ```
#jmeter.reportgenerator.apdex_satisfied_threshold=500

# Sets the tolerance threshold for the APDEX calculation (in milliseconds).
#jmeter.reportgenerator.apdex_tolerated_threshold=1500

# Sets satisfaction and tolerance threshold to specific samples.Use sample names or regular
# expression. Format is : sample_name:satisfaction|tolerance[,;]
# Notice the semicolon between sample name and values, the pipe between thresholds and the 
# comma or semicolon at the end to separate different samples. Don't forget to escape after
# comma or semicolon to span multiple lines. Ex : 
#jmeter.reportgenerator.apdex_per_transaction=sample(\\d+):1000|2000,\
#                                            samples12:3000|4000;\
#                                            scenar01-12:5000|6000  
```
