### PR TITLE
Prevent use of the same array in CollectionProperty (close #58743)

### DIFF
--- a/src/core/org/apache/jmeter/testelement/property/AbstractProperty.java
+++ b/src/core/org/apache/jmeter/testelement/property/AbstractProperty.java
@@ -297,11 +297,6 @@ public abstract class AbstractProperty implements JMeterProperty {
      * @return Collection of JMeterProperty objects
      */
     protected Collection<JMeterProperty> normalizeList(Collection<?> coll) {
-        if (coll.isEmpty()) {
-            @SuppressWarnings("unchecked") // empty collection, local var is here to allow SuppressWarnings
-            Collection<JMeterProperty> okColl = (Collection<JMeterProperty>) coll;
-            return okColl;
-        }
         try {
             @SuppressWarnings("unchecked") // empty collection
             Collection<JMeterProperty> newColl = coll.getClass().newInstance();
@@ -324,11 +319,6 @@ public abstract class AbstractProperty implements JMeterProperty {
      * @return converted Map
      */
     protected Map<String, JMeterProperty> normalizeMap(Map<?,?> coll) {
-        if (coll.isEmpty()) {
-            @SuppressWarnings("unchecked")// empty collection ok to cast, local var is here to allow SuppressWarnings
-            Map<String, JMeterProperty> emptyColl = (Map<String, JMeterProperty>) coll;
-            return emptyColl;
-        }
         try {
             @SuppressWarnings("unchecked") // empty collection
             Map<String, JMeterProperty> newColl = coll.getClass().newInstance();


### PR DESCRIPTION
CollectionProperty constructor receives an empty ObjectTableModel.objects
collection but normalizeList will return it as-is instead of creating a
new empty collection.

The two classes share the same array but add different kind of classes.

NOTE: Basically the bug is in AbstractProperty.normalizeList because it should never reuse the same instance. I've done the patch as you see it because it has the lowest impact and does not change the normalizeList API (perhaps reusing is expected in some cases?)

Let me know if I should redo the patch by just changing normalizeList!

Constructor stacktrace:
at org.apache.jmeter.testelement.property.CollectionProperty.<init>(CollectionProperty.java:40)
at org.apache.jmeter.testelement.property.AbstractProperty.makeProperty(AbstractProperty.java:395)
at org.apache.jmeter.testelement.property.AbstractProperty.createProperty(AbstractProperty.java:368)
at org.apache.jmeter.testbeans.gui.TestBeanGUI.setPropertyInElement(TestBeanGUI.java:277)
at org.apache.jmeter.testbeans.gui.TestBeanGUI.modifyTestElement(TestBeanGUI.java:266)
at org.apache.jmeter.gui.tree.JMeterTreeModel.addComponent(JMeterTreeModel.java:148)
at org.apache.jmeter.gui.action.AddToTree.doAction(AddToTree.java:70)
at org.apache.jmeter.gui.action.ActionRouter.performAction(ActionRouter.java:74)
at org.apache.jmeter.gui.action.ActionRouter.lambda$actionPerformed$28(ActionRouter.java:59)
at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
