### PR TITLE
Make smaller scripts shellcheck compatible

### DIFF
--- a/bin/heapdump.sh
+++ b/bin/heapdump.sh
@@ -19,6 +19,6 @@
 
 #   P1 = command port for JMeter instance (defaults to 4445)
 
-DIRNAME=`dirname $0`
+DIRNAME="$(dirname "$0")"
 
-java -cp ${DIRNAME}/ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient HeapDump "$@"
+java -cp "${DIRNAME}/ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient HeapDump "$@"

--- a/bin/mirror-server
+++ b/bin/mirror-server
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-exec $0.sh "$@" 
+exec "$0.sh" "$@"
 
 ##   Licensed to the Apache Software Foundation (ASF) under one or more
 ##   contributor license agreements.  See the NOTICE file distributed with

--- a/bin/mirror-server.sh
+++ b/bin/mirror-server.sh
@@ -18,7 +18,7 @@
 #   Run the JMeter mirror server in non-GUI mode
 #   P1 = port to use (default 8080)
 
-cd `dirname $0`
+cd "$(dirname "$0")" || exit 1
 
 CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/jorphan.jar:../lib/oro-2.0.8.jar
 CP=${CP}:../lib/slf4j-api-1.7.25.jar:../lib/jcl-over-slf4j-1.7.25.jar:../lib/log4j-slf4j-impl-2.8.2.jar

--- a/bin/shutdown.sh
+++ b/bin/shutdown.sh
@@ -19,6 +19,6 @@
 
 #   P1 = command port for JMeter instance (defaults to 4445)
 
-DIRNAME=`dirname $0`
+DIRNAME="$(dirname "$0")"
 
-java -cp ${DIRNAME}/ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient Shutdown "$@"
+java -cp "${DIRNAME}/ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient Shutdown "$@"

--- a/bin/stoptest.sh
+++ b/bin/stoptest.sh
@@ -19,6 +19,6 @@
 
 #   P1 = command port for JMeter instance (defaults to 4445)
 
-DIRNAME=`dirname $0`
+DIRNAME="$(dirname "$0")"
 
-java -cp ${DIRNAME}/ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient StopTestNow "$@"
+java -cp "${DIRNAME}/ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient StopTestNow "$@"

--- a/extras/proxycert.sh
+++ b/extras/proxycert.sh
@@ -35,7 +35,7 @@ STOREPASSWORD=password
 KEYPASSWORD=password
 
 ## generate the keystore with the certificate
-keytool -genkeypair -alias jmeter -keystore ${KEYSTORE} -keypass ${KEYPASSWORD} -storepass ${STOREPASSWORD} -validity ${VALIDITY} -keyalg RSA -dname "${DNAME}"
+keytool -genkeypair -alias jmeter -keystore ${KEYSTORE} -keypass ${KEYPASSWORD} -storepass ${STOREPASSWORD} -validity "${VALIDITY}" -keyalg RSA -dname "${DNAME}"
 
 ## show the contents
 keytool -list -v -keystore ${KEYSTORE} -storepass ${STOREPASSWORD}


### PR DESCRIPTION
Per https://bz.apache.org/bugzilla/show_bug.cgi?id=61399 - modifying smaller scripts for shellcheck compatibility.