### PR TITLE
Fixing bin/jmeter.sh version error, working as expected with Oracle J…

### DIFF
--- a/bin/jmeter.sh
+++ b/bin/jmeter.sh
@@ -6,9 +6,9 @@
 ##   The ASF licenses this file to You under the Apache License, Version 2.0
 ##   (the "License"); you may not use this file except in compliance with
 ##   the License.  You may obtain a copy of the License at
-## 
+##
 ##       http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ##   Unless required by applicable law or agreed to in writing, software
 ##   distributed under the License is distributed on an "AS IS" BASIS,
 ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,19 +30,24 @@
 # Minimal version to run JMeter
 MINIMAL_VERSION=1.8.0
 
-# Check if Java is present and the minimal version requirement
 _java=`type java | awk '{ print $ NF }'`
 CURRENT_VERSION=`"$_java" -version 2>&1 | awk -F'"' '/version/ {print $2}'`
-minimal_version=`echo $MINIMAL_VERSION | awk -F'.' '{ print $2 }'`
-current_version=`echo $CURRENT_VERSION | awk -F'.' '{ print $2 }'`
-if [ $current_version ]; then
-        if [ $current_version -lt $minimal_version ]; then
-                 echo "Error: Java version is too low to run JMeter. Needs at least Java >= ${MINIMAL_VERSION}." 
-                 exit 1
-        fi
-    else
-         echo "Not able to find Java executable or version. Please check your Java installation."
-         exit 1
+# Check if version is from OpenJDK, containig 1.${version}.x
+if [ ${#CURRENT_VERSION} -lt 1 ]; then
+    CURRENT_VERSION=`echo $CURRENT_VERSION | awk -F'.' '{ print $2 }'`
+else
+    MINIMAL_VERSION=`echo $MINIMAL_VERSION | awk -F'.' '{ print $2 }'`
+fi
+
+# Check if Java is present and the minimal version requirement
+if [ $CURRENT_VERSION ]; then
+    if [ $CURRENT_VERSION -lt $MINIMAL_VERSION ]; then
+        echo "Error: Java version is too low to run JMeter. Needs at least Java >= ${MINIMAL_VERSION}."
+        exit 1
+    fi
+else
+    echo "Not able to find Java executable or version. Please check your Java installation."
+    exit 1
 fi
 
 JMETER_OPTS=""


### PR DESCRIPTION
Java 9 and OpenJDK 9. New binary from Java HotSpot just displays java version "9" which was breaking service initialization.

```
+ MINIMAL_VERSION=1.8.0
++ awk '{ print $ NF }'
++ type java
+ _java=/usr/bin/java
++ /usr/bin/java -version
++ awk '-F"' '/version/ {print $2}'
+ CURRENT_VERSION=9
++ echo 1.8.0
++ awk -F. '{ print $2 }'
+ minimal_version=8
++ echo 9
++ awk -F. '{ print $2 }'
+ current_version=
+ '[' ']'
+ echo 'Not able to find Java executable or version. Please check your Java installation.'
Not able to find Java executable or version. Please check your Java installation.
+ exit 1
```

As you can see, current_version is empty, and can't be checked.

Java version return:
`java version "9"
Java(TM) SE Runtime Environment (build 9+181)
Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)`