### PR TITLE
Improve wording and formatting of jmeter.properties

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -8,9 +8,9 @@
 ##   The ASF licenses this file to You under the Apache License, Version 2.0
 ##   (the "License"); you may not use this file except in compliance with
 ##   the License.  You may obtain a copy of the License at
-## 
+##
 ##       http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ##   Unless required by applicable law or agreed to in writing, software
 ##   distributed under the License is distributed on an "AS IS" BASIS,
 ##   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -177,7 +177,7 @@ jmeter.laf.mac=System
 #jmeter.tree.icons.size=32x32
 
 #Components to not display in JMeter GUI (GUI class name or static label)
-# These elements are deprecated and will be removed in next version: 
+# These elements are deprecated and will be removed in next version:
 # MongoDB Script, MongoDB Source Config, Monitor Results
 # BSF Elements
 not_in_menu=org.apache.jmeter.protocol.mongodb.sampler.MongoScriptSampler,org.apache.jmeter.protocol.mongodb.config.MongoSourceElement,\
@@ -261,7 +261,7 @@ remote_hosts=127.0.0.1
 # On the client:
 # - set remote_hosts=server:1234
 
-# Parameter that controls the RMI port used by the RemoteSampleListenerImpl (The Controler)
+# Parameter that controls the RMI port used by RemoteSampleListenerImpl (The Controller)
 # Default value is 0 which means port is randomly assigned
 # You may need to open Firewall port on the Controller machine
 #client.rmi.localport=0
@@ -275,7 +275,7 @@ remote_hosts=127.0.0.1
 #client.retries_delay=5000
 
 # When all initialization tries was made, test will fail if some remote engines are failed
-# Set following property to true to ignore failed nodes and proceed with test 
+# Set following property to true to ignore failed nodes and proceed with test
 #client.continue_on_fail=false
 
 # To change the default port (1099) used to access the server:
@@ -311,7 +311,7 @@ remote_hosts=127.0.0.1
 # Following properties apply to Apache HttpClient
 #---------------------------------------------------------------------------
 
-# set the socket timeout (or use the parameter http.socket.timeout) 
+# set the socket timeout (or use the parameter http.socket.timeout)
 # for AJP Sampler implementation.
 # Value is in milliseconds
 #httpclient.timeout=0
@@ -336,7 +336,7 @@ remote_hosts=127.0.0.1
 
 # AuthManager Kerberos configuration
 # Name of application module used in jaas.conf
-#kerberos_jaas_application=JMeter  
+#kerberos_jaas_application=JMeter
 
 # Should ports be stripped from urls before constructing SPNs
 # for SPNEGO authentication
@@ -358,7 +358,7 @@ remote_hosts=127.0.0.1
 
 # true if it's OK to retry requests that have been sent
 # This will retry Idempotent and non Idempotent requests
-# This should usually be false, but it can be useful 
+# This should usually be false, but it can be useful
 # when testing against some Load Balancers like Amazon ELB
 #httpclient4.request_sent_retry_enabled=false
 
@@ -368,15 +368,16 @@ remote_hosts=127.0.0.1
 # If <= 0, idle timeout will only apply if the server sends a Keep-Alive header
 #httpclient4.idletimeout=0
 
-# Check connections if the elapsed time (Milliseconds) since the last 
+# Check connections if the elapsed time (Milliseconds) since the last
 # use of the connection exceed this value
 #httpclient4.validate_after_inactivity=1700
 
-# TTL (in Milliseconds) represents an absolute value. 
-# No matter what, the connection will not be re-used beyond its TTL. 
+# TTL (in Milliseconds) represents an absolute value.
+# No matter what, the connection will not be re-used beyond its TTL.
 #httpclient4.time_to_live=2000
 
-# Max size in bytes of PUT body to retain in result sampler. Bigger results will be clipped.
+# Max size in bytes of PUT body to retain in result sampler.
+# Bigger results will be clipped.
 #httpclient4.max_body_retain_size=32768
 
 #---------------------------------------------------------------------------
@@ -387,7 +388,7 @@ remote_hosts=127.0.0.1
 #cacheable_methods=GET
 # N.B. This property is currently a temporary solution for Bug 56162
 
-# Since 2.12, JMeter does not create anymore a Sample Result with 204 response 
+# Since 2.12, JMeter does not create anymore a Sample Result with 204 response
 # code for a resource found in cache which is inline with what browser do.
 #cache_manager.cached_resource_mode=RETURN_NO_SAMPLE
 
@@ -397,10 +398,17 @@ remote_hosts=127.0.0.1
 # RETURN_CUSTOM_STATUS
 
 # Those mode have the following behaviours:
-# RETURN_NO_SAMPLE : this mode returns no Sample Result, it has no additional configuration
-# RETURN_200_CACHE : this mode will return Sample Result with response code to 200 and response message to "(ex cache)", you can modify response message by setting 
+# RETURN_NO_SAMPLE:
+# this mode returns no Sample Result, it has no additional configuration
+
+# RETURN_200_CACHE:
+# this mode will return Sample Result with response code to 200 and
+# response message to "(ex cache)", you can modify response message by setting
 # RETURN_200_CACHE.message=(ex cache)
-# RETURN_CUSTOM_STATUS : This mode lets you select what response code and message you want to return, if you use this mode you need to set those properties
+
+# RETURN_CUSTOM_STATUS:
+# This mode lets you select what response code and message you want to return,
+# if you use this mode you need to set those properties
 # RETURN_CUSTOM_STATUS.code=
 # RETURN_CUSTOM_STATUS.message=
 
@@ -414,9 +422,8 @@ remote_hosts=127.0.0.1
 # legitimate values: xml, csv, db.  Only xml and csv are currently supported.
 #jmeter.save.saveservice.output_format=csv
 
-
-# true when field should be saved; false otherwise
-
+# The below properties are true when field should be saved; false otherwise
+#
 # assertion_results_failure_message only affects CSV output
 #jmeter.save.saveservice.assertion_results_failure_message=true
 #
@@ -462,7 +469,7 @@ remote_hosts=127.0.0.1
 # where the fields' values are separated by specified delimiters.
 # Default:
 #jmeter.save.saveservice.default_delimiter=,
-# For TAB, since JMeter 2.3 one can use:
+# For TAB, since JMeter 2.3, one can use:
 #jmeter.save.saveservice.default_delimiter=\t
 
 # Only applies to CSV format files:
@@ -617,7 +624,7 @@ cssParser.types=text/css
 # It can be disabled by setting its value to 0
 #css.parser.cache.size=400
 
-# Let the CSS Parser ingore all css errors
+# Let the CSS Parser ignore all css errors
 #css.parser.ignore_all_css_errors=true
 
 #---------------------------------------------------------------------------
@@ -635,14 +642,14 @@ htmlParser.className=org.apache.jmeter.protocol.http.parser.LagartoBasedHtmlPars
 # Default parser before 2.10
 #htmlParser.className=org.apache.jmeter.protocol.http.parser.JTidyHTMLParser
 # Note that Regexp extractor may detect references that have been commented out.
-# In many cases it will work OK, but you should be aware that it may generate 
+# In many cases it will work OK, but you should be aware that it may generate
 # additional references.
 #htmlParser.className=org.apache.jmeter.protocol.http.parser.RegexpHTMLParser
-# This parser is based on JSoup, it should be the most accurate but less performant
-# than LagartoBasedHtmlParser
+# This parser is based on JSoup, it should be the most accurate but less
+# performant than LagartoBasedHtmlParser
 #htmlParser.className=org.apache.jmeter.protocol.http.parser.JsoupBasedHtmlParser
 
-#Used by HTTPSamplerBase to associate htmlParser with content types below 
+#Used by HTTPSamplerBase to associate htmlParser with content types below
 htmlParser.types=text/html application/xhtml+xml application/xml text/xml
 
 #---------------------------------------------------------------------------
@@ -651,8 +658,8 @@ htmlParser.types=text/html application/xhtml+xml application/xml text/xml
 
 wmlParser.className=org.apache.jmeter.protocol.http.parser.RegexpHTMLParser
 
-#Used by HTTPSamplerBase to associate wmlParser with content types below 
-wmlParser.types=text/vnd.wap.wml 
+#Used by HTTPSamplerBase to associate wmlParser with content types below
+wmlParser.types=text/vnd.wap.wml
 
 #---------------------------------------------------------------------------
 # Remote batching configuration
@@ -662,9 +669,9 @@ wmlParser.types=text/vnd.wap.wml
 # - false means server configuration will be used
 #sample_sender_client_configured=true
 
-# By default when Stripping modes are used JMeter since 3.1 will strip 
+# By default when Stripping modes are used JMeter since 3.1 will strip
 # response even for SampleResults in error.
-# If you want to revert to previous behaviour (no stripping of Responses in error) 
+# If you want to revert to previous behaviour (no stripping of Responses in error)
 # set this property to false
 #sample_sender_strip_also_on_error=true
 
@@ -700,7 +707,7 @@ wmlParser.types=text/vnd.wap.wml
 #mode=DiskStore
 # Same as DiskStore but strips response data from SampleResult
 #mode=StrippedDiskStore
-# Note: the mode is currently resolved on the client; 
+# Note: the mode is currently resolved on the client;
 # other properties (e.g. time_threshold) are resolved on the server.
 
 #---------------------------------------------------------------------------
@@ -769,7 +776,7 @@ summariser.name=summary
 #summariser.out=true
 
 # Ignore SampleResults generated by TransactionControllers
-# defaults to true 
+# defaults to true
 #summariser.ignore_transaction_controller_sample_result=true
 
 
@@ -790,20 +797,20 @@ summariser.name=summary
 # BackendListener - configuration
 #---------------------------------------------------------------------------
 #
-# Backend metrics window mode (fixed=fixed-size window, timed=time boxed) 
+# Backend metrics window mode (fixed=fixed-size window, timed=time boxed)
 #backend_metrics_window_mode=fixed
 # Backend metrics sliding window size for Percentiles, Min, Max
 #backend_metrics_window=100
 
-# Backend metrics sliding window size for Percentiles, Min, Max 
+# Backend metrics sliding window size for Percentiles, Min, Max
 # when backend_metrics_window_mode is timed
-# Setting this value too high can lead to OOM 
+# Setting this value too high can lead to OOM
 #backend_metrics_large_window=5000
 
 ########################
 # Graphite Backend
 ########################
-# Send interval in second 
+# Send interval in second
 # Defaults to 1 second
 #backend_graphite.send_interval=1
 
@@ -811,7 +818,7 @@ summariser.name=summary
 # Influx Backend
 ########################
 
-# Send interval in second 
+# Send interval in second
 # Defaults to 5 seconds
 #backend_influxdb.send_interval=5
 #Influxdb timeouts
@@ -861,7 +868,7 @@ beanshell.server.file=../extras/startup.bsh
 #Path to Groovy file containing utility functions to make available to __groovy function
 #groovy.utilities=
 
-# Example 
+# Example
 #groovy.utilities=bin/utility.groovy
 
 #---------------------------------------------------------------------------
@@ -918,7 +925,7 @@ csvdataset.file.encoding_list=UTF-8|UTF-16|ISO-8859-15|US-ASCII
 # "Equals" response assertions will be very likely to fail against search results.
 #
 #ldapsampler.max_sorted_results=1000
- 
+
 # Number of characters to log for each of three sections (starting matching section, diff section,
 #   ending matching section where not all sections will appear for all diffs) diff display when an Equals
 #   assertion fails. So a value of 100 means a maximum of 300 characters of diff text will be displayed
@@ -931,8 +938,8 @@ csvdataset.file.encoding_list=UTF-8|UTF-16|ISO-8859-15|US-ASCII
 #---------------------------------------------------------------------------
 # Miscellaneous configuration
 #---------------------------------------------------------------------------
-# Used to control what happens when you start a test and 
-# have listeners that could overwrite existing result files 
+# Used to control what happens when you start a test and
+# have listeners that could overwrite existing result files
 # Possible values:
 # ASK : Ask user
 # APPEND : Append results to existing file
@@ -953,7 +960,7 @@ csvdataset.file.encoding_list=UTF-8|UTF-16|ISO-8859-15|US-ASCII
 #jmeter.expertMode=true
 
 # Max size of bytes stored in memory per SampleResult
-# Ensure you don't exceed max capacity of a Java Array and remember 
+# Ensure you don't exceed max capacity of a Java Array and remember
 # that the higher it is, the higher JMeter will consume heap
 # Defaults to 0, which means no truncation
 #httpsampler.max_bytes_to_store_per_request=0
@@ -971,7 +978,7 @@ csvdataset.file.encoding_list=UTF-8|UTF-16|ISO-8859-15|US-ASCII
 #httpsampler.separate.container=true
 
 # If embedded resources download fails due to missing resources or other reasons, if this property is true
-# Parent sample will not be marked as failed 
+# Parent sample will not be marked as failed
 #httpsampler.ignore_failed_embedded_resources=false
 
 #keep alive time for the parallel download threads (in seconds)
@@ -1002,7 +1009,7 @@ csvdataset.file.encoding_list=UTF-8|UTF-16|ISO-8859-15|US-ASCII
 # CookieManager behaviour - prefix to add to cookie name before storing it as a variable
 # Default is COOKIE_; to remove the prefix, define it as one or more spaces
 #CookieManager.name.prefix=
- 
+
 # CookieManager behaviour - check received cookies are valid before storing them?
 # Default is true. Use false to revert to previous behaviour
 #CookieManager.check.cookies=true
@@ -1035,7 +1042,7 @@ cookies=cookies
 #jmeterengine.force.system.exit=false
 
 # How long to pause (in ms) in the daemon thread before reporting that the JVM has failed to exit.
-# If the value is <= 0, the JMeter does not start the daemon thread 
+# If the value is <= 0, the JMeter does not start the daemon thread
 #jmeter.exit.check.pause=2000
 
 # If running non-GUI, then JMeter listens on the following port for a shutdown message.
@@ -1063,7 +1070,7 @@ cookies=cookies
 #jsyntaxtextarea.font.family=Hack
 #jsyntaxtextarea.font.size=14
 
-# Set this to false to disable the use of JSyntaxTextArea for the Console Logger panel 
+# Set this to false to disable the use of JSyntaxTextArea for the Console Logger panel
 #loggerpanel.usejsyntaxtext=true
 
 # Maximum size of HTML page that can be displayed; default=10 mbytes
@@ -1206,7 +1213,7 @@ system.properties=system.properties
 # Default Timer GUI class added to Test Plan by DefaultThinkTimeCreator
 #think_time_creator.default_timer_implementation=org.apache.jmeter.timers.gui.UniformRandomTimerGui
 
-# Default constant pause of Timer 
+# Default constant pause of Timer
 #think_time_creator.default_constant_pause=1000
 
 # Default range pause of Timer
@@ -1230,4 +1237,3 @@ jmeter.reportgenerator.apdex_tolerated_threshold=1500
 
 # Implementation of interface org.apache.jmeter.gui.action.TreeNodeNamingPolicy
 #naming_policy.impl=org.apache.jmeter.gui.action.impl.DefaultTreeNodeNamingPolicy
-	


### PR DESCRIPTION
- fixed some typos,
- re-formatted some lines to aid readability and 
- removed extra whitespace.