### PR TITLE
Expansion of "Add expand/collapse all menu in render XML view" (PR #294)

### DIFF
--- a/src/components/org/apache/jmeter/visualizers/RenderAsXML.java
+++ b/src/components/org/apache/jmeter/visualizers/RenderAsXML.java
@@ -49,9 +49,9 @@ public class RenderAsXML extends SamplerResultTab
 
     private static final Logger log = LoggerFactory.getLogger(RenderAsXML.class);
 
-    private static final byte[] XML_PFX = {'<','?','x','m','l',' '};//"<?xml "
+    private static final byte[] XML_PFX = {'<', '?', 'x', 'm', 'l', ' '};//"<?xml "
 
-    public RenderAsXML(){
+    public RenderAsXML() {
         activateSearchExtension = false; // TODO work out how to search the XML pane
     }
 
@@ -66,8 +66,8 @@ public class RenderAsXML extends SamplerResultTab
         results.setCaretPosition(0);
         byte[] source = res.getResponseData();
         final ByteArrayInputStream baIS = new ByteArrayInputStream(source);
-        for(int i=0; i<source.length-XML_PFX.length; i++){
-            if (JOrphanUtils.startsWith(source, XML_PFX, i)){
+        for (int i = 0; i < source.length - XML_PFX.length; i++) {
+            if (JOrphanUtils.startsWith(source, XML_PFX, i)) {
                 baIS.skip(i);// NOSONAR Skip the leading bytes (if any)
                 break;
             }
@@ -78,7 +78,8 @@ public class RenderAsXML extends SamplerResultTab
         org.w3c.dom.Document document = tidy.parseDOM(baIS, null);
         document.normalize();
         if (tidy.getParseErrors() > 0) {
-            showErrorMessageDialog(sw.toString(),
+            showErrorMessageDialog(
+                    sw.toString(),
                     "Tidy: " + tidy.getParseErrors() + " errors, " + tidy.getParseWarnings() + " warnings",
                     JOptionPane.WARNING_MESSAGE);
         }
@@ -99,7 +100,7 @@ public class RenderAsXML extends SamplerResultTab
     /*
      *
      * A Dom tree panel for to display response as tree view author <a
-     * href="mailto:d.maung@mdl.com">Dave Maung</a> 
+     * href="mailto:d.maung@mdl.com">Dave Maung</a>
      * TODO implement to find any nodes in the tree using TreePath.
      *
      */
@@ -126,7 +127,6 @@ public class RenderAsXML extends SamplerResultTab
             } catch (SAXException e) {
                 log.warn("Error trying to parse document", e);
             }
-
         }
 
         /**
@@ -134,7 +134,6 @@ public class RenderAsXML extends SamplerResultTab
          * We let user insert them however in DOMTreeView, we don't display them.
          *
          * @param parent {@link Node}
-         * @return
          */
         private Node getFirstElement(Node parent) {
             NodeList childNodes = parent.getChildNodes();
@@ -142,7 +141,7 @@ public class RenderAsXML extends SamplerResultTab
             for (int i = 0; i < childNodes.getLength(); i++) {
                 Node childNode = childNodes.item(i);
                 toReturn = childNode;
-                if (childNode.getNodeType() == Node.ELEMENT_NODE){
+                if (childNode.getNodeType() == Node.ELEMENT_NODE) {
                     break;
                 }
 
@@ -154,16 +153,19 @@ public class RenderAsXML extends SamplerResultTab
          * This class is to view as tooltext. This is very useful, when the
          * contents has long string and does not fit in the view. it will also
          * automatically wrap line for each 100 characters since tool tip
-         * support html. 
+         * support html.
          */
         private static class DomTreeRenderer extends DefaultTreeCellRenderer {
 
             private static final long serialVersionUID = 240210061375790195L;
 
             @Override
-            public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded,
+            public Component getTreeCellRendererComponent(
+                    JTree tree, Object value, boolean sel, boolean expanded,
                     boolean leaf, int row, boolean phasFocus) {
-                super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, phasFocus);
+
+                super.getTreeCellRendererComponent(
+                        tree, value, sel, expanded, leaf, row, phasFocus);
 
                 DefaultMutableTreeNode valueTreeNode = (DefaultMutableTreeNode) value;
                 setToolTipText(getHTML(valueTreeNode.toString(), "<br>", 100)); // $NON-NLS-1$
@@ -172,11 +174,6 @@ public class RenderAsXML extends SamplerResultTab
 
             /**
              * get the html
-             *
-             * @param str
-             * @param separator
-             * @param maxChar
-             * @return
              */
             private String getHTML(String str, String separator, int maxChar) {
                 StringBuilder strBuf = new StringBuilder("<html><body bgcolor=\"yellow\"><b>"); // $NON-NLS-1$
@@ -197,21 +194,21 @@ public class RenderAsXML extends SamplerResultTab
             private String encode(char c) {
                 String toReturn = String.valueOf(c);
                 switch (c) {
-                case '<': // $NON-NLS-1$
-                    toReturn = "&lt;"; // $NON-NLS-1$
-                    break;
-                case '>': // $NON-NLS-1$
-                    toReturn = "&gt;"; // $NON-NLS-1$
-                    break;
-                case '\'': // $NON-NLS-1$
-                    toReturn = "&apos;"; // $NON-NLS-1$
-                    break;
-                case '\"': // $NON-NLS-1$
-                    toReturn = "&quot;"; // $NON-NLS-1$
-                    break;
-                default:
-                    // ignored
-                    break;
+                    case '<': // $NON-NLS-1$
+                        toReturn = "&lt;"; // $NON-NLS-1$
+                        break;
+                    case '>': // $NON-NLS-1$
+                        toReturn = "&gt;"; // $NON-NLS-1$
+                        break;
+                    case '\'': // $NON-NLS-1$
+                        toReturn = "&apos;"; // $NON-NLS-1$
+                        break;
+                    case '\"': // $NON-NLS-1$
+                        toReturn = "&quot;"; // $NON-NLS-1$
+                        break;
+                    default:
+                        // ignored
+                        break;
 
                 }
                 return toReturn;

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -2794,8 +2794,8 @@ are part of the test plan.</p></description>
 <component name="View Results Tree" index="&sect-num;.3.6" width="910" height="659" screenshot="view_results_tree.png">
 <description>
 <note>
-View Results Tree MUST NOT BE USED during load test as it consumes a lot of resources (memory and CPU). Use it only for either functional testing or 
-during Test Plan debugging and Validation.
+View Results Tree MUST NOT BE USED during load test as it consumes a lot of resources (memory and CPU).
+Use it only for either functional testing or during Test Plan debugging and Validation.
 </note>
 The View Results Tree shows a tree of all sample responses, allowing you to view the
 response for any sample.  In addition to showing the response, you can see the time it took to get
@@ -2895,8 +2895,9 @@ video/
 </source>
 <br/></td></tr>
 <tr><td><code>XML</code></td>
-<td>The <i>XML view</i> will show response in tree style. 
+<td>The <i>XML view</i> will show response in tree style.
 Any DTD nodes or Prolog nodes will not show up in tree; however, response may contain those nodes.
+You can right-click on any node and expand or collapse all nodes below it.
 <br/></td></tr>
 <tr><td><code>XPath Tester</code></td>
 <td>The <i>XPath Tester</i> only works for text responses. It shows the plain text in the upper panel.


### PR DESCRIPTION
## Description

Update and expansion to PR #294. I hope @max3163 doesn't mind. It improves upon the UX of the original (good) idea by having the right click also select the node, rather than right click bring up the menu but not changing the selected node which felt counter intuitive.

## Motivation and Context

Makes exploring the XML results far easier, especially for large documents.

## How Has This Been Tested?

Manually downloading a few different xml docs and right clicking, expanding and collapsing in various places.

## Screenshots (if appropriate):
Right clicking on the element, selects it and brings up the menu:
![Right-click on element](https://user-images.githubusercontent.com/3393038/32809390-93ddce74-c98e-11e7-98a0-ba6db1814109.png)
Expands all:
![Expand All](https://user-images.githubusercontent.com/3393038/32809399-99c05500-c98e-11e7-83e9-a334aedd692b.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines

