### PR TITLE
Added header check to checkstyle, fixed errors and minor cleanup

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -26,60 +26,63 @@
 <module name="Checker">
 
   <property name="localeLanguage" value="en"/>
+  <property name="charset" value="UTF-8"/>
+  <property name="severity" value="error"/>
+  <property name="fileExtensions" value="java, groovy, properties, xml"/>
 
   <!-- Verify that EVERY source file has the appropriate license -->
-<!-- 
-  <module name="Header">
-    <property name="headerFile" value="${checkstyle.header.file}"/>
+  <module name="RegexpHeader">
+    <property name="headerFile" value="java.header.regex"/>
+    <property name="multiLines" value="10"/>
+    <property name="fileExtensions" value="java, groovy"/>
   </module>
--->
- 
+
   <!-- No tabs allowed! -->
   <module name="FileTabCharacter">
-    <property name="fileExtensions" value="java, xml, xsd, dtd, htm, html, txt"/>
+    <property name="fileExtensions" value="java, groovy, xml, xsd, dtd, htm, html, txt"/>
   </module>
-  
+
   <module name="NewlineAtEndOfFile"/>
 
   <module name="TreeWalker">
-   
+
     <!-- Operator must be at end of wrapped line -->
-<!--     
+<!--
     <module name="OperatorWrap">
       <property name="option" value="eol"/>
     </module>
 -->
-    
+
     <!-- Interfaces must be types (not just constants) -->
     <module name="InterfaceIsType"/>
 
     <!-- Must have class / interface header comments -->
 <!--
     <module name="JavadocType"/>
--->        
+-->
      <!-- Require method javadocs, allow undeclared RTE -->
-<!-- 
+<!--
     <module name="JavadocMethod">
       <property name="allowUndeclaredRTE" value="true"/>
       <property name="allowMissingThrowsTags" value="true"/>
     </module>
--->        
+-->
 
     <!-- Require field javadoc -->
-<!--     
+<!--
     <module name="JavadocVariable"/>
--->        
-            
+-->
+
     <!-- No public fields -->
-<!-- 
+<!--
     <module name="VisibilityModifier">
        <property name="protectedAllowed" value="true"/>
     </module>
--->        
-    
+-->
+
     <!-- Require hash code override when equals is -->
     <module name="EqualsHashCode"/>
-    
+
     <!-- Disallow unnecessary instantiation of Boolean, String -->
     <module name="IllegalInstantiation">
       <property name="classes" value="java.lang.Boolean, java.lang.String"/>
@@ -91,11 +94,6 @@
     <module name="FileContentsHolder"/>
 
   </module>
-  
-  <!-- Require package javadoc -->
-<!--  
-  <module name="JavadocPackage"/>
--->
 
   <!-- Setup special comments to suppress specific checks from source files
   CHECKSTYLE\:OFF and CHECKSTYLE\:ON -->
@@ -106,7 +104,7 @@
     <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
   </module>
 
-  <!-- 
+  <!--
       Allow comment to suppress checkstyle for a single line
       e.g. // CHECKSTYLE IGNORE MagicNumber
    -->

--- a/java.header.regex
+++ b/java.header.regex
@@ -1,0 +1,10 @@
+/\*
+^ \* Licensed to the Apache Software Foundation .*$
+ \*.*
+ \*.*
+ \*.*
+ \*.*
+ \*.*
+ \*
+ \*.*http://www.apache.org/licenses/LICENSE-2.0$
+ \*.*\*\/

--- a/src/components/org/apache/jmeter/assertions/gui/SMIMEAssertionGui.java
+++ b/src/components/org/apache/jmeter/assertions/gui/SMIMEAssertionGui.java
@@ -1,20 +1,20 @@
- /*
-  * Licensed to the Apache Software Foundation (ASF) under one or more
-  * contributor license agreements.  See the NOTICE file distributed with
-  * this work for additional information regarding copyright ownership.
-  * The ASF licenses this file to You under the Apache License, Version 2.0
-  * (the "License"); you may not use this file except in compliance with
-  * the License.  You may obtain a copy of the License at
-  *
-  *   http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  *
-  */
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 package org.apache.jmeter.assertions.gui;
 

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
@@ -51,9 +51,6 @@ public class BackendListener extends AbstractTestElement
     implements Backend, Serializable, SampleListener, 
         TestStateListener, NoThreadClone, Remoteable {
 
-    /**
-     * 
-     */
     private static final class ListenerClientData {
         private BackendListenerClient client;
         private BlockingQueue<SampleResult> queue;
@@ -64,9 +61,6 @@ public class BackendListener extends AbstractTestElement
         private CountDownLatch latch;
     }
 
-    /**
-     * 
-     */
     private static final long serialVersionUID = 1L;
 
     private static final Logger log = LoggerFactory.getLogger(BackendListener.class);
@@ -289,16 +283,11 @@ public class BackendListener extends AbstractTestElement
     }
 
     // TestStateListener implementation
-    /**
-     *  Implements TestStateListener.testStarted() 
-     **/
     @Override
     public void testStarted() {
         testStarted("local"); //$NON-NLS-1$
     }
 
-    /** Implements TestStateListener.testStarted(String) 
-     **/
     @Override
     public void testStarted(String host) {
         if (log.isDebugEnabled()) {
@@ -397,8 +386,6 @@ public class BackendListener extends AbstractTestElement
         }
     }
 
-    /** Implements TestStateListener.testEnded(String)
-     **/
     @Override
     public void testEnded() {
         testEnded("local"); //$NON-NLS-1$
@@ -487,7 +474,6 @@ public class BackendListener extends AbstractTestElement
      * Sets the queue size
      *
      * @param queueSize the size of the queue
-     *
      */
     public void setQueueSize(String queueSize) {
         setProperty(QUEUE_SIZE, queueSize, DEFAULT_QUEUE_SIZE);

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListenerContext.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListenerContext.java
@@ -1,5 +1,4 @@
 /*
-
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -44,7 +43,6 @@ public class BackendListenerContext {
      * teardownTest.
      */
 
-    /** Logging */
     private static final Logger log = LoggerFactory.getLogger(BackendListenerContext.class);
 
     /**
@@ -53,7 +51,6 @@ public class BackendListenerContext {
     private final Map<String, String> params;
 
     /**
-     *
      * @param args
      *            the initialization parameters.
      */

--- a/src/core/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/org/apache/jmeter/threads/JMeterThread.java
@@ -1,5 +1,4 @@
 /*
-
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/core/org/apache/jmeter/util/CustomX509TrustManager.java
+++ b/src/core/org/apache/jmeter/util/CustomX509TrustManager.java
@@ -1,18 +1,18 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.jmeter.util;

--- a/src/core/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
+++ b/src/core/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
@@ -1,18 +1,18 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.jmeter.util;
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  *
  * Used by JsseSSLManager to set up the Java https socket handling
  */
-
 public class HttpSSLProtocolSocketFactory
     extends SSLSocketFactory {// for java sockets
 

--- a/src/core/org/apache/jmeter/util/JMeterTreeNodeTransferable.java
+++ b/src/core/org/apache/jmeter/util/JMeterTreeNodeTransferable.java
@@ -1,18 +1,18 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.jmeter.util;

--- a/src/jorphan/org/apache/log/ContextMap.java
+++ b/src/jorphan/org/apache/log/ContextMap.java
@@ -1,16 +1,16 @@
-/* 
- * Copyright 1999-2004 The Apache Software Foundation
- * Licensed  under the  Apache License,  Version 2.0  (the "License");
- * you may not use  this file  except in  compliance with the License.
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- * 
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */

--- a/src/jorphan/org/apache/log/LogEvent.java
+++ b/src/jorphan/org/apache/log/LogEvent.java
@@ -1,19 +1,20 @@
-/* 
- * Copyright 1999-2004 The Apache Software Foundation
- * Licensed  under the  Apache License,  Version 2.0  (the "License");
- * you may not use  this file  except in  compliance with the License.
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- * 
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.log;
 
 import java.io.ObjectStreamException;

--- a/src/jorphan/org/apache/log/LogTarget.java
+++ b/src/jorphan/org/apache/log/LogTarget.java
@@ -1,19 +1,20 @@
-/* 
- * Copyright 1999-2004 The Apache Software Foundation
- * Licensed  under the  Apache License,  Version 2.0  (the "License");
- * you may not use  this file  except in  compliance with the License.
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- * 
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.log;
 
 /**

--- a/src/jorphan/org/apache/log/Logger.java
+++ b/src/jorphan/org/apache/log/Logger.java
@@ -1,19 +1,20 @@
-/* 
- * Copyright 1999-2004 The Apache Software Foundation
- * Licensed  under the  Apache License,  Version 2.0  (the "License");
- * you may not use  this file  except in  compliance with the License.
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- * 
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.log;
 
 /**

--- a/src/jorphan/org/apache/log/Priority.java
+++ b/src/jorphan/org/apache/log/Priority.java
@@ -1,19 +1,20 @@
-/* 
- * Copyright 1999-2004 The Apache Software Foundation
- * Licensed  under the  Apache License,  Version 2.0  (the "License");
- * you may not use  this file  except in  compliance with the License.
- * You may obtain a copy of the License at 
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- * 
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.log;
 
 import java.io.Serializable;

--- a/src/protocol/http/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
@@ -1,23 +1,22 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.jmeter.protocol.http.control.gui;
 
-import org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui;
 import org.apache.jmeter.protocol.http.sampler.AjpSampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;

--- a/src/protocol/http/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -5,9 +5,9 @@
  * licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
@@ -1,18 +1,18 @@
 /*
- *  Licensed to the Apache Software Foundation (ASF) under one or more
- *  contributor license agreements.  See the NOTICE file distributed with
- *  this work for additional information regarding copyright ownership.
- *  The ASF licenses this file to You under the Apache License, Version 2.0
- *  (the "License"); you may not use this file except in compliance with
- *  the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.jmeter.protocol.http.sampler;
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HttpClientDefaultParameters.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HttpClientDefaultParameters.java
@@ -1,20 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.jmeter.protocol.http.sampler;

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/JMeterClientConnectionOperator.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/JMeterClientConnectionOperator.java
@@ -1,25 +1,18 @@
 /*
- * ====================================================================
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- * ====================================================================
- * 
- * This software consists of voluntary contributions made by many
- * individuals on behalf of the Apache Software Foundation. For more
- * information on the Apache Software Foundation, please see
- * <http://www.apache.org/>.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.jmeter.protocol.http.sampler;

--- a/src/protocol/http/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -1,17 +1,17 @@
 /*
-o * Licensed to the Apache Software Foundation (ASF) under one or more
+ * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership. The ASF
  * licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * 
+ *
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */


### PR DESCRIPTION
## Description
Added Java Apache licence header check, used a regex so that we don't have to change 100s of files and it still does the job of catching any file with a missing header, however it doesn't match the current format listed http://www.apache.org/dev/apply-license.html but it matches the majority of the ones in the code base at the moment.

## Motivation and Context
Prevent/notify when files are missing a header rather than rely on someone spotting it.

## How Has This Been Tested?
`ant checkstyle`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Dev enhancement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
