### PR TITLE
Enable running of JUnit tests from within IntelliJ with default config

### DIFF
--- a/test/src/org/apache/jmeter/junit/JMeterTestCase.java
+++ b/test/src/org/apache/jmeter/junit/JMeterTestCase.java
@@ -41,24 +41,27 @@ public abstract class JMeterTestCase {
     // Used by findTestFile
     private static final String filePrefix;
 
-
     /*
      * If not running under AllTests.java, make sure that the properties (and
      * log file) are set up correctly.
-     * 
-     * N.B. In order for this to work correctly, the JUnit test must be started
-     * in the bin directory, and all the JMeter jars (plus any others needed at
-     * run-time) need to be on the classpath.
-     * 
+     *
+     * N.B. This assumes the JUnit test are executed in the
+     * project root, bin directory or one level down, and all the JMeter jars
+     * (plus any others needed at run-time) need to be on the classpath.
      */
     static {
         if (JMeterUtils.getJMeterProperties() == null) {
             String file = "jmeter.properties";
             File f = new File(file);
             if (!f.canRead()) {
-                System.out.println("Can't find " + file + " - trying bin directory");
-                file = "bin/" + file;// JMeterUtils assumes Unix-style separators
-                filePrefix = "bin/";
+                System.out.println("Can't find " + file + " - trying bin/ and ../bin");
+                if (!new File("bin/" + file).canRead()) {
+                    // When running tests inside IntelliJ
+                    filePrefix = "../bin/"; // JMeterUtils assumes Unix-style separators
+                } else {
+                    filePrefix = "bin/"; // JMeterUtils assumes Unix-style separators
+                }
+                file = filePrefix + file;
             } else {
                 filePrefix = "";
             }

--- a/test/src/org/apache/jmeter/junit/JMeterTestCaseJUnit.java
+++ b/test/src/org/apache/jmeter/junit/JMeterTestCaseJUnit.java
@@ -51,19 +51,23 @@ public abstract class JMeterTestCaseJUnit extends TestCase {
      * If not running under AllTests.java, make sure that the properties (and
      * log file) are set up correctly.
      * 
-     * N.B. In order for this to work correctly, the JUnit test must be started
-     * in the bin directory, and all the JMeter jars (plus any others needed at
-     * run-time) need to be on the classpath.
-     * 
+     * N.B. This assumes the JUnit test are executed in the
+     * project root, bin directory or one level down, and all the JMeter jars
+     * (plus any others needed at run-time) need to be on the classpath.
      */
     static {
         if (JMeterUtils.getJMeterProperties() == null) {
             String file = "jmeter.properties";
             File f = new File(file);
             if (!f.canRead()) {
-                System.out.println("Can't find " + file + " - trying bin directory");
-                file = "bin/" + file;// JMeterUtils assumes Unix-style separators
-                filePrefix = "bin/";
+                System.out.println("Can't find " + file + " - trying bin/ and ../bin");
+                if (!new File("bin/" + file).canRead()) {
+                    // When running tests inside IntelliJ
+                    filePrefix = "../bin/"; // JMeterUtils assumes Unix-style separators
+                } else {
+                    filePrefix = "bin/"; // JMeterUtils assumes Unix-style separators
+                }
+                file = filePrefix + file;
             } else {
                 filePrefix = "";
             }


### PR DESCRIPTION
## Description
With the default IntelliJ config tests are not run in the `bin` or project root folder which meant tests didn't run without a custom run setting.

## Motivation and Context
Makes running tests far easier in IntelliJ.

## How Has This Been Tested?
Running a sample of unit tests in IntelliJ

## Screenshots (if appropriate):

## Types of changes
- Dev enhancement
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
