### PR TITLE
Tidy JavaDoc and fix error in getTop5ErrorMetrics method.

### DIFF
--- a/src/core/org/apache/jmeter/report/processor/Top5ErrorsSummaryData.java
+++ b/src/core/org/apache/jmeter/report/processor/Top5ErrorsSummaryData.java
@@ -19,12 +19,11 @@ package org.apache.jmeter.report.processor;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * Summary data for TOP 5 of errors.
  * Compute a map of Sample / Number of errors
+ *
  * @since 3.1
  */
 public class Top5ErrorsSummaryData {
@@ -34,72 +33,52 @@ public class Top5ErrorsSummaryData {
     private long total;
     private long errors;
 
-    /**
-     */
     public Top5ErrorsSummaryData() {
         countPerError = new HashMap<>();
     }
 
     /**
-     * 
-     * @param errorMessage String error message to add
+     * Stores the provided error message and counts the number of times it is
+     * registered.
+     *
+     * @param errorMessage String error message to register
      */
     public void registerError(String errorMessage) {
         Long value = countPerError.get(errorMessage);
-        if(value == null) {
+        if (value == null) {
             countPerError.put(errorMessage, ONE);
         } else {
-            countPerError.put(errorMessage, Long.valueOf(value.longValue()+1));
+            countPerError.put(errorMessage, Long.valueOf(value.longValue() + 1));
         }
     }
-    
-    /**
-     * Increment errors
-     */
+
     public void incErrors() {
         errors++;
     }
-    
-    /**
-     * Increment total
-     */
+
     public void incTotal() {
         total++;
     }
 
-    /**
-     * @return the total
-     */
     public long getTotal() {
         return total;
     }
 
-    /**
-     * @return the errors
-     */
     public long getErrors() {
         return errors;
     }
 
     /**
-     * Return Top 5 errors
+     * Return Top 5 errors and associated frequency.
+     *
      * @return array of [String, Long]
      */
     public Object[][] getTop5ErrorsMetrics() {
-        SortedSet<Map.Entry<String, Long>> reverseSortedSet = new TreeSet<>(
-                (Map.Entry<String, Long> e1,Map.Entry<String, Long> e2) 
-                    -> e2.getValue().compareTo(e1.getValue()));
-        
-        reverseSortedSet.addAll(countPerError.entrySet());
-        Object[][] result = new Object[Top5ErrorsBySamplerConsumer.MAX_NUMBER_OF_ERRORS_IN_TOP][2];
-        int size = 0;
-        for (Map.Entry<String, Long> entry : reverseSortedSet) {
-            if(size == Top5ErrorsBySamplerConsumer.MAX_NUMBER_OF_ERRORS_IN_TOP) {
-                break;
-            }
-            result[size] = new Object[] {entry.getKey(), entry.getValue()};
-            size++;
-        }
-        return result;
+        int maxSize = Top5ErrorsBySamplerConsumer.MAX_NUMBER_OF_ERRORS_IN_TOP;
+        return countPerError.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(maxSize)
+                .map(e -> new Object[]{e.getKey(), e.getValue()})
+                .toArray(e -> new Object[maxSize][2]);
     }
 }


### PR DESCRIPTION
## Description
Fixed bug whereby calling `registerError` with the following data set `["A", "B", "C", "D", "E", "F"]` would return `[["A", 1], [null, null], [null, null], [null, null], [null, null]]` instead of `[["A", 1], ["B", 1], ["C", 1], ["D", 1], ["E", 1]]`.

Improved JavaDoc for `registerError`
Also removed JavaDoc which did not add anything to the method names.

## Motivation and Context
Made the code more readable and at the same time fixed a subtle error.

## How Has This Been Tested?
On my spock branch:
```groovy
    def "errors with the same frequency are preserved up until the size limit"() {
        given:
            def testData = ["A", "B", "C", "D", "E", "F"]
            for (def key : testData) {
                sut.registerError(key)
            }
        expect:
            sut.getTop5ErrorsMetrics() == [["A", 1], ["B", 1], ["C", 1], ["D", 1], ["E", 1]]
    }
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
