### PR TITLE
Fix main frame position

### DIFF
--- a/src/core/org/apache/jmeter/JMeter.java
+++ b/src/core/org/apache/jmeter/JMeter.java
@@ -376,7 +376,9 @@ public class JMeter implements JMeterPlugin {
         MainFrame main = new MainFrame(treeModel, treeLis);
         splash.setProgress(100);
         ComponentUtil.centerComponentInWindow(main, 80);
+        main.setLocationRelativeTo(splash);
         main.setVisible(true);
+        main.toFront();
         instance.actionPerformed(new ActionEvent(main, 1, ActionNames.ADD_ALL));
         if (testFile != null) {
             try {

--- a/src/jorphan/org/apache/jorphan/gui/ComponentUtil.java
+++ b/src/jorphan/org/apache/jorphan/gui/ComponentUtil.java
@@ -18,8 +18,7 @@
 
 package org.apache.jorphan.gui;
 
-import java.awt.Component;
-import java.awt.Dimension;
+import java.awt.*;
 
 /**
  * This class is a Util for awt Component and could be used to place them in
@@ -49,8 +48,8 @@ public final class ComponentUtil {
             return;
         }
         double percent = percentOfScreen / 100.d;
-        Dimension dimension = component.getToolkit().getScreenSize();
-        component.setSize((int) (dimension.getWidth() * percent), (int) (dimension.getHeight() * percent));
+        Rectangle bounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration().getBounds();
+        component.setSize((int) (bounds.getWidth() * percent), (int) (bounds.getHeight() * percent));
         centerComponentInWindow(component);
     }
 
@@ -61,10 +60,9 @@ public final class ComponentUtil {
      *            the component you want to center in window
      */
     public static void centerComponentInWindow(Component component) {
-        Dimension dimension = component.getToolkit().getScreenSize();
-
-        component.setLocation((int) ((dimension.getWidth() - component.getWidth()) / 2),
-                (int) ((dimension.getHeight() - component.getHeight()) / 2));
+        Rectangle bounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration().getBounds();
+        component.setLocation((int) ((bounds.getWidth() - component.getWidth()) / 2),
+                (int) ((bounds.getHeight() - component.getHeight()) / 2));
         component.validate();
         component.repaint();
     }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -174,6 +174,7 @@ Summary
 
 <ch_section>Non-functional changes</ch_section>
 <ul>
+    <li>Show JMeter window on the top of other windows. Show JMeter window relative to default graphics device with relative size to it. Implemented by Artem Fedorov (artem at blazemeter.com) and contributed by BlazeMeter Ltd.</li>
     <li>Updated to bsh-2.0b6 (from bsh-2.0b5)</li>
     <li>Updated to rhino-1.7.7.2 (from rhino-1.7.7.1)</li>
     <li><bug>61642</bug>Improve FTP test coverage</li>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -174,7 +174,7 @@ Summary
 
 <ch_section>Non-functional changes</ch_section>
 <ul>
-    <li>Show JMeter window on the top of other windows. Show JMeter window relative to default graphics device with relative size to it. Implemented by Artem Fedorov (artem at blazemeter.com) and contributed by BlazeMeter Ltd.</li>
+    <li>Move JMeter window at the top the stacking order of any other windows. Show JMeter window relative to default graphics device with relative size to it. Implemented by Artem Fedorov (artem at blazemeter.com) and contributed by BlazeMeter Ltd.</li>
     <li>Updated to bsh-2.0b6 (from bsh-2.0b5)</li>
     <li>Updated to rhino-1.7.7.2 (from rhino-1.7.7.1)</li>
     <li><bug>61642</bug>Improve FTP test coverage</li>


### PR DESCRIPTION
1) Move JMeter window at the top the stacking order of any other windows. (Before: after start JMeter this window can be located under another window)
2) Show JMeter window relative to default graphics device with relative size to it. (Problem now is if you have 2 monitors JMeter shows main frame with dimension relative to summary screen resolution. For example 2 monitors 1920x1080 are summarized to 3840x1080 and JMeter window width will be 80% from 3840)