### PR TITLE
Test isIgnore after post processor and assertions

### DIFF
--- a/src/core/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/org/apache/jmeter/threads/JMeterThread.java
@@ -515,12 +515,14 @@ public class JMeterThread implements Runnable, Interruptible {
             threadContext.setPreviousResult(result);
             runPostProcessors(pack.getPostProcessors());
             checkAssertions(pack.getAssertions(), result, threadContext);
-            // Do not send subsamples to listeners which receive the transaction sample
-            List<SampleListener> sampleListeners = getSampleListeners(pack, transactionPack, transactionSampler);
-            notifyListeners(sampleListeners, result);
+            if ( !result.isIgnore() ) {
+                // Do not send subsamples to listeners which receive the transaction sample
+                List<SampleListener> sampleListeners = getSampleListeners(pack, transactionPack, transactionSampler);
+                notifyListeners(sampleListeners, result);
+            }
             compiler.done(pack);
             // Add the result as subsample of transaction if we are in a transaction
-            if (transactionSampler != null) {
+            if (transactionSampler != null && !result.isIgnore() ) {
                 transactionSampler.addSubSamplerResult(result);
             }
 


### PR DESCRIPTION
Actually, the new setIgnore() method allow to not send the sampleResut to all listeners. 
But you have to set the property in the sampler, you can't change it on a post-processor or in a assertion script.

This PR allow it