### PR TITLE
Bug 61827 - TextFile always adds newline to end of string

### DIFF
--- a/src/jorphan/org/apache/jorphan/io/TextFile.java
+++ b/src/jorphan/org/apache/jorphan/io/TextFile.java
@@ -19,17 +19,10 @@
 package org.apache.jorphan.io;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,26 +31,21 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Note this is just as memory-inefficient as handling a text file can be. Use
  * with restraint.
- *
  */
 public class TextFile extends File {
     private static final long serialVersionUID = 240L;
 
     private static final Logger log = LoggerFactory.getLogger(TextFile.class);
 
-    /**
-     * File encoding. null means use the platform's default.
-     */
+    /** File encoding. null means use the platform's default. */
     private String encoding = null;
 
     /**
      * Create a TextFile object to handle the named file with the given
      * encoding.
      *
-     * @param filename
-     *            File to be read and written through this object.
-     * @param encoding
-     *            Encoding to be used when reading and writing this file.
+     * @param filename File to be read and written through this object.
+     * @param encoding Encoding to be used when reading and writing this file.
      */
     public TextFile(File filename, String encoding) {
         super(filename.toString());
@@ -68,8 +56,7 @@ public class TextFile extends File {
      * Create a TextFile object to handle the named file with the platform
      * default encoding.
      *
-     * @param filename
-     *            File to be read and written through this object.
+     * @param filename File to be read and written through this object.
      */
     public TextFile(File filename) {
         super(filename.toString());
@@ -79,8 +66,7 @@ public class TextFile extends File {
      * Create a TextFile object to handle the named file with the platform
      * default encoding.
      *
-     * @param filename
-     *            Name of the file to be read and written through this object.
+     * @param filename Name of the file to be read and written through this object.
      */
     public TextFile(String filename) {
         super(filename);
@@ -90,10 +76,8 @@ public class TextFile extends File {
      * Create a TextFile object to handle the named file with the given
      * encoding.
      *
-     * @param filename
-     *            Name of the file to be read and written through this object.
-     * @param encoding
-     *            Encoding to be used when reading and writing this file.
+     * @param filename Name of the file to be read and written through this object.
+     * @param encoding Encoding to be used when reading and writing this file.
      */
     public TextFile(String filename, String encoding) {
         super(filename);
@@ -101,29 +85,19 @@ public class TextFile extends File {
     }
 
     /**
-     * Create the file with the given string as content -- or replace it's
+     * Create the file with the given string as content -- or replace its
      * content with the given string if the file already existed.
      *
-     * @param body
-     *            New content for the file.
+     * @param body New content for the file.
      */
     public void setText(String body) {
-        Writer writer = null;
-        OutputStream outputStream = null;
+        Charset charset = encoding != null
+                ? Charset.forName(encoding)
+                : Charset.defaultCharset();
         try {
-            outputStream = new FileOutputStream(this);
-            if (encoding == null) {
-                writer = new OutputStreamWriter(outputStream);
-            } else {
-                writer = new OutputStreamWriter(outputStream, encoding);
-            }
-            writer.write(body);
-            writer.flush();
-        } catch (IOException ioe) {
-            log.error("", ioe);
-        } finally {
-            JOrphanUtils.closeQuietly(writer);
-            JOrphanUtils.closeQuietly(outputStream);
+            Files.write(this.toPath(), body.getBytes(charset));
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 
@@ -133,16 +107,16 @@ public class TextFile extends File {
      * @return the content of the file
      */
     public String getText() {
-        String lineEnd = System.getProperty("line.separator"); //$NON-NLS-1$
         Charset charset = encoding != null
                 ? Charset.forName(encoding)
                 : Charset.defaultCharset();
-        try (Stream<String> stream = Files.lines(this.toPath(), charset)) {
-            return stream.collect(Collectors.joining(lineEnd));
+        try {
+            byte[] encoded = Files.readAllBytes(this.toPath());
+            return new String(encoded, charset);
         } catch (IOException ioex) {
-            log.error("", ioex); //$NON-NLS-1$
+            log.error("Failed to getText", ioex);
+            return "";
         }
-        return "";
     }
 
     /**
@@ -153,8 +127,7 @@ public class TextFile extends File {
     }
 
     /**
-     * @param string
-     *            Encoding to be used to read and write this file.
+     * @param string Encoding to be used to read and write this file.
      */
     public void setEncoding(String string) {
         encoding = string;
@@ -189,7 +162,7 @@ public class TextFile extends File {
         TextFile other = (TextFile) obj;
         if (encoding == null) {
             return other.encoding == null;
-        } 
+        }
         return encoding.equals(other.encoding);
     }
 }

--- a/src/jorphan/org/apache/jorphan/io/TextFile.java
+++ b/src/jorphan/org/apache/jorphan/io/TextFile.java
@@ -18,16 +18,16 @@
 
 package org.apache.jorphan.io;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
@@ -134,34 +134,15 @@ public class TextFile extends File {
      */
     public String getText() {
         String lineEnd = System.getProperty("line.separator"); //$NON-NLS-1$
-        StringBuilder sb = new StringBuilder();
-        Reader reader = null;
-        BufferedReader br = null;
-        FileInputStream fileInputStream = null;
-        try {
-            fileInputStream = new FileInputStream(this);
-            if (encoding == null) {
-                reader = new InputStreamReader(fileInputStream);                
-            } else {
-                reader = new InputStreamReader(fileInputStream, encoding);
-            }
-            br = new BufferedReader(reader);
-            String line = "NOTNULL"; //$NON-NLS-1$
-            while (line != null) {
-                line = br.readLine();
-                if (line != null) {
-                    sb.append(line + lineEnd);
-                }
-            }
-        } catch (IOException ioe) {
-            log.error("", ioe); //$NON-NLS-1$
-        } finally {
-            JOrphanUtils.closeQuietly(br);
-            JOrphanUtils.closeQuietly(reader); 
-            JOrphanUtils.closeQuietly(fileInputStream); 
+        Charset charset = encoding != null
+                ? Charset.forName(encoding)
+                : Charset.defaultCharset();
+        try (Stream<String> stream = Files.lines(this.toPath(), charset)) {
+            return stream.collect(Collectors.joining(lineEnd));
+        } catch (IOException ioex) {
+            log.error("", ioex); //$NON-NLS-1$
         }
-
-        return sb.toString();
+        return "";
     }
 
     /**

--- a/src/jorphan/org/apache/jorphan/io/TextFile.java
+++ b/src/jorphan/org/apache/jorphan/io/TextFile.java
@@ -91,13 +91,10 @@ public class TextFile extends File {
      * @param body New content for the file.
      */
     public void setText(String body) {
-        Charset charset = encoding != null
-                ? Charset.forName(encoding)
-                : Charset.defaultCharset();
         try {
-            Files.write(this.toPath(), body.getBytes(charset));
-        } catch (IOException e) {
-            e.printStackTrace();
+            Files.write(this.toPath(), body.getBytes(getCharset()));
+        } catch (IOException ioe) {
+            log.error("", ioe);
         }
     }
 
@@ -107,16 +104,19 @@ public class TextFile extends File {
      * @return the content of the file
      */
     public String getText() {
-        Charset charset = encoding != null
-                ? Charset.forName(encoding)
-                : Charset.defaultCharset();
         try {
             byte[] encoded = Files.readAllBytes(this.toPath());
-            return new String(encoded, charset);
-        } catch (IOException ioex) {
-            log.error("Failed to getText", ioex);
+            return new String(encoded, getCharset());
+        } catch (IOException ioe) {
+            log.error("Failed to getText", ioe);
             return "";
         }
+    }
+
+    private Charset getCharset() {
+        return encoding != null
+                    ? Charset.forName(encoding)
+                    : Charset.defaultCharset();
     }
 
     /**

--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/PublisherSampler.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/PublisherSampler.java
@@ -79,9 +79,11 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
      */
     public static String[] getSupportedEncodings() {
         // Only get JVM standard charsets
-        return Stream.concat(NO_ENCODING.stream(),
+        return Stream.concat(
+                NO_ENCODING.stream(),
                 Arrays.stream(StandardCharsets.class.getDeclaredFields())
-                        .filter(f -> Modifier.isStatic(f.getModifiers()) && Modifier.isPublic(f.getModifiers())
+                        .filter(f -> Modifier.isStatic(f.getModifiers())
+                                && Modifier.isPublic(f.getModifiers())
                                 && f.getType() == Charset.class)
                         .map(f -> {
                             try {
@@ -89,8 +91,10 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
                             } catch (IllegalArgumentException | IllegalAccessException e) {
                                 throw new RuntimeException(e);
                             }
-                        }).map(Charset::displayName).sorted())
-                .toArray(size -> new String[size]);
+                        })
+                        .map(Charset::displayName)
+                        .sorted())
+                .toArray(String[]::new);
     }
 
     private static final long serialVersionUID = 233L;
@@ -119,9 +123,9 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
     private static final String JMS_FILE_ENCODING = "jms.file_encoding"; // $NON-NLS-1$
 
     /** File extensions for text files **/
-    private static final String[] EXT_FILE_TEXT = { ".txt", ".obj" };
+    private static final String[] TEXT_FILE_EXTS = { ".txt", ".obj" };
     /** File extensions for binary files **/
-    private static final String[] EXT_FILE_BIN = { ".dat" };
+    private static final String[] BIN_FILE_EXTS = { ".dat" };
 
     // --
 
@@ -193,8 +197,7 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
     public SampleResult sample() {
         String configChoice = getConfigChoice();
         if (fileCache == null) {
-            Cache<Object, Object> newCache = buildCache(configChoice);
-            fileCache = newCache;
+            fileCache = buildCache(configChoice);
         }
 
         SampleResult result = new SampleResult();
@@ -224,19 +227,18 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
             for (int idx = 0; idx < loop; idx++) {
                 Message msg;
                 if (JMSPublisherGui.TEXT_MSG_RSC.equals(type)) {
-                    String tmsg = getRenderedContent(String.class, EXT_FILE_TEXT);
+                    String tmsg = getRenderedContent(String.class, TEXT_FILE_EXTS);
                     msg = publisher.publish(tmsg, getDestination(), msgProperties, deliveryMode, priority, expiration);
                     buffer.append(tmsg);
                 } else if (JMSPublisherGui.MAP_MSG_RSC.equals(type)) {
                     @SuppressWarnings("unchecked")
-                    Map<String, Object> map = getRenderedContent(Map.class, EXT_FILE_TEXT);
-                    Map<String, Object> m = map;
-                    msg = publisher.publish(m, getDestination(), msgProperties, deliveryMode, priority, expiration);
+                    Map<String, Object> map = getRenderedContent(Map.class, TEXT_FILE_EXTS);
+                    msg = publisher.publish(map, getDestination(), msgProperties, deliveryMode, priority, expiration);
                 } else if (JMSPublisherGui.OBJECT_MSG_RSC.equals(type)) {
-                    Serializable omsg = getRenderedContent(Serializable.class, EXT_FILE_TEXT);
+                    Serializable omsg = getRenderedContent(Serializable.class, TEXT_FILE_EXTS);
                     msg = publisher.publish(omsg, getDestination(), msgProperties, deliveryMode, priority, expiration);
                 } else if (JMSPublisherGui.BYTES_MSG_RSC.equals(type)) {
-                    byte[] bmsg = getRenderedContent(byte[].class, EXT_FILE_BIN);
+                    byte[] bmsg = getRenderedContent(byte[].class, BIN_FILE_EXTS);
                     msg = publisher.publish(bmsg, getDestination(), msgProperties, deliveryMode, priority, expiration);
                 } else {
                     throw new JMSException(type + " is not recognised");
@@ -311,8 +313,7 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
         case JMSPublisherGui.USE_FILE_RSC:
             return getInputFile();
         case JMSPublisherGui.USE_RANDOM_RSC:
-            String fname = FSERVER.getRandomFile(getRandomPath(), ext).getAbsolutePath();
-            return fname;
+            return FSERVER.getRandomFile(getRandomPath(), ext).getAbsolutePath();
         default:
             throw new IllegalArgumentException("Type of input not handled:" + getConfigChoice());
         }

--- a/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRenderer.java
+++ b/src/protocol/jms/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRenderer.java
@@ -42,6 +42,4 @@ class TextMessageRenderer implements MessageRenderer<String> {
     String getContent(FileKey key) {
         return new TextFile(key.getFilename(), key.getEncoding()).getText();
     }
-
-
 }

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRendererTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,27 +77,22 @@ public class BinaryMessageRendererTest extends MessageRendererTest<byte[]> {
 
     @Test
     public void getValueFromFile_withNoVar() {
-        String text = format("éè€%n");
+        String text = format("éè€");
         assertValueFromFile(text, "utf8.txt", true);
         assertCacheContentInString(text);
-
     }
 
     @Test
     public void getValueFromFile_withOneVar() {
         String value = "éè€";
         jmeterCtxService.get().getVariables().put("oneVar", value);
-        assertValueFromFile(format("%s%n", value), "oneVar.txt", true);
-        assertCacheContentInString(format("${oneVar}%n"));
+        assertValueFromFile(format("%s", value), "oneVar.txt", true);
+        assertCacheContentInString(format("${oneVar}"));
     }
-
-
 
     @Test
     public void getValueFromFile_withInvalidEncoding() {
-        error.expect(RuntimeException.class);
-        error.expectCause(instanceOf(UnsupportedEncodingException.class));
-
+        error.expect(UnsupportedCharsetException.class);
         render.getValueFromFile(getResourceFile("utf8.txt"), "banana", true, cache);
     }
 

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRendererTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.protocol.jms.sampler.render;
 
-import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -77,7 +76,7 @@ public class BinaryMessageRendererTest extends MessageRendererTest<byte[]> {
 
     @Test
     public void getValueFromFile_withNoVar() {
-        String text = format("éè€");
+        String text = "éè€";
         assertValueFromFile(text, "utf8.txt", true);
         assertCacheContentInString(text);
     }
@@ -86,8 +85,8 @@ public class BinaryMessageRendererTest extends MessageRendererTest<byte[]> {
     public void getValueFromFile_withOneVar() {
         String value = "éè€";
         jmeterCtxService.get().getVariables().put("oneVar", value);
-        assertValueFromFile(format("%s", value), "oneVar.txt", true);
-        assertCacheContentInString(format("${oneVar}"));
+        assertValueFromFile(value, "oneVar.txt", true);
+        assertCacheContentInString("${oneVar}");
     }
 
     @Test

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/MessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/MessageRendererTest.java
@@ -28,9 +28,6 @@ import org.junit.Rule;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
-/**
- *
- */
 public abstract class MessageRendererTest<T> {
 
     protected Cache<Object,Object> cache = Caffeine.newBuilder().build();

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRendererTest.java
@@ -27,9 +27,6 @@ import java.io.Serializable;
 import org.apache.jmeter.protocol.jms.sampler.PublisherSampler;
 import org.junit.Test;
 
-/**
- *
- */
 public class ObjectMessageRendererTest extends MessageRendererTest<Serializable> {
 
     private ObjectMessageRenderer render = RendererFactory.getInstance().getObject();
@@ -65,7 +62,7 @@ public class ObjectMessageRendererTest extends MessageRendererTest<Serializable>
         String filename = getResourceFile("object_cp1252.xml");
         Serializable object = getRenderer().getValueFromFile(filename, "Cp1252", true, cache);
         assertObject(object, "eéè€");
-        assertEquals("cache", format("%s%n", getUnicodeContent()), getFirstCachedValue());
+        assertEquals("cache", format("%s", getUnicodeContent()), getFirstCachedValue());
 
     }
 
@@ -74,7 +71,7 @@ public class ObjectMessageRendererTest extends MessageRendererTest<Serializable>
         String filename = getResourceFile("object_utf8.xml");
         Serializable object = getRenderer().getValueFromFile(filename, PublisherSampler.DEFAULT_ENCODING, true, cache);
         assertObject(object, "eéè€");
-        assertEquals("cache", format("%s%n", getUnicodeContent()), getFirstCachedValue());
+        assertEquals("cache", format("%s", getUnicodeContent()), getFirstCachedValue());
 
     }
 
@@ -85,7 +82,7 @@ public class ObjectMessageRendererTest extends MessageRendererTest<Serializable>
         assertObject(object, "eéè€");
         Person p = (Person) object;
         assertEquals("object.name", "eéè€", p.getName());
-        assertEquals("cache", format("<?xml version=\"1.0\" encoding=\"Windows-1252\"?>%n%s%n", getUnicodeContent()), getFirstCachedValue());
+        assertEquals("cache", format("<?xml version=\"1.0\" encoding=\"Windows-1252\"?>%n%s", getUnicodeContent()), getFirstCachedValue());
 
     }
 

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRendererTest.java
@@ -62,7 +62,7 @@ public class ObjectMessageRendererTest extends MessageRendererTest<Serializable>
         String filename = getResourceFile("object_cp1252.xml");
         Serializable object = getRenderer().getValueFromFile(filename, "Cp1252", true, cache);
         assertObject(object, "eéè€");
-        assertEquals("cache", format("%s", getUnicodeContent()), getFirstCachedValue());
+        assertEquals("cache", getUnicodeContent(), getFirstCachedValue());
 
     }
 
@@ -71,7 +71,7 @@ public class ObjectMessageRendererTest extends MessageRendererTest<Serializable>
         String filename = getResourceFile("object_utf8.xml");
         Serializable object = getRenderer().getValueFromFile(filename, PublisherSampler.DEFAULT_ENCODING, true, cache);
         assertObject(object, "eéè€");
-        assertEquals("cache", format("%s", getUnicodeContent()), getFirstCachedValue());
+        assertEquals("cache", getUnicodeContent(), getFirstCachedValue());
 
     }
 

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRendererTest.java
@@ -25,9 +25,6 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-/**
- *
- */
 public class TextMessageRendererTest extends MessageRendererTest<String> {
 
     private TextMessageRenderer render = RendererFactory.getInstance().getText();
@@ -49,36 +46,35 @@ public class TextMessageRendererTest extends MessageRendererTest<String> {
     private void assertContent(String resource, String encoding) {
         String filename = getResourceFile(resource);
         String actual = render.getContent(new FileKey(filename, encoding));
-        assertEquals(format("éè€%n"), actual);
+        assertEquals(format("éè€"), actual);
     }
-
 
     @Test
     public void getValueFromFileWithNoVar() {
-        assertValueFromFile(format("noVar%n"), "noVar.txt", true);
+        assertValueFromFile(format("noVar"), "noVar.txt", true);
     }
 
     @Test
     public void getValueFromFileWithOneVar() {
         jmeterCtxService.get().getVariables().put("oneVar", "foobar");
-        assertValueFromFile(format("foobar%n"), "oneVar.txt", true);
+        assertValueFromFile(format("foobar"), "oneVar.txt", true);
     }
 
     @Test
     public void checkCache() {
         jmeterCtxService.get().getVariables().put("oneVar", "foo");
-        assertValueFromFile(format("foo%n"), "oneVar.txt", true);
-        assertEquals(format("${oneVar}%n"), getFirstCachedValue());
+        assertValueFromFile(format("foo"), "oneVar.txt", true);
+        assertEquals(format("${oneVar}"), getFirstCachedValue());
 
         jmeterCtxService.get().getVariables().put("oneVar", "bar");
-        assertValueFromFile(format("bar%n"), "oneVar.txt", true);
-        assertEquals(format("${oneVar}%n"), getFirstCachedValue());
+        assertValueFromFile(format("bar"), "oneVar.txt", true);
+        assertEquals(format("${oneVar}"), getFirstCachedValue());
     }
 
     @Test
     public void checkNoVariable() {
         jmeterCtxService.get().getVariables().put("oneVar", "RAW");
-        assertValueFromFile(format("${oneVar}%n"), "oneVar.txt", false);
+        assertValueFromFile(format("${oneVar}"), "oneVar.txt", false);
     }
 
     @Test

--- a/test/src/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRendererTest.java
+++ b/test/src/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRendererTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.protocol.jms.sampler.render;
 
-import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
@@ -46,35 +45,35 @@ public class TextMessageRendererTest extends MessageRendererTest<String> {
     private void assertContent(String resource, String encoding) {
         String filename = getResourceFile(resource);
         String actual = render.getContent(new FileKey(filename, encoding));
-        assertEquals(format("éè€"), actual);
+        assertEquals("éè€", actual);
     }
 
     @Test
     public void getValueFromFileWithNoVar() {
-        assertValueFromFile(format("noVar"), "noVar.txt", true);
+        assertValueFromFile("noVar", "noVar.txt", true);
     }
 
     @Test
     public void getValueFromFileWithOneVar() {
         jmeterCtxService.get().getVariables().put("oneVar", "foobar");
-        assertValueFromFile(format("foobar"), "oneVar.txt", true);
+        assertValueFromFile("foobar", "oneVar.txt", true);
     }
 
     @Test
     public void checkCache() {
         jmeterCtxService.get().getVariables().put("oneVar", "foo");
-        assertValueFromFile(format("foo"), "oneVar.txt", true);
-        assertEquals(format("${oneVar}"), getFirstCachedValue());
+        assertValueFromFile("foo", "oneVar.txt", true);
+        assertEquals("${oneVar}", getFirstCachedValue());
 
         jmeterCtxService.get().getVariables().put("oneVar", "bar");
-        assertValueFromFile(format("bar"), "oneVar.txt", true);
-        assertEquals(format("${oneVar}"), getFirstCachedValue());
+        assertValueFromFile("bar", "oneVar.txt", true);
+        assertEquals("${oneVar}", getFirstCachedValue());
     }
 
     @Test
     public void checkNoVariable() {
         jmeterCtxService.get().getVariables().put("oneVar", "RAW");
-        assertValueFromFile(format("${oneVar}"), "oneVar.txt", false);
+        assertValueFromFile("${oneVar}", "oneVar.txt", false);
     }
 
     @Test

--- a/test/src/org/apache/jorphan/io/TextFileSpec.groovy
+++ b/test/src/org/apache/jorphan/io/TextFileSpec.groovy
@@ -5,29 +5,29 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.nio.charset.Charset
-import java.nio.charset.IllegalCharsetNameException
 import java.nio.charset.StandardCharsets
 
 @Unroll
 class TextFileSpec extends Specification {
 
-    def tempFile = File.createTempFile("TextFile", ".unittest")
+    def tmpFile = File.createTempFile("TextFile", ".unittest")
+    def tmpPath = tmpFile.getAbsolutePath()
 
     def setup() {
-        tempFile.deleteOnExit()
+        tmpFile.deleteOnExit()
     }
 
     def "getText of empty file is empty string"() {
         given:
-            def sut = new TextFile(tempFile.getAbsolutePath())
+            def sut = new TextFile(tmpPath)
         expect:
             sut.getText() == ""
     }
 
     def "getText returns exact content of file"() {
         given:
-            def sut = new TextFile(tempFile.getAbsolutePath())
-            FileUtils.write(tempFile, content, Charset.defaultCharset())
+            def sut = new TextFile(tmpPath)
+            FileUtils.write(tmpFile, content, Charset.defaultCharset())
         expect:
             sut.getText() == content
         where:
@@ -36,8 +36,8 @@ class TextFileSpec extends Specification {
 
     def "getText returns exact content of file with specific charset"() {
         given:
-            def sut = new TextFile(tempFile.getAbsolutePath(), encoding)
-            FileUtils.write(tempFile, content, charset)
+            def sut = new TextFile(tmpPath, encoding)
+            FileUtils.write(tmpFile, content, charset)
         expect:
             sut.getText() == content
         where:
@@ -50,7 +50,7 @@ class TextFileSpec extends Specification {
 
     def "setText sets exact content of file"() {
         given:
-            def sut = new TextFile(tempFile.getAbsolutePath())
+            def sut = new TextFile(tmpPath)
         when:
             sut.setText(content)
         then:
@@ -61,7 +61,7 @@ class TextFileSpec extends Specification {
 
     def "setText sets exact content of file other charset"() {
         given:
-            def sut = new TextFile(tempFile.getAbsolutePath(), encoding)
+            def sut = new TextFile(tmpPath, encoding)
         when:
             sut.setText(content, encoding)
         then:
@@ -75,9 +75,13 @@ class TextFileSpec extends Specification {
     }
 
     def "getText throws exception with invalid encoding"() {
+        given:
+            def sut = new TextFile(tmpPath, invalidEncoding)
         when:
-            new TextFile(tempFile.getAbsolutePath(), "invalid encoding").getText()
+            sut.getText()
         then:
-            thrown(IllegalCharsetNameException)
+            thrown(IllegalArgumentException)
+        where:
+            invalidEncoding << ["", "invalid", "invalid encoding"]
     }
 }

--- a/test/src/org/apache/jorphan/io/TextFileSpec.groovy
+++ b/test/src/org/apache/jorphan/io/TextFileSpec.groovy
@@ -16,14 +16,14 @@ class TextFileSpec extends Specification {
         tempFile.deleteOnExit()
     }
 
-    def "read lines"() {
+    def "getText of empty file is empty string"() {
         given:
             def sut = new TextFile(tempFile.getAbsolutePath())
         expect:
             sut.getText() == ""
     }
 
-    def "read lines returns exact content of file"() {
+    def "getText returns exact content of file"() {
         given:
             def sut = new TextFile(tempFile.getAbsolutePath())
             FileUtils.write(tempFile, content, Charset.defaultCharset())
@@ -33,7 +33,7 @@ class TextFileSpec extends Specification {
             content << ["a\nb\nc", "\"a\nb\nc\n"]
     }
 
-    def "read lines returns exact content of file other charset"() {
+    def "getText returns exact content of file with specific charset"() {
         given:
             def sut = new TextFile(tempFile.getAbsolutePath(), encoding)
             FileUtils.write(tempFile, content, charset)
@@ -45,5 +45,31 @@ class TextFileSpec extends Specification {
             "a\nb\nc\n" | StandardCharsets.UTF_16     | "UTF_16"
             "a\nb\nc"   | StandardCharsets.ISO_8859_1 | "ISO_8859_1"
             "a\nb\nc\n" | StandardCharsets.ISO_8859_1 | "ISO_8859_1"
+    }
+
+    def "setText sets exact content of file"() {
+        given:
+            def sut = new TextFile(tempFile.getAbsolutePath())
+        when:
+            sut.setText(content)
+        then:
+            sut.getText() == content
+        where:
+            content << ["a\nb\nc", "\"a\nb\nc\n"]
+    }
+
+    def "setText sets exact content of file other charset"() {
+        given:
+            def sut = new TextFile(tempFile.getAbsolutePath(), encoding)
+        when:
+            sut.setText(content, encoding)
+        then:
+            sut.getText(encoding) == content
+        where:
+            content     | encoding
+            "a\nb\nc"   | "UTF_16"
+            "a\nb\nc\n" | "UTF_16"
+            "a\nb\nc"   | "ISO_8859_1"
+            "a\nb\nc\n" | "ISO_8859_1"
     }
 }

--- a/test/src/org/apache/jorphan/io/TextFileSpec.groovy
+++ b/test/src/org/apache/jorphan/io/TextFileSpec.groovy
@@ -5,6 +5,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.nio.charset.Charset
+import java.nio.charset.IllegalCharsetNameException
 import java.nio.charset.StandardCharsets
 
 @Unroll
@@ -71,5 +72,12 @@ class TextFileSpec extends Specification {
             "a\nb\nc\n" | "UTF_16"
             "a\nb\nc"   | "ISO_8859_1"
             "a\nb\nc\n" | "ISO_8859_1"
+    }
+
+    def "getText throws exception with invalid encoding"() {
+        when:
+            new TextFile(tempFile.getAbsolutePath(), "invalid encoding").getText()
+        then:
+            thrown(IllegalCharsetNameException)
     }
 }

--- a/test/src/org/apache/jorphan/io/TextFileSpec.groovy
+++ b/test/src/org/apache/jorphan/io/TextFileSpec.groovy
@@ -1,0 +1,49 @@
+package org.apache.jorphan.io
+
+import org.apache.commons.io.FileUtils
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+@Unroll
+class TextFileSpec extends Specification {
+
+    def tempFile = File.createTempFile("TextFile", ".unittest")
+
+    def setup() {
+        tempFile.deleteOnExit()
+    }
+
+    def "read lines"() {
+        given:
+            def sut = new TextFile(tempFile.getAbsolutePath())
+        expect:
+            sut.getText() == ""
+    }
+
+    def "read lines returns exact content of file"() {
+        given:
+            def sut = new TextFile(tempFile.getAbsolutePath())
+            FileUtils.write(tempFile, content, Charset.defaultCharset())
+        expect:
+            sut.getText() == content
+        where:
+            content << ["a\nb\nc", "\"a\nb\nc\n"]
+    }
+
+    def "read lines returns exact content of file other charset"() {
+        given:
+            def sut = new TextFile(tempFile.getAbsolutePath(), encoding)
+            FileUtils.write(tempFile, content, charset)
+        expect:
+            sut.getText() == content
+        where:
+            content     | charset                     | encoding
+            "a\nb\nc"   | StandardCharsets.UTF_16     | "UTF_16"
+            "a\nb\nc\n" | StandardCharsets.UTF_16     | "UTF_16"
+            "a\nb\nc"   | StandardCharsets.ISO_8859_1 | "ISO_8859_1"
+            "a\nb\nc\n" | StandardCharsets.ISO_8859_1 | "ISO_8859_1"
+    }
+}


### PR DESCRIPTION
## Description
Re-wrote `getText` (and `setText` while I was there) for `TextFile` because `getText` always appends a newline separator at the end of the file regardless if the original file has one or not.

This changes the behaviour slightly and currently breaks some tests. I'm not sure if it's the tests' fault or the change. I've "fixed" the tests, but these need reviewing by someone who knows how the JMS stuff and anything else which uses it works and any assumptions they made. It also returned the new lines of the file not the system new lines.

## Motivation and Context
https://bz.apache.org/bugzilla/show_bug.cgi?id=61827
> a new line is adding to the content of the file read by a JMS publisher sampler.
The issue is on the getText method of the TextFile : 
=> sb.append(line + lineEnd);

## How Has This Been Tested?

Added unit tests to demo the new behaviour, previous code would have failed by adding an extra newline to end of file which did not end in a new line.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
