### PR TITLE
Supply Subject Alternative Name on HTTPS certs.

### DIFF
--- a/src/jorphan/org/apache/jorphan/exec/KeyToolUtils.java
+++ b/src/jorphan/org/apache/jorphan/exec/KeyToolUtils.java
@@ -281,18 +281,19 @@ public class KeyToolUtils {
     private static void generateSignedCert(File keystore, String password,
             int validity, String alias, String subject) throws IOException {
         String dname = "cn=" + subject + ", o=JMeter Proxy (TEMPORARY TRUST ONLY)";
-        KeyToolUtils.genkeypair(keystore, alias, password, validity, dname, null);
+        String ext = "san=dns:" + subject;
+        KeyToolUtils.genkeypair(keystore, alias, password, validity, dname, ext);
         //rem generate cert for DOMAIN using CA and import it
 
         // get the certificate request
         ByteArrayOutputStream certReqOut = new ByteArrayOutputStream();
-        KeyToolUtils.keytool("-certreq", keystore, password, alias, null, certReqOut);
+        KeyToolUtils.keytool("-certreq", keystore, password, alias, null, certReqOut, "-ext", ext);
 
         // create the certificate
         //rem ku:c=dig,keyE means KeyUsage:critical=digitalSignature,keyEncipherment
         InputStream certReqIn = new ByteArrayInputStream(certReqOut.toByteArray());
         ByteArrayOutputStream certOut = new ByteArrayOutputStream();
-        KeyToolUtils.keytool("-gencert", keystore, password, INTERMEDIATE_CA_ALIAS, certReqIn, certOut, "-ext", "ku:c=dig,keyE");
+        KeyToolUtils.keytool("-gencert", keystore, password, INTERMEDIATE_CA_ALIAS, certReqIn, certOut, "-ext", "ku:c=dig,keyE", "-ext ", ext);
 
         // import the certificate
         InputStream certIn = new ByteArrayInputStream(certOut.toByteArray());


### PR DESCRIPTION
Recently browsers have started to not trust a certificate if it doesn’t have a Subject Alternative Name (SAN) that matches the domain name. This causes the HTTPS proxy to generate warnings in the browser even if the CA certificate is trusted.

This sets the SAN on all the certificates that are generated so that the browsers trust them.
