### PR TITLE
Fixed about dialog position on first view

### DIFF
--- a/src/core/org/apache/jmeter/gui/action/AboutCommand.java
+++ b/src/core/org/apache/jmeter/gui/action/AboutCommand.java
@@ -82,7 +82,7 @@ public class AboutCommand extends AbstractAction {
      * the product image and the copyright notice. The dialog box is centered
      * over the MainFrame.
      */
-    void about() {
+    private void about() {
         JFrame mainFrame = GuiPackage.getInstance().getMainFrame();
         JDialog dialog = initDialog(mainFrame);
 
@@ -91,7 +91,6 @@ public class AboutCommand extends AbstractAction {
         Dimension d1 = mainFrame.getSize();
         Dimension d2 = dialog.getSize();
         dialog.setLocation(p.x + (d1.width - d2.width) / 2, p.y + (d1.height - d2.height) / 2);
-        dialog.pack();
         dialog.setVisible(true);
     }
 
@@ -99,44 +98,46 @@ public class AboutCommand extends AbstractAction {
      * @param mainFrame {@link JFrame}
      * @return {@link JDialog} initializing it if necessary
      */
-    private static final JDialog initDialog(JFrame mainFrame) {
-        if (about == null) {
-            about = new EscapeDialog(mainFrame, "About Apache JMeter...", false);
-            about.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                    about.setVisible(false);
-                }
-            });
-
-            JLabel jmeter = new JLabel(JMeterUtils.getImage("jmeter.png"));
-            JLabel copyright = new JLabel(JMeterUtils.getJMeterCopyright(), SwingConstants.CENTER);
-            JLabel rights = new JLabel("All Rights Reserved.", SwingConstants.CENTER);
-            JLabel version = new JLabel("Apache JMeter Version " + JMeterUtils.getJMeterVersion(), SwingConstants.CENTER);
-            JLabel releaseNotes = new JLabel("<html><a href=\"https://jmeter.apache.org/changes.html\">Release notes</a></html>", SwingConstants.CENTER);
-            releaseNotes.addMouseListener(new MouseAdapter() {
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                    if (e.getClickCount() > 0) {
-                        ActionRouter.getInstance().doActionNow(
-                                new ActionEvent(e.getSource(), e.getID(), ActionNames.LINK_RELEASE_NOTES));
-                    }
-                }
-            });
-            JPanel infos = new JPanel();
-            infos.setOpaque(false);
-            infos.setLayout(new GridLayout(0, 1));
-            infos.setBorder(new EmptyBorder(5, 5, 5, 5));
-            infos.add(copyright);
-            infos.add(rights);
-            infos.add(version);
-            infos.add(releaseNotes);
-            Container panel = about.getContentPane();
-            panel.setLayout(new BorderLayout());
-            panel.setBackground(Color.white);
-            panel.add(jmeter, BorderLayout.NORTH);
-            panel.add(infos, BorderLayout.SOUTH);
+    private JDialog initDialog(JFrame mainFrame) {
+        if (about != null) {
+            return about;
         }
+        about = new EscapeDialog(mainFrame, "About Apache JMeter", false);
+        about.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                about.setVisible(false);
+            }
+        });
+
+        JLabel jmeterLogo = new JLabel(JMeterUtils.getImage("jmeter.png"));
+        JLabel copyright = new JLabel(JMeterUtils.getJMeterCopyright(), SwingConstants.CENTER);
+        JLabel rights = new JLabel("All Rights Reserved.", SwingConstants.CENTER);
+        JLabel version = new JLabel("Apache JMeter Version " + JMeterUtils.getJMeterVersion(), SwingConstants.CENTER);
+        JLabel releaseNotes = new JLabel("<html><a href=\"https://jmeter.apache.org/changes.html\">Release notes</a></html>", SwingConstants.CENTER);
+        releaseNotes.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() > 0) {
+                    ActionRouter.getInstance().doActionNow(
+                            new ActionEvent(e.getSource(), e.getID(), ActionNames.LINK_RELEASE_NOTES));
+                }
+            }
+        });
+        JPanel infos = new JPanel();
+        infos.setOpaque(false);
+        infos.setLayout(new GridLayout(0, 1));
+        infos.setBorder(new EmptyBorder(5, 5, 5, 5));
+        infos.add(copyright);
+        infos.add(rights);
+        infos.add(version);
+        infos.add(releaseNotes);
+        Container panel = about.getContentPane();
+        panel.setLayout(new BorderLayout());
+        panel.setBackground(Color.white);
+        panel.add(jmeterLogo, BorderLayout.NORTH);
+        panel.add(infos, BorderLayout.SOUTH);
+        about.pack();
         return about;
     }
 }


### PR DESCRIPTION
## Description
When viewing "About JMeter" dialog it was positioned with the top corner in the middle rather than in the centre of the screen because the first time the dialog wasn't `pack()`'ed so didn't have any size.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
