### PR TITLE
More hooks for testplan modifications

### DIFF
--- a/src/core/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/org/apache/jmeter/gui/GuiPackage.java
@@ -139,6 +139,10 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
     /** GUI Logging Event Bus. */
     private GuiLogEventBus logEventBus = new GuiLogEventBus();
 
+    /** Listeners for events on test plan */
+    private List<TestPlanListener> testPlanListeners = Collections.synchronizedList(new ArrayList<>());
+
+
     /**
      * Private constructor to permit instantiation only from within this class.
      * Use {@link #getInstance()} to retrieve a singleton instance.
@@ -707,6 +711,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      */
     public void clearTestPlan() {
         getTreeModel().clearTestPlan();
+        testPlanListeners.stream().forEach(l -> l.testPlanCleared());
         nodesToGui.clear();
         setTestPlanFile(null);
         undoHistory.clear();
@@ -969,4 +974,21 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
             return shouldSaveBeforeRunByPreference();
         }
     }
+
+    /**
+     * Adds a test plan listener.
+     * @param listener
+     */
+    public void addTestPlanListener(TestPlanListener listener) {
+        testPlanListeners.add(listener);
+    }
+
+    /**
+     * Removes a test plan listener.
+     * @param listener
+     */
+    public void removeTestPlanListener(TestPlanListener listener) {
+        testPlanListeners.remove(listener);
+    }
+
 }

--- a/src/core/org/apache/jmeter/gui/TestPlanListener.java
+++ b/src/core/org/apache/jmeter/gui/TestPlanListener.java
@@ -1,0 +1,6 @@
+package org.apache.jmeter.gui;
+
+public interface TestPlanListener {
+
+    void testPlanCleared();
+}

--- a/src/core/org/apache/jmeter/gui/action/Remove.java
+++ b/src/core/org/apache/jmeter/gui/action/Remove.java
@@ -89,6 +89,7 @@ public class Remove extends AbstractAction {
         if (testElement.canRemove()) {
             GuiPackage.getInstance().getTreeModel().removeNodeFromParent(node);
             GuiPackage.getInstance().removeNode(testElement);
+            testElement.removed();
         } else {
             String message = testElement.getClass().getName() + " is busy";
             JOptionPane.showMessageDialog(null, message, "Cannot remove item", JOptionPane.ERROR_MESSAGE);

--- a/src/core/org/apache/jmeter/testelement/TestElement.java
+++ b/src/core/org/apache/jmeter/testelement/TestElement.java
@@ -332,4 +332,10 @@ public interface TestElement extends Cloneable {
      *            to be associated
      */
     void setComment(String comment);
+
+    /**
+     * Called when the test element is removed from the test plan.
+     */
+    default void removed() {
+    }
 }


### PR DESCRIPTION
## Description
In my JMeter websocket plugin (https://bitbucket.org/pjtr/jmeter-websocket-samplers) I want to hide advanced options for first time users. One of my design goals for this plugin was to make it very easy to use, so that first-time users are not overwhelmed with loads of options they don't know how to use and this will only confuse them. Up till now, i think i succeeded (but of course that's for others to judge ;-)).

However, i'm now at the point that i need to add functionality that will only be used by advanced users. To keep the UI simple and clear for others, these advanced options must be explicitly enabled. Currently, this is done by setting a JMeter property. It works, but what i would like is that users can simply enable this (and other) option(s) by adding a special Config element in their test plan and enable/disable the options they want to use. This keeps the settings (e.g. whether options are enabled or not) in the testplan, which will avoid surprises when a testplan that relies on these
features is being loaded in a JMeter instance that doesn't have the property set.

I've been experimenting with this approach and i'm pretty happy with it.
However, to make it work correctly, i need some extra hooks in JMeter.

## Changes
A "removed" method is added to TestElement, so a test element can react on
it being removed from the test plan. I need this for the functionality explained above, because when the user removes the special Configuration element that enables certain options,
these options must be disabled.

A "TestPlanListener" is added, and its "testPlanCleared" method is called when the test plan is clear.
Similarly to change 1, when a testplan is closed and another one is loaded, i need a hook to reset the state of the advanced options. Of course, when included in JMeter, the TestPlanListener should probably be extended with some other methods to make it a consistent interface; for now i just wanted to create a working proof-of-concept.

## Motivation and Context
See above.

## How Has This Been Tested?
I used the added features in (a branch of) my plugin, see https://bitbucket.org/pjtr/jmeter-websocket-samplers/commits/branch/configure-options-in-testplan

## Screenshots (if appropriate):
n.a.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.
I'm happy to add docs or adapt the source according to the projects style or requirements, just let me know.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
