### PR TITLE
let GUI component (dynamically) decide whether it can be added via th…

### DIFF
--- a/src/core/org/apache/jmeter/gui/JMeterGUIComponent.java
+++ b/src/core/org/apache/jmeter/gui/JMeterGUIComponent.java
@@ -223,7 +223,7 @@ public interface JMeterGUIComponent extends ClearGui {
 
     /**
      * Returns whether a component of this type can be added to the test plan.
-     * @return true is the component can be added, false otherwise.
+     * @return true if the component can be added, false otherwise.
      */
     default boolean canBeAdded() {
         return true;

--- a/src/core/org/apache/jmeter/gui/JMeterGUIComponent.java
+++ b/src/core/org/apache/jmeter/gui/JMeterGUIComponent.java
@@ -220,4 +220,12 @@ public interface JMeterGUIComponent extends ClearGui {
      * @see org.apache.jmeter.gui.util.MenuFactory
      */
     Collection<String> getMenuCategories();
+
+    /**
+     * Returns whether a component of this type can be added to the test plan.
+     * @return true is the component can be added, false otherwise.
+     */
+    default boolean canBeAdded() {
+        return true;
+    }
 }

--- a/src/core/org/apache/jmeter/gui/util/MenuFactory.java
+++ b/src/core/org/apache/jmeter/gui/util/MenuFactory.java
@@ -511,6 +511,7 @@ public final class MenuFactory {
 
         JMenuItem newMenuChoice = new JMenuItem(info.getLabel());
         newMenuChoice.setName(info.getClassName());
+        newMenuChoice.setEnabled(info.getEnabled(actionCommand));
         newMenuChoice.addActionListener(ActionRouter.getInstance());
         if (actionCommand != null) {
             newMenuChoice.setActionCommand(actionCommand);

--- a/src/core/org/apache/jmeter/gui/util/MenuInfo.java
+++ b/src/core/org/apache/jmeter/gui/util/MenuInfo.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.gui.util;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.gui.JMeterGUIComponent;
+import org.apache.jmeter.gui.action.ActionNames;
 
 /**
  * Class to hold additional information needed when building the GUI lists
@@ -73,5 +74,17 @@ public class MenuInfo {
 
     public int getSortOrder() {
         return sortOrder;
+    }
+
+    /**
+     * Returns whether the menu item represented by this MenuInfo object should be enabled
+     * @param actionCommand    the action command name for the menu item
+     * @return true when menu item should be enabled, false otherwise.
+     */
+    public boolean getEnabled(String actionCommand) {
+        if (ActionNames.ADD.equals(actionCommand))
+            return guiComp.canBeAdded();
+        else
+            return true;
     }
 }

--- a/src/core/org/apache/jmeter/gui/util/MenuInfo.java
+++ b/src/core/org/apache/jmeter/gui/util/MenuInfo.java
@@ -82,9 +82,11 @@ public class MenuInfo {
      * @return true when menu item should be enabled, false otherwise.
      */
     public boolean getEnabled(String actionCommand) {
-        if (ActionNames.ADD.equals(actionCommand))
+        if (ActionNames.ADD.equals(actionCommand)) {
             return guiComp.canBeAdded();
-        else
+        }
+        else {
             return true;
+        }
     }
 }


### PR DESCRIPTION
…e menu or not; the menu item will be enabled/disabled accordingly.

## Description
Added the ability to have menu items for GUI components dynamically disabled/enabled.
The question whether a specific test element can be added (to the testplan) is delegated to the corresponding GUI component.

## Motivation and Context
In my websocket plugin (https://bitbucket.org/pjtr/jmeter-websocket-samplers), i have a config element that enables the user to configure specific (advanced) properties of the plugin (previously, this was done via JMeter properties, which is of course cumbersome). To avoid funny behaviour in the plugin and to avoid confusion of the user, such a config element should only be added once.

## How Has This Been Tested?
I tested it with my websocket plugin, see https://bitbucket.org/pjtr/jmeter-websocket-samplers/commits/branch/limit-number-of-advanced-options-element

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
