### PR TITLE
Fix StackOverFlowError in ThroughputController. Bug 62062

### DIFF
--- a/src/components/org/apache/jmeter/control/ThroughputController.java
+++ b/src/components/org/apache/jmeter/control/ThroughputController.java
@@ -197,8 +197,9 @@ public class ThroughputController
     public boolean isDone() {
         return subControllersAndSamplers.isEmpty()
                 || (getStyle() == BYNUMBER
-                && getExecutions() >= getMaxThroughputAsInt()
-                && current >= getSubControllers().size());
+                && (getExecutions() >= getMaxThroughputAsInt()
+                && current >= getSubControllers().size())
+                || (getMaxThroughputAsInt() == 0));
     }
 
     @Override

--- a/test/src/org/apache/jmeter/control/ThroughputControllerSpec.groovy
+++ b/test/src/org/apache/jmeter/control/ThroughputControllerSpec.groovy
@@ -80,6 +80,35 @@ class ThroughputControllerSpec extends Specification {
             sut.testEnded()
     }
 
+    /**
+     * <pre>
+     *   - innerLoop
+     *     - ThroughputController (sut)
+     *        - sampler one
+     *        - sampler two
+     * </pre>
+     */
+    def "0 maxThroughput does not run any samplers inside the TC and cause StackOverFlowError"() {
+        given:
+        sut.setStyle(ThroughputController.BYNUMBER)
+        sut.setMaxThroughput(0)
+
+        LoopController innerLoop = new LoopController()
+        innerLoop.setLoops(10000)
+        innerLoop.addTestElement(sut)
+        innerLoop.addIterationListener(sut)
+        innerLoop.initialize()
+        innerLoop.setRunningVersion(true)
+        sut.testStarted()
+        sut.setRunningVersion(true)
+
+        when:
+            innerLoop.next() == null;
+            innerLoop.next() == null
+        then:
+            sut.testEnded()
+    }
+
     def "33.33% will run all the samplers inside the TC every 3 iterations"() {
         given:
             sut.setStyle(ThroughputController.BYPERCENT)

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -339,6 +339,7 @@ itself does not have to be edited anymore.</p>
     <li><bug>61556</bug>Clarify in documentation performance impacts of <code>${}</code> var usage in IfController and groovy. Contributed by Justin McCartney (be_strew at yahoo.co.uk)</li>
     <li><bug>61713</bug>Test Fragment has option to Change Controller and Insert Parent. Contributed by Ubik Load Pack (support at ubikloadpack.com)</li>
     <li><bug>61965</bug>Module and Include Controller should not allow to add meaningless elements in their context.</li>
+    <li><bug>62062</bug>Fix StackOverFlowError in ThroughputController. Implemented by Artem Fedorov (artem.fedorov at blazemeter.com) and contributed by BlazeMeter Ltd.</li>
 </ul>
 
 <h3>Listeners</h3>


### PR DESCRIPTION
When I ran the following Test Plan I got the `java.lang.StackOverflowError`
```
   - innerLoop
     - ThroughputController (sut)
        - sampler one
        - sampler two
```


```
...
at org.apache.jmeter.control.GenericController.nextIsAController(GenericController.java:222)
at org.apache.jmeter.control.GenericController.next(GenericController.java:173)
at org.apache.jmeter.control.LoopController.next(LoopController.java:128)
at org.apache.jmeter.control.LoopController.nextIsNull(LoopController.java:163)
at org.apache.jmeter.control.GenericController.next(GenericController.java:168)
at org.apache.jmeter.control.LoopController.next(LoopController.java:128)
at org.apache.jmeter.control.GenericController.nextIsAController(GenericController.java:222)
at org.apache.jmeter.control.GenericController.next(GenericController.java:173)
at org.apache.jmeter.control.LoopController.next(LoopController.java:128)
at org.apache.jmeter.control.LoopController.nextIsNull(LoopController.java:163)
at org.apache.jmeter.control.GenericController.next(GenericController.java:168)
at org.apache.jmeter.control.LoopController.next(LoopController.java:128)
at org.apache.jmeter.control.GenericController.nextIsAController(GenericController.java:222)
at org.apache.jmeter.control.GenericController.next(GenericController.java:173)
...
```
This PR contains the test that reproduced this bug and the fix.