### PR TITLE
Add a 'go to top' button that gets shown, when page is scrolled down

### DIFF
--- a/xdocs/css/new-style.css
+++ b/xdocs/css/new-style.css
@@ -19,6 +19,19 @@
   width: 60em;
 }
 
+#topButton {
+    position: fixed;
+    bottom: 0rem;
+    right: 0rem;
+    background: #dedede;
+    margin: 1rem;
+    padding: .5rem;
+    border-radius: 10px;
+    border-color: #a0a0a0;
+    display: none;
+    z-index: 999;
+}
+
 .social-media {
   display: inline-block;
   float: right;

--- a/xdocs/stylesheets/website-style.xsl
+++ b/xdocs/stylesheets/website-style.xsl
@@ -142,8 +142,8 @@
           </div>
         </div>
         <script><![CDATA[(function(){
-            // fill in the current location into social links on this page.
             "use strict";
+            // enable 'go to top' button functionality
             document.addEventListener('scroll', function() {
                 if (document.body.scrollTop > 500 || document.documentElement.scrollTop > 500) {
                     document.getElementById("topButton").style.display = "block";
@@ -151,6 +151,7 @@
                     document.getElementById("topButton").style.display = "none";
                 }
             });
+            // fill in the current location into social links on this page.
             var as = document.getElementsByTagName('a');
             var loc = document.location.href;
             if (!loc.toLowerCase().startsWith('http')) {

--- a/xdocs/stylesheets/website-style.xsl
+++ b/xdocs/stylesheets/website-style.xsl
@@ -126,6 +126,7 @@
           <xsl:apply-templates select="body/section"></xsl:apply-templates>
           <xsl:call-template name="pagelinks" />
           <xsl:call-template name="share-links" />
+          <a href="#top" id="topButton">Go to top</a>
         </div>
         <div class="footer">
           <div class="copyright">
@@ -143,6 +144,13 @@
         <script><![CDATA[(function(){
             // fill in the current location into social links on this page.
             "use strict";
+            document.addEventListener('scroll', function() {
+                if (document.body.scrollTop > 500 || document.documentElement.scrollTop > 500) {
+                    document.getElementById("topButton").style.display = "block";
+                } else {
+                    document.getElementById("topButton").style.display = "none";
+                }
+            });
             var as = document.getElementsByTagName('a');
             var loc = document.location.href;
             if (!loc.toLowerCase().startsWith('http')) {


### PR DESCRIPTION
## Description
The JMeter html documentation contains rather long pages, which take a lot of time to scroll down and a long time to scroll back up again. This patch adds a button (link really) to the bottom of the screen, that gets shown, when a page is scrolled down. A click on the link will take the user back up to the top.

## How Has This Been Tested?
A test has been made with firefox (v58) on the locally generated pages (ant docs-site)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [No documentation needed] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
