### PR TITLE
Logging of JUnitSampler exceptions

### DIFF
--- a/src/junit/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
+++ b/src/junit/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
@@ -412,6 +412,7 @@ public class JUnitSampler extends AbstractSampler implements ThreadListener {
                     tr.addError(theClazz, cause);
                 } else {
                     tr.addError(theClazz, e);
+                    log.warn("caught exception", e);
                 }
             } catch (IllegalAccessException | IllegalArgumentException e) {
                 tr.addError(theClazz, e);

--- a/src/junit/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
+++ b/src/junit/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
@@ -410,6 +410,7 @@ public class JUnitSampler extends AbstractSampler implements ThreadListener {
                     tr.addFailure(theClazz, afe);
                 } else if (cause != null) {
                     tr.addError(theClazz, cause);
+                    log.warn("caught exception", cause);
                 } else {
                     tr.addError(theClazz, e);
                     log.warn("caught exception", e);


### PR DESCRIPTION
## Description
Logging of any non-assert exception generated inside a test.

## Motivation and Context
The main motivation is to speedup fixing of errors inside test methods.  We have a big test suite that
is run using the JUnitSampler using this pattern:

```java
private final Logger logger = LoggerFactory.getLogger(getClass());

@Test
public void testName() {
    try {
       // test body
    } catch (Exception ex) {
        logger.warn("caught exception", ex);
        throw ex;  
   }
}
```

With this change the code would be simpler:

```java
@Test
public void testName() {
     // test body
}

```

## How Has This Been Tested?
Still to be tested. Since we are using jmeter-maven-plugin, we need to install the JMeter core in the local maven repository. There is a quick way to do this using ant?

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
