### PR TITLE
Translation of "Precise Throughput timer" in French

### DIFF
--- a/src/components/org/apache/jmeter/timers/poissonarrivals/PreciseThroughputTimerResources_fr.properties
+++ b/src/components/org/apache/jmeter/timers/poissonarrivals/PreciseThroughputTimerResources_fr.properties
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-displayName=Precise Throughput Timer
+displayName=Compteur de d\u00e9bit avanc\u00e9
 delay.displayName=Retarder les threads pour assurer le d\u00e9bit cible
 throughput.displayName=D\u00e9bit cible (en nombre d'\u00e9chantillons par "p\u00e9riode de d\u00e9bit")
 throughput.shortDescription=Nombre maximal d'\u00e9chantillons que vous souhaitez recevoir par "p\u00e9riode de traitement", y compris tous les threads d'un groupe, provenant de tous les \u00e9chantillonneurs concern\u00e9s


### PR DESCRIPTION
## Description
translation for "Precise Throughput timer" in French

## Motivation and Context
Fixing bug_62310 ; the French label of "Precise Troughput Timer" is not translated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
