### PR TITLE
Adds parameter supports for RMI keystore creation scripts

### DIFF
--- a/bin/create-rmi-keystore.bat
+++ b/bin/create-rmi-keystore.bat
@@ -15,6 +15,6 @@ rem   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem   See the License for the specific language governing permissions and
 rem   limitations under the License.
 rem
-keytool -genkey -keyalg RSA -alias rmi -keystore rmi_keystore.jks -storepass changeit -validity 7 -keysize 2048
+keytool -genkey -keyalg RSA -alias rmi -keystore rmi_keystore.jks -storepass changeit -validity 7 -keysize 2048 %*
 
 echo "Copy the generated rmi_keystore.jks to jmeter/bin folder or reference it in property 'server.rmi.ssl.keystore.file'"

--- a/bin/create-rmi-keystore.sh
+++ b/bin/create-rmi-keystore.sh
@@ -15,6 +15,6 @@
 ##   See the License for the specific language governing permissions and
 ##   limitations under the License.
 ##
-keytool -genkey -keyalg RSA -alias rmi -keystore rmi_keystore.jks -storepass changeit -validity 7 -keysize 2048
+keytool -genkey -keyalg RSA -alias rmi -keystore rmi_keystore.jks -storepass changeit -validity 7 -keysize 2048 "$@"
 
 echo "Copy the generated rmi_keystore.jks to jmeter/bin folder or reference it in property 'server.rmi.ssl.keystore.file'"


### PR DESCRIPTION
Helps to integrate script into non-interactive process.

## Description
<!--- Provide a general summary of your changes in the Title above -->
Pass script parameters to keytool command

<!--- Describe your changes in detail here -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It helps caller to customize key creation and also enable to integrate script into non-interactive process.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
`${JMETER_HOME}/bin/create-rmi-keystore.sh -dname 'o=Foobar' -keypass 'f0o84R!'`

`%JMETER_HOME%\bin\create-rmi-keystore.bat -dname 'o=Foobar' -keypass 'f0o84R!'`

<!--- Include details of your testing environment, tests ran to see how -->
* Linux: Debian 8 (Docker) + Open JDK 8u111
* Windows:  7 Pro + Oracle JDK 8u152

<!--- your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
