### PR TITLE
Open different RemoteObjects on different ports.

### DIFF
--- a/src/core/org/apache/jmeter/samplers/RemoteSampleListenerImpl.java
+++ b/src/core/org/apache/jmeter/samplers/RemoteSampleListenerImpl.java
@@ -37,8 +37,8 @@ public class RemoteSampleListenerImpl extends java.rmi.server.UnicastRemoteObjec
 
     private final SampleListener sampleListener;
     
-    private static final int DEFAULT_LOCAL_PORT = 
-        JMeterUtils.getPropDefault("client.rmi.localport", 0); // $NON-NLS-1$
+    private static final int DEFAULT_LOCAL_PORT = addOffset(
+        JMeterUtils.getPropDefault("client.rmi.localport", 0), 2); // $NON-NLS-1$
 
     public RemoteSampleListenerImpl(Object listener) throws RemoteException {
         super(DEFAULT_LOCAL_PORT, RmiUtils.createClientSocketFactory(),  RmiUtils.createServerSocketFactory());
@@ -52,6 +52,13 @@ public class RemoteSampleListenerImpl extends java.rmi.server.UnicastRemoteObjec
         } else {
             sampleListener = null;
         }
+    }
+
+    private static int addOffset(int port, int offset) {
+        if (port == 0) {
+            return 0;
+        }
+        return port + offset;
     }
 
     @Override

--- a/src/core/org/apache/jmeter/threads/RemoteThreadsListenerImpl.java
+++ b/src/core/org/apache/jmeter/threads/RemoteThreadsListenerImpl.java
@@ -49,8 +49,8 @@ public class RemoteThreadsListenerImpl extends UnicastRemoteObject implements
     /**
      * 
      */
-    private static final int DEFAULT_LOCAL_PORT = 
-            JMeterUtils.getPropDefault("client.rmi.localport", 0); // $NON-NLS-1$
+    private static final int DEFAULT_LOCAL_PORT = addOffset(
+            JMeterUtils.getPropDefault("client.rmi.localport", 0), 1); // $NON-NLS-1$
 
     /**
      * @throws RemoteException if failed to export object
@@ -78,6 +78,13 @@ public class RemoteThreadsListenerImpl extends UnicastRemoteObject implements
         } catch (IOException e) {
             log.error("Exception finding implementations of {}", RemoteThreadsLifeCycleListener.class, e);
         }
+    }
+
+    private static int addOffset(int port, int offset) {
+        if (port == 0) {
+            return 0;
+        }
+        return port + offset;
     }
 
     /**

--- a/xdocs/usermanual/remote-test.xml
+++ b/xdocs/usermanual/remote-test.xml
@@ -92,10 +92,10 @@ there is no need to start RMI registry separately.
 To revert to the previous behaviour, define the JMeter property <source>server.rmi.create=false</source> on the server host systems.
 </p>
 <p>
-By default, RMI uses a dynamic port for the JMeter server engine. This can cause problems for firewalls,
+By default, RMI uses dynamic ports for the JMeter server engine. This can cause problems for firewalls,
 so you can define the JMeter property <code>server.rmi.localport</code> 
-to control this port number.
-If this is non-zero, it will be used as the local port number for the server engine.
+to control this port numbers.
+If this is non-zero, it will be used as the base for local port numbers for the server engine. At the moment JMeter will open up to three ports beginning with the port defined in <code>server.rmi.localport</code>.
 </p>
 <p><b>Step 2: Add the server IP to your client's Properties File</b></p>
 <p>Edit the properties file <i>on the controlling JMeter machine</i>.  In <code>JMETER_HOME/bin/jmeter.properties</code>,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->
When using RMI over SSL with fixed `client.rmi.localport` JMeter currently throws an exception as it has problems to bind RemoteObjects to the same port more than once.
This change will use offsets for the different RemoteObjects, so that it will be possible again to use a fixed port for those RMI objects.
There is another bug in JMeter, that prevents a complete fix: Some of the remote listeners will get initialized twice in GUI mode. That will lead to some similar problems.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This bug was reported on the [users mailing list](https://lists.apache.org/thread.html/2de9386fb0f0c073eb9602837338c60981f1d22ded85661424ffa83e@%3Cuser.jmeter.apache.org%3E)  and on [SO as "unable to start jmeter 4.0 client with ssl rmi"](https://stackoverflow.com/questions/50752126/unable-to-start-jmeter-4-0-client-with-ssl-rmi).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran the tests and started a simple distributed setup with RMI over SSL.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
