### PR TITLE
Fixed typo in url encoding documentation

### DIFF
--- a/docs/usermanual/functions.html
+++ b/docs/usermanual/functions.html
@@ -3251,7 +3251,7 @@ Function to encode a string to a <span class="code">application/x-www-form-urlen
 </p>
 
 <p>
-For example, the string <pre class="source">${__urldecode(Word "school" is "&eacute;cole" in french)}</pre> returns
+For example, the string <pre class="source">${__urlencode(Word "school" is "&eacute;cole" in french)}</pre> returns
  <span class="code">Word+%22school%22+is+%22%C3%A9cole%22+in+french</span>.
 </p>
     


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
Literally just wanted to fix an annoying typo I came across
