### PR TITLE
Fix IllegalArgumentException for File properties wich allow null value

### DIFF
--- a/src/core/org/apache/jmeter/testbeans/gui/FieldStringEditor.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/FieldStringEditor.java
@@ -27,7 +27,7 @@ import javax.swing.JTextField;
 
 
 /**
- * This class implements a property editor for non-null String properties that
+ * This class implements a property editor for possible null String properties that
  * supports custom editing (i.e.: provides a GUI component) based on a text
  * field.
  * <p>
@@ -47,7 +47,7 @@ class FieldStringEditor extends PropertyEditorSupport implements ActionListener,
      * Value on which we started the editing. Used to avoid firing
      * PropertyChanged events when there's not been such change.
      */
-    private String initialValue = "";
+    private String initialValue;
 
     protected FieldStringEditor() {
         super();
@@ -55,6 +55,7 @@ class FieldStringEditor extends PropertyEditorSupport implements ActionListener,
         textField = new JTextField();
         textField.addActionListener(this);
         textField.addFocusListener(this);
+        initialValue = textField.getText();
     }
 
     @Override
@@ -75,10 +76,11 @@ class FieldStringEditor extends PropertyEditorSupport implements ActionListener,
 
     @Override
     public void setValue(Object value) {
-        if (value instanceof String) {
+        // null value always fail instanceof check therefore we process it separately
+        if (value == null || value instanceof String) {
             setAsText((String) value);
         } else {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Expected String but got "+value.getClass()+", value="+value);
         }
     }
 
@@ -99,7 +101,9 @@ class FieldStringEditor extends PropertyEditorSupport implements ActionListener,
     public void firePropertyChange() {
         String newValue = getAsText();
 
-        if (initialValue.equals(newValue)) {
+        if (initialValue != null && initialValue.equals(newValue)
+         || initialValue == null && newValue == null
+        ) {
             return;
         }
         initialValue = newValue;


### PR DESCRIPTION
## Description
This fix the `IllegalArgumentException` when `TestBean` class contains nullable `File` field (in my case field has name `vendorSKPath`):
```
2018-08-02 11:42:54,940 DEBUG o.a.j.t.g.GenericTestBeanCustomizer: Property vendorSKPath has editor class null
2018-08-02 11:42:54,941 DEBUG o.a.j.t.g.WrapperEditor: <-java.lang.String:
2018-08-02 11:42:54,941 DEBUG o.a.j.t.g.WrapperEditor: ->""
2018-08-02 11:42:54,941 DEBUG o.a.j.t.g.GenericTestBeanCustomizer: Property vendorSKPath has property editor org.apache.jmeter.testbeans.gui.FileEditor@1f236f6d
2018-08-02 11:42:54,941 DEBUG o.a.j.t.g.WrapperEditor: <-NULL:null
2018-08-02 11:42:54,941 WARN o.a.j.g.a.Load: Unexpected error. java.lang.IllegalArgumentException
java.lang.IllegalArgumentException: null
	at org.apache.jmeter.testbeans.gui.FieldStringEditor.setValue(FieldStringEditor.java:82) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.testbeans.gui.WrapperEditor.setValue(WrapperEditor.java:349) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.testbeans.gui.FileEditor.setValue(FileEditor.java:214) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.testbeans.gui.GenericTestBeanCustomizer.setEditorValue(GenericTestBeanCustomizer.java:477) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.testbeans.gui.GenericTestBeanCustomizer.<init>(GenericTestBeanCustomizer.java:289) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.testbeans.gui.TestBeanGUI.init(TestBeanGUI.java:417) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.testbeans.gui.TestBeanGUI.configure(TestBeanGUI.java:299) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.tree.JMeterTreeModel.addComponent(JMeterTreeModel.java:159) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.tree.JMeterTreeModel.addSubTree(JMeterTreeModel.java:133) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.tree.JMeterTreeModel.addSubTree(JMeterTreeModel.java:133) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.tree.JMeterTreeModel.addSubTree(JMeterTreeModel.java:133) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.tree.JMeterTreeModel.addSubTree(JMeterTreeModel.java:125) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.GuiPackage.addSubTree(GuiPackage.java:522) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.Load.insertLoadedTree(Load.java:193) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.Load.loadProjectFile(Load.java:130) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.Load.loadProjectFile(Load.java:101) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.LoadRecentProject.doActionAfterCheck(LoadRecentProject.java:67) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.AbstractActionWithNoRunningTest.doAction(AbstractActionWithNoRunningTest.java:45) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.ActionRouter.performAction(ActionRouter.java:88) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at org.apache.jmeter.gui.action.ActionRouter.lambda$actionPerformed$0(ActionRouter.java:70) ~[ApacheJMeter_core.jar:4.1-SNAPSHOT.20180802]
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311) [?:1.8.0_181]
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758) [?:1.8.0_181]
	at java.awt.EventQueue.access$500(EventQueue.java:97) [?:1.8.0_181]
	at java.awt.EventQueue$3.run(EventQueue.java:709) [?:1.8.0_181]
	at java.awt.EventQueue$3.run(EventQueue.java:703) [?:1.8.0_181]
	at java.security.AccessController.doPrivileged(Native Method) [?:1.8.0_181]
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74) [?:1.8.0_181]
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728) [?:1.8.0_181]
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205) [?:1.8.0_181]
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116) [?:1.8.0_181]
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105) [?:1.8.0_181]
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101) [?:1.8.0_181]
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93) [?:1.8.0_181]
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82) [?:1.8.0_181]
```

```java
public class WithFile implements TestBean {
    File file;
    public void setFile(File file) { this.file = file; }
    public File getFile() { return file; }
}

public class WithFileBeanInfo extends BeanInfoSupport {
    public WithFileBeanInfo() {
        super(WithFile.class);
        property("file");
    }
}
```

## Motivation and Context
Though in the comment to the class `FieldStringEditor` it is told that it processes only non-null strings:
https://github.com/apache/jmeter/blob/0a6f36c6e3c6043587c7765103b1d22354bb55bc/src/core/org/apache/jmeter/testbeans/gui/FieldStringEditor.java#L29-L37

the class `WrappedEditor` can call `setValue` with `null`:
https://github.com/apache/jmeter/blob/0a6f36c6e3c6043587c7765103b1d22354bb55bc/src/core/org/apache/jmeter/testbeans/gui/WrapperEditor.java#L332-L349

So I think that comment also need to be updated, but I am not sure. It is possible that this class as envisioned shall not allow `null` and it is necessary to do fix in other place, but in case of my testing this fix works fine.

## How Has This Been Tested?
Create plugin with any `TestBean` class with nullable `File` field as show above

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
