### PR TITLE
Fixed ant version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_script:
   - test "x$RUN_CHECKSTYLE" != 'xtrue' || ant -Djava.awt.headless=true download_checkstyle
 
 before_install:
-    - wget --no-check-certificate https://www.apache.org/dist/ant/binaries/apache-ant-1.10.4-bin.tar.gz
-    - tar -xzvf apache-ant-1.10.4-bin.tar.gz
-    - export PATH="$(pwd)/apache-ant-1.10.4/bin:$PATH"
+    - wget --no-check-certificate https://www.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz
+    - tar -xzvf apache-ant-1.10.5-bin.tar.gz
+    - export PATH="$(pwd)/apache-ant-1.10.5/bin:$PATH"
     - echo $(ant -version)
 
 # skip default "install" command


### PR DESCRIPTION
## Description
Changed ant version in the travis configuration.

## Motivation and Context
The ant version pointed out in travis configuration is not available anymore at the given link.

## How Has This Been Tested?
The first two travis jobs now succeed as before.
See https://travis-ci.org/bangnab/jmeter/builds/417424931
The third one fails due to jodd being incompatible with jdk 11.

## Types of changes
- Fixed build

## Checklist:
Nothing to do.
