### PR TITLE
Fix to 62336

### DIFF
--- a/src/core/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/org/apache/jmeter/gui/MainFrame.java
@@ -684,14 +684,14 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
                 //Bug 62336
-                AWTEvent current_event = EventQueue.getCurrentEvent();
-                String key_text = "";
-                if(current_event instanceof KeyEvent) {
-                    KeyEvent key_event = (KeyEvent)current_event;
-                    key_text = KeyEvent.getKeyText( key_event.getKeyCode() );
+                AWTEvent currentEvent = EventQueue.getCurrentEvent();
+                String keyText = "";
+                if( currentEvent instanceof KeyEvent ) {
+                    KeyEvent keyEvent = (KeyEvent) currentEvent;
+                    keyText = KeyEvent.getKeyText(keyEvent.getKeyCode());
                 }
                 
-                String propname = "gui.quick_" + key_text;
+                String propname = "gui.quick_" + keyText;
                 String comp = JMeterUtils.getProperty(propname);
                 log.debug("Event {}: {}", propname, comp);
 

--- a/src/core/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/org/apache/jmeter/gui/MainFrame.java
@@ -18,11 +18,13 @@
 
 package org.apache.jmeter.gui;
 
+import java.awt.AWTEvent;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
+import java.awt.EventQueue;
 import java.awt.Insets;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
@@ -36,6 +38,7 @@ import java.awt.dnd.DropTargetEvent;
 import java.awt.dnd.DropTargetListener;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -680,7 +683,15 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
 
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
-                String propname = "gui.quick_" + actionEvent.getActionCommand();
+                //Bug 62336
+                AWTEvent current_event = EventQueue.getCurrentEvent();
+                String key_text = "";
+                if(current_event instanceof KeyEvent) {
+                    KeyEvent key_event = (KeyEvent)current_event;
+                    key_text = KeyEvent.getKeyText( key_event.getKeyCode() );
+                }
+                
+                String propname = "gui.quick_" + key_text;
                 String comp = JMeterUtils.getProperty(propname);
                 log.debug("Event {}: {}", propname, comp);
 


### PR DESCRIPTION
## Description
Keyboard shortcut Ctrl +6 is not working.
Was reproduced for Java 8 on Windows 10.
actionEvent.getActionCommand() in MainFrame unexpected returning null only for CTRL-6. getActionCommand was replaced with alternative code. New version working stable.

## Motivation and Context
All CTRL-{N} working stable, after fix.
https://bz.apache.org/bugzilla/show_bug.cgi?id=62336

## How Has This Been Tested?
Tested on Java 8 and  Java 9 on Windows 10. Issue was reproduced. New code working fine. 

## Screenshots (if appropriate):

## Types of changes
- Bug fix 62336. Was changed org.apache.jmeter.gui.MainFarme around line 686.


## Checklist:
Path	Filename	Extension	Status	Lines added	Lines removed	Last Modified	Size
src/core/org/apache/jmeter/gui/MainFrame.java	MainFrame.java	.java	Modified	12	1		


[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
