### PR TITLE
Fix undefined disabled icon

### DIFF
--- a/src/core/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
+++ b/src/core/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
@@ -67,7 +67,7 @@ public class JMeterCellRenderer extends DefaultTreeCellRenderer {
                 // icon
                 ic = node.getIcon();
                 if (ic != null) {
-                    setIcon(ic);
+                    setDisabledIcon(ic);
                 }
             }
         }


### PR DESCRIPTION
## Description
When a TestElement does not define a disabled icon, `JMeterTreeNode.getIcon(false)` returns null (via `GUIFactory.getIcon`).
This situation is incorrectly handled in `JMeterCellRenderer.getTreeCellRendererComponent`, though comments acknowledge the condition:
```
            if (!enabled)// i.e. no disabled icon found
            {
                // Must therefore set the enabled icon so there is at least some
                // icon
                ic = node.getIcon();
                if (ic != null) {
                    setIcon(ic);
                }
```

## Motivation and Context
The above issue causes the wrong disabled icon to be displayed, e.g. when a TestElement defines its own icon via `BeanInfoSupport.setIcon`.

## How Has This Been Tested?
Tested with a locally patched class for JMeter v4.0 (Java 8, Windows 10), via manually disabling test plan elements.

## Screenshots (if appropriate):
![Wrong Icon](https://raw.githubusercontent.com/tilln/jmeter-wssecurity/issue/icon/docs/wrongicon.png)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.
