### PR TITLE
Bug 62785. -Incomplete search path applied to the filenames used in the upload functionality of the HTTP sampler

### DIFF
--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -1464,8 +1464,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
                         entityEnclosingRequest.setHeader(HTTPConstants.HEADER_CONTENT_TYPE, HTTPConstants.APPLICATION_X_WWW_FORM_URLENCODED);
                     }
                 }
-
-                FileEntity fileRequestEntity = new FileEntity(new File(file.getPath()),(ContentType) null);
+                FileEntity fileRequestEntity = new FileEntity(FileServer.getFileServer().getResolvedFile(file.getPath()), (ContentType) null);
                 entityEnclosingRequest.setEntity(fileRequestEntity);
 
                 // We just add placeholder text for file content

--- a/test/src/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplers.java
+++ b/test/src/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplers.java
@@ -19,13 +19,18 @@
 package org.apache.jmeter.protocol.http.sampler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.services.FileServer;
 import org.junit.Test;
+
+import java.io.File;
 
 public class TestHTTPSamplers {
 
@@ -363,5 +368,24 @@ public class TestHTTPSamplers {
         sampler.setHTTPFiles(new HTTPFileArg[]{new HTTPFileArg("","","mime2")});
         file = sampler.getHTTPFiles()[0];
         assertEquals("mime2", file.getMimeType());
+    }
+
+    @Test
+    public void testRawBodyFromFile() {
+        String baseDirPath = FileServer.getFileServer().getBaseDir();
+        File baseDir = new File(baseDirPath);
+        try {
+            FileServer.getFileServer().setBase(baseDir.getParentFile());
+            HTTPSamplerBase sampler = new HTTPSampler3();
+            sampler.setMethod("POST");
+            sampler.setPath("http://httpbin.org/post");
+            sampler.setHTTPFiles(new HTTPFileArg[]{new HTTPFileArg("bin/jmeter.properties", "", "")});
+
+            SampleResult sample = sampler.sample();
+            System.out.println(sample.getResponseDataAsString());
+            assertFalse(sample.getResponseDataAsString().contains("java.io.FileNotFoundException:"));
+        } finally {
+            FileServer.getFileServer().setBase(baseDir);
+        }
     }
 }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -124,6 +124,7 @@ Summary
 
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
+    <li><bug>62785</bug>HTTP Request throws java.io.FileNotFoundException when upload file without param name and MIME type. Implemented by Artem Fedorov (artem.fedorov at blazemeter.com) and contributed by BlazeMeter.</li>
 </ul>
 
 <h3>Other Samplers</h3>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -124,7 +124,7 @@ Summary
 
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
-    <li><bug>62785</bug>HTTP Request throws java.io.FileNotFoundException when upload file without param name and MIME type. Implemented by Artem Fedorov (artem.fedorov at blazemeter.com) and contributed by BlazeMeter.</li>
+    <li><bug>62785</bug>Incomplete search path applied to the filenames used in the upload functionality of the HTTP sampler. Implemented by Artem Fedorov (artem.fedorov at blazemeter.com) and contributed by BlazeMeter.</li>
 </ul>
 
 <h3>Other Samplers</h3>


### PR DESCRIPTION
https://bz.apache.org/bugzilla/show_bug.cgi?id=62785
