### PR TITLE
Use isEmpty instead of comparing size of a collection to zero

### DIFF
--- a/src/core/org/apache/jmeter/engine/DistributedRunner.java
+++ b/src/core/org/apache/jmeter/engine/DistributedRunner.java
@@ -107,7 +107,7 @@ public class DistributedRunner {
 
         if (!addrs.isEmpty()) {
             String msg = "Following remote engines could not be configured:" + addrs;
-            if (!continueOnFail || engines.size() == 0) {
+            if (!continueOnFail || engines.isEmpty()) {
                 stop();
                 throw new RuntimeException(msg); // NOSONAR
             } else {

--- a/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -487,7 +487,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
     public void setObject(Object map) {
         propertyMap = (Map<String, Object>) map;
 
-        if (propertyMap.size() == 0) {
+        if (propertyMap.isEmpty()) {
             // Uninitialized -- set it to the defaults:
             for (PropertyDescriptor descriptor : descriptors) {
                 Object value = descriptor.getValue(DEFAULT);

--- a/src/core/org/apache/jmeter/testelement/property/CollectionProperty.java
+++ b/src/core/org/apache/jmeter/testelement/property/CollectionProperty.java
@@ -186,7 +186,7 @@ public class CollectionProperty extends MultiProperty {
      */
     @Override
     protected Class<? extends JMeterProperty> getPropertyType() {
-        if (value != null && value.size() > 0) {
+        if (value != null && !value.isEmpty()) {
             return value.iterator().next().getClass();
         }
         return NullProperty.class;

--- a/src/protocol/mail/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
+++ b/src/protocol/mail/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
@@ -1019,7 +1019,7 @@ public class SmtpPanel extends JPanel {
     }
 
     private JButton addHeaderActionPerformed(ActionEvent evt){
-        if(headerFields.size() == 0){
+        if(headerFields.isEmpty()){
             headerFieldName.setVisible(true);
             headerFieldValue.setVisible(true);
         }


### PR DESCRIPTION
## Description
Use `isEmpty()` on collections instead of comparing their size to zero

## Motivation and Context
The `isEmpty()` check can be done a lot faster than calculating the size of a collection. This is mainly a performance optimiziation, but it does make the intention of the code a bit clearer, too.

## How Has This Been Tested?
No functional change has been done, so the normal test suite should catch any unintended changes.

## Screenshots (if appropriate):

## Types of changes
- make code a bit clearer and perhaps a bit faster

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
