### PR TITLE
Use simpler code for "static" String concatenation

### DIFF
--- a/src/components/org/apache/jmeter/assertions/XPathAssertion.java
+++ b/src/components/org/apache/jmeter/assertions/XPathAssertion.java
@@ -104,18 +104,17 @@ public class XPathAssertion extends AbstractScopedAssertion implements Serializa
         } catch (SAXException e) {
             log.debug("Caught sax exception.", e);
             result.setError(true);
-            result.setFailureMessage(new StringBuilder("SAXException: ").append(e.getMessage()).toString());
+            result.setFailureMessage("SAXException: " + e.getMessage());
             return result;
         } catch (IOException e) {
             log.warn("Cannot parse result content.", e);
             result.setError(true);
-            result.setFailureMessage(new StringBuilder("IOException: ").append(e.getMessage()).toString());
+            result.setFailureMessage("IOException: " + e.getMessage());
             return result;
         } catch (ParserConfigurationException e) {
             log.warn("Cannot parse result content.", e);
             result.setError(true);
-            result.setFailureMessage(new StringBuilder("ParserConfigurationException: ").append(e.getMessage())
-                    .toString());
+            result.setFailureMessage("ParserConfigurationException: " + e.getMessage());
             return result;
         } catch (TidyException e) {
             result.setError(true);

--- a/src/components/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/org/apache/jmeter/extractor/RegexExtractor.java
@@ -153,7 +153,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
                     for (int i = 1; i <= matchCount; i++) {
                         match = getCorrectMatch(matches, i);
                         if (match != null) {
-                            final String refName_n = new StringBuilder(refName).append(UNDERSCORE).append(i).toString();
+                            final String refName_n = refName + UNDERSCORE + i;
                             vars.put(refName_n, generateResult(match));
                             saveGroups(vars, refName_n, match);
                         }
@@ -161,7 +161,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
                 }
                 // Remove any left-over variables
                 for (int i = matchCount + 1; i <= prevCount; i++) {
-                    final String refName_n = new StringBuilder(refName).append(UNDERSCORE).append(i).toString();
+                    final String refName_n = refName + UNDERSCORE + i;
                     vars.remove(refName_n);
                     removeGroups(vars, refName_n);
                 }

--- a/src/components/org/apache/jmeter/extractor/XPath2Extractor.java
+++ b/src/components/org/apache/jmeter/extractor/XPath2Extractor.java
@@ -75,11 +75,11 @@ PostProcessor, Serializable {
     //- JMX file attributes
 
     private String concat(String s1,String s2){
-        return new StringBuilder(s1).append("_").append(s2).toString(); // $NON-NLS-1$
+        return s1 + "_" + s2; // $NON-NLS-1$
     }
 
     private String concat(String s1, int i){
-        return new StringBuilder(s1).append("_").append(i).toString(); // $NON-NLS-1$
+        return s1 + "_" + i; // $NON-NLS-1$
     }
 
 

--- a/src/components/org/apache/jmeter/extractor/XPathExtractor.java
+++ b/src/components/org/apache/jmeter/extractor/XPathExtractor.java
@@ -91,11 +91,11 @@ public class XPathExtractor extends AbstractScopedTestElement implements
 
 
     private String concat(String s1,String s2){
-        return new StringBuilder(s1).append("_").append(s2).toString(); // $NON-NLS-1$
+        return s1 + "_" + s2; // $NON-NLS-1$
     }
 
     private String concat(String s1, int i){
-        return new StringBuilder(s1).append("_").append(i).toString(); // $NON-NLS-1$
+        return s1 + "_" + i; // $NON-NLS-1$
     }
 
     /**
@@ -169,7 +169,7 @@ public class XPathExtractor extends AbstractScopedTestElement implements
             log.error("IOException on ({})", getXPathQuery(), e);
             AssertionResult ass = new AssertionResult(getName());
             ass.setError(true);
-            ass.setFailureMessage(new StringBuilder("IOException: ").append(e.getLocalizedMessage()).toString());
+            ass.setFailureMessage("IOException: " + e.getLocalizedMessage());
             previousResult.addAssertionResult(ass);
             previousResult.setSuccessful(false);
         } catch (ParserConfigurationException e) {// Should not happen

--- a/src/functions/org/apache/jmeter/functions/XPathFileContainer.java
+++ b/src/functions/org/apache/jmeter/functions/XPathFileContainer.java
@@ -56,9 +56,7 @@ public class XPathFileContainer {
 
     public XPathFileContainer(String file, String xpath) throws FileNotFoundException, IOException,
             ParserConfigurationException, SAXException, TransformerException {
-        if(log.isDebugEnabled()) {
-            log.debug("XPath(" + file + ") xpath " + xpath);
-        }
+        log.debug("XPath({}) xpath {}", file, xpath);
         fileName = file;
         nextRow = 0;
         nodeList=load(xpath);
@@ -72,7 +70,7 @@ public class XPathFileContainer {
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             nl = XPathUtil.selectNodeList(builder.parse(bis), xpath);
             if(log.isDebugEnabled()) {
-                log.debug("found " + nl.getLength());
+                log.debug("found {}", nl.getLength());
             }
         } catch (TransformerException | SAXException
                 | ParserConfigurationException | IOException e) {
@@ -100,7 +98,7 @@ public class XPathFileContainer {
         {
             nextRow = 0;
         }
-        log.debug(new StringBuilder("Row: ").append(row).toString());
+        log.debug("Row: {}", row);
         return row;
     }
 


### PR DESCRIPTION
## Description
Simplify code for String concatenation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Java is smart enough to compile simple string concatenation `"something" + x` to
the same code as `new StringBuilder("something").append(x).toString()`.
The latter is really hard to read, so use the simpler one.

While at it, use string formats for the logger (as it is some sort of string
concatenation, too). And since we use the string formatter, we don't have
to guard the log level anymore for the simple case.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- code simplification, no functional change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
