### PR TITLE
Use log string format instead of doing the concatenation ourselves

### DIFF
--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -312,20 +312,20 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         for (final String parser : parsers) {
             String classname = JMeterUtils.getProperty(parser + ".className");//$NON-NLS-1$
             if (classname == null) {
-                log.error("Cannot find .className property for " + parser+", ensure you set property:'" + parser + ".className'");
+                log.error("Cannot find .className property for {}, ensure you set property: '{}.className'", parser, parser);
                 continue;
             }
             String typeList = JMeterUtils.getProperty(parser + ".types");//$NON-NLS-1$
             if (typeList != null) {
                 String[] types = JOrphanUtils.split(typeList, " ", true);
                 for (final String type : types) {
-                    log.info("Parser for " + type + " is " + classname);
+                    log.info("Parser for {} is {}", type, classname);
                     PARSERS_FOR_CONTENT_TYPE.put(type, classname);
                 }
             } else {
-                log.warn("Cannot find .types property for " + parser
-                        + ", as a consequence parser will not be used, to make it usable, define property:'"
-                        + parser + ".types'");
+                log.warn(
+                        "Cannot find .types property for {}, as a consequence parser will not be used, to make it usable, define property:'{}.types'",
+                        parser, parser);
             }
         }
     }
@@ -641,9 +641,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @param contentEncoding - the encoding, may be null
      */
     public void addEncodedArgument(String name, String value, String metaData, String contentEncoding) {
-        if (log.isDebugEnabled()) {
-            log.debug("adding argument: name: " + name + " value: " + value + " metaData: " + metaData + " contentEncoding: " + contentEncoding);
-        }
+        log.debug("adding argument: name: {} value: {} metaData: {} contentEncoding: {}", name, value, metaData,
+                contentEncoding);
 
         HTTPArgument arg;
         final boolean nonEmptyEncoding = !StringUtils.isEmpty(contentEncoding);
@@ -659,7 +658,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             try {
                 valueEncoded = arg.getEncodedValue(contentEncoding);
             } catch (UnsupportedEncodingException e) { // NOSONAR 
-                log.warn("Unable to get encoded value using encoding " + contentEncoding);
+                log.warn("Unable to get encoded value using encoding {}", contentEncoding);
                 valueEncoded = arg.getEncodedValue();
             }
         } else {
@@ -794,7 +793,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 return HTTPConstants.DEFAULT_HTTPS_PORT;
             }
             if (!HTTPConstants.PROTOCOL_HTTP.equalsIgnoreCase(prot)) {
-                log.warn("Unexpected protocol: " + prot);
+                log.warn("Unexpected protocol: {}", prot);
                 // TODO - should this return something else?
             }
             return HTTPConstants.DEFAULT_HTTP_PORT;
@@ -885,9 +884,9 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         if (mgr != null) {
             lValue = mgr.merge(value);
             if (log.isDebugEnabled()) {
-                log.debug("Existing HeaderManager '" + mgr.getName() + "' merged with '" + lValue.getName() + "'");
+                log.debug("Existing HeaderManager '{}' merged with '{}'", mgr.getName(), lValue.getName());
                 for (int i = 0; i < lValue.getHeaders().size(); i++) {
-                    log.debug("    " + lValue.getHeader(i).getName() + "=" + lValue.getHeader(i).getValue());
+                    log.debug("    {}={}", lValue.getHeader(i).getName(), lValue.getHeader(i).getValue());
                 }
             }
         }
@@ -1097,7 +1096,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             try {
                 item = (HTTPArgument) objectValue;
             } catch (ClassCastException e) { // NOSONAR
-                log.warn("Unexpected argument type: " + objectValue.getClass().getName() +" cannot be cast to HTTPArgument");
+                log.warn("Unexpected argument type: {} cannot be cast to HTTPArgument", objectValue.getClass().getName());
                 item = new HTTPArgument((Argument) objectValue);
             }
             final String encodedName = item.getEncodedName();
@@ -1120,7 +1119,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             try {
                 buf.append(item.getEncodedValue(lContentEncoding));
             } catch(UnsupportedEncodingException e) { // NOSONAR
-                log.warn("Unable to encode parameter in encoding " + lContentEncoding + ", parameter value not included in query string");
+                log.warn("Unable to encode parameter in encoding {}, parameter value not included in query string", lContentEncoding );
             }
         }
         return buf.toString();
@@ -1143,11 +1142,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      */
     public void parseArguments(String queryString, String contentEncoding) {
         String[] args = JOrphanUtils.split(queryString, QRY_SEP);
-        final boolean isDebug = log.isDebugEnabled();
         for (String arg : args) {
-            if (isDebug) {
-                log.debug("Arg: " + arg);
-            }
+            log.debug("Arg: {}", arg);
             // need to handle four cases:
             // - string contains name=value
             // - string contains name=
@@ -1170,9 +1166,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 value = "";
             }
             if (name.length() > 0) {
-                if (isDebug) {
-                    log.debug("Name: " + name + " Value: " + value + " Metadata: " + metaData);
-                }
+                log.debug("Name: {} Value: {} Metadata: {}", name, value, metaData);
                 // If we know the encoding, we can decode the argument value,
                 // to make it easier to read for the user
                 if (!StringUtils.isEmpty(contentEncoding)) {
@@ -1307,7 +1301,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                     pattern = JMeterUtils.getPattern(re);
                     localMatcher = JMeterUtils.getMatcher();// don't fetch unless pattern compiles
                 } catch (MalformedCachePatternException e) { // NOSONAR
-                    log.warn("Ignoring embedded URL match string: " + e.getMessage());
+                    log.warn("Ignoring embedded URL match string: {}", e.getMessage());
                 }
             }
 
@@ -1327,7 +1321,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 // if the user choose a number of parallel downloads of 1
                 // no need to use another thread, do the sample on the current thread
                 if (maxConcurrentDownloads == 1) {
-                    log.warn("Number of parallel downloads set to 1, (sampler name=" + getName()+")");
+                    log.warn("Number of parallel downloads set to 1, (sampler name={})", getName());
                     isConcurrentDwn = false;
                 }
             }
@@ -1438,7 +1432,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         try {
             return ConversionUtils.sanitizeUrl(url).toURL();
         } catch (Exception e1) { // NOSONAR
-            log.error("Error escaping URL:'" + url + "', message:" + e1.getMessage());
+            log.error("Error escaping URL:'{}', message:{}", url, e1.getMessage());
             return url;
         }
     }
@@ -1464,7 +1458,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             return userAgentHdr.trim();
         } else {
             if (log.isInfoEnabled()) {
-                log.info("No user agent extracted from requestHeaders:" + res);
+                log.info("No user agent extracted from requestHeaders:{}", res);
             }
             return null;
         }
@@ -1558,9 +1552,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         for (redirect = 0; redirect < MAX_REDIRECTS; redirect++) {
             boolean invalidRedirectUrl = false;
             String location = lastRes.getRedirectLocation();
-            if (log.isDebugEnabled()) {
-                log.debug("Initial location: " + location);
-            }
+            log.debug("Initial location: {}", location);
             if (REMOVESLASHDOTDOT) {
                 location = ConversionUtils.removeSlashDotDot(location);
             }
@@ -1568,9 +1560,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             // replacing them automatically with %20. We want to emulate
             // this behaviour.
             location = encodeSpaces(location);
-            if (log.isDebugEnabled()) {
-                log.debug("Location after /. and space transforms: " + location);
-            }
+            log.debug("Location after /. and space transforms: {}", location);
             // Change all but HEAD into GET (Bug 55450)
             String method = lastRes.getHTTPMethod();
             method = computeMethodForRedirect(method);
@@ -1578,9 +1568,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             try {
                 URL url = ConversionUtils.makeRelativeURL(lastRes.getURL(), location);
                 url = ConversionUtils.sanitizeUrl(url).toURL();
-                if (log.isDebugEnabled()) {
-                    log.debug("Location as URL: " + url.toString());
-                }
+                log.debug("Location as URL: {}", url);
                 HTTPSampleResult tempRes = sample(url, method, true, frameDepth);
                 if (tempRes != null) {
                     lastRes = tempRes;
@@ -1671,7 +1659,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         HTTPSampleResult res = pRes;
         if (!areFollowingRedirect && res.isRedirect()) {
             if(log.isDebugEnabled()) {
-                log.debug("Location set to - " + res.getRedirectLocation());
+                log.debug("Location set to - {}", res.getRedirectLocation());
             }
 
             if (getFollowRedirects()) {
@@ -1918,7 +1906,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             return ((org.apache.commons.io.output.ByteArrayOutputStream) w).toByteArray();
         }
         
-        log.warn("Unknown stream type " + w.getClass());
+        log.warn("Unknown stream type {}", w.getClass());
         
         return null;
     }


### PR DESCRIPTION
## Description
Simplify code.

## Motivation and Context
Make code a bit more readable by using placeholders for the
parameters. We can get rid of a few `if` statements, where
parameters are used directly in the log statements.

## How Has This Been Tested?
No functional change.

## Screenshots (if appropriate):

## Types of changes
- code cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
