### PR TITLE
Use SHA-512 checksums instead of MD5 to verify jar downloads

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -32,7 +32,7 @@
 # The following properties are used to download the jars if necessary.
 #
 # xxx.loc - example location where the jar or zip can be found (omit trailing /)
-# xxx.md5 - MD5 hash of the jar (used to check downloads)
+# xxx.sha512 - MD5 hash of the jar (used to check downloads)
 #
 # xxx.zip - name of zip file (if the jar is not available as an independent download)
 # xxx.ent - the jar entry name in Zip file
@@ -45,22 +45,22 @@ maven2.repo                 = https://repo1.maven.org/maven2
 accessors-smart.version     = 1.2
 accessors-smart.jar         = accessors-smart-${accessors-smart.version}.jar
 accessors-smart.loc         = ${maven2.repo}/net/minidev/accessors-smart/${accessors-smart.version}
-accessors-smart.md5         = c28b871d258b4d347559d2eb7ecec4a3
+accessors-smart.sha512      = 39FE6A5EBD2AE2D33D8737C8407A8CAA4F6A62CE2057D726BB82496D35104B76F230BBB9721E1DB5F535FEFA3D70EE88C0A5A5E4A3F1266D7317CAE897AD0882
 
 apache-bsf.version          = 2.4.0
 apache-bsf.jar              = bsf-${apache-bsf.version}.jar
 apache-bsf.loc              = ${maven2.repo}/bsf/bsf/${apache-bsf.version}
-apache-bsf.md5              = 16e82d858c648962fb5c959f21959039
+apache-bsf.sha512           = CF2FF6EA53CD13EA842CAD398F1BE24539BEC68A5CBBD088492ADAB50BC782CDE6D9F4C0B6A24DEAEEE537809C90631C43F9A680FF2826C28CCF1B39380954E3
 
 asm.version                 = 6.1
 asm.jar                     = asm-${asm.version}.jar
 asm.loc                     = ${maven2.repo}/org/ow2/asm/asm/${asm.version}
-asm.md5                     = 9c0d6d49f51c2ed0d916acef4ba45d0d
+asm.sha512                  = 5AAB6C9CC5D60BE870D36A2B11DE5921B06E148DF26DD84794D6000B9F48520C8D71494E71E40E11D6B1B5435E548D572D7BF5AF9E66C3ED8F1466CC69B32BCC
 
 beanshell.version           = 2.0b6
 beanshell.jar               = bsh-${beanshell.version}.jar
 beanshell.loc               = ${maven2.repo}/org/apache-extras/beanshell/bsh/${beanshell.version}
-beanshell.md5               = 0f27117d5b4cfeea1d0634125313fac0
+beanshell.sha512            = A39321A99A8A619A48B65752F6EE6B8F11D3B28EBB051082EC70A70A0D5041E83D144378DF191929E3D6562BD5EE4C4F1CCADB0BA42055529D18800A41D8AE18
 
 # Bouncy Castle jars (compile and test only - not distributed)
 # Currently only needed for SMIMEAssertion
@@ -68,427 +68,427 @@ beanshell.md5               = 0f27117d5b4cfeea1d0634125313fac0
 bcmail.version              = 1.60
 bcmail.jar                  = bcmail-jdk15on-${bcmail.version}.jar
 bcmail.loc                  = ${maven2.repo}/org/bouncycastle/bcmail-jdk15on/${bcmail.version}
-bcmail.md5                  = 43955f9f9b98389d316d4cd0bbff07d0
+bcmail.sha512               = 79B43DF17AB209A1026FC3CDA644B2611A72E861D3673CE846E078CED93A0991E16C91667FA854FEE7E92F5553338D1C9783BB2FBF426EB6FD19C8CE3582B26E
 
 bcprov.version              = 1.60
 bcprov.jar                  = bcprov-jdk15on-${bcprov.version}.jar
 bcprov.loc                  = ${maven2.repo}/org/bouncycastle/bcprov-jdk15on/${bcprov.version}
-bcprov.md5                  = 435ff931af9ed4430d2a27456b0386b2
+bcprov.sha512               = 1C08D82349E333720C08FC467FF6489B14B8633A09019BF8BB5E6A3C426DFAE6DCC415648FE1FB4A2DA8631548F4947AB6CA1BC90B3190A05040F4D2EB271A10
 
 bcpkix.version              = 1.60
 bcpkix.jar                  = bcpkix-jdk15on-${bcprov.version}.jar
 bcpkix.loc                  = ${maven2.repo}/org/bouncycastle/bcpkix-jdk15on/${bcprov.version}
-bcpkix.md5                  = edc6f012c19cf74d70964187a4ab32ba
+bcpkix.sha512               = D44CDAC998A0D804AC452725C9E84B7D517C838CC6770CECDB214E1DF50EFC5EC2D067A91A5009F1316A5635CF7A1D213F2EE2A4E7497C66E1C7BBD5D2D4445F
 
 dec.version                 = 0.1.2
 dec.jar                     = dec-${dec.version}.jar
 dec.loc                     = ${maven2.repo}/org/brotli/dec/${dec.version}
-dec.md5                     = 4b1cd14cf29733941cc536b27e6aedfa
+dec.sha512                  = D4CD2B33F7C358012FF01DB6A13EBFE1E8051A580698BFFCD942C47451012CF53CE49A400B1C8BF7502B01E631D79D7C6417202A145622572D79FD145CCDE61A
 
 caffeine.version            = 2.6.2
 caffeine.jar                = caffeine-${caffeine.version}.jar
 caffeine.loc                = ${maven2.repo}/com/github/ben-manes/caffeine/caffeine/${caffeine.version}
-caffeine.md5                = 97a80024e99a27279faa17509850c606
+caffeine.sha512             = 6521F1BFEFCD6E2991A7D017BBA8D751C5BA4694D335B61B4E732A2B795C748532BE7A5A63107B6BB70F816CEEEA4659B77EBAC68AD02C44CD813C478F759A06
 
 commons-codec.version       = 1.11
 commons-codec.jar           = commons-codec-${commons-codec.version}.jar
 commons-codec.loc           = ${maven2.repo}/commons-codec/commons-codec/${commons-codec.version}
-commons-codec.md5           = 567159b1ae257a43e1391a8f59d24cfe
+commons-codec.sha512        = D9586162B257386B5871E7E9AE255A38014A9EFAEEF5148DE5E40A3B0200364DAD8516BDDD554352AA2E5337BEC2CC11DF88C76C4FDDE96A40F3421AA60650D7
 
 commons-collections.version = 3.2.2
 commons-collections.jar     = commons-collections-${commons-collections.version}.jar
 commons-collections.loc     = ${maven2.repo}/commons-collections/commons-collections/${commons-collections.version}
-commons-collections.md5     = f54a8510f834a1a57166970bfc982e94
+commons-collections.sha512  = 51C72F9ACA7726F3C387095E66BE85A6DF97C74B00A25434B89188C1B8EAB6E2B55ACCF7B9BD412430D22BD09324DEC076E300B3D1FA39FCCAD471F0F2A3DA16
 
 commons-dbcp2.version       = 2.4.0
 commons-dbcp2.jar           = commons-dbcp2-${commons-dbcp2.version}.jar
 commons-dbcp2.loc           = ${maven2.repo}/org/apache/commons/commons-dbcp2/${commons-dbcp2.version}
-commons-dbcp2.md5           = 51370385bd93d25be964a54d0748ecbb
+commons-dbcp2.sha512        = D018C681564003EB3FB8FCA2028E06CD27416A1FFD60255880EFDEAABBF7A39A3B95E57E591A0510658DC2EAFFE2D561B04AAAD9255CE8DE23A694C42399F9FA
 
 commons-io.version          = 2.6
 commons-io.jar              = commons-io-${commons-io.version}.jar
 commons-io.loc              = ${maven2.repo}/commons-io/commons-io/${commons-io.version}
-commons-io.md5              = 467c2a1f64319c99b5faf03fc78572af
+commons-io.sha512           = 4DE22E2A50711F756A5542474395D8619DCA0A8BE0407B722605005A1167F8C306BC5EEF7F0B8252F5508C817C1CEB759171E4E18D4EB9697DFDD809AC39673F
 
 commons-jexl2.version       = 2.1.1
 commons-jexl2.jar           = commons-jexl-${commons-jexl2.version}.jar
 commons-jexl2.loc           = ${maven2.repo}/org/apache/commons/commons-jexl/${commons-jexl2.version}
-commons-jexl2.md5           = 4ad8f5c161dd3a50e190334555675db9
+commons-jexl2.sha512        = DCD62490CC386516F66427F5E478C308F6937EB6D64A34A02DE56255129DED20BEDB85C01B5C794D95CA3C4D6A11D58FA920779C5E517B78A881C5A229E4FBA2
 
 commons-jexl3.version       = 3.1
 commons-jexl3.jar           = commons-jexl3-${commons-jexl3.version}.jar
 commons-jexl3.loc           = ${maven2.repo}/org/apache/commons/commons-jexl3/${commons-jexl3.version}
-commons-jexl3.md5           = d59fed0ea84b84a1574b023eacd47f1a
+commons-jexl3.sha512        = 6AD2D83CFB29CB6C19DB70D4A89E8BD317B10DA736AC0B9B37C3F4DF8E428AE5987BF73AA1BA9439955E7278B7E056B009B691E2E64925E3E3C5B2CFA1349D9F
 
 commons-lang3.version       = 3.8
 commons-lang3.jar           = commons-lang3-${commons-lang3.version}.jar
 commons-lang3.loc           = ${maven2.repo}/org/apache/commons/commons-lang3/${commons-lang3.version}
-commons-lang3.md5           = 0e9023b7d40f09a8f7bdb32889ef4449
+commons-lang3.sha512        = 18E35F8E88EDB1050D47A722405BE20D668D8D989C7026FE02B6ECFCF8A68256E0D7397F2F5704DD454B420BBDF927B10BC463F46FC7990A3A0D27E132E78639
 
 commons-math3.version         = 3.6.1
 commons-math3.jar             = commons-math3-${commons-math3.version}.jar
 commons-math3.loc             = ${maven2.repo}/org/apache/commons/commons-math3/${commons-math3.version}
-commons-math3.md5             = 5b730d97e4e6368069de1983937c508e
+commons-math3.sha512          = 8BC2438B3B4D9A6BE4A47A58410B2D4D0E56E05787AB24BADAB8CBC9075D61857E8D2F0BFFEDAD33F18F8A356541D00F80A8597B5DEDB995BE8480D693D03226
 
 commons-net.version         = 3.6
 commons-net.jar             = commons-net-${commons-net.version}.jar
 commons-net.loc             = ${maven2.repo}/commons-net/commons-net/${commons-net.version}
-commons-net.md5             = b46661b01cc7aeec501f1cd3775509f1
+commons-net.sha512          = DBA414CEA9FB4B47DFE6D20C347BD91052185DD958996BFDD1E709F66B5FA7812EBB0DAD80C47E72BCC0075B3B5526C705216EFE771CAC1CC53B2F7923124FAF
 
 commons-pool2.version         = 2.6.0
 commons-pool2.jar             = commons-pool2-${commons-pool2.version}.jar
 commons-pool2.loc             = ${maven2.repo}/org/apache/commons/commons-pool2/${commons-pool2.version}
-commons-pool2.md5             = 249e596118f3545c4bdbf6560a2e38eb
+commons-pool2.sha512          = C31D44FF2D527DEC5189BAF8AE1D888C37A53A60283C58CBEACD723C773DB8219DD54E0FCA15F29F781E0AF66E60E894254D6AAC80178207B51DD2F9DCC972C3
 
 darcula.version            = e208efb96f70e4be9dc362fbb46f6e181ef501dd
 darcula.jar                = darcula.jar
 darcula.loc                = https://github.com/bulenkov/Darcula/raw/${darcula.version}/build
-darcula.md5                = 5afdcd4e299f71fb9dfd1740937bfbea
+darcula.sha512             = 80F3335D8EA3FB3FF07A12A79C958C4E3F8BB542511C52825A8B3694AC96F027E24396CE9EDCEFA44EE93B5CBED4E4AED4575E6AAED56F363BAE92C52EE85D22
 
 # dnsjava for DNSCacheManager (http://www.dnsjava.org/ BSD license)
 dnsjava.version             = 2.1.8
 dnsjava.jar                 = dnsjava-${dnsjava.version}.jar
 dnsjava.loc                 = ${maven2.repo}/dnsjava/dnsjava/${dnsjava.version}
-dnsjava.md5                 = 540f330717bca9d29c8762cf6daca443
+dnsjava.sha512              = A4BCB8BBB43906F42FAF1802C504CCC9C616E49AFD5DD7DB77676D13AAED79A300979FFC2195B680A9C6D5F03466B611B6F1338D824099816AA224B234760F4B
 
 # Freemarker
 freemarker.version          = 2.3.28
 freemarker.loc               = ${maven2.repo}/org/freemarker/freemarker/${freemarker.version}
 freemarker.jar               = freemarker-${freemarker.version}.jar
-freemarker.md5               = c5e35d814518da7b0247d42311b8e296
+freemarker.sha512            = 44435CB2B6BA02ABACDC4A21BEA44A2DC50FAA1B486FC5B2F79097A68F1F98CA24AA835448AC5DEC33A1869EED1B8A32AC285E95FDABBDAFAA810D575951894E
 
 # Groovy
 groovy-all.version        = 2.4.15
 groovy-all.loc            = ${maven2.repo}/org/codehaus/groovy/groovy-all/${groovy-all.version}
 groovy-all.jar            = groovy-all-${groovy-all.version}.jar
-groovy-all.md5            = 9c857ec7544a0324b25186fdb65bb71b
+groovy-all.sha512         = FC30F48E1D64959BE90CD25C4E68E44AA3A9D80D319323A291F2655C65036D860525F55ED902AD0E5CDC114143D20A165876E80DFE949E5C9AD4D8A0AD7F39E7
 
 # hamcrest-core
 hamcrest-core.version        = 1.3
 hamcrest-core.loc            = ${maven2.repo}/org/hamcrest/hamcrest-core/${hamcrest-core.version}
 hamcrest-core.jar            = hamcrest-core-${hamcrest-core.version}.jar
-hamcrest-core.md5            = 6393363b47ddcbba82321110c3e07519
+hamcrest-core.sha512         = E237AE735AAC4FA5A7253EC693191F42EF7DDCE384C11D29FBF605981C0BE077D086757409ACAD53CB5B9E53D86A07CC428D459FF0F5B00D32A8CBBCA390BE49
 
 # hamcrest-date
 hamcrest-date.version        = 2.0.4
 hamcrest-date.loc            = ${maven2.repo}/org/exparity/hamcrest-date/${hamcrest-date.version}
 hamcrest-date.jar            = hamcrest-date-${hamcrest-date.version}.jar
-hamcrest-date.md5            = e37d0c3e0a578f4da48d0e8fee6e4c44
+hamcrest-date.sha512         = DC0FB7DDE5B151E09C619C080BD0AB6405596A0E926126342C65EDE6E25F65519B5B6A02BF25C02AD75A31EB26C6B41672CDAB97CC8B5AD983D025651A33CDD6
 
 # Apache HttpASyncClient 4.x
 httpasyncclient.version          = 4.1.3
 httpasyncclient.jar              = httpasyncclient-${httpasyncclient.version}.jar
 httpasyncclient.loc              = ${maven2.repo}/org/apache/httpcomponents/httpasyncclient/${httpasyncclient.version}
-httpasyncclient.md5              = 73d4a443918f4f7124339d2161e2ae54
+httpasyncclient.sha512           = 32CB1EE6E34C883FF7F4ADE7EAF563152962B0E40E6795F93D1600FFE1CED7102062C8D0C2C31F4FC9606F1F500EA554E5D83B7AE650C1D78A3BE312808E6F35
 
 # Apache HttpClient 4.x
 httpclient.version          = 4.5.6
 httpclient.jar              = httpclient-${httpclient.version}.jar
 httpclient.loc              = ${maven2.repo}/org/apache/httpcomponents/httpclient/${httpclient.version}
-httpclient.md5              = 877aca56579fea38c6358d06408976ba
+httpclient.sha512           = 32CB1EE6E34C883FF7F4ADE7EAF563152962B0E40E6795F93D1600FFE1CED7102062C8D0C2C31F4FC9606F1F500EA554E5D83B7AE650C1D78A3BE312808E6F35
 
 # Required for HttpClient
 httpmime.version            = 4.5.6
 httpmime.jar                = httpmime-${httpmime.version}.jar
 httpmime.loc                = ${maven2.repo}/org/apache/httpcomponents/httpmime/${httpmime.version}
-httpmime.md5                = 420691e1f1627f04fbc4b52eccddddd5
+httpmime.sha512             = 9841DB7779B647DE4668DED9B79E8C510A653076384FC3059EF186EA5D82828E149DE48C016B5CB89A1BEABE60981429265A8324BE3108473C57AF77A62ABD6A
 
 # Required for HttpClient
 httpcore.version            = 4.4.10
 httpcore.jar                = httpcore-${httpcore.version}.jar
 httpcore.loc                = ${maven2.repo}/org/apache/httpcomponents/httpcore/${httpcore.version}
-httpcore.md5                = 0aa2d618716ab34e5c0389b44814700a
+httpcore.sha512             = 7F58003E9EEC977627401C4C6BC720AF257094F492B0F73C43FB547E0D161017657F5C9C0B834704C5C00112B91E88EE9E4C255CC1E31AA62BA979D21393AED4
 
 # Required for HttpASyncClient
 httpcore-nio.version            = 4.4.10
 httpcore-nio.jar                = httpcore-nio-${httpcore-nio.version}.jar
 httpcore-nio.loc                = ${maven2.repo}/org/apache/httpcomponents/httpcore-nio/${httpcore-nio.version}
-httpcore-nio.md5                = b8ddfe970fc30e47d367b1bbded52317
+httpcore-nio.sha512             = 002AF5F72B68A4FF1B1FF46B788013283D195E1D62EE1D7B102AA930B30F77F7E215A6D18EDBEA0FCCD18FB1FA3A66CC4AEF6070D72D6D1886F0044DFE0E16C7
 
 jakarta-oro.version         = 2.0.8
 jakarta-oro.jar             = oro-${jakarta-oro.version}.jar
 jakarta-oro.loc             = ${maven2.repo}/oro/oro/${jakarta-oro.version}
-jakarta-oro.md5             = 42E940D5D2D822F4DC04C65053E630AB
+jakarta-oro.sha512          = 9A98E493C4D771322B1331EC05AB0E363A83D8AC2AF8018D96A44DF2BF5BFC97D33EBE6F6F93E46AB10BF1536F0C29E9D9569318ED49BC18B4E96B1A8B476D37
 
 jcharts.version             = 0.7.5
 jcharts.jar                 = jcharts-${jcharts.version}.jar
 jcharts.loc                 = ${maven2.repo}/jcharts/jcharts/${jcharts.version}
-jcharts.md5                 = 13927D8077C991E7EBCD8CB284746A7A
+jcharts.sha512              = 3953900BEBE38F4242499D106D59425F54B73C0478C3050F0DC0917D5C36CC35F94CCFEA96E6BF85E9B1282BD572F55AFEF1B485F81F5ED9493CC4D3828F5A0B
 
 rhino.version               = 1.7.10
 rhino.jar                   = rhino-${rhino.version}.jar
 rhino.loc                   = ${maven2.repo}/org/mozilla/rhino/${rhino.version}
-rhino.md5                   = 95376a6a78a8ac54321fd8012c9e27a8
+rhino.sha512                = FF4F8BFA5F1AFDD4F2E4C34DE8AA3CE18E4955F3804A3B864CB54583B7CB20621302786D625A2E4ED9EE879452F2E5BA70E855E65C34E58CF7F716D8A4515BC2
 
 javax.activation-api.version           = 1.2.0
 javax.activation-api.jar               = javax.activation-api-${javax.activation-api.version}.jar
 javax.activation-api.loc               = ${maven2.repo}/javax/activation/javax.activation-api/${javax.activation-api.version}
-javax.activation-api.md5               = 5e50e56bcf4a3ef3bc758f69f7643c3b
+javax.activation-api.sha512            = 8EE0DB43AE402F0079A836EF2BFF5D15160E3FF9D585C3283F4CF474BE4EDD2FCC8714D8F032EFD72CAE77EC5F6D304FC24FA094D9CDBA5CF72966CC964AF6C9
 
 javax.activation.version           = 1.2.0
 javax.activation.jar               = javax.activation-${javax.activation.version}.jar
 javax.activation.loc               = ${maven2.repo}/com/sun/activation/javax.activation/${javax.activation.version}
-javax.activation.md5               = be7c430df50b330cffc4848a3abedbfb
+javax.activation.sha512            = B4CBDD8FD1703E4B2E1E691DB78FBCF2232D836F740D1821C4C191A14F9472508E27A40D06E4B6B153964AF68032959C22945BA169A0CA4018B7748162F420A6
 
 jodd-core.version           = 4.1.4
 jodd-core.jar               = jodd-core-${jodd-core.version}.jar
 jodd-core.loc               = ${maven2.repo}/org/jodd/jodd-core/${jodd-core.version}
-jodd-core.md5               = 1ab42839ca15f9df2e569f48cc1ce8bf
+jodd-core.sha512            = 5BCCD68E34E768B15C24A5C40E3203B4EE49D5BACDB2DF9F7AE972C5A8907FC64932A67ADF67851A3A34D4C99AC2F1D7802C775134297C1B73A4CA02892A5B64
 
 jodd-lagarto.version        = 4.1.4
 jodd-lagarto.jar            = jodd-lagarto-${jodd-lagarto.version}.jar
 jodd-lagarto.loc            = ${maven2.repo}/org/jodd/jodd-lagarto/${jodd-lagarto.version}
-jodd-lagarto.md5            = 93a2318f25da86e997f56e687a61f38d
+jodd-lagarto.sha512         = 88755F6697BD80DE57B279675BFDD9E6930216E861964F8E4BBDF643CFBF9975842C52E9843DE62C7ED60DCD3EBC14DF1ED61BA1E0A3A2B46D0EF2F458A50E36
 
 jodd-log.version            = 4.1.4
 jodd-log.jar                = jodd-log-${jodd-log.version}.jar
 jodd-log.loc                = ${maven2.repo}/org/jodd/jodd-log/${jodd-log.version}
-jodd-log.md5                = 436605704ffa02f9aabbcd3a779e8995
+jodd-log.sha512             = DB2BD75B63C3D656D012F0144463E480D15BA5CACFC395CDEF36552888E49CDE13B044F6520705BA667554B5A0EF79344E8AF7B6DE33743C98689A537949ED02
 
 jodd-props.version          = 4.1.4
 jodd-props.jar              = jodd-props-${jodd-props.version}.jar
 jodd-props.loc              = ${maven2.repo}/org/jodd/jodd-props/${jodd-props.version}
-jodd-props.md5              = e7a5017de253a20ce924ff4ce245d33d
+jodd-props.sha512           = 02C7BA9ACE183D59E4C4B6F3F2F49AF92D2D0E3C9A6B4AA4763E9DD879AD4A7AF30E49F5E824D0A70F0C4840AC03EEC9270FE82CB71CBFA6E0B531A250039A3B
 
 json-path.version           = 2.4.0
 json-path.jar               = json-path-${json-path.version}.jar
 json-path.loc               = ${maven2.repo}/com/jayway/jsonpath/json-path/${json-path.version}
-json-path.md5               = 29169b4b1115bc851e5734ef35ecd42a
+json-path.sha512            = B55B30CF85CA12E6A492FD48D4B6BB0B1F3BA610C195AA1A36EDA2A80E24BF7688A6A802362D398108E822F6DCB7B713CF421BB4208897FC4F5CC7B8B9B4C97C
 
 json-smart.version          = 2.3
 json-smart.jar              = json-smart-${json-smart.version}.jar
 json-smart.loc              = ${maven2.repo}/net/minidev/json-smart/${json-smart.version}
-json-smart.md5              = f2a921d4baaa7308de04eed4d8d72715
+json-smart.sha512           = 977FFE05C17965B403A60471EB6C160103263BBE454E942D67D4D725E1826B504DE6C15038FF01EA90632BF9AD8A31B47C6662613BB905F020EFFA68C44D6F9A
 
 jsoup.version               = 1.11.2
 jsoup.jar                   = jsoup-${jsoup.version}.jar
 jsoup.loc                   = ${maven2.repo}/org/jsoup/jsoup/${jsoup.version}
-jsoup.md5                   = 798fe34ab37709e67188cbdf6a504435
+jsoup.sha512                = D38078985C5A2E36EE0DB158E098CBF450599AC4910E23F663F0DE61F41CCB7378701BE04BB881D036D7B8E2EBF6FC4F2FBECE6F991BFB918006B8E39ABB8185
 
 junit.version               = 4.12
 junit.jar                   = junit-${junit.version}.jar
 junit.loc                   = ${maven2.repo}/junit/junit/${junit.version}
-junit.md5                   = 5b38c40c97fbd0adee29f91e60405584
+junit.sha512                = 5974670C3D178A12DA5929BA5DD9B4F5FF461BDC1B92618C2C36D53E88650DF7ADBF3C1684017BB082B477CB8F40F15DCF7526F06F06183F93118BA9EBEACCCE
 
 spock-core.version          = 1.0-groovy-2.4
 spock-core.jar              = spock-core-${spock-core.version}.jar
 spock-core.loc              = ${maven2.repo}/org/spockframework/spock-core/${spock-core.version}
-spock-core.md5              = 2fbbeaf95dd10b445c6c581c9b945075
+spock-core.sha512           = 078C0B16688EAA3134043E58ED4273981797EA92F08723B5508C7D7E4F635278DD5CA731FB294DA2A1F35674623D969EE423D4344C2C822E1D4CB8D4F3383790
 
 cglib-nodep.version         = 3.2.7
 cglib-nodep.jar             = cglib-nodep-${cglib-nodep.version}.jar
 cglib-nodep.loc             = ${maven2.repo}/cglib/cglib-nodep/${cglib-nodep.version}
-cglib-nodep.md5             = 79710fbb3060795bd9d999773a52e7f9
+cglib-nodep.sha512          = 51AB981E18A008DC2B729A21FE7EEFE1962E34AF4DEB73C338473AE9CE926B9F6AB3858EC3E21CF209DFF191D720E9612EF77B02FD83BF4FC06BEEDE3A4A1D05
 
 objenesis.version           = 2.6
 objenesis.jar               = objenesis-${objenesis.version}.jar
 objenesis.loc               = ${maven2.repo}/org/objenesis/objenesis/${objenesis.version}
-objenesis.md5               = 5ffac3f51405ca9b2915970a224b3e8f
+objenesis.sha512            = 23A593BDED8CB43236FAAD2018B008DA47BF4E29CC60C2E98FD4F2ED578FE2BADDD3A98547DC14273017C82CB19CE8EAAAB71D49273411856A2BA1A5D51015FC
 
 mongo-java-driver.version   = 2.11.3
 mongo-java-driver.jar       = mongo-java-driver-${mongo-java-driver.version}.jar
 mongo-java-driver.loc       = ${maven2.repo}/org/mongodb/mongo-java-driver/${mongo-java-driver.version}
-mongo-java-driver.md5       = 90647a53231eb75715fda30759ff4ff7
+mongo-java-driver.sha512    = 737A0D037A6BEF711539FB89E8D7388EEF8F7B11393291412329D76DFB0C1695718CB903E60C63CA8144C95F53CA9EF66E80B4DFD5DA73E0E989467DC4B61337
 
 ph-css.version              = 6.1.1
 ph-css.jar                  = ph-css-${ph-css.version}.jar
 ph-css.loc                  = ${maven2.repo}/com/helger/ph-css/${ph-css.version}
-ph-css.md5                  = 305d487297f42d4f4fc7b3e42f9baf01
+ph-css.sha512               = EED6A6C680424C4337A8FFE8431F5E042841FBACE3529622125837F9E4D89B3DA8675BD74799957384CAC77ACB9F0AE031BAB3883CD87291E03ED823EDE8EC31
 
 ph-commons.version          = 9.1.2
 ph-commons.jar              = ph-commons-${ph-commons.version}.jar
 ph-commons.loc              = ${maven2.repo}/com/helger/ph-commons/${ph-commons.version}
-ph-commons.md5              = 32009e8c87cabb9596287e562ff60707
+ph-commons.sha512           = 95FFAEA5FB5F53BFFDA52D50A9E84947D67B17497723E195180D3CAE3B34F73E72E4D5D09ECB0A394D701D016F853664BC177A17CA6E997A77676C3DDC549631
 
 rsyntaxtextarea.version     = 2.6.1
 rsyntaxtextarea.jar         = rsyntaxtextarea-${rsyntaxtextarea.version}.jar
 rsyntaxtextarea.loc         = ${maven2.repo}/com/fifesoft/rsyntaxtextarea/${rsyntaxtextarea.version}
-rsyntaxtextarea.md5         = cf5a26609efa7e834df891e54abf0634
+rsyntaxtextarea.sha512      = 5CD84236EBBEFBB238BC4BC9AC5F702BC45E9F2CB494F7D6A8159FE141C35DC45FEE24DEA5843EC01384FF81944203C09D026697C4BDD9DB568861B8C238BD13
 
 slf4j-api.version           = 1.7.25
 slf4j-api.jar               = slf4j-api-${slf4j-api.version}.jar
 slf4j-api.loc               = ${maven2.repo}/org/slf4j/slf4j-api/${slf4j-api.version}
-slf4j-api.md5               = caafe376afb7086dcbee79f780394ca3
+slf4j-api.sha512            = 5DD6271FD5B34579D8E66271BAB75C89BACA8B2EBEAA9966DE391284BD08F2D720083C6E0E1EDDA106ECF8A04E9A32116DE6873F0F88C19C049C0FE27E5D820B
 
 slf4j-ext.version           = 1.7.25
 slf4j-ext.jar               = slf4j-ext-${slf4j-ext.version}.jar
 slf4j-ext.loc               = ${maven2.repo}/org/slf4j/slf4j-ext/${slf4j-ext.version}
-slf4j-ext.md5               = e85f2c9a7adfaedbbbe97fab4a7c1d4e
+slf4j-ext.sha512            = 04EC30ABC9CFC6A895ACEB60FF67A1883A066196BD06B7E7440375F54ECAEC3487310974EAABD8401F85B6FA1D53E15541394359D78427CC32894709205E8279
 
 jcl-over-slf4j.version      = 1.7.25
 jcl-over-slf4j.jar          = jcl-over-slf4j-${jcl-over-slf4j.version}.jar
 jcl-over-slf4j.loc          = ${maven2.repo}/org/slf4j/jcl-over-slf4j/${jcl-over-slf4j.version}
-jcl-over-slf4j.md5          = 56b22adc639b09b2e917f42d68b26600
+jcl-over-slf4j.sha512       = 0A703864B269DE6F7BC98DF0FA98AA943CC327A4CA2915899D460E4A071FCC3FBE70957EB91B740CC935D0960B3D98F30C54A0A4019D7AE8C6D50F51EDB8D149
 
 log4j-api.version           = 2.11.0
 log4j-api.jar               = log4j-api-${log4j-api.version}.jar
 log4j-api.loc               = ${maven2.repo}/org/apache/logging/log4j/log4j-api/${log4j-api.version}
-log4j-api.md5               = a581600f3010fcbf0d9b3d4907142395
+log4j-api.sha512            = 72E37483A4BD3F338885A08242005E76347D13F879937ACCCB4B3DFF3909D832BDF8B7091D4BC1E6F201A43D906D348F0FA27BFEFDDCE7D27F13E23604B7E570
 
 log4j-core.version          = 2.11.0
 log4j-core.jar              = log4j-core-${log4j-core.version}.jar
 log4j-core.loc              = ${maven2.repo}/org/apache/logging/log4j/log4j-core/${log4j-core.version}
-log4j-core.md5              = 2abec2ce665e0d529a3f28fffbbb2dd3
+log4j-core.sha512           = C79153BAE0743D9130C4697216C941FA5261D1CA1A7AF8D78C4EBB8CEEB28E0D3BEFEF98895042FDD31B5B9C17E5408EA60490B108618A1B83C2D146E3D816F2
 
 log4j-1.2-api.version       = 2.11.0
 log4j-1.2-api.jar           = log4j-1.2-api-${log4j-1.2-api.version}.jar
 log4j-1.2-api.loc           = ${maven2.repo}/org/apache/logging/log4j/log4j-1.2-api/${log4j-1.2-api.version}
-log4j-1.2-api.md5           = fb3b054b376fc7dce4dd9fef9f26cefa
+log4j-1.2-api.sha512        = 17DB99E9F53DAF78F3699E68CD02271B41335BE702E0356B642042D9A2848EB8EB5E40279546CDE146FCFC56EC28A67D096F4EE8720268FEC1CAEAEFB5BC1B48
 
 log4j-slf4j-impl.version    = 2.11.0
 log4j-slf4j-impl.jar        = log4j-slf4j-impl-${log4j-slf4j-impl.version}.jar
 log4j-slf4j-impl.loc        = ${maven2.repo}/org/apache/logging/log4j/log4j-slf4j-impl/${log4j-slf4j-impl.version}
-log4j-slf4j-impl.md5        = 137b44346128f7e78fefcb7d16cc5981
+log4j-slf4j-impl.sha512     = 4082692C66F3511183541D1ADB9E00031FCF0761A7EF84F4317C77AC314473FF1971C9B610EB97358FA8FCE147E2953B2F3E6C9EBC7B893883ED5466984C609F
 
 sonarqube-ant-task.version  = 2.5
 sonarqube-ant-task.jar      = sonarqube-ant-task-${sonarqube-ant-task.version}.jar
 sonarqube-ant-task.loc      = ${maven2.repo}/org/sonarsource/scanner/ant/sonarqube-ant-task/${sonarqube-ant-task.version}
-sonarqube-ant-task.md5      = 0458ef676194411fcccad3bdec8b22c9
+sonarqube-ant-task.sha512   = D21DC7D16102E08C8418257FF3CF19B5F9A179B3440C02D11ECCFF3831DA1861095D1264528CEE718D1BD0F118D8384D168BB3C555009B0BC12BA4D82E645973
 
 jtidy.version               = r938
 jtidy.jar                   = jtidy-${jtidy.version}.jar
 jtidy.loc                   = ${maven2.repo}/net/sf/jtidy/jtidy/${jtidy.version}
-jtidy.md5                   = 6A9121561B8F98C0A8FB9B6E57F50E6B
+jtidy.sha512                = 4C6CC198BD8CDE62B6CC9091ED95A4114EAAD035C196317C891F8F2263B28649A33B1F26F74F2B043A17CEC2A3D025EDA81ACF317FDF2D04641FA646E486B345
 
 # Apache Tika to extract text from various documents
 tika-core.version           = 1.19.1
 tika-core.jar               = tika-core-${tika-core.version}.jar
 tika-core.loc               = ${maven2.repo}/org/apache/tika/tika-core/${tika-core.version}
-tika-core.md5               = c69747bc68274128fb7b8db0a6e3795a
+tika-core.sha512            = E094EE91485FE6C4819896C69A6FACE658E68F50E1F0FD73D64C94F0213CFF4A7EAE9CB115404239CF157DF044F044B501B87069C03B24E03CAEC311864087AC
 
 tika-parsers.version        = 1.19.1
 tika-parsers.jar            = tika-parsers-${tika-parsers.version}.jar
 tika-parsers.loc            = ${maven2.repo}/org/apache/tika/tika-parsers/${tika-parsers.version}
-tika-parsers.md5            = 637fbd863c68dee8b5d915d0bf115302
+tika-parsers.sha512         = 34739112F2F3B745B39F0E524747B74EB3042DD1BB3CC1531EC075AABC0EF8EC317949321DA54A2385F7240446881B14554C9155D718B7B77960DA9602E5AF88
 
 # XStream can be found at: http://x-stream.github.io
 xstream.version             = 1.4.10
 xstream.jar                 = xstream-${xstream.version}.jar
 xstream.loc                 = ${maven2.repo}/com/thoughtworks/xstream/xstream/${xstream.version}
-xstream.md5                 = d00eec778910f95b26201395ac64cca0
+xstream.sha512              = 19271DFF2CEA8D5DF6725B6938F4533BF4258B857C9BCFEE0891589D20D21FC49433694BEA2E0E647E722C8392EF714D4368B604D6D97B4649155B67C7C7988F
 
 # XMLPull is required by XStream 1.4.x
 xmlpull.version             = 1.1.3.1
 xmlpull.jar                 = xmlpull-${xmlpull.version}.jar
 xmlpull.loc                 = ${maven2.repo}/xmlpull/xmlpull/${xmlpull.version}
-xmlpull.md5                 = cc57dacc720eca721a50e78934b822d2
+xmlpull.sha512              = 54D1090623497E81270B2AF633268656E8855E1EDCE2217886431039516A391BA9F8D8DB3C21A0B5E51C7F7CB672D63EBE77BE75708B760B06F399486960F261
 
 xpp3.version                = 1.1.4c
 xpp3.jar                    = xpp3_min-${xpp3.version}.jar
 xpp3.loc                    = ${maven2.repo}/xpp3/xpp3_min/${xpp3.version}
-xpp3.md5                    = DCD95BCB84B09897B2B66D4684C040DA
+xpp3.sha512                 = 34989289CE8ED861499F31742EE1E7B9DC3C59973CE915A7B561D33D98968E77DB5BB94C1692802CCDBD86D04CAA7DB67748EFAFB1402428B2D6AE3056497618
 
 # Xalan can be found at: http://xml.apache.org/xalan-j/
 xalan.version               = 2.7.2
 xalan.jar                   = xalan-${xalan.version}.jar
 xalan.loc                   = ${maven2.repo}/xalan/xalan/${xalan.version}
-xalan.md5                   = 6aa6607802502c8016b676f25f8e4873
+xalan.sha512                = 00F859C5BD65F6DC91E396CE91FE2F6D30B2354D6B419CD9EA96984C5403E5CD1342BB9362B0AE1F2792612F0DF731C4F7AC92F16A825BB7E22089C27A129C6C
 
 serializer.version          = 2.7.2
 serializer.jar              = serializer-${serializer.version}.jar
 serializer.loc              = ${maven2.repo}/xalan/serializer/${serializer.version}
-serializer.md5              = e8325763fd4235f174ab7b72ed815db1
+serializer.sha512           = 884D865865858A46306A3680DF69F3F0EFA0DF1313706B54E6900D36AF21E17CB6828F5A6BAC551C59F7F80BDD1CB64C3FDBDE44E213519C4AF87969E9E70774
 
 # Xerces can be found at: http://xerces.apache.org/xerces2-j/
 xerces.version              = 2.12.0
 xerces.jar                  = xercesImpl-${xerces.version}.jar
 xerces.loc                  = ${maven2.repo}/xerces/xercesImpl/${xerces.version}
-xerces.md5                  = b89632b53c4939a2982bcb52806f6dec
+xerces.sha512               = 3a527c420ed28a4b6aeab2c9f8b456b9b02edacfeebcee4056257bf02341cecadc89d394fce6f9487b457f6b795cdb626882ed4cf39c1049782909ff291494e5
 
 xml-apis.version            = 1.4.01
 xml-apis.jar                = xml-apis-${xml-apis.version}.jar
 xml-apis.loc                = ${maven2.repo}/xml-apis/xml-apis/${xml-apis.version}
-xml-apis.md5                = 7eaad6fea5925cca6c36ee8b3e02ac9d
+xml-apis.sha512             = 8DB0283B6840CD6407957D296B802E3EDF90653E2722F8E29F86C1C0B60996C4B43E9E065E6864DAB89B2138DDB0174D9B4FDDA4A93F94EEB884783DB82F3268
 
 # Codecs were previously provided by Batik
 xmlgraphics-commons.version = 2.2
 xmlgraphics-commons.jar     = xmlgraphics-commons-${xmlgraphics-commons.version}.jar
 xmlgraphics-commons.loc     = ${maven2.repo}/org/apache/xmlgraphics/xmlgraphics-commons/${xmlgraphics-commons.version}
-xmlgraphics-commons.md5     = 025a1e9ec9075ee4c07a0e7eff3f21d9
+xmlgraphics-commons.sha512  = 77F07E7CCCE8F55DFBDDBC4A9777AAACEBD13A55EDB67124017683C0E0BBDCF5BFA54D91A86DE700E3116FBABC066B1810D189C4832BF1464DB9C52A3C9F554A
 
 # JavaMail jars (N.B. these are available under CDDL)
 javamail.version            = 1.5.0-b01
 javamail.jar                = mail-${javamail.version}.jar
 javamail.loc                = ${maven2.repo}/javax/mail/mail/${javamail.version}
-javamail.md5                = 7b56e34995f7f1cb55d7806b935f90a4
+javamail.sha512             = 801A910F70DD743982872DCDEA46C24C6378E82C2CD2D970902A9CE5864191D3847BCFF6D5B81AEB89BABF056A30A70A03AA5687586D52CBFAAEAE3A5D6649F9
 
 # Geronimo JMS jar
 jms.version                 = 1.1.1
 jms.jar                     = geronimo-jms_1.1_spec-${jms.version}.jar
 jms.loc                     = ${maven2.repo}/org/apache/geronimo/specs/geronimo-jms_1.1_spec/${jms.version}
-jms.md5                     = d80ce71285696d36c1add1989b94f084
+jms.sha512                  = 94CB8660775596B298DB93E11FDBB28D2A582B161F7A6D667D41946F59E8B114AA80E15C28C4186F05B43F432B1AC555D845AD870309609202382C3F6061E319
 
 # The following jars are only needed for source distributions
 # They are used for building the documentation
 velocity.version            = 1.7
 velocity.jar                = velocity-${velocity.version}.jar
 velocity.loc                = ${maven2.repo}/org/apache/velocity/velocity/${velocity.version}
-velocity.md5                = 3692dd72f8367cb35fb6280dc2916725
+velocity.sha512             = E521785D947CAE1A02070B26A43D235B6319439A6364C58266D3F9C458F9A099406C10AAB5F51C5DB5BA541E88322CB35203C6758B4B8BB65F9539A345DA9A04
 
 # required by Velocity
 commons-lang.version        = 2.6
 commons-lang.jar            = commons-lang-${commons-lang.version}.jar
 commons-lang.loc            = ${maven2.repo}/commons-lang/commons-lang/${commons-lang.version}
-commons-lang.md5            = 4d5c1693079575b362edf41500630bbd
+commons-lang.sha512         = 4A5A3DBE4941C645E2CCA068CCA5C1882CFE988B02E7CD981D1E51784900767D1DEAB0E0E0566F559C9FCABB4A180E436D5BB948902D4F4106F37360466AFB42
 
 # required by anakia
 jdom.version                = 1.1.3
 jdom.jar                    = jdom-${jdom.version}.jar
 jdom.loc                    = ${maven2.repo}/org/jdom/jdom/${jdom.version}
-jdom.md5                    = 140bfed13341fe2039eee0f26a16d705
+jdom.sha512                 = 921A79A4759724DAD02830E75FEF0F3A3B2BB1D14D572CA4E1F97BF7A93CC5413EE41B3B231331F1EF459E77F8AE1FBF43DCDF621D18BD72331F98B24C4E8284
 
 # Optional for use by checkstyle
 checkstyle-all.version       = 8.8
 checkstyle-all.jar           = checkstyle-${checkstyle-all.version}-all.jar
 checkstyle-all.loc           = https://downloads.sourceforge.net/checkstyle/checkstyle/${checkstyle-all.version}/checkstyle-${checkstyle-all.version}-all.jar?ts=${EPOCHSECONDS}&use_mirror=autoselect
-checkstyle-all.md5           = 7c9aa14dbfa2b4645d258860a41194ce
+checkstyle-all.sha512        = 4484FED4321FC1D96607D453FAA3A1435BFFFD61B21CC0B3E6E381BCA47BCDE17B34A55A160820B7DEECE3BFA67AC92DC53D0FC64576C82FFAEAE1E80B033CA6
 
 # Optional for use by rat
 rat.version                  = 0.12
 rat.jar                      = apache-rat-${rat.version}.jar
 rat.loc                      = ${maven2.repo}/org/apache/rat/apache-rat/${rat.version}
-rat.md5                      = f4cc7b4de337e9f250a949467c5e1b42
+rat.sha512                   = C4006170C6E33E7430BD00C3A8EA6B753CC44E13E8214774D8C51BCBBC991F4B614739CE7F5E52D37CB21ECAED6AA5FBACF68686485BAF217351AB1705B7EEF2
 
 rat-tasks.jar                = apache-rat-tasks-${rat.version}.jar
 rat-tasks.loc                = ${maven2.repo}/org/apache/rat/apache-rat-tasks/${rat.version}
-rat-tasks.md5                = 96b699581b4475ed5756a0c24af745e8
+rat-tasks.sha512             = 6751C22CC838AAE95B7D3F1E82A8FA21169DA496D648596E1A3D21AA86FF0B28A55C572D99604F2283D47AAFC0B7B30B491A94B9547E11FFCA2278B189C154A3
 
 # Optional for use by JaCoCo
 jacocoant.version            = 0.8.2
 jacocoant.jar                = org.jacoco.ant-${jacocoant.version}-nodeps.jar
 jacocoant.loc                = ${maven2.repo}/org/jacoco/org.jacoco.ant/${jacocoant.version}
-jacocoant.md5                = f347ad6f684aadb07b3f3e96d93f657c
+jacocoant.sha512             = F031344C43236F88A92B90DF8CEF0B439CFCFA9E4C0BFCD864763794AE24F3967416CEB560E30E18D6879B7E270CE2B2FE3898A1FF8D8A3AF5D85C8E6C04AA60
 
 # Optional for use by JDBC_TESTS.jmx
 hsqldb.version               = 2.4.0
 hsqldb.jar                   = hsqldb-${hsqldb.version}.jar
 hsqldb.loc                   = ${maven2.repo}/org/hsqldb/hsqldb/${hsqldb.version}
-hsqldb.md5                   = 72cae1d3ef411edc74bc3ff4d12bd47c
+hsqldb.sha512                = 1161375DC48C6259BF9C219AADBE33D933260AD9D9EF1F4A006B4C81B4763603690446952B30002DAC6DA8373A1A9843902806C1C49B38149CD4584B8F0B423F
 
 # Optional for use by JMS_TESTS.jmx
 activemq-all.version         = 5.15.6
 activemq-all.jar             = activemq-all-${activemq-all.version}.jar
 activemq-all.loc             = ${maven2.repo}/org/apache/activemq/activemq-all/${activemq-all.version}
-activemq-all.md5             = a7e19a075c3713ba13e7b6f59ad5b4db
+activemq-all.sha512          = E8C9C4DAFB4F943F694E1DC3CAD9306CC763276424680BABE75C771043042022307388919A0325163E9A4AAFA1086BAA5723E414E477445FA5596A275C1302BC
 
 # Used by XPath 2
 Saxon-HE.version              = 9.8.0-12
 Saxon-HE.jar                  = Saxon-HE-${Saxon-HE.version}.jar
 Saxon-HE.loc                 = ${maven2.repo}/net/sf/saxon/Saxon-HE/${Saxon-HE.version}
-Saxon-HE.md5                  = 80e040add296c6545b92d7cb1b648534
+Saxon-HE.sha512               = 775038E7ECA4841CDF9C0807925B29CD0DFC38BCA35007F2FC1F0217B076A90A1D745F9F2993B29C30435DD90B557B3DDE23E51652E6E63B634745DF0411E89A
 
 # Optional for use by FTP_TESTS.jmx
 mina-core.version            = 2.0.16
 mina-core.jar                = mina-core-${mina-core.version}.jar
 mina-core.loc                = ${maven2.repo}/org/apache/mina/mina-core/${mina-core.version}
-mina-core.md5                = fd86528fa9d9ba8fb8c37e3ac28fa45f
+mina-core.sha512             = AFF3EC5FF5F9CDB2BB0B5C137A9FFAB7A54FDC5CD7745B14F3063122C2F6D47E702E3932BF5B0EF688CD88B573D99030E48FBA0FCDFF4C141DDC2679D108E9A8
 
 ftplet-api.version           = 1.1.1
 ftplet-api.jar               = ftplet-api-${ftplet-api.version}.jar
 ftplet-api.loc               = ${maven2.repo}/org/apache/ftpserver/ftplet-api/${ftplet-api.version}
-ftplet-api.md5               = a17a7513f5a7e2cd717f7b0fbd15241a
+ftplet-api.sha512            = 70C9E913E578460BB9B8F014C47B9C9634B9454F194EF105CFD4EB896857DC47D292B1AB88C267FF6BC0E608BFEA0BB900DB6E4D88E5F5D9096EF6A4B4CDD51C
 
 ftpserver-core.version       = 1.1.1
 ftpserver-core.jar           = ftpserver-core-${ftpserver-core.version}.jar
 ftpserver-core.loc           = ${maven2.repo}/org/apache/ftpserver/ftpserver-core/${ftpserver-core.version}
-ftpserver-core.md5           = 62b0a623ff211013d3056dbdf26139b2
+ftpserver-core.sha512        = D880495D077694475D27C081488728085FC19B8E1F113E8BA64656A3DE0A7DBC612F341EC653F3CB719B889916DE20DBD188898EED7A8CFECBAF9BE52A237118

--- a/build.xml
+++ b/build.xml
@@ -2368,7 +2368,7 @@ run JMeter unless all the JMeter jars are added.
   </target>
 
 <!--
-    Utility target to create MD5 checksums in standard format (with *filename)
+    Utility target to create SHA-512 checksums in standard format (with *filename)
     Usage:
     <antcall target="_hash">
         <param name="path" value="archive.jar|zip|gz"/>
@@ -3234,15 +3234,15 @@ run JMeter unless all the JMeter jars are added.
         <param name="loc" value="${@{jarname}.loc}"/>
         <param name="jar" value="${@{jarname}.jar}"/>
         <param name="path" value="@{dest.dir}"/>
-        <param name="md5"  value="${@{jarname}.md5}"/>
-        <param name="_checkMD5" value="true"/>
+        <param name="sha512"  value="${@{jarname}.sha512}"/>
+        <param name="_checkSHA512" value="true"/>
       </antcall>
       <antcall target="_check_jarfile">
         <param name="loc" value="${@{jarname}.loc}"/>
         <param name="jar" value="${@{jarname}.jar}"/>
         <param name="path" value="@{dest.dir}"/>
-        <param name="md5"  value="${@{jarname}.md5}"/>
-        <param name="_checkMD5" value="true"/>
+        <param name="sha512"  value="${@{jarname}.sha512}"/>
+        <param name="_checkSHA512" value="true"/>
         <param name="zip" value="${@{jarname}.zip}"/>
         <param name="ent" value="${@{jarname}.ent}"/>
         <param name="zipprop" value="@{jarname}.zip"/>
@@ -3297,10 +3297,10 @@ run JMeter unless all the JMeter jars are added.
       <!-- This requires Ant 1.7.0 or later -->
       <mapper type="flatten"/>
     </unzip>
-    <antcall target="_checkMD5">
+    <antcall target="_checkSHA512">
       <param name="file" value="${ent}"/>
       <param name="path" value="${build.dir}"/>
-      <param name="md5"  value="${md5}"/>
+      <param name="sha512"  value="${sha512}"/>
     </antcall>
     <move preservelastmodified="true" overwrite="true"
           file="${build.dir}/${ent}" tofile="${path}/${jar}" verbose="true"/>
@@ -3312,28 +3312,28 @@ run JMeter unless all the JMeter jars are added.
     <get src="${loc}/${jar}"
          dest="${build.dir}/${jar}"
          usetimestamp="false" ignoreerrors="false"/>
-    <antcall target="_checkMD5">
+    <antcall target="_checkSHA512">
       <param name="file" value="${jar}"/>
       <param name="path" value="${build.dir}"/>
-      <param name="md5"  value="${md5}"/>
+      <param name="sha512"  value="${sha512}"/>
     </antcall>
     <move preservelastmodified="true" overwrite="true"
           file="${build.dir}/${jar}" tofile="${path}/${jar}" verbose="true"/>
   </target>
 
-  <!-- Ant subroutine, required to localise MD5OK property -->
-  <target name="_checkMD5" if="_checkMD5">
+  <!-- Ant subroutine, required to localise SHA512OK property -->
+  <target name="_checkSHA512" if="_checkSHA512">
     <!--
     @param path - location of file
     @param file - file name
     -->
-    <checksum algorithm="MD5" file="${path}/${file}" property="MD5"/>
-    <condition property="MD5OK">
-      <equals arg1="${MD5}" arg2="${md5}" casesensitive="false"/>
+    <checksum algorithm="SHA-512" file="${path}/${file}" property="SHA512"/>
+    <condition property="SHA512OK">
+      <equals arg1="${SHA512}" arg2="${sha512}" casesensitive="false"/>
     </condition>
-    <fail unless="MD5OK">Bad Checksum: for ${file}
-        expected ${md5}
-        actual   ${MD5}</fail>
+    <fail unless="SHA512OK">Bad Checksum: for ${file}
+        expected ${sha512}
+        actual   ${SHA512}</fail>
     <echo level="info" message="Checksum OK: ${file}"/>
   </target>
 
@@ -3574,10 +3574,10 @@ run JMeter unless all the JMeter jars are added.
     <fail message="Invalid call sequence - file.exists should not be defined" if="file.exists"/>
     <available file="${file}" property="file.exists"/>
     <fail message="Could not find file ${file}" unless="file.exists"/>
-    <antcall target="_checkMD5">
+    <antcall target="_checkSHA512">
       <param name="file" value="${jar}"/>
       <param name="path" value="${path}"/>
-      <param name="md5"  value="${md5}"/>
+      <param name="sha512"  value="${sha512}"/>
     </antcall>
     <!--echo level="info" message="Found ${file}"/-->
   </target>


### PR DESCRIPTION
## Description
Change the checksums for the downloaded jars from MD5 to SHA-512.

## Motivation and Context
MD5 is considered broken, so we should verify downloaded artefacts for our build process with a non broken checksum. SHA-512 is considered safe -- at the moment.
## How Has This Been Tested?
`ant download_jars` and other download targets have been run without problems.
 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.
 No documentation found for the old md5 checksums construct.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
