### PR TITLE
Render min and max values in Summary Report as `#N/A`

### DIFF
--- a/src/components/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/org/apache/jmeter/visualizers/SummaryReport.java
@@ -44,6 +44,7 @@ import javax.swing.Timer;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
+import javax.swing.text.NumberFormatter;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.gui.util.FileDialoger;
@@ -55,6 +56,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.Calculator;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.apache.jorphan.gui.MinMaxLongRenderer;
 import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.gui.ObjectTableSorter;
@@ -126,8 +128,8 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
             null, // Label
             null, // count
             null, // Mean
-            null, // Min
-            null, // Max
+            new MinMaxLongRenderer("#0"), // Min //$NON-NLS-1$
+            new MinMaxLongRenderer("#0"), // Max //$NON-NLS-1$
             new NumberRenderer("#0.00"), // Std Dev. //$NON-NLS-1$
             new NumberRenderer("#0.00%"), // Error %age //$NON-NLS-1$
             new RateRenderer("#.0"),      // Throughput //$NON-NLS-1$
@@ -142,8 +144,8 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
             null, // Label
             null, // count
             null, // Mean
-            null, // Min
-            null, // Max
+            new DecimalFormat("#0"), // Min //$NON-NLS-1$
+            new DecimalFormat("#0"), // Max //$NON-NLS-1$
             new DecimalFormat("#0.00"), // Std Dev. //$NON-NLS-1$
             new DecimalFormat("#0.000%"), // Error %age //$NON-NLS-1$
             new DecimalFormat("#.00000"),      // Throughput //$NON-NLS-1$

--- a/src/jorphan/org/apache/jorphan/gui/MinMaxLongRenderer.java
+++ b/src/jorphan/org/apache/jorphan/gui/MinMaxLongRenderer.java
@@ -1,0 +1,31 @@
+package org.apache.jorphan.gui;
+
+/**
+ * Renders a min or max value and hides the extrema as they
+ * are used for initialization of the values and will likely be interpreted as
+ * random values.
+ * <p>
+ * {@link Long#MIN_VALUE} and {@link Long#MAX_VALUE} will be displayed as
+ * {@code #N/A}.
+ *
+ */
+public class MinMaxLongRenderer extends NumberRenderer { // NOSONAR
+
+    private static final long serialVersionUID = 1L;
+
+    public MinMaxLongRenderer(String format) {
+        super(format);
+    }
+
+    @Override
+    public void setValue(Object value) {
+        if (value instanceof Long) {
+            long longValue = ((Long) value).longValue();
+            if (!(longValue == Long.MAX_VALUE || longValue == Long.MIN_VALUE)) {
+                setText(formatter.format(longValue));
+                return;
+            }
+        }
+        setText("#N/A");
+    }
+}


### PR DESCRIPTION
## Description
Render min and max values in Summary Report as `#N/A`

## Motivation and context
In the Summary Report min and max values are initialized with
`Long#MAX_VALUE` and `Long#MIN_VALUE` to work easily with them.

Those initial values are looking weird in the rendered view.
Hide them by replacing the extrema by the text `#N/A`.

Bugzilla Id: 62822

## How Has This Been Tested?
Used the GUI to display `Summary Report` and run a simple test.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
