### PR TITLE
Display an info message, when no JavaFX is found and RenderInBrowser …

### DIFF
--- a/src/components/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -465,7 +465,13 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
                 }
                 renderer.setBackgroundColor(getBackground());
                 map.put(renderer.getClass().getName(), renderer);
-            } catch (Exception | NoClassDefFoundError e) { // NOSONAR See bug 60583
+            } catch (NoClassDefFoundError e) { // NOSONAR See bug 60583
+                if (e.getMessage() != null && e.getMessage().contains("javafx")) {
+                    log.info("Add JavaFX to your Java installation if you want to use renderer: {}", clazz);
+                } else {
+                    log.warn("Error loading result renderer: {}", clazz, e);
+                }
+            } catch (Exception e) {
                 log.warn("Error loading result renderer: {}", clazz, e);
             }
         }


### PR DESCRIPTION
…is used

## Description
Currently we will log a full exception stack trace in warning level, when no
JavaFX was found and `RenderInBrowser` is initialized.

Reduce the log level to info and display a short message that the user should
install JavaFX in their Java environment, if they want to use the renderer.

## Motivation and Context
The user is probably scared when an exception stack trace is shown in their log file. This change should help the user to take the needed steps more easily.

## How Has This Been Tested?
Tested through GUI.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
