### PR TITLE
SHA1 is alias for SHA-1, but SHA-1 would work in most scenario

### DIFF
--- a/src/core/org/apache/jmeter/save/SaveService.java
+++ b/src/core/org/apache/jmeter/save/SaveService.java
@@ -203,7 +203,7 @@ public class SaveService {
 
     private static String getChecksumForPropertiesFile()
             throws NoSuchAlgorithmException, IOException {
-        MessageDigest md = MessageDigest.getInstance("SHA1");
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
         File saveServiceFile = getSaveServiceFile();
         try (BufferedReader reader = 
                 Files.newBufferedReader(saveServiceFile.toPath(), Charset.defaultCharset())) {


### PR DESCRIPTION
https://docs.oracle.com/javase/7/docs/api/java/security/MessageDigest.html

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->
I meet issue like https://bugs.openjdk.java.net/browse/JDK-8202365
SHA1 MessageDigest not available

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->



## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
