### PR TITLE
Enhancement 62829 - Allow specifying proxy scheme to use

### DIFF
--- a/src/core/org/apache/jmeter/JMeter.java
+++ b/src/core/org/apache/jmeter/JMeter.java
@@ -170,6 +170,7 @@ public class JMeter implements JMeterPlugin {
     
     private static final int SYSTEM_PROPERTY    = 'D';// $NON-NLS-1$
     private static final int JMETER_GLOBAL_PROP = 'G';// $NON-NLS-1$
+    private static final int PROXY_SCHEME       = 'E';// $NON-NLS-1$
     private static final int PROXY_HOST         = 'H';// $NON-NLS-1$
     private static final int JMETER_PROPERTY    = 'J';// $NON-NLS-1$
     private static final int LOGLEVEL           = 'L';// $NON-NLS-1$
@@ -228,6 +229,9 @@ public class JMeter implements JMeterPlugin {
     private static final CLOptionDescriptor D_SERVER_OPT =
             new CLOptionDescriptor("server", CLOptionDescriptor.ARGUMENT_DISALLOWED, SERVER_OPT,
                     "run the JMeter server");
+    private static final CLOptionDescriptor D_PROXY_SCHEME =
+            new CLOptionDescriptor("proxyScheme", CLOptionDescriptor.ARGUMENT_REQUIRED, PROXY_SCHEME,
+                    "Set a proxy scheme to use for the proxy server");
     private static final CLOptionDescriptor D_PROXY_HOST =
             new CLOptionDescriptor("proxyHost", CLOptionDescriptor.ARGUMENT_REQUIRED, PROXY_HOST,
                     "Set a proxy server for JMeter to use");
@@ -319,6 +323,7 @@ public class JMeter implements JMeterPlugin {
             D_JMLOGFILE_OPT,
             D_NONGUI_OPT,
             D_SERVER_OPT,
+            D_PROXY_SCHEME,
             D_PROXY_HOST,
             D_PROXY_PORT,
             D_NONPROXY_HOSTS,
@@ -752,7 +757,11 @@ public class JMeter implements JMeterPlugin {
             System.setProperty("https.proxyHost", h);// $NON-NLS-1$
             System.setProperty("http.proxyPort",  p);// $NON-NLS-1$
             System.setProperty("https.proxyPort", p);// $NON-NLS-1$
-            log.info("Set http[s].proxyHost: {} Port: {}", h, p);
+            String proxyScheme = parser.getArgumentById(PROXY_SCHEME).getArgument();
+            if(!StringUtils.isBlank(proxyScheme)){
+                System.setProperty("http.proxyScheme",  proxyScheme );// $NON-NLS-1$
+            }
+            log.info("Set scheme: {} proxyHost: {} Port: {}", proxyScheme, h, p);
         } else if (parser.getArgumentById(PROXY_HOST) != null || parser.getArgumentById(PROXY_PORT) != null) {
             throw new IllegalUserActionException(JMeterUtils.getResString("proxy_cl_error"));// $NON-NLS-1$
         }

--- a/src/core/org/apache/jmeter/resources/messages.properties
+++ b/src/core/org/apache/jmeter/resources/messages.properties
@@ -1382,6 +1382,7 @@ web_cannot_convert_parameters_to_raw=Cannot convert parameters to Body Data \nbe
 web_cannot_switch_tab=You cannot switch because data cannot be converted\n to target Tab data; empty data to switch
 web_parameters_lost_message=Switching to Body Data will convert the parameters.\nParameter table will be cleared when you select\nanother node or save the test plan.\nOK to proceed?
 web_proxy_server_title=Proxy Server
+web_proxy_scheme=Scheme
 web_request=HTTP Request
 web_server=Web Server
 web_server_client=Client implementation

--- a/src/core/org/apache/jmeter/resources/messages_fr.properties
+++ b/src/core/org/apache/jmeter/resources/messages_fr.properties
@@ -1371,6 +1371,7 @@ web_cannot_convert_parameters_to_raw=Ne peut pas convertir les param\u00E8tres e
 web_cannot_switch_tab=Vous ne pouvez pas basculer car ces donn\u00E9es ne peuvent \u00EAtre converties.\nVider les donn\u00E9es pour basculer.
 web_parameters_lost_message=Basculer vers les Donn\u00E9es POST brutes va convertir en format brut\net perdre le format tabulaire quand vous s\u00E9lectionnerez un autre noeud\nou \u00E0 la sauvegarde du plan de test, \u00EAtes-vous s\u00FBr ?
 web_proxy_server_title=Requ\u00EAte via un serveur proxy
+web_proxy_scheme=sch\u00E8me
 web_request=Requ\u00EAte HTTP
 web_server=Serveur web
 web_server_client=Impl\u00E9mentation client

--- a/src/protocol/http/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -68,6 +68,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
     private JLabeledTextField embeddedRE; // regular expression used to match against embedded resource URLs
     private JTextField sourceIpAddr; // does not apply to Java implementation
     private JComboBox<String> sourceIpType = new JComboBox<>(HTTPSamplerBase.getSourceTypeList());
+    private JTextField proxyScheme;
     private JTextField proxyHost;
     private JTextField proxyPort;
     private JTextField proxyUser;
@@ -150,6 +151,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
             config.removeProperty(HTTPSamplerBase.IP_SOURCE_TYPE);
         }
 
+        config.setProperty(HTTPSamplerBase.PROXYSCHEME, proxyScheme.getText(),"");
         config.setProperty(HTTPSamplerBase.PROXYHOST, proxyHost.getText(),"");
         config.setProperty(HTTPSamplerBase.PROXYPORT, proxyPort.getText(),"");
         config.setProperty(HTTPSamplerBase.PROXYUSER, proxyUser.getText(),"");
@@ -174,6 +176,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
         embeddedRE.setText(""); // $NON-NLS-1$
         sourceIpAddr.setText(""); // $NON-NLS-1$
         sourceIpType.setSelectedIndex(HTTPSamplerBase.SourceType.HOSTNAME.ordinal()); //default: IP/Hostname
+        proxyScheme.setText(""); // $NON-NLS-1$
         proxyHost.setText(""); // $NON-NLS-1$
         proxyPort.setText(""); // $NON-NLS-1$
         proxyUser.setText(""); // $NON-NLS-1$
@@ -198,6 +201,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
                 samplerBase.getPropertyAsInt(HTTPSamplerBase.IP_SOURCE_TYPE,
                         HTTPSamplerBase.SOURCE_TYPE_DEFAULT));
 
+        proxyScheme.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYSCHEME));
         proxyHost.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYHOST));
         proxyPort.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYPORT));
         proxyUser.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYUSER));
@@ -377,6 +381,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
      */
     protected final JPanel getProxyServerPanel(){
         JPanel proxyServer = new HorizontalPanel();
+        proxyServer.add(getProxySchemePanel(), BorderLayout.WEST);
         proxyServer.add(getProxyHostPanel(), BorderLayout.CENTER);
         proxyServer.add(getProxyPortPanel(), BorderLayout.EAST);
 
@@ -393,6 +398,19 @@ public class HttpDefaultsGui extends AbstractConfigGui {
         return proxyServerPanel;
     }
 
+    private JPanel getProxySchemePanel() {
+        proxyScheme = new JTextField(5);
+
+        JLabel label = new JLabel(JMeterUtils.getResString("web_proxy_scheme")); // $NON-NLS-1$
+        label.setLabelFor(proxyScheme);
+        label.setFont(FONT_SMALL);
+
+        JPanel panel = new JPanel(new BorderLayout(5, 0));
+        panel.add(label, BorderLayout.WEST);
+        panel.add(proxyScheme, BorderLayout.CENTER);
+        return panel;
+    }
+
     private JPanel getProxyHostPanel() {
         proxyHost = new JTextField(10);
 
@@ -405,7 +423,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
         panel.add(proxyHost, BorderLayout.CENTER);
         return panel;
     }
-    
+
     private JPanel getProxyPortPanel() {
         proxyPort = new JTextField(10);
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -65,6 +65,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
     private JLabeledTextField embeddedRE; // regular expression used to match against embedded resource URLs
     private JTextField sourceIpAddr; // does not apply to Java implementation
     private JComboBox<String> sourceIpType = new JComboBox<>(HTTPSamplerBase.getSourceTypeList());
+    private JTextField proxyScheme;
     private JTextField proxyHost;
     private JTextField proxyPort;
     private JTextField proxyUser;
@@ -102,6 +103,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         if (!isAJP) {
             sourceIpAddr.setText(samplerBase.getIpSource());
             sourceIpType.setSelectedIndex(samplerBase.getIpSourceType());
+            proxyScheme.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYSCHEME));
             proxyHost.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYHOST));
             proxyPort.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYPORT));
             proxyUser.setText(samplerBase.getPropertyAsString(HTTPSamplerBase.PROXYUSER));
@@ -141,6 +143,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         if (!isAJP) {
             samplerBase.setIpSource(sourceIpAddr.getText());
             samplerBase.setIpSourceType(sourceIpType.getSelectedIndex());
+            samplerBase.setProperty(HTTPSamplerBase.PROXYSCHEME, proxyScheme.getText(),"");
             samplerBase.setProperty(HTTPSamplerBase.PROXYHOST, proxyHost.getText(),"");
             samplerBase.setProperty(HTTPSamplerBase.PROXYPORT, proxyPort.getText(),"");
             samplerBase.setProperty(HTTPSamplerBase.PROXYUSER, proxyUser.getText(),"");
@@ -330,6 +333,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         if (!isAJP) {
             sourceIpAddr.setText(""); // $NON-NLS-1$
             sourceIpType.setSelectedIndex(HTTPSamplerBase.SourceType.HOSTNAME.ordinal()); //default: IP/Hostname
+            proxyScheme.setText(""); // $NON-NLS-1$
             proxyHost.setText(""); // $NON-NLS-1$
             proxyPort.setText(""); // $NON-NLS-1$
             proxyUser.setText(""); // $NON-NLS-1$
@@ -362,6 +366,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
      */
     protected final JPanel getProxyServerPanel(){
         JPanel proxyServer = new HorizontalPanel();
+        proxyServer.add(getProxySchemePanel(), BorderLayout.WEST);
         proxyServer.add(getProxyHostPanel(), BorderLayout.CENTER);
         proxyServer.add(getProxyPortPanel(), BorderLayout.EAST);
 
@@ -378,6 +383,19 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         return proxyServerPanel;
     }
 
+    private JPanel getProxySchemePanel() {
+        proxyScheme = new JTextField(5);
+
+        JLabel label = new JLabel(JMeterUtils.getResString("web_proxy_scheme")); // $NON-NLS-1$
+        label.setLabelFor(proxyScheme);
+        label.setFont(FONT_SMALL);
+
+        JPanel panel = new JPanel(new BorderLayout(5, 0));
+        panel.add(label, BorderLayout.WEST);
+        panel.add(proxyScheme, BorderLayout.CENTER);
+        return panel;
+    }
+
     private JPanel getProxyHostPanel() {
         proxyHost = new JTextField(10);
 
@@ -390,7 +408,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         panel.add(proxyHost, BorderLayout.CENTER);
         return panel;
     }
-    
+
     private JPanel getProxyPortPanel() {
         proxyPort = new JTextField(10);
 

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
@@ -268,6 +268,15 @@ public abstract class HTTPAbstractImpl implements Interruptible, HTTPConstantsIn
     }
 
     /**
+     * Invokes {@link HTTPSamplerBase#getProxyScheme()}
+     *
+     * @return the configured host scheme to use for proxy
+     */
+    protected String getProxyScheme() {
+        return testElement.getProxyScheme();
+    }
+
+    /**
      * Invokes {@link HTTPSamplerBase#getProxyHost()}
      *
      * @return the configured host to use as a proxy

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHCAbstractImpl.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPHCAbstractImpl.java
@@ -43,6 +43,8 @@ public abstract class HTTPHCAbstractImpl extends HTTPAbstractImpl {
 
     private static final Logger log = LoggerFactory.getLogger(HTTPHCAbstractImpl.class);
 
+    protected static final String PROXY_SCHEME = System.getProperty("http.proxyScheme","");
+
     protected static final String PROXY_HOST = System.getProperty("http.proxyHost","");
 
     protected static final String NONPROXY_HOSTS = System.getProperty("http.nonProxyHosts","");

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -132,6 +132,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     public static final String PORT = "HTTPSampler.port"; // $NON-NLS-1$
 
+    public static final String PROXYSCHEME = "HTTPSampler.proxyScheme"; // $NON-NLS-1$
+
     public static final String PROXYHOST = "HTTPSampler.proxyHost"; // $NON-NLS-1$
 
     public static final String PROXYPORT = "HTTPSampler.proxyPort"; // $NON-NLS-1$
@@ -823,6 +825,10 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     public int getResponseTimeout() {
         return getPropertyAsInt(RESPONSE_TIMEOUT, 0);
+    }
+
+    public String getProxyScheme() {
+        return getPropertyAsString(PROXYSCHEME);
     }
 
     public String getProxyHost() {

--- a/xdocs/usermanual/get-started.xml
+++ b/xdocs/usermanual/get-started.xml
@@ -389,6 +389,7 @@ options when <code>-jar</code> is used.</p>
 the firewall/proxy server hostname and port number.  To do so, run the <code>jmeter[.bat]</code> file
 from a command line with the following parameters:</p>
 <dl>
+<dt><code>-E</code></dt><dd>[proxy scheme to use - optional - for non-http]</dd>
 <dt><code>-H</code></dt><dd>[proxy server hostname or ip address]</dd>
 <dt><code>-P</code></dt><dd>[proxy server port]</dd>
 <dt><code>-N</code></dt><dd>[nonproxy hosts] (e.g. <code>*.apache.org|localhost</code>)</dd>
@@ -396,11 +397,17 @@ from a command line with the following parameters:</p>
 <dt><code>-a</code></dt><dd>[password for proxy authentication - if required]</dd>
 </dl>
 <b>Example</b>:
-<source>jmeter -H my.proxy.server -P 8000 -u username -a password -N localhost</source>
-<p>You can also use <code>--proxyHost</code>, <code>--proxyPort</code>, <code>--username</code>, and <code>--password</code> as parameter names</p>
+<source>jmeter -E https -H my.proxy.server -P 8000 -u username -a password -N localhost</source>
+<p>You can also use <code>--proxyScheme</code>, <code>--proxyHost</code>, <code>--proxyPort</code>, <code>--username</code>, and <code>--password</code> as parameter names</p>
 <note>
 Parameters provided on a command-line may be visible to other users on the system.
 </note>
+<p>
+If the proxy scheme is provided, then JMeter sets the following System properties:
+</p>
+<ul>
+<li><code>http.proxyScheme</code></li>
+</ul>
 <p>
 If the proxy host and port are provided, then JMeter sets the following System properties:
 </p>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->
A proxy could be running using https but currently there is no way
to specify it. This enhancement allows user to specify proxy scheme to use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://bz.apache.org/bugzilla/show_bug.cgi?id=62829

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
ant package-and-check
ant test
Tested using ant run_gui
Tested on Mac and using on Ubuntu headless tests.
Using these changes with a proxy server using https


## Screenshots (if appropriate):
Attached to bugzilla ticket.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
