### PR TITLE
Change Test Action (old name) to "Flow Control Action" in Component Reference

### DIFF
--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -60,7 +60,7 @@
 <description>
     <p>
     Samplers perform the actual work of JMeter.
-    Each sampler (except <complink name="Test Action" />) generates one or more sample results.
+    Each sampler (except <complink name="Flow Control Action" />) generates one or more sample results.
     The sample results have various attributes (success/fail, elapsed time, data size etc.) and can be viewed in the various listeners.
     </p>
 </description>
@@ -1748,7 +1748,7 @@ The current implementation is quite basic, and is mainly intended for debugging 
 
 <component name="Flow Control Action" was="Test Action" index="&sect-num;.1.18" width="467" height="184" screenshot="test_action.png">
 <description>
-The Test Action sampler is a sampler that is intended for use in a conditional controller.
+The Flow Control Action sampler is a sampler that is intended for use in a conditional controller.
 Rather than generate a sample, the test element either pauses or stops the selected target.
 <p>This sampler can also be useful in conjunction with the Transaction Controller, as it allows
 pauses to be included without needing to generate a sample. 
@@ -4873,7 +4873,7 @@ please ensure that you select "<code>Store the message using MIME (raw)</code>" 
     To apply a timer to a single sampler, add the timer as a child element of the sampler.
     The timer will be applied before the sampler is executed.
     To apply a timer after a sampler, either add it to the next sampler, or add it as the
-    child of a <complink name="Test Action"/> Sampler.
+    child of a <complink name="Flow Control Action"/> Sampler.
     </note>
 </description>
 <component name="Constant Timer" index="&sect-num;.6.1" anchor="constant" width="372" height="100" screenshot="timers/constant_timer.png">


### PR DESCRIPTION
Change Test Action (old name) to "Flow Control Action" in document

## Description
Change Test Action (old name) to "Flow Control Action" in document

## Motivation and Context
Document still uses old name "Test Action"

## How Has This Been Tested?
NA


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X ] My code follows the [code style][style-guide] of this project.
- [X ] I have updated the documentation accordingly.

