### PR TITLE
Class#newInstance deprecation with Java 9

### DIFF
--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
@@ -279,7 +279,7 @@ public class BackendListener extends AbstractTestElement
             return new ErrorBackendListenerClient();
         }
         try {
-            return (BackendListenerClient) clientClass.newInstance();
+            return (BackendListenerClient) clientClass.getConstructor().newInstance();
         } catch (Exception e) {
             log.error("Exception creating: {}", clientClass, e);
             return new ErrorBackendListenerClient();

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -170,9 +170,9 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
             String newClassName = ((String) classnameCombo.getSelectedItem()).trim();
             try {
                 BackendListenerClient client = (BackendListenerClient) Class.forName(newClassName, true,
-                        Thread.currentThread().getContextClassLoader()).newInstance();
+                        Thread.currentThread().getContextClassLoader()).getConstructor().newInstance();
                 BackendListenerClient oldClient = (BackendListenerClient) Class.forName(className, true,
-                        Thread.currentThread().getContextClassLoader()).newInstance();
+                        Thread.currentThread().getContextClassLoader()).getConstructor().newInstance();
 
                 Arguments currArgs = new Arguments();
                 argsPanel.modifyTestElement(currArgs);

--- a/src/core/org/apache/jmeter/gui/action/ActionRouter.java
+++ b/src/core/org/apache/jmeter/gui/action/ActionRouter.java
@@ -369,7 +369,7 @@ public final class ActionRouter implements ActionListener {
             }
             for (String strClassName : listClasses) {
                 Class<?> commandClass = Class.forName(strClassName);
-                Command command = (Command) commandClass.newInstance();
+                Command command = (Command) commandClass.getConstructor().newInstance();
                 for (String commandName : command.getActionNames()) {
                     Set<Command> commandObjects = commands.computeIfAbsent(commandName, k -> new HashSet<>());
                     commandObjects.add(command);

--- a/src/core/org/apache/jmeter/gui/action/AddThinkTimeBetweenEachStep.java
+++ b/src/core/org/apache/jmeter/gui/action/AddThinkTimeBetweenEachStep.java
@@ -132,12 +132,13 @@ public class AddThinkTimeBetweenEachStep extends AbstractAction {
      * @param guiPackage {@link GuiPackage}
      * @param parentNode {@link JMeterTreeNode}
      * @return array of {@link JMeterTreeNode}
-     * @throws IllegalUserActionException
+     * @throws IllegalUserActionException when Timer can't be created for this node
+     * @throws ReflectiveOperationException when Class for the ThinkTimeCreator can't be instantiated
      */
     private JMeterTreeNode[] createThinkTime(GuiPackage guiPackage, JMeterTreeNode parentNode) 
-        throws Exception {
+        throws ReflectiveOperationException, IllegalUserActionException {
         Class<?> clazz = Class.forName(DEFAULT_IMPLEMENTATION);
-        ThinkTimeCreator thinkTimeCreator = (ThinkTimeCreator) clazz.newInstance();
+        ThinkTimeCreator thinkTimeCreator = (ThinkTimeCreator) clazz.getConstructor().newInstance();
         return thinkTimeCreator.createThinkTime(guiPackage, parentNode);
     }
     

--- a/src/core/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -71,7 +71,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
     @Override
     public Object clone() {
         try {
-            TestElement clonedElement = this.getClass().newInstance();
+            TestElement clonedElement = this.getClass().getConstructor().newInstance();
 
             PropertyIterator iter = propertyIterator();
             while (iter.hasNext()) {
@@ -79,7 +79,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
             }
             clonedElement.setRunningVersion(runningVersion);
             return clonedElement;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new AssertionError(e); // clone should never return null
         }
     }

--- a/src/core/org/apache/jmeter/testelement/property/AbstractProperty.java
+++ b/src/core/org/apache/jmeter/testelement/property/AbstractProperty.java
@@ -255,7 +255,7 @@ public abstract class AbstractProperty implements JMeterProperty {
 
     protected JMeterProperty getBlankProperty() {
         try {
-            JMeterProperty prop = getPropertyType().newInstance();
+            JMeterProperty prop = getPropertyType().getConstructor().newInstance();
             if (prop instanceof NullProperty) {
                 return new StringProperty();
             }
@@ -295,7 +295,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     protected Collection<JMeterProperty> normalizeList(Collection<?> coll) {
         try {
             @SuppressWarnings("unchecked") // empty collection
-            Collection<JMeterProperty> newColl = coll.getClass().newInstance();
+            Collection<JMeterProperty> newColl = coll.getClass().getConstructor().newInstance();
             for (Object item : coll) {
                 newColl.add(convertObject(item));
             }
@@ -317,7 +317,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     protected Map<String, JMeterProperty> normalizeMap(Map<?,?> coll) {
         try {
             @SuppressWarnings("unchecked") // empty collection
-            Map<String, JMeterProperty> newColl = coll.getClass().newInstance();
+            Map<String, JMeterProperty> newColl = coll.getClass().getConstructor().newInstance();
             for (Map.Entry<?,?> entry : coll.entrySet()) {
                 Object key = entry.getKey();
                 Object prop = entry.getValue();

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -96,15 +96,15 @@ public class BeanShellInterpreter {
         this(null, null);
     }
 
-    /**
+    /**Exception
      *
      * @param init initialisation file
-     * @param _log logger to pass to interpreter
+     * @param log logger to pass to interpreter
      * @throws ClassNotFoundException when beanshell can not be instantiated
      */
-    public BeanShellInterpreter(String init, Logger _log)  throws ClassNotFoundException {
+    public BeanShellInterpreter(String init, Logger log)  throws ClassNotFoundException {
         initFile = init;
-        logger = _log;
+        logger = log;
         init();
     }
 

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -114,8 +114,8 @@ public class BeanShellInterpreter {
             throw new ClassNotFoundException(BSH_INTERPRETER);
         }
         try {
-            bshInstance = bshClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            bshInstance = bshClass.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
             log.error("Can't instantiate BeanShell", e);
             throw new ClassNotFoundException("Can't instantiate BeanShell", e);
         } 
@@ -136,16 +136,16 @@ public class BeanShellInterpreter {
                         +File.separator+initFile;
                 in = new File(fileToUse);
                 if (!in.exists()) {
-                    log.warn("Cannot find init file: "+initFile);
+                    log.warn("Cannot find init file: {}", initFile);
                 }
             }
             if (!in.canRead()) {
-                log.warn("Cannot read init file: "+fileToUse);
+                log.warn("Cannot read init file: {}", fileToUse);
             }
             try {
                 source(fileToUse);
             } catch (JMeterException e) {
-                log.warn("Cannot source init file: "+fileToUse,e);
+                log.warn("Cannot source init file: {}", fileToUse,e);
             }
         }
     }

--- a/src/protocol/http/org/apache/jmeter/protocol/http/parser/BaseParser.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/parser/BaseParser.java
@@ -58,22 +58,21 @@ public abstract class BaseParser implements LinkExtractorParser {
         // Is there a cached parser?
         LinkExtractorParser parser = PARSERS.get(parserClassName);
         if (parser != null) {
-            LOG.debug("Fetched " + parserClassName);
+            LOG.debug("Fetched {}", parserClassName);
             return parser;
         }
 
         try {
-            Object clazz = Class.forName(parserClassName).newInstance();
+            Object clazz = Class.forName(parserClassName).getConstructor().newInstance();
             if (clazz instanceof LinkExtractorParser) {
                 parser = (LinkExtractorParser) clazz;
             } else {
                 throw new LinkExtractorParseException(new ClassCastException(parserClassName));
             }
-        } catch (InstantiationException | ClassNotFoundException
-                | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new LinkExtractorParseException(e);
         }
-        LOG.info("Created " + parserClassName);
+        LOG.info("Created {}", parserClassName);
         if (parser.isReusable()) {
             LinkExtractorParser currentParser = PARSERS.putIfAbsent(
                     parserClassName, parser);// cache the parser if not already

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.testelement.TestCloneable;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jorphan.util.JMeterException;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,18 +198,17 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     public void instantiateParser() {
         if (parser == null) {
             try {
-                if (this.getParserClassName() != null && this.getParserClassName().length() > 0) {
-                    if (this.getLogFile() != null && this.getLogFile().length() > 0) {
-                        parser = (LogParser) Class.forName(getParserClassName()).newInstance();
+                if (StringUtils.isNotBlank(this.getParserClassName())) {
+                    if (StringUtils.isNotBlank(this.getLogFile())) {
+                        parser = (LogParser) Class.forName(getParserClassName()).getConstructor().newInstance();
                         parser.setSourceFile(this.getLogFile());
                         parser.setFilter(filter);
                     } else {
                         log.error("No log file specified");
                     }
                 }
-            } catch (InstantiationException | ClassNotFoundException
-                    | IllegalAccessException e) {
-                log.error("", e);
+            } catch (ReflectiveOperationException e) {
+                log.error("Can't instantiate {}", getParserClassName(), e);
             }
         }
     }
@@ -306,11 +306,11 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     }
 
     protected void initFilter() {
-        if (filter == null && filterClassName != null && filterClassName.length() > 0) {
+        if (filter == null && Strings.isNotBlank(filterClassName)) {
             try {
-                filter = (Filter) Class.forName(filterClassName).newInstance();
-            } catch (Exception e) {
-                log.warn("Couldn't instantiate filter '" + filterClassName + "'", e);
+                filter = (Filter) Class.forName(filterClassName).getConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                log.warn("Couldn't instantiate filter '{}'", filterClassName, e);
             }
         }
     }
@@ -321,26 +321,21 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     @Override
     public Object clone() {
         AccessLogSampler s = (AccessLogSampler) super.clone();
-        if (started) {
-            if (filterClassName != null && filterClassName.length() > 0) {
-
-                try {
-                    if (TestCloneable.class.isAssignableFrom(Class.forName(filterClassName))) {
-                        initFilter();
-                        s.filter = (Filter) ((TestCloneable) filter).clone();
-                    }
-                    if (TestCloneable.class.isAssignableFrom(Class.forName(parserClassName)))
-                    {
-                        instantiateParser();
-                        s.parser = (LogParser)((TestCloneable)parser).clone();
-                        if (filter != null)
-                        {
-                            s.parser.setFilter(s.filter);
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("Could not clone cloneable filter", e);
+        if (started && StringUtils.isNotBlank(filterClassName)) {
+            try {
+                if (TestCloneable.class.isAssignableFrom(Class.forName(filterClassName))) {
+                    initFilter();
+                    s.filter = (Filter) ((TestCloneable) filter).clone();
                 }
+                if (TestCloneable.class.isAssignableFrom(Class.forName(parserClassName))) {
+                    instantiateParser();
+                    s.parser = (LogParser) ((TestCloneable) parser).clone();
+                    if (filter != null) {
+                        s.parser.setFilter(s.filter);
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Could not clone cloneable filter", e);
             }
         }
         return s;

--- a/test/src/org/apache/jorphan/test/AllTests.java
+++ b/test/src/org/apache/jorphan/test/AllTests.java
@@ -308,11 +308,10 @@ public final class AllTests {
         if (args.length >= 3) {
             try {
                 System.out.println("Using initializeProperties() from " + args[2]);
-                UnitTestManager um = (UnitTestManager) Class.forName(args[2]).newInstance();
+                UnitTestManager um = (UnitTestManager) Class.forName(args[2]).getConstructor().newInstance();
                 System.out.println("Setting up initial properties using: " + args[1]);
                 um.initializeProperties(args[1]);
-            } catch (ClassNotFoundException | IllegalAccessException
-                    | InstantiationException e) {
+            } catch (ReflectiveOperationException e) {
                 System.out.println("Couldn't create: " + args[2]);
                 e.printStackTrace();
             }


### PR DESCRIPTION
## Description
Change invocation of Class#newInstance to Class#getConstructor#newInstance
And do some cleanup using StringUtils.isNotBlank

## Motivation and Context
Java 9 deprecates Class#newInstance, so this will get rid of the deprecation warnings

## How Has This Been Tested?
ran tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
