### PR TITLE
Get rid of deprecated new instance calls

### DIFF
--- a/src/components/org/apache/jmeter/visualizers/RequestPanel.java
+++ b/src/components/org/apache/jmeter/visualizers/RequestPanel.java
@@ -63,7 +63,7 @@ public class RequestPanel {
         for (String clazz : classesToAdd) {
             try {
                 // Instantiate requestview classes
-                final RequestView requestView = (RequestView) Class.forName(clazz).newInstance();
+                final RequestView requestView = (RequestView) Class.forName(clazz).getDeclaredConstructor().newInstance();
                 if (rawTab.equals(requestView.getLabel())) {
                     rawObject = requestView; // use later
                 } else {

--- a/src/components/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -459,7 +459,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         for (String clazz : classesToAdd) {
             try {
                 // Instantiate render classes
-                final ResultRenderer renderer = (ResultRenderer) Class.forName(clazz).newInstance();
+                final ResultRenderer renderer = (ResultRenderer) Class.forName(clazz).getDeclaredConstructor().newInstance();
                 if (textRenderer.equals(renderer.toString())){
                     textObject=renderer;
                 }

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListener.java
@@ -279,7 +279,7 @@ public class BackendListener extends AbstractTestElement
             return new ErrorBackendListenerClient();
         }
         try {
-            return (BackendListenerClient) clientClass.newInstance();
+            return (BackendListenerClient) clientClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             log.error("Exception creating: {}", clientClass, e);
             return new ErrorBackendListenerClient();

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -35,6 +35,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -204,7 +205,7 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
                 // values that they did in the original test.
                 if (currArgsMap.containsKey(name)) {
                     String newVal = currArgsMap.get(name);
-                    if (newVal != null && newVal.length() > 0) {
+                    if (StringUtils.isNotBlank(newVal)) {
                         value = newVal;
                     }
                 }

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -169,10 +169,8 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
 
             String newClassName = ((String) classnameCombo.getSelectedItem()).trim();
             try {
-                BackendListenerClient client = (BackendListenerClient) Class.forName(newClassName, true,
-                        Thread.currentThread().getContextClassLoader()).newInstance();
-                BackendListenerClient oldClient = (BackendListenerClient) Class.forName(className, true,
-                        Thread.currentThread().getContextClassLoader()).newInstance();
+                BackendListenerClient client = createBackendListenerClient(newClassName);
+                BackendListenerClient oldClient = createBackendListenerClient(className);
 
                 Arguments currArgs = new Arguments();
                 argsPanel.modifyTestElement(currArgs);
@@ -220,6 +218,13 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
                 log.error("Error getting argument list for {}", newClassName, e);
             }
         }
+    }
+
+
+    private BackendListenerClient createBackendListenerClient(String newClassName)
+            throws ReflectiveOperationException {
+        return (BackendListenerClient) Class.forName(newClassName, true,
+                Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
     }
 
     /**

--- a/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -177,39 +177,8 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
                 Map<String, String> currArgsMap = currArgs.getArgumentsAsMap();
                 Map<String, String> userArgMap = new HashMap<>();
                 userArgMap.putAll(currArgsMap);
-                Arguments newArgs = new Arguments();
-                Arguments defaultArgs = null;
-                try {
-                    defaultArgs = client.getDefaultParameters();
-                    Arguments currentUserArgs = oldClient.getDefaultParameters();
-                    if(currentUserArgs != null) {
-                        userArgMap.keySet().removeAll(currentUserArgs.getArgumentsAsMap().keySet());
-                    }
-                } catch (AbstractMethodError e) {
-                    log.warn("BackendListenerClient doesn't implement "
-                            + "getDefaultParameters.  Default parameters won't "
-                            + "be shown.  Please update your client class: {}", newClassName);
-                }
-
-                if (defaultArgs != null) {
-                    for (JMeterProperty jMeterProperty : defaultArgs.getArguments()) {
-                        Argument arg = (Argument) jMeterProperty.getObjectValue();
-                        String name = arg.getName();
-                        String value = arg.getValue();
-
-                        // If a user has set parameters in one test, and then
-                        // selects a different test which supports the same
-                        // parameters, those parameters should have the same
-                        // values that they did in the original test.
-                        if (currArgsMap.containsKey(name)) {
-                            String newVal = currArgsMap.get(name);
-                            if (newVal != null && newVal.length() > 0) {
-                                value = newVal;
-                            }
-                        }
-                        newArgs.addArgument(name, value);
-                    }
-                }
+                Arguments defaultArgs = extractDefaultArguments(client, userArgMap, oldClient.getDefaultParameters());
+                Arguments newArgs = copyDefaultArguments(currArgsMap, defaultArgs);
                 userArgMap.forEach(newArgs::addArgument);
 
                 className = newClassName;
@@ -218,6 +187,48 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
                 log.error("Error getting argument list for {}", newClassName, e);
             }
         }
+    }
+
+
+    private Arguments copyDefaultArguments(Map<String, String> currArgsMap, Arguments defaultArgs) {
+        Arguments newArgs = new Arguments();
+        if (defaultArgs != null) {
+            for (JMeterProperty jMeterProperty : defaultArgs.getArguments()) {
+                Argument arg = (Argument) jMeterProperty.getObjectValue();
+                String name = arg.getName();
+                String value = arg.getValue();
+
+                // If a user has set parameters in one test, and then
+                // selects a different test which supports the same
+                // parameters, those parameters should have the same
+                // values that they did in the original test.
+                if (currArgsMap.containsKey(name)) {
+                    String newVal = currArgsMap.get(name);
+                    if (newVal != null && newVal.length() > 0) {
+                        value = newVal;
+                    }
+                }
+                newArgs.addArgument(name, value);
+            }
+        }
+        return newArgs;
+    }
+
+
+    private Arguments extractDefaultArguments(BackendListenerClient client, Map<String, String> userArgMap,
+            Arguments currentUserArguments) {
+        Arguments defaultArgs = null;
+        try {
+            defaultArgs = client.getDefaultParameters();
+            if(currentUserArguments != null) {
+                userArgMap.keySet().removeAll(currentUserArguments.getArgumentsAsMap().keySet());
+            }
+        } catch (AbstractMethodError e) {
+            log.warn("BackendListenerClient doesn't implement "
+                    + "getDefaultParameters.  Default parameters won't "
+                    + "be shown.  Please update your client class: {}", client.getClass().getName());
+        }
+        return defaultArgs;
     }
 
 

--- a/src/components/org/apache/jmeter/visualizers/backend/graphite/GraphiteBackendListenerClient.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/graphite/GraphiteBackendListenerClient.java
@@ -340,7 +340,7 @@ public class GraphiteBackendListenerClient extends AbstractBackendListenerClient
             }
         }
         Class<?> clazz = Class.forName(graphiteMetricsSenderClass);
-        this.graphiteMetricsManager = (GraphiteMetricsSender) clazz.newInstance();
+        this.graphiteMetricsManager = (GraphiteMetricsSender) clazz.getDeclaredConstructor().newInstance();
         graphiteMetricsManager.setup(graphiteHost, graphitePort, rootMetricsPrefix);
         if (useRegexpForSamplersList) {
             pattern = Pattern.compile(samplersList);

--- a/src/components/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -365,7 +365,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         userTag = userTagBuilder.toString();
 
         Class<?> clazz = Class.forName(influxdbMetricsSender);
-        this.influxdbMetricsManager = (InfluxdbMetricsSender) clazz.newInstance();
+        this.influxdbMetricsManager = (InfluxdbMetricsSender) clazz.getDeclaredConstructor().newInstance();
         influxdbMetricsManager.setup(influxdbUrl);
         samplersToFilter = Pattern.compile(samplersRegex);
         addAnnotation(true);

--- a/src/core/org/apache/jmeter/NewDriver.java
+++ b/src/core/org/apache/jmeter/NewDriver.java
@@ -240,7 +240,7 @@ public final class NewDriver {
 
             try {
                 Class<?> initialClass = loader.loadClass("org.apache.jmeter.JMeter");// $NON-NLS-1$
-                Object instance = initialClass.newInstance();
+                Object instance = initialClass.getDeclaredConstructor().newInstance();
                 Method startup = initialClass.getMethod("start", new Class[] { new String[0].getClass() });// $NON-NLS-1$
                 startup.invoke(instance, new Object[] { args });
             } catch(Throwable e){ // NOSONAR We want to log home directory in case of exception

--- a/src/core/org/apache/jmeter/engine/util/CompoundVariable.java
+++ b/src/core/org/apache/jmeter/engine/util/CompoundVariable.java
@@ -72,7 +72,7 @@ public class CompoundVariable implements Function {
             List<String> classes = ClassFinder.findClassesThatExtend(JMeterUtils.getSearchPaths(),
                     new Class[] { Function.class }, true, contain, notContain);
             for (String clazzName : classes) {
-                Function tempFunc = (Function) Class.forName(clazzName).newInstance();
+                Function tempFunc = (Function) Class.forName(clazzName).getDeclaredConstructor().newInstance();
                 String referenceKey = tempFunc.getReferenceKey();
                 if (referenceKey.length() > 0) { // ignore self
                     functions.put(referenceKey, tempFunc.getClass());
@@ -195,7 +195,7 @@ public class CompoundVariable implements Function {
     static Object getNamedFunction(String functionName) throws InvalidVariableException {
         if (functions.containsKey(functionName)) {
             try {
-                return functions.get(functionName).newInstance();
+                return functions.get(functionName).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 log.error("Exception occurred while instantiating a function: {}", functionName, e); // $NON-NLS-1$
                 throw new InvalidVariableException(e);

--- a/src/core/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/org/apache/jmeter/gui/GuiPackage.java
@@ -363,7 +363,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
                     "Missing jar? See log file." ,
                     JOptionPane.ERROR_MESSAGE);
             throw new RuntimeException(e.toString(), e); // Probably a missing jar
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+        } catch ( ReflectiveOperationException e) {
             log.error("Problem retrieving gui for " + objClass, e);
             throw new RuntimeException(e.toString(), e); // Programming error: bail out.
         }
@@ -389,9 +389,9 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      * @throws IllegalAccessException
      *             if access rights do not allow the default constructor to be
      *             called
+     * @throws ReflectiveOperationException when construction of guiClass fails
      */
-    private JMeterGUIComponent getGuiFromCache(Class<?> guiClass, Class<?> testClass) throws InstantiationException,
-            IllegalAccessException {
+    private JMeterGUIComponent getGuiFromCache(Class<?> guiClass, Class<?> testClass) throws ReflectiveOperationException {
         JMeterGUIComponent comp;
         if (guiClass == TestBeanGUI.class) {
             comp = testBeanGUIs.get(testClass);
@@ -402,7 +402,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
         } else {
             comp = guis.get(guiClass);
             if (comp == null) {
-                comp = (JMeterGUIComponent) guiClass.newInstance();
+                comp = (JMeterGUIComponent) guiClass.getDeclaredConstructor().newInstance();
                 if (!(comp instanceof UnsharedComponent)) {
                     guis.put(guiClass, comp);
                 }
@@ -909,7 +909,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
 
             try {
                 Class<?> implementationClass = Class.forName(namingPolicyImplementation);
-                this.namingPolicy = (TreeNodeNamingPolicy) implementationClass.newInstance();
+                this.namingPolicy = (TreeNodeNamingPolicy) implementationClass.getDeclaredConstructor().newInstance();
 
             } catch (Exception ex) {
                 log.error("Failed to create configured naming policy:" + namingPolicyImplementation + ", will use default one", ex);

--- a/src/core/org/apache/jmeter/gui/action/ActionRouter.java
+++ b/src/core/org/apache/jmeter/gui/action/ActionRouter.java
@@ -369,7 +369,7 @@ public final class ActionRouter implements ActionListener {
             }
             for (String strClassName : listClasses) {
                 Class<?> commandClass = Class.forName(strClassName);
-                Command command = (Command) commandClass.newInstance();
+                Command command = (Command) commandClass.getDeclaredConstructor().newInstance();
                 for (String commandName : command.getActionNames()) {
                     Set<Command> commandObjects = commands.computeIfAbsent(commandName, k -> new HashSet<>());
                     commandObjects.add(command);

--- a/src/core/org/apache/jmeter/gui/action/AddThinkTimeBetweenEachStep.java
+++ b/src/core/org/apache/jmeter/gui/action/AddThinkTimeBetweenEachStep.java
@@ -132,12 +132,13 @@ public class AddThinkTimeBetweenEachStep extends AbstractAction {
      * @param guiPackage {@link GuiPackage}
      * @param parentNode {@link JMeterTreeNode}
      * @return array of {@link JMeterTreeNode}
-     * @throws IllegalUserActionException
+     * @throws ReflectiveOperationException when class instantiation for {@value #DEFAULT_IMPLEMENTATION} fails
+     * @throws IllegalUserActionException when {@link ThinkTimeCreator#createThinkTime(GuiPackage, JMeterTreeNode)} throws this
      */
-    private JMeterTreeNode[] createThinkTime(GuiPackage guiPackage, JMeterTreeNode parentNode) 
-        throws Exception {
+    private JMeterTreeNode[] createThinkTime(GuiPackage guiPackage, JMeterTreeNode parentNode)
+            throws ReflectiveOperationException, IllegalUserActionException  {
         Class<?> clazz = Class.forName(DEFAULT_IMPLEMENTATION);
-        ThinkTimeCreator thinkTimeCreator = (ThinkTimeCreator) clazz.newInstance();
+        ThinkTimeCreator thinkTimeCreator = (ThinkTimeCreator) clazz.getDeclaredConstructor().newInstance();
         return thinkTimeCreator.createThinkTime(guiPackage, parentNode);
     }
     

--- a/src/core/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -222,7 +222,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
                     Class<?> commandClass = Class.forName(strClassName);
                     if (!Modifier.isAbstract(commandClass.getModifiers())) {
                         log.debug("Instantiating: {}", commandClass);
-                        MenuCreator creator = (MenuCreator) commandClass.newInstance();
+                        MenuCreator creator = (MenuCreator) commandClass.getDeclaredConstructor().newInstance();
                         creators.add(creator);
                     }
                 } catch (Exception e) {

--- a/src/core/org/apache/jmeter/gui/util/MenuFactory.java
+++ b/src/core/org/apache/jmeter/gui/util/MenuFactory.java
@@ -171,7 +171,7 @@ public final class MenuFactory {
                         || (testBeanGUI.isExpert() && !JMeterUtils.isExpertMode());
                 item = testBeanGUI;
             } else {
-                item = (JMeterGUIComponent) c.newInstance();
+                item = (JMeterGUIComponent) c.getDeclaredConstructor().newInstance();
             }
         } catch (NoClassDefFoundError e) {
             log.warn("Configuration error, probably corrupt or missing third party library(jar)? Could not create class: {}.",

--- a/src/core/org/apache/jmeter/gui/util/PowerTableModel.java
+++ b/src/core/org/apache/jmeter/gui/util/PowerTableModel.java
@@ -160,48 +160,48 @@ public class PowerTableModel extends DefaultTableModel {
             return colClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { String.class });
-                return constr.newInstance(new Object[] { "" });
+                Constructor<?> constr = colClass.getConstructor(String.class);
+                return constr.newInstance("");
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Integer.TYPE });
-                return constr.newInstance(new Object[] { Integer.valueOf(0) });
+                Constructor<?> constr = colClass.getConstructor(Integer.TYPE);
+                return constr.newInstance(Integer.valueOf(0));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Long.TYPE });
-                return constr.newInstance(new Object[] { Long.valueOf(0L) });
+                Constructor<?> constr = colClass.getConstructor(Long.TYPE);
+                return constr.newInstance(Long.valueOf(0L));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Boolean.TYPE });
-                return constr.newInstance(new Object[] { Boolean.FALSE });
+                Constructor<?> constr = colClass.getConstructor(Boolean.TYPE);
+                return constr.newInstance(Boolean.FALSE);
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Float.TYPE });
-                return constr.newInstance(new Object[] { Float.valueOf(0F) });
+                Constructor<?> constr = colClass.getConstructor(Float.TYPE);
+                return constr.newInstance(Float.valueOf(0F));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Double.TYPE });
-                return constr.newInstance(new Object[] { Double.valueOf(0D) });
+                Constructor<?> constr = colClass.getConstructor(Double.TYPE);
+                return constr.newInstance(Double.valueOf(0D));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Character.TYPE });
-                return constr.newInstance(new Object[] { Character.valueOf(' ') });
+                Constructor<?> constr = colClass.getConstructor(Character.TYPE);
+                return constr.newInstance(Character.valueOf(' '));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Byte.TYPE });
-                return constr.newInstance(new Object[] { Byte.valueOf(Byte.MIN_VALUE) });
+                Constructor<?> constr = colClass.getConstructor(Byte.TYPE);
+                return constr.newInstance(Byte.valueOf(Byte.MIN_VALUE));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
             try {
-                Constructor<?> constr = colClass.getConstructor(new Class[] { Short.TYPE });
-                return constr.newInstance(new Object[] { Short.valueOf(Short.MIN_VALUE) });
+                Constructor<?> constr = colClass.getConstructor(Short.TYPE);
+                return constr.newInstance(Short.valueOf(Short.MIN_VALUE));
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
             }
         }

--- a/src/core/org/apache/jmeter/gui/util/PowerTableModel.java
+++ b/src/core/org/apache/jmeter/gui/util/PowerTableModel.java
@@ -157,7 +157,7 @@ public class PowerTableModel extends DefaultTableModel {
     private Object createDefaultValue(int i) { // CHECKSTYLE IGNORE ReturnCount
         Class<?> colClass = getColumnClass(i);
         try {
-            return colClass.newInstance();
+            return colClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             try {
                 Constructor<?> constr = colClass.getConstructor(new Class[] { String.class });

--- a/src/core/org/apache/jmeter/gui/util/PowerTableModel.java
+++ b/src/core/org/apache/jmeter/gui/util/PowerTableModel.java
@@ -19,9 +19,9 @@
 package org.apache.jmeter.gui.util;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.event.TableModelEvent;
@@ -39,6 +39,10 @@ public class PowerTableModel extends DefaultTableModel {
     private Data model = new Data();
 
     private Class<?>[] columnClasses;
+
+    private static final List<Object> DEFAULT_ARGS = Collections.unmodifiableList(Arrays.asList("", Integer.valueOf(0),
+            Long.valueOf(0L), Boolean.FALSE, Float.valueOf(0F), Double.valueOf(0D), Character.valueOf(' '),
+            Byte.valueOf(Byte.MIN_VALUE), Short.valueOf(Short.MIN_VALUE)));
 
     public PowerTableModel(String[] headers, Class<?>[] classes) {
         if (headers.length != classes.length){
@@ -159,50 +163,13 @@ public class PowerTableModel extends DefaultTableModel {
         try {
             return colClass.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
-            try {
-                Constructor<?> constr = colClass.getConstructor(String.class);
-                return constr.newInstance("");
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Integer.TYPE);
-                return constr.newInstance(Integer.valueOf(0));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Long.TYPE);
-                return constr.newInstance(Long.valueOf(0L));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Boolean.TYPE);
-                return constr.newInstance(Boolean.FALSE);
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Float.TYPE);
-                return constr.newInstance(Float.valueOf(0F));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Double.TYPE);
-                return constr.newInstance(Double.valueOf(0D));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Character.TYPE);
-                return constr.newInstance(Character.valueOf(' '));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Byte.TYPE);
-                return constr.newInstance(Byte.valueOf(Byte.MIN_VALUE));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
-            }
-            try {
-                Constructor<?> constr = colClass.getConstructor(Short.TYPE);
-                return constr.newInstance(Short.valueOf(Short.MIN_VALUE));
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ignored) {
+            for (Object initArg: DEFAULT_ARGS) {
+                try {
+                    Constructor<?> constr = colClass.getConstructor(initArg.getClass());
+                    return constr.newInstance(initArg);
+                } catch (ReflectiveOperationException ignored) {
+                    // no need to log this, as we are just trying out all available default args
+                }
             }
         }
         return "";

--- a/src/core/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -333,7 +333,7 @@ public class ReportGenerator {
         String className = graphConfiguration.getClassName();
         try {
             Class<?> clazz = Class.forName(className);
-            Object obj = clazz.newInstance();
+            Object obj = clazz.getDeclaredConstructor().newInstance();
             AbstractGraphConsumer graph = (AbstractGraphConsumer) obj;
             graph.setName(graphName);
             
@@ -358,8 +358,7 @@ public class ReportGenerator {
                     .excludesControllers() ? excludeControllerFilter
                     : nameFilter;
             entryPoint.addSampleConsumer(graph);
-        } catch (ClassNotFoundException | IllegalAccessException
-                | InstantiationException | ClassCastException ex) {
+        } catch (ClassCastException | IllegalArgumentException |  ReflectiveOperationException | SecurityException ex) {
             String error = String.format(INVALID_CLASS_FMT, className);
             log.error(error, ex);
             throw new GenerationException(error, ex);
@@ -373,14 +372,13 @@ public class ReportGenerator {
         String className = exporterConfiguration.getClassName();
         try {
             Class<?> clazz = Class.forName(className);
-            Object obj = clazz.newInstance();
+            Object obj = clazz.getDeclaredConstructor().newInstance();
             DataExporter exporter = (DataExporter) obj;
             exporter.setName(exporterName);
 
             // Export data
             exporter.export(sampleContext, testFile, configuration);
-        } catch (ClassNotFoundException | IllegalAccessException
-                | InstantiationException | ClassCastException ex) {
+        } catch (ReflectiveOperationException | ClassCastException ex) {
             String error = String.format(INVALID_CLASS_FMT, className);
             throw new GenerationException(error, ex);
         } catch (ExportException ex) {

--- a/src/core/org/apache/jmeter/save/SaveService.java
+++ b/src/core/org/apache/jmeter/save/SaveService.java
@@ -284,7 +284,7 @@ public class SaveService {
         if (useMapper){
             jmxsaver.registerConverter((Converter) Class.forName(key).getConstructor(Mapper.class).newInstance(jmxsaver.getMapper()));
         } else {
-            jmxsaver.registerConverter((Converter) Class.forName(key).newInstance());
+            jmxsaver.registerConverter((Converter) Class.forName(key).getDeclaredConstructor().newInstance());
         }
     }
 

--- a/src/core/org/apache/jmeter/save/converters/TestElementConverter.java
+++ b/src/core/org/apache/jmeter/save/converters/TestElementConverter.java
@@ -96,7 +96,7 @@ public class TestElementConverter extends AbstractCollectionConverter {
         }
         context.put(SaveService.TEST_CLASS_NAME, targetName); // needed by property converters  (Bug 52466)
         try {
-            TestElement el = (TestElement) type.newInstance();
+            TestElement el = (TestElement) type.getDeclaredConstructor().newInstance();
             // No need to check version, just process the attributes if present
             ConversionHelp.restoreSpecialProperties(el, reader);
             // Slight hack - we need to ensure the TestClass is not reset by the previous call
@@ -110,7 +110,7 @@ public class TestElementConverter extends AbstractCollectionConverter {
                 reader.moveUp();
             }
             return el;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             log.error("TestElement not instantiable: {}", type, e);
             return null;
         }

--- a/src/core/org/apache/jmeter/save/converters/TestElementPropertyConverter.java
+++ b/src/core/org/apache/jmeter/save/converters/TestElementPropertyConverter.java
@@ -101,7 +101,7 @@ public class TestElementPropertyConverter extends AbstractCollectionConverter {
             prop.setName(ConversionHelp.decode(reader.getAttribute(ConversionHelp.ATT_NAME)));
             String element = reader.getAttribute(ConversionHelp.ATT_ELEMENT_TYPE);
             boolean isHeader = HEADER_CLASSNAME.equals(element);
-            prop.setObjectValue(mapper().realClass(element).newInstance());// Always decode
+            prop.setObjectValue(mapper().realClass(element).getDeclaredConstructor().newInstance());// Always decode
             TestElement te = (TestElement)prop.getObjectValue();
             // No need to check version, just process the attributes if present
             ConversionHelp.restoreSpecialProperties(te, reader);
@@ -122,7 +122,7 @@ public class TestElementPropertyConverter extends AbstractCollectionConverter {
                 reader.moveUp();
             }
             return prop;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             log.error("Couldn't unmarshall TestElementProperty", e);
             return new TestElementProperty("ERROR", new ConfigTestElement());// $NON-NLS-1$
         }

--- a/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -243,8 +243,8 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
 
                 if (editorClass != null) {
                     try {
-                        propertyEditor = (PropertyEditor) editorClass.newInstance();
-                    } catch (InstantiationException | IllegalAccessException e) {
+                        propertyEditor = (PropertyEditor) editorClass.getDeclaredConstructor().newInstance();
+                    } catch (ReflectiveOperationException e) {
                         log.error("Can't create property editor.", e);
                         throw new Error(e.toString());
                     }

--- a/src/core/org/apache/jmeter/testbeans/gui/TableEditor.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/TableEditor.java
@@ -298,7 +298,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
         @Override
         public void actionPerformed(ActionEvent e) {
             try {
-                model.addRow(clazz.newInstance());
+                model.addRow(clazz.getDeclaredConstructor().newInstance());
                 
                 removeButton.setEnabled(true);
                 clearButton.setEnabled(true);
@@ -321,7 +321,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
                 for (String clipboardLine : clipboardLines) {
                     String[] columns = clipboardLine.split("\t"); // $NON-NLS-1$
 
-                    model.addRow(clazz.newInstance());
+                    model.addRow(clazz.getDeclaredConstructor().newInstance());
                     
                     for (int i=0; i < columns.length; i++) {
                         model.setValueAt(columns[i], model.getRowCount() - 1, i);

--- a/src/core/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
+++ b/src/core/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
@@ -174,8 +174,8 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
 
     private Customizer createCustomizer() {
         try {
-            return (Customizer) customizerClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            return (Customizer) customizerClass.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
             log.error("Could not instantiate customizer of {}", customizerClass, e);
             throw new Error(e.toString());
         }
@@ -198,7 +198,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
    @Override
     public TestElement createTestElement() {
         try {
-            TestElement element = (TestElement) testBeanClass.newInstance();
+            TestElement element = (TestElement) testBeanClass.getDeclaredConstructor().newInstance();
             // In other GUI component, clearGUI resets the value to defaults one as there is one GUI per Element
             // With TestBeanGUI as it's shared, its default values are only known here, we must call setValues with 
             // element (as it holds default values)
@@ -209,7 +209,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
             // put the default values back into the new element
             modifyTestElement(element);
             return element;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             log.error("Can't create test element", e);
             throw new Error(e); // Programming error. Don't continue.
         }

--- a/src/core/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -71,7 +71,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
     @Override
     public Object clone() {
         try {
-            TestElement clonedElement = this.getClass().newInstance();
+            TestElement clonedElement = this.getClass().getDeclaredConstructor().newInstance();
 
             PropertyIterator iter = propertyIterator();
             while (iter.hasNext()) {
@@ -79,7 +79,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
             }
             clonedElement.setRunningVersion(runningVersion);
             return clonedElement;
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             throw new AssertionError(e); // clone should never return null
         }
     }

--- a/src/core/org/apache/jmeter/testelement/property/AbstractProperty.java
+++ b/src/core/org/apache/jmeter/testelement/property/AbstractProperty.java
@@ -255,7 +255,7 @@ public abstract class AbstractProperty implements JMeterProperty {
 
     protected JMeterProperty getBlankProperty() {
         try {
-            JMeterProperty prop = getPropertyType().newInstance();
+            JMeterProperty prop = getPropertyType().getDeclaredConstructor().newInstance();
             if (prop instanceof NullProperty) {
                 return new StringProperty();
             }
@@ -295,7 +295,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     protected Collection<JMeterProperty> normalizeList(Collection<?> coll) {
         try {
             @SuppressWarnings("unchecked") // empty collection
-            Collection<JMeterProperty> newColl = coll.getClass().newInstance();
+            Collection<JMeterProperty> newColl = coll.getClass().getDeclaredConstructor().newInstance();
             for (Object item : coll) {
                 newColl.add(convertObject(item));
             }
@@ -317,7 +317,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     protected Map<String, JMeterProperty> normalizeMap(Map<?,?> coll) {
         try {
             @SuppressWarnings("unchecked") // empty collection
-            Map<String, JMeterProperty> newColl = coll.getClass().newInstance();
+            Map<String, JMeterProperty> newColl = coll.getClass().getDeclaredConstructor().newInstance();
             for (Map.Entry<?,?> entry : coll.entrySet()) {
                 Object key = entry.getKey();
                 Object prop = entry.getValue();

--- a/src/core/org/apache/jmeter/testelement/property/CollectionProperty.java
+++ b/src/core/org/apache/jmeter/testelement/property/CollectionProperty.java
@@ -143,7 +143,7 @@ public class CollectionProperty extends MultiProperty {
     private Collection<JMeterProperty> cloneCollection() {
         try {
             @SuppressWarnings("unchecked") // value is of type Collection<JMeterProperty>
-            Collection<JMeterProperty> newCol = value.getClass().newInstance();
+            Collection<JMeterProperty> newCol = value.getClass().getDeclaredConstructor().newInstance();
             for (JMeterProperty jMeterProperty : this) {
                 newCol.add(jMeterProperty.clone());
             }

--- a/src/core/org/apache/jmeter/testelement/property/MapProperty.java
+++ b/src/core/org/apache/jmeter/testelement/property/MapProperty.java
@@ -118,7 +118,7 @@ public class MapProperty extends MultiProperty {
     private Map<String, JMeterProperty> cloneMap() {
         try {
             @SuppressWarnings("unchecked") // value is the correct class
-            Map<String, JMeterProperty> newCol = value.getClass().newInstance();
+            Map<String, JMeterProperty> newCol = value.getClass().getDeclaredConstructor().newInstance();
             PropertyIterator iter = valueIterator();
             while (iter.hasNext()) {
                 JMeterProperty item = iter.next();

--- a/src/core/org/apache/jmeter/threads/RemoteThreadsListenerImpl.java
+++ b/src/core/org/apache/jmeter/threads/RemoteThreadsListenerImpl.java
@@ -67,7 +67,7 @@ public class RemoteThreadsListenerImpl extends UnicastRemoteObject implements
                     Class<?> commandClass = Class.forName(strClassName);
                     if (!Modifier.isAbstract(commandClass.getModifiers())) {
                         log.debug("Instantiating: {}", commandClass);
-                        RemoteThreadsLifeCycleListener listener = (RemoteThreadsLifeCycleListener) commandClass.newInstance();
+                        RemoteThreadsLifeCycleListener listener = (RemoteThreadsLifeCycleListener) commandClass.getDeclaredConstructor().newInstance();
                         listeners.add(listener);
                     }
                 } catch (Exception e) {

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -114,8 +114,8 @@ public class BeanShellInterpreter {
             throw new ClassNotFoundException(BSH_INTERPRETER);
         }
         try {
-            bshInstance = bshClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+            bshInstance = bshClass.getDeclaredConstructor().newInstance();
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             log.error("Can't instantiate BeanShell", e);
             throw new ClassNotFoundException("Can't instantiate BeanShell", e);
         } 

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -136,16 +136,16 @@ public class BeanShellInterpreter {
                         +File.separator+initFile;
                 in = new File(fileToUse);
                 if (!in.exists()) {
-                    log.warn("Cannot find init file: "+initFile);
+                    log.warn("Cannot find init file: {}", initFile);
                 }
             }
             if (!in.canRead()) {
-                log.warn("Cannot read init file: "+fileToUse);
+                log.warn("Cannot read init file: {}", fileToUse);
             }
             try {
                 source(fileToUse);
             } catch (JMeterException e) {
-                log.warn("Cannot source init file: "+fileToUse,e);
+                log.warn("Cannot source init file: {}", fileToUse,e);
             }
         }
     }

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -66,14 +66,10 @@ public class BeanShellInterpreter {
             Class<String> string = String.class;
             Class<Object> object = Object.class;
 
-            get = clazz.getMethod("get", //$NON-NLS-1$
-                    new Class[] { string });
-            eval = clazz.getMethod("eval", //$NON-NLS-1$
-                    new Class[] { string });
-            set = clazz.getMethod("set", //$NON-NLS-1$
-                    new Class[] { string, object });
-            source = clazz.getMethod("source", //$NON-NLS-1$
-                    new Class[] { string });
+            get = clazz.getMethod("get", string); //$NON-NLS-1$
+            eval = clazz.getMethod("eval", string); //$NON-NLS-1$
+            set = clazz.getMethod("set", string, object); //$NON-NLS-1$
+            source = clazz.getMethod("source", string); //$NON-NLS-1$
         } catch (ClassNotFoundException|SecurityException | NoSuchMethodException e) {
             log.error("Beanshell Interpreter not found", e);
         } finally {

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -95,12 +95,12 @@ public class BeanShellInterpreter {
     /**
      *
      * @param init initialisation file
-     * @param _log logger to pass to interpreter
+     * @param log logger to pass to interpreter
      * @throws ClassNotFoundException when beanshell can not be instantiated
      */
-    public BeanShellInterpreter(String init, Logger _log)  throws ClassNotFoundException {
+    public BeanShellInterpreter(String init, Logger log)  throws ClassNotFoundException {
         initFile = init;
-        logger = _log;
+        logger = log;
         init();
     }
 

--- a/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JMeterError;
 import org.apache.jorphan.util.JMeterException;
 import org.slf4j.Logger;
@@ -122,7 +123,7 @@ public class BeanShellInterpreter {
                 log.warn("Can't set logger variable", e);
             }
         }
-        if (initFile != null && initFile.length() > 0) {
+        if (StringUtils.isNotBlank(initFile)) {
             String fileToUse=initFile;
             // Check file so we can distinguish file error from script error
             File in = new File(fileToUse);

--- a/src/core/org/apache/jmeter/util/BeanShellServer.java
+++ b/src/core/org/apache/jmeter/util/BeanShellServer.java
@@ -77,17 +77,17 @@ public class BeanShellServer implements Runnable {
             Class<String> string = String.class;
             Class<Object> object = Object.class;
 
-            Method eval = interpreter.getMethod("eval", new Class[] { string });//$NON-NLS-1$
-            Method setObj = interpreter.getMethod("set", new Class[] { string, object });//$NON-NLS-1$
-            Method setInt = interpreter.getMethod("set", new Class[] { string, int.class });//$NON-NLS-1$
-            Method source = interpreter.getMethod("source", new Class[] { string });//$NON-NLS-1$
+            Method eval = interpreter.getMethod("eval", string);//$NON-NLS-1$
+            Method setObj = interpreter.getMethod("set", string, object);//$NON-NLS-1$
+            Method setInt = interpreter.getMethod("set", string, int.class);//$NON-NLS-1$
+            Method source = interpreter.getMethod("source", string);//$NON-NLS-1$
 
-            setObj.invoke(instance, new Object[] { "t", this });//$NON-NLS-1$
-            setInt.invoke(instance, new Object[] { "portnum", Integer.valueOf(serverport) });//$NON-NLS-1$
+            setObj.invoke(instance, "t", this );//$NON-NLS-1$
+            setInt.invoke(instance, "portnum", Integer.valueOf(serverport));//$NON-NLS-1$
 
             if (serverfile.length() > 0) {
                 try {
-                    source.invoke(instance, new Object[] { serverfile });
+                    source.invoke(instance, serverfile);
                 } catch (InvocationTargetException ite) {
                     Throwable cause = ite.getCause();
                     if (log.isWarnEnabled()) {
@@ -99,8 +99,8 @@ public class BeanShellServer implements Runnable {
                     }
                 }
             }
-            eval.invoke(instance, new Object[] { "setAccessibility(true);" });//$NON-NLS-1$
-            eval.invoke(instance, new Object[] { "server(portnum);" });//$NON-NLS-1$
+            eval.invoke(instance, "setAccessibility(true);");//$NON-NLS-1$
+            eval.invoke(instance, "server(portnum);");//$NON-NLS-1$
 
         } catch (ClassNotFoundException e) {
             log.error("Beanshell Interpreter not found");

--- a/src/core/org/apache/jmeter/util/BeanShellServer.java
+++ b/src/core/org/apache/jmeter/util/BeanShellServer.java
@@ -73,7 +73,7 @@ public class BeanShellServer implements Runnable {
 
         try {
             Class<?> interpreter = loader.loadClass("bsh.Interpreter");//$NON-NLS-1$
-            Object instance = interpreter.newInstance();
+            Object instance = interpreter.getDeclaredConstructor().newInstance();
             Class<String> string = String.class;
             Class<Object> object = Object.class;
 

--- a/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
+++ b/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
@@ -104,18 +104,18 @@ public class ObjectTableModel extends DefaultTableModel {
 
         int numClasses = classes.size();
         if (numClasses != numHeaders){
-            log.warn("Header count="+numHeaders+" but classes count="+numClasses);
+            log.warn("Header count={} but classes count={}", numHeaders, numClasses);
         }
 
         // Functor count = 0 is handled specially
         int numWrite = writeFunctors.length;
         if (numWrite > 0 && numWrite != numHeaders){
-            log.warn("Header count="+numHeaders+" but writeFunctor count="+numWrite);
+            log.warn("Header count={} but writeFunctor count={}", numHeaders, numWrite);
         }
 
         int numRead = readFunctors.length;
         if (numRead > 0 && numRead != numHeaders){
-            log.warn("Header count="+numHeaders+" but readFunctor count="+numRead);
+            log.warn("Header count={} but readFunctor count={}", numHeaders, numRead);
         }
     }
 
@@ -138,7 +138,7 @@ public class ObjectTableModel extends DefaultTableModel {
     }
 
     public void addRow(Object value) {
-        log.debug("Adding row value: " + value);
+        log.debug("Adding row value: {}", value);
         if (objectClass != null) {
             final Class<?> valueClass = value.getClass();
             if (!objectClass.isAssignableFrom(valueClass)){
@@ -259,7 +259,7 @@ public class ObjectTableModel extends DefaultTableModel {
             try {
                 value = objectClass.getDeclaredConstructor().newInstance();
             } catch (ReflectiveOperationException e) {
-                log.error("Cannot create instance of class "+objectClass.getName(),e);
+                log.error("Cannot create instance of class {}", objectClass.getName(),e);
                 return false;
             }
         } else {
@@ -271,14 +271,14 @@ public class ObjectTableModel extends DefaultTableModel {
             if (setMethod != null
                  && !setMethod.checkMethod(value,getColumnClass(i))) {
                     status=false;
-                    log.warn(caller.getName()+" is attempting to use nonexistent "+setMethod.toString());
+                    log.warn("{} is attempting to use nonexistent {}", caller.getName(), setMethod);
             }
             
             Functor getMethod = readFunctors.get(i);
             if (getMethod != null 
                  && !getMethod.checkMethod(value)) {
                     status=false;
-                    log.warn(caller.getName()+" is attempting to use nonexistent "+getMethod.toString());
+                    log.warn("{} is attempting to use nonexistent {}", caller.getName(), getMethod);
             }
 
         }

--- a/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
+++ b/src/jorphan/org/apache/jorphan/gui/ObjectTableModel.java
@@ -257,11 +257,8 @@ public class ObjectTableModel extends DefaultTableModel {
         Object value;
         if (_value == null && objectClass != null) {
             try {
-                value = objectClass.newInstance();
-            } catch (InstantiationException e) {
-                log.error("Cannot create instance of class "+objectClass.getName(),e);
-                return false;
-            } catch (IllegalAccessException e) {
+                value = objectClass.getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
                 log.error("Cannot create instance of class "+objectClass.getName(),e);
                 return false;
             }

--- a/src/jorphan/org/apache/jorphan/reflect/ClassTools.java
+++ b/src/jorphan/org/apache/jorphan/reflect/ClassTools.java
@@ -41,9 +41,8 @@ public class ClassTools {
     public static Object construct(String className) throws JMeterException {
         Object instance = null;
         try {
-            instance = ClassUtils.getClass(className).newInstance();
-        } catch (ClassNotFoundException | IllegalAccessException
-                | InstantiationException e) {
+            instance = ClassUtils.getClass(className).getDeclaredConstructor().newInstance();
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             throw new JMeterException(e);
         }
         return instance;

--- a/src/protocol/http/org/apache/jmeter/protocol/http/parser/BaseParser.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/parser/BaseParser.java
@@ -63,14 +63,13 @@ public abstract class BaseParser implements LinkExtractorParser {
         }
 
         try {
-            Object clazz = Class.forName(parserClassName).newInstance();
+            Object clazz = Class.forName(parserClassName).getDeclaredConstructor().newInstance();
             if (clazz instanceof LinkExtractorParser) {
                 parser = (LinkExtractorParser) clazz;
             } else {
                 throw new LinkExtractorParseException(new ClassCastException(parserClassName));
             }
-        } catch (InstantiationException | ClassNotFoundException
-                | IllegalAccessException e) {
+        } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             throw new LinkExtractorParseException(e);
         }
         LOG.info("Created " + parserClassName);

--- a/src/protocol/http/org/apache/jmeter/protocol/http/parser/BaseParser.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/parser/BaseParser.java
@@ -58,7 +58,7 @@ public abstract class BaseParser implements LinkExtractorParser {
         // Is there a cached parser?
         LinkExtractorParser parser = PARSERS.get(parserClassName);
         if (parser != null) {
-            LOG.debug("Fetched " + parserClassName);
+            LOG.debug("Fetched {}", parserClassName);
             return parser;
         }
 
@@ -72,7 +72,7 @@ public abstract class BaseParser implements LinkExtractorParser {
         } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             throw new LinkExtractorParseException(e);
         }
-        LOG.info("Created " + parserClassName);
+        LOG.info("Created {}", parserClassName);
         if (parser.isReusable()) {
             LinkExtractorParser currentParser = PARSERS.putIfAbsent(
                     parserClassName, parser);// cache the parser if not already

--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/Daemon.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/Daemon.java
@@ -128,7 +128,7 @@ public class Daemon extends Thread implements Stoppable {
                     Socket clientSocket = mainSocket.accept();
                     if (running) {
                         // Pass request to new proxy thread
-                        Proxy thd = proxyClass.newInstance();
+                        Proxy thd = proxyClass.getDeclaredConstructor().newInstance();
                         thd.configure(clientSocket, target, pageEncodings, formEncodings);
                         thd.start();
                     }

--- a/src/protocol/http/org/apache/jmeter/protocol/http/proxy/SamplerCreatorFactory.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/proxy/SamplerCreatorFactory.java
@@ -61,7 +61,7 @@ public class SamplerCreatorFactory {
                         if(log.isDebugEnabled()) {
                             log.debug("Instantiating: {}", commandClass.getName());
                         }
-                        SamplerCreator creator = (SamplerCreator) commandClass.newInstance();
+                        SamplerCreator creator = (SamplerCreator) commandClass.getDeclaredConstructor().newInstance();
                         String[] contentTypes = creator.getManagedContentTypes();
                         for (String contentType : contentTypes) {
                             if(log.isDebugEnabled()) {

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -199,15 +199,14 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
             try {
                 if (StringUtils.isNotBlank(this.getParserClassName())) {
                     if (StringUtils.isNotBlank(this.getLogFile())) {
-                        parser = (LogParser) Class.forName(getParserClassName()).newInstance();
+                        parser = (LogParser) Class.forName(getParserClassName()).getDeclaredConstructor().newInstance();
                         parser.setSourceFile(this.getLogFile());
                         parser.setFilter(filter);
                     } else {
                         log.error("No log file specified");
                     }
                 }
-            } catch (InstantiationException | ClassNotFoundException
-                    | IllegalAccessException e) {
+            } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
                 log.error("", e);
             }
         }
@@ -308,7 +307,7 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     protected void initFilter() {
         if (filter == null && StringUtils.isNotBlank(filterClassName)) {
             try {
-                filter = (Filter) Class.forName(filterClassName).newInstance();
+                filter = (Filter) Class.forName(filterClassName).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 log.warn("Couldn't instantiate filter '" + filterClassName + "'", e);
             }

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -309,7 +309,7 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
             try {
                 filter = (Filter) Class.forName(filterClassName).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
-                log.warn("Couldn't instantiate filter '" + filterClassName + "'", e);
+                log.warn("Couldn't instantiate filter '{}'", filterClassName, e);
             }
         }
     }

--- a/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -197,8 +197,8 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     public void instantiateParser() {
         if (parser == null) {
             try {
-                if (this.getParserClassName() != null && this.getParserClassName().length() > 0) {
-                    if (this.getLogFile() != null && this.getLogFile().length() > 0) {
+                if (StringUtils.isNotBlank(this.getParserClassName())) {
+                    if (StringUtils.isNotBlank(this.getLogFile())) {
                         parser = (LogParser) Class.forName(getParserClassName()).newInstance();
                         parser.setSourceFile(this.getLogFile());
                         parser.setFilter(filter);
@@ -306,7 +306,7 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     }
 
     protected void initFilter() {
-        if (filter == null && filterClassName != null && filterClassName.length() > 0) {
+        if (filter == null && StringUtils.isNotBlank(filterClassName)) {
             try {
                 filter = (Filter) Class.forName(filterClassName).newInstance();
             } catch (Exception e) {
@@ -321,26 +321,24 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     @Override
     public Object clone() {
         AccessLogSampler s = (AccessLogSampler) super.clone();
-        if (started) {
-            if (filterClassName != null && filterClassName.length() > 0) {
+        if (started && StringUtils.isNotBlank(filterClassName)) {
 
-                try {
-                    if (TestCloneable.class.isAssignableFrom(Class.forName(filterClassName))) {
-                        initFilter();
-                        s.filter = (Filter) ((TestCloneable) filter).clone();
-                    }
-                    if (TestCloneable.class.isAssignableFrom(Class.forName(parserClassName)))
-                    {
-                        instantiateParser();
-                        s.parser = (LogParser)((TestCloneable)parser).clone();
-                        if (filter != null)
-                        {
-                            s.parser.setFilter(s.filter);
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("Could not clone cloneable filter", e);
+            try {
+                if (TestCloneable.class.isAssignableFrom(Class.forName(filterClassName))) {
+                    initFilter();
+                    s.filter = (Filter) ((TestCloneable) filter).clone();
                 }
+                if (TestCloneable.class.isAssignableFrom(Class.forName(parserClassName)))
+                {
+                    instantiateParser();
+                    s.parser = (LogParser)((TestCloneable)parser).clone();
+                    if (filter != null)
+                    {
+                        s.parser.setFilter(s.filter);
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Could not clone cloneable filter", e);
             }
         }
         return s;

--- a/src/protocol/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
@@ -190,7 +190,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
         String className = classNameLabeledChoice.getText().trim();
         try {
             JavaSamplerClient client = (JavaSamplerClient) Class.forName(className, true,
-                    Thread.currentThread().getContextClassLoader()).newInstance();
+                    Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
 
             Arguments currArgs = new Arguments();
             argsPanel.modifyTestElement(currArgs);
@@ -270,7 +270,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
     private boolean classOk(String className) {
         try {
             JavaSamplerClient client = (JavaSamplerClient) Class.forName(className, true,
-                    Thread.currentThread().getContextClassLoader()).newInstance();
+                    Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
             // Just to use client
             return client != null;
         } catch (Exception ex) {

--- a/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JavaSampler.java
+++ b/src/protocol/java/org/apache/jmeter/protocol/java/sampler/JavaSampler.java
@@ -219,7 +219,7 @@ public class JavaSampler extends AbstractSampler implements TestStateListener, I
         }
         JavaSamplerClient client;
         try {
-            client = (JavaSamplerClient) javaClass.newInstance();
+            client = (JavaSamplerClient) javaClass.getDeclaredConstructor().newInstance();
 
             if (log.isDebugEnabled()) {
                 log.debug(whoAmI() + "\tCreated:\t" + getClassname() + "@"

--- a/src/protocol/tcp/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
+++ b/src/protocol/tcp/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
@@ -334,7 +334,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
             return null;
         }
         try {
-            tcpClient = (TCPClient) javaClass.newInstance();
+            tcpClient = (TCPClient) javaClass.getDeclaredConstructor().newInstance();
             if (getPropertyAsString(EOL_BYTE, "").length()>0){
                 tcpClient.setEolByte(getEolByte());
                 log.info("Using eolByte={}", getEolByte());

--- a/test/src/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/test/src/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -326,7 +326,7 @@ public class TestHTMLParser extends JMeterTestCaseJUnit {
             HTMLParser.getParser(TestClass.class.getName());
             fail("Should not have been able to create the parser");
         } catch (LinkExtractorParseException e) {
-            if (e.getCause() instanceof InstantiationException) {
+            if (e.getCause() instanceof ReflectiveOperationException) {
                 return;
             }
             throw e;

--- a/test/src/org/apache/jorphan/test/AllTests.java
+++ b/test/src/org/apache/jorphan/test/AllTests.java
@@ -308,11 +308,10 @@ public final class AllTests {
         if (args.length >= 3) {
             try {
                 System.out.println("Using initializeProperties() from " + args[2]);
-                UnitTestManager um = (UnitTestManager) Class.forName(args[2]).newInstance();
+                UnitTestManager um = (UnitTestManager) Class.forName(args[2]).getDeclaredConstructor().newInstance();
                 System.out.println("Setting up initial properties using: " + args[1]);
                 um.initializeProperties(args[1]);
-            } catch (ClassNotFoundException | IllegalAccessException
-                    | InstantiationException e) {
+            } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
                 System.out.println("Couldn't create: " + args[2]);
                 e.printStackTrace();
             }


### PR DESCRIPTION
## Description
This basically is an update to #431 

Get rid of calls to `Class#newInstance()` by replacing them with `Class#getDeclaredConstructor()#newInstance()`

And while I edited the classes I cleaned them up a bit, when eclipse showed warnings. I think those snippets should be committed separately, but I left them in here, so that they can be discussed if necessary.

## Motivation and Context
Java 9 deprecates Class#newInstance(). 

## How Has This Been Tested?
Tests should run when github merges this for testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- cleanup

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
