### PR TITLE
Try running on java-ea for travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ before_install:
 # skip default "install" command
 install: true
 
+env:
+  global:
+  - ANT_OPTS="-Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true"
+
 matrix:
   include:
     - jdk: oraclejdk8
@@ -21,20 +25,20 @@ matrix:
       script: ant -Djava.awt.headless=true checkstyle
     - jdk: oraclejdk8
       script: 
-          - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
+          - ant coverage-travis
       after_success:
           - bash <(curl -s https://codecov.io/bash)
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
     - jdk: openjdk8
       script: 
-          - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
+          - ant coverage-travis
     - jdk: openjdk11
       script: 
-          - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
+          - ant coverage-travis
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
     - jdk: openjdk-ea
       script: 
-          - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
+          - ant coverage-travis
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
     - allow_failures:
       - jdk: openjdk-ea

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
     - jdk: openjdk8
       script: 
-          - ant coverage-travis
+          - ant test
     - jdk: openjdk11
       script: 
-          - ant coverage-travis
+          - ant test
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
     - jdk: openjdk-ea
       script: 
-          - ant coverage-travis
+          - ant test
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
     - allow_failures:
       - jdk: openjdk-ea

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
       script: 
           - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
+    - jdk: openjdk-ea
+      script: 
+          - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
+      sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
 # disable building with jdk9 as it has a bug and will not compile JMeter
 # see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8193802
 #    - jdk: oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ matrix:
       script: 
           - ant test
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
-    - allow_failures:
-      - jdk: openjdk-ea
+  allow_failures:
+    - jdk: openjdk-ea
 # disable building with jdk9 as it has a bug and will not compile JMeter
 # see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8193802
 #    - jdk: oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ matrix:
       script: 
           - ant -Ddisable-svnCheck=true -Djava.awt.headless=true -Drmi_force_localhost=true -Dskip.bug52310=true coverage-travis
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
+    - allow_failures:
+      - jdk: openjdk-ea
 # disable building with jdk9 as it has a bug and will not compile JMeter
 # see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8193802
 #    - jdk: oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,20 +23,24 @@ matrix:
     - jdk: oraclejdk8
       env: RUN_CHECKSTYLE=true
       script: ant -Djava.awt.headless=true checkstyle
-    - jdk: oraclejdk8
+    - name: Coverage on our default build with Oracle Java 8
+      jdk: oraclejdk8
       script: 
           - ant coverage-travis
       after_success:
           - bash <(curl -s https://codecov.io/bash)
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
-    - jdk: openjdk8
+    - name: Tests with OpenJDK 8
+      jdk: openjdk8
       script: 
           - ant test
-    - jdk: openjdk11
+    - name: Tests with OpenJDK 11
+      jdk: openjdk11
       script: 
           - ant test
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work
-    - jdk: openjdk-ea
+    - name: Tests with OpenJDK EA
+      jdk: openjdk-ea
       script: 
           - ant test
       sudo: true # otherwise TEST_HTTPS.jmx -> analytics.usa.gov does not work


### PR DESCRIPTION
## Description
Enable builds for Java EA on travis ci

## Motivation and Context
We should get early warnings, when JMeter doesn't run on EA versions of Java.

## How Has This Been Tested?
Will get tested by travis :)

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
