### PR TITLE
Slight performance overhead can be saved by using Random.nextDouble i…

### DIFF
--- a/src/components/org/apache/jmeter/timers/PoissonRandomTimer.java
+++ b/src/components/org/apache/jmeter/timers/PoissonRandomTimer.java
@@ -336,7 +336,7 @@ public class PoissonRandomTimer extends RandomTimer implements Serializable {
         double p = 1;
         do {
             k = k + 1;
-	    Random rand = new Random();
+            Random rand = new Random();
             double u = rand.nextDouble();
             p = p * u;
         } while (p > L);

--- a/src/components/org/apache/jmeter/timers/PoissonRandomTimer.java
+++ b/src/components/org/apache/jmeter/timers/PoissonRandomTimer.java
@@ -19,6 +19,7 @@
 package org.apache.jmeter.timers;
 
 import java.io.Serializable;
+import java.util.Random;
 
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -335,7 +336,8 @@ public class PoissonRandomTimer extends RandomTimer implements Serializable {
         double p = 1;
         do {
             k = k + 1;
-            double u = Math.random();
+	    Random rand = new Random();
+            double u = rand.nextDouble();
             p = p * u;
         } while (p > L);
         return k - 1;


### PR DESCRIPTION
…nstead of Math.random for any instance of Math.random. 

## Description
Though this is not the only instance of Math.random in the codebase, any instance of it can be replaced by Random.nextDouble. Though not performance critical, this can reduce performance overhead when done across all instances of Math.random.

- Added import for java.util.Random
- Replaced the instance of Math.random with Random.nextDouble

I have a list of every applicable Math.random -> Random.nextDouble instance and will share such list if it is okay to move forward with such modifications.

## Motivation and Context
Though not performance critical, this can reduce performance overhead when done across all instances of Math.random.

## Types of changes
- Reduced overhead in performance

## Checklist:
- [ x ] My code follows the [code style][style-guide] of this project.
- [ x ] I have updated the documentation accordingly. (Documentation did need to be updated)

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
