### PR TITLE
Fix link name due to rename

### DIFF
--- a/docs/usermanual/test_plan.html
+++ b/docs/usermanual/test_plan.html
@@ -569,7 +569,7 @@ Timers can be added as children of samplers or controllers in order to restrict 
 </p>
 
 <p>
-To provide a pause at a single place in a test plan, one can use the <a href="../usermanual/component_reference.html#Test_Action">Test Action</a> Sampler.
+To provide a pause at a single place in a test plan, one can use the <a href="../usermanual/component_reference.html#Flow_Control_Action">Flow Control Action</a> Sampler.
 </p>
 
 </div>


### PR DESCRIPTION
Test Action sampler was renamed to Flow Control Action.