### PR TITLE
Graphs rebase

### DIFF
--- a/bin/report-template/content/js/graph.js.fmkr
+++ b/bin/report-template/content/js/graph.js.fmkr
@@ -667,9 +667,7 @@ var connectTimeOverTimeInfos = {
                     axisLabelPadding: 20,
                 },
                 yaxis: {
-
                     axisLabel: "Percentile Connect Time in ms",
-
                     axisLabelUseCanvas: true,
                     axisLabelFontSizePixels: 12,
                     axisLabelFontFamily: 'Verdana, Arial',

--- a/bin/report-template/content/js/graph.js.fmkr
+++ b/bin/report-template/content/js/graph.js.fmkr
@@ -669,6 +669,7 @@ var connectTimeOverTimeInfos = {
                 yaxis: {
 
                     axisLabel: "Percentile Connect Time in ms",
+
                     axisLabelUseCanvas: true,
                     axisLabelFontSizePixels: 12,
                     axisLabelFontFamily: 'Verdana, Arial',

--- a/bin/report-template/content/js/graph.js.fmkr
+++ b/bin/report-template/content/js/graph.js.fmkr
@@ -667,7 +667,8 @@ var connectTimeOverTimeInfos = {
                     axisLabelPadding: 20,
                 },
                 yaxis: {
-                    axisLabel: "Average Connect Time in ms",
+
+                    axisLabel: "Percentile Connect Time in ms",
                     axisLabelUseCanvas: true,
                     axisLabelFontSizePixels: 12,
                     axisLabelFontFamily: 'Verdana, Arial',
@@ -899,7 +900,7 @@ var latenciesVsRequestInfos = {
                 axisLabelPadding: 20,
             },
             yaxis: {
-                axisLabel: "Median Latency in ms",
+                axisLabel: "Percentile Latency in ms",
                 axisLabelUseCanvas: true,
                 axisLabelFontSizePixels: 12,
                 axisLabelFontFamily: 'Verdana, Arial',
@@ -914,7 +915,7 @@ var latenciesVsRequestInfos = {
             },
             tooltip: true,
             tooltipOpts: {
-                content: "%s : Median Latency time at %x req/s was %y ms"
+                content: "%s : Percentile Latency time at %x req/s was %y ms"
             },
             colors: ["#9ACD32", "#FF6347"]
         };

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
@@ -240,8 +240,6 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
      *
      * @param propertyKey
      *            the property key
-     * @param defaultValue
-     *            the default value
      * @param seriesName Series name
      * @param valueSelector Graph value selector
      * @param seriesSelector Graph series selector

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
@@ -28,7 +28,12 @@ import org.apache.jmeter.report.processor.Aggregator;
 import org.apache.jmeter.report.processor.AggregatorFactory;
 import org.apache.jmeter.report.processor.ListResultData;
 import org.apache.jmeter.report.processor.MapResultData;
+import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.ValueResultData;
+import org.apache.jmeter.report.processor.graph.AbstractGraphValueSelector;
+import org.apache.jmeter.report.processor.graph.AbstractSeriesSelector;
+import org.apache.jmeter.util.JMeterUtils;
+
 
 /**
  * <p>
@@ -230,6 +235,27 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
                         value.doubleValue())));
     }
 
+ /**
+     * Creates the group info for elapsed time percentile depending on jmeter
+     * properties.
+     *
+     * @param propertyKey
+     *            the property key
+     * @param defaultValue
+     *            the default value
+     * @param seriesName Series name
+     * @return the group info
+     */
+    protected final GroupInfo createPercentileGroupInfo(String propertyKey, int defaultValue, String seriesName,AbstractGraphValueSelector valueSelector,AbstractSeriesSelector seriesSelector) {
+        int property = JMeterUtils.getPropDefault(propertyKey, defaultValue);
+        PercentileAggregatorFactory factory = new PercentileAggregatorFactory();
+        factory.setPercentileIndex(property);
+
+
+        return new GroupInfo(factory, seriesSelector,
+                valueSelector, false, false);
+
+  }  
     /**
      * Adds a value map build from specified parameters to the result map.
      *

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
@@ -85,6 +85,7 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
     public static final String RESULT_SERIES_IS_CONTROLLER = "isController";
     public static final String RESULT_SERIES_IS_OVERALL = "isOverall";
 
+    public static final int DEFAULT_PERCENTAGE_VALUE = 95;
     public static final String DEFAULT_OVERALL_SERIES_FORMAT = "Overall %s";
     public static final String DEFAULT_AGGREGATED_KEYS_SERIES_FORMAT = "%s-Aggregated";
 
@@ -247,10 +248,10 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
      * @return the group info
      */
     protected final GroupInfo createPercentileGroupInfo(String propertyKey,
-                                                        int defaultValue, String seriesName,
+                                                        String seriesName,
                                                         AbstractGraphValueSelector valueSelector,
                                                         AbstractSeriesSelector seriesSelector) {
-        int property = JMeterUtils.getPropDefault(propertyKey, defaultValue);
+        int property = JMeterUtils.getPropDefault(propertyKey, DEFAULT_PERCENTAGE_VALUE);
         PercentileAggregatorFactory factory = new PercentileAggregatorFactory();
         factory.setPercentileIndex(property);
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
@@ -30,8 +30,6 @@ import org.apache.jmeter.report.processor.ListResultData;
 import org.apache.jmeter.report.processor.MapResultData;
 import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.ValueResultData;
-import org.apache.jmeter.report.processor.graph.AbstractGraphValueSelector;
-import org.apache.jmeter.report.processor.graph.AbstractSeriesSelector;
 import org.apache.jmeter.util.JMeterUtils;
 
 
@@ -244,18 +242,21 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
      * @param defaultValue
      *            the default value
      * @param seriesName Series name
+     * @param valueSelector Graph value selector
+     * @param seriesSelector Graph series selector
      * @return the group info
      */
-    protected final GroupInfo createPercentileGroupInfo(String propertyKey, int defaultValue, String seriesName,AbstractGraphValueSelector valueSelector,AbstractSeriesSelector seriesSelector) {
+    protected final GroupInfo createPercentileGroupInfo(String propertyKey,
+                                                        int defaultValue, String seriesName,
+                                                        AbstractGraphValueSelector valueSelector,
+                                                        AbstractSeriesSelector seriesSelector) {
         int property = JMeterUtils.getPropDefault(propertyKey, defaultValue);
         PercentileAggregatorFactory factory = new PercentileAggregatorFactory();
         factory.setPercentileIndex(property);
 
-
         return new GroupInfo(factory, seriesSelector,
                 valueSelector, false, false);
-
-  }  
+  }
     /**
      * Adds a value map build from specified parameters to the result map.
      *

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
@@ -29,7 +29,6 @@ import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
 import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
 import org.apache.jmeter.util.JMeterUtils;
-
 /**
  * The class ConnectTimeOverTimeGraphConsumer provides a graph to visualize Connection time
  * per time period (defined by granularity)
@@ -39,6 +38,8 @@ import org.apache.jmeter.util.JMeterUtils;
 public class ConnectTimeOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer {
     private static final boolean CONNECT_TIME_SAVED =
             JMeterUtils.getPropDefault("jmeter.save.saveservice.connect_time", true); //$NON-NLS-1$
+    private static final String PERCENTILE_FORMAT = "%dth percentile";
+    private static final String PERCENTILE_PROPERTY = "aggregate_rpt_pct2";
 
     /*
      * (non-Javadoc)
@@ -54,22 +55,28 @@ public class ConnectTimeOverTimeGraphConsumer extends AbstractOverTimeGraphConsu
         return keysSelector;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.jmeter.report.csv.processor.impl.AbstractGraphConsumer#
-     * createGroupInfos()
-     */
+  
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.apache.jmeter.report.csv.processor.impl.AbstractGraphConsumer#
+   * createGroupInfos()
+   */
     @Override
     protected Map<String, GroupInfo> createGroupInfos() {
         if(!CONNECT_TIME_SAVED) {
             return Collections.emptyMap();
         }
+
+
+        ConnectTimeValueSelector valueSelector = new ConnectTimeValueSelector(false);
+        NameSeriesSelector seriesSelector = new NameSeriesSelector();
+
         HashMap<String, GroupInfo> groupInfos = new HashMap<>();
-        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, new GroupInfo(
-                new MeanAggregatorFactory(), new NameSeriesSelector(),
-                // We ignore Transaction Controller results
-                new ConnectTimeValueSelector(false), false, false));
+        groupInfos.put(PERCENTILE_PROPERTY, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                        String.format(
+                                PERCENTILE_FORMAT, Integer.valueOf(95)),valueSelector,seriesSelector));
         return groupInfos;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
@@ -69,7 +69,7 @@ public class ConnectTimeOverTimeGraphConsumer extends AbstractOverTimeGraphConsu
 
         HashMap<String, GroupInfo> groupInfos = new HashMap<>();
         groupInfos.put(PERCENTILE_PROPERTY, //$NON-NLS-1$
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, //$NON-NLS-1$
                         String.format(
                                 PERCENTILE_FORMAT, Integer.valueOf(95)),valueSelector,seriesSelector));
         return groupInfos;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jmeter.report.processor.MeanAggregatorFactory;
-import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.AbstractOverTimeGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ConnectTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
@@ -55,7 +53,6 @@ public class ConnectTimeOverTimeGraphConsumer extends AbstractOverTimeGraphConsu
         return keysSelector;
     }
 
-  
   /*
    * (non-Javadoc)
    *
@@ -67,8 +64,6 @@ public class ConnectTimeOverTimeGraphConsumer extends AbstractOverTimeGraphConsu
         if(!CONNECT_TIME_SAVED) {
             return Collections.emptyMap();
         }
-
-
         ConnectTimeValueSelector valueSelector = new ConnectTimeValueSelector(false);
         NameSeriesSelector seriesSelector = new NameSeriesSelector();
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -21,13 +21,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.jmeter.report.processor.MaxAggregatorFactory;
-import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractOverTimeGraphConsumer;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.LatencyValueSelector;
 import org.apache.jmeter.report.processor.graph.StaticSeriesSelector;
 import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
-import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class LatencyOverTimeGraphConsumer provides a graph to visualize latency

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -80,7 +80,7 @@ public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer 
         seriesSelector.setSeriesName(seriesName);
 
         groupInfos.put(PERCENTILE_PROPERTY,
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95,
+                createPercentileGroupInfo(PERCENTILE_PROPERTY,
                         seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -79,8 +79,8 @@ public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer 
         String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
         seriesSelector.setSeriesName(seriesName);
 
-        groupInfos.put(PERCENTILE_PROPERTY, //$NON-NLS-1$
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+        groupInfos.put(PERCENTILE_PROPERTY, 
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, 
                         seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -20,13 +20,14 @@ package org.apache.jmeter.report.processor.graph.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jmeter.report.processor.MeanAggregatorFactory;
-import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
+import org.apache.jmeter.report.processor.MaxAggregatorFactory;
+import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractOverTimeGraphConsumer;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.LatencyValueSelector;
-import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
+import org.apache.jmeter.report.processor.graph.StaticSeriesSelector;
 import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
+import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class LatencyOverTimeGraphConsumer provides a graph to visualize latency
@@ -35,7 +36,9 @@ import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
  * @since 3.0
  */
 public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer {
-
+    private static final String PERCENTILE_FORMAT = "%dth percentile";
+    private static final String PERCENTILE_PROPERTY = "aggregate_rpt_pct2";
+    /*
     /*
      * (non-Javadoc)
      *
@@ -50,6 +53,17 @@ public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer 
         return keysSelector;
     }
 
+    /**
+     * Creates the group info for max elapsed time
+     * @return the group info
+     */
+    private GroupInfo createMaxGroupInfo() {
+        StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
+        seriesSelector.setSeriesName("Max");
+        return new GroupInfo(new MaxAggregatorFactory(), seriesSelector,
+                new LatencyValueSelector(false), false, false);
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -59,10 +73,17 @@ public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer 
     @Override
     protected Map<String, GroupInfo> createGroupInfos() {
         HashMap<String, GroupInfo> groupInfos = new HashMap<>();
-        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, new GroupInfo(
-                new MeanAggregatorFactory(), new NameSeriesSelector(),
-                // We ignore Transaction Controller results
-                new LatencyValueSelector(false), false, false));
+        groupInfos.put("aggregate_report_max", //$NON-NLS-1$
+            createMaxGroupInfo());
+
+        LatencyValueSelector valueSelector = new LatencyValueSelector(false);
+        StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
+        String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
+        seriesSelector.setSeriesName(seriesName);
+
+        groupInfos.put(PERCENTILE_PROPERTY, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                        seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -79,7 +79,7 @@ public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer 
         String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
         seriesSelector.setSeriesName(seriesName);
 
-        groupInfos.put(PERCENTILE_PROPERTY, 
+        groupInfos.put(PERCENTILE_PROPERTY,
                 createPercentileGroupInfo(PERCENTILE_PROPERTY, 95,
                         seriesName,valueSelector,seriesSelector));
         return groupInfos;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -80,7 +80,7 @@ public class LatencyOverTimeGraphConsumer extends AbstractOverTimeGraphConsumer 
         seriesSelector.setSeriesName(seriesName);
 
         groupInfos.put(PERCENTILE_PROPERTY, 
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, 
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95,
                         seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
@@ -21,15 +21,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.jmeter.report.core.Sample;
-import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.AbstractVersusRequestsGraphConsumer;
 import org.apache.jmeter.report.processor.graph.GraphKeysSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.LatencyValueSelector;
-import org.apache.jmeter.report.processor.graph.StaticSeriesSelector;
 import org.apache.jmeter.report.processor.graph.StatusSeriesSelector;
-import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class LatencyVSRequestGraphConsumer provides a graph to visualize

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
@@ -72,7 +72,7 @@ public class LatencyVSRequestGraphConsumer extends
         String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
 
         groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, //$NON-NLS-1$
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, //$NON-NLS-1$
                         seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
@@ -21,13 +21,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.jmeter.report.core.Sample;
-import org.apache.jmeter.report.processor.MedianAggregatorFactory;
+import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.AbstractVersusRequestsGraphConsumer;
 import org.apache.jmeter.report.processor.graph.GraphKeysSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.LatencyValueSelector;
+import org.apache.jmeter.report.processor.graph.StaticSeriesSelector;
 import org.apache.jmeter.report.processor.graph.StatusSeriesSelector;
+import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class LatencyVSRequestGraphConsumer provides a graph to visualize
@@ -37,6 +39,8 @@ import org.apache.jmeter.report.processor.graph.StatusSeriesSelector;
  */
 public class LatencyVSRequestGraphConsumer extends
         AbstractVersusRequestsGraphConsumer {
+    private static final String PERCENTILE_FORMAT = "%dth percentile";
+    private static final String PERCENTILE_PROPERTY = "aggregate_rpt_pct2";
 
     /*
      * (non-Javadoc)
@@ -65,10 +69,14 @@ public class LatencyVSRequestGraphConsumer extends
     @Override
     protected Map<String, GroupInfo> createGroupInfos() {
         HashMap<String, GroupInfo> groupInfos = new HashMap<>(1);
-        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, new GroupInfo(
-                new MedianAggregatorFactory(), new StatusSeriesSelector(),
-                // We ignore Transaction Controller results
-                new LatencyValueSelector(true), false, false));
+
+        LatencyValueSelector valueSelector = new LatencyValueSelector(true);
+        StatusSeriesSelector seriesSelector = new StatusSeriesSelector();
+        String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
+
+        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                        seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
@@ -66,7 +66,7 @@ public class ResponseTimeOverTimeGraphConsumer extends
         String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
 
         groupInfos.put(PERCENTILE_PROPERTY, //$NON-NLS-1$
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, //$NON-NLS-1$
                         seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
@@ -20,13 +20,11 @@ package org.apache.jmeter.report.processor.graph.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractOverTimeGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ElapsedTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
 import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
-import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class ResponseTimeOverTimeGraphConsumer provides a graph to visualize mean

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
@@ -20,13 +20,13 @@ package org.apache.jmeter.report.processor.graph.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jmeter.report.processor.MeanAggregatorFactory;
-import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
+import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractOverTimeGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ElapsedTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
 import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
+import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class ResponseTimeOverTimeGraphConsumer provides a graph to visualize mean
@@ -36,6 +36,8 @@ import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
  */
 public class ResponseTimeOverTimeGraphConsumer extends
         AbstractOverTimeGraphConsumer {
+    private static final String PERCENTILE_FORMAT = "%dth percentile";
+    private static final String PERCENTILE_PROPERTY = "aggregate_rpt_pct2";
 
     /*
      * (non-Javadoc)
@@ -59,11 +61,15 @@ public class ResponseTimeOverTimeGraphConsumer extends
      */
     @Override
     protected Map<String, GroupInfo> createGroupInfos() {
-        HashMap<String, GroupInfo> groupInfos = new HashMap<>(1);
-        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, new GroupInfo(
-                new MeanAggregatorFactory(), new NameSeriesSelector(),
-                // We include Transaction Controller results
-                new ElapsedTimeValueSelector(false), false, false));
+        HashMap<String, GroupInfo> groupInfos = new HashMap<>();
+
+        ElapsedTimeValueSelector valueSelector = new ElapsedTimeValueSelector(false);
+        NameSeriesSelector seriesSelector = new NameSeriesSelector();
+        String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
+
+        groupInfos.put(PERCENTILE_PROPERTY, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                        seriesName,valueSelector,seriesSelector));
         return groupInfos;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
@@ -72,7 +72,7 @@ public class ResponseTimeVSRequestGraphConsumer extends
         String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
 
         groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, //$NON-NLS-1$
-                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, //$NON-NLS-1$
                         seriesName,valueSelector,seriesSelector));
 
         return groupInfos;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
@@ -21,15 +21,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.jmeter.report.core.Sample;
-import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.AbstractVersusRequestsGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ElapsedTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GraphKeysSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.StaticSeriesSelector;
-import org.apache.jmeter.util.JMeterUtils;
-
 
 /**
  * The class ResponseTimeVSRequestGraphConsumer provides a graph to visualize
@@ -69,7 +66,6 @@ public class ResponseTimeVSRequestGraphConsumer extends
         HashMap<String, GroupInfo> groupInfos = new HashMap<>(1);
 
         StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
-        
         seriesSelector.setSeriesName(String.format(
                                 PERCENTILE_FORMAT, Integer.valueOf(95)));
         ElapsedTimeValueSelector valueSelector = new ElapsedTimeValueSelector(true);

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
@@ -21,13 +21,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.jmeter.report.core.Sample;
-import org.apache.jmeter.report.processor.MedianAggregatorFactory;
+import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.AbstractVersusRequestsGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ElapsedTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GraphKeysSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
-import org.apache.jmeter.report.processor.graph.StatusSeriesSelector;
+import org.apache.jmeter.report.processor.graph.StaticSeriesSelector;
+import org.apache.jmeter.util.JMeterUtils;
+
 
 /**
  * The class ResponseTimeVSRequestGraphConsumer provides a graph to visualize
@@ -36,7 +38,8 @@ import org.apache.jmeter.report.processor.graph.StatusSeriesSelector;
  */
 public class ResponseTimeVSRequestGraphConsumer extends
         AbstractVersusRequestsGraphConsumer {
-
+    private static final String PERCENTILE_FORMAT = "%dth percentile";
+    private static final String PERCENTILE_PROPERTY = "aggregate_rpt_pct2";
     /*
      * (non-Javadoc)
      *
@@ -64,10 +67,18 @@ public class ResponseTimeVSRequestGraphConsumer extends
     @Override
     protected Map<String, GroupInfo> createGroupInfos() {
         HashMap<String, GroupInfo> groupInfos = new HashMap<>(1);
-        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, new GroupInfo(
-                new MedianAggregatorFactory(), new StatusSeriesSelector(),
-                // We ignore Transaction Controller results
-                new ElapsedTimeValueSelector(true), false, false));
+
+        StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
+        
+        seriesSelector.setSeriesName(String.format(
+                                PERCENTILE_FORMAT, Integer.valueOf(95)));
+        ElapsedTimeValueSelector valueSelector = new ElapsedTimeValueSelector(true);
+        String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
+
+        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, //$NON-NLS-1$
+                createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, //$NON-NLS-1$
+                        seriesName,valueSelector,seriesSelector));
+
         return groupInfos;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
@@ -22,12 +22,13 @@ import java.util.Map;
 
 import org.apache.jmeter.report.core.Sample;
 import org.apache.jmeter.report.processor.MapResultData;
-import org.apache.jmeter.report.processor.MeanAggregatorFactory;
+import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ElapsedTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GraphKeysSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
+import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class TimeVSThreadGraphConsumer provides a graph to visualize average response time
@@ -36,7 +37,8 @@ import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
  * @since 3.0
  */
 public class TimeVSThreadGraphConsumer extends AbstractGraphConsumer {
-
+    private static final String PERCENTILE_FORMAT = "%dth percentile";
+    private static final String PERCENTILE_PROPERTY = "aggregate_rpt_pct2";
     /*
      * (non-Javadoc)
      *
@@ -54,6 +56,7 @@ public class TimeVSThreadGraphConsumer extends AbstractGraphConsumer {
         };
     }
 
+
     /*
      * (non-Javadoc)
      *
@@ -64,10 +67,12 @@ public class TimeVSThreadGraphConsumer extends AbstractGraphConsumer {
     protected Map<String, GroupInfo> createGroupInfos() {
         HashMap<String, GroupInfo> groupInfos = new HashMap<>(1);
 
-        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, new GroupInfo(
-                new MeanAggregatorFactory(), new NameSeriesSelector(),
-                // We include Transaction Controller results
-                new ElapsedTimeValueSelector(false), false, true));
+        NameSeriesSelector seriesSelector = new NameSeriesSelector();
+        ElapsedTimeValueSelector valueSelector = new ElapsedTimeValueSelector(false);
+        String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
+
+        groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, //$NON-NLS-1$
+            createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, seriesName,valueSelector,seriesSelector));
 
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
@@ -69,7 +69,7 @@ public class TimeVSThreadGraphConsumer extends AbstractGraphConsumer {
         String seriesName = String.format(PERCENTILE_FORMAT, Integer.valueOf(95));
 
         groupInfos.put(AbstractGraphConsumer.DEFAULT_GROUP, //$NON-NLS-1$
-            createPercentileGroupInfo(PERCENTILE_PROPERTY, 95, seriesName,valueSelector,seriesSelector));
+            createPercentileGroupInfo(PERCENTILE_PROPERTY, seriesName,valueSelector,seriesSelector));
 
         return groupInfos;
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
@@ -22,13 +22,11 @@ import java.util.Map;
 
 import org.apache.jmeter.report.core.Sample;
 import org.apache.jmeter.report.processor.MapResultData;
-import org.apache.jmeter.report.processor.PercentileAggregatorFactory;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.report.processor.graph.ElapsedTimeValueSelector;
 import org.apache.jmeter.report.processor.graph.GraphKeysSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.NameSeriesSelector;
-import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * The class TimeVSThreadGraphConsumer provides a graph to visualize average response time

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
@@ -54,7 +54,6 @@ public class TimeVSThreadGraphConsumer extends AbstractGraphConsumer {
         };
     }
 
-
     /*
      * (non-Javadoc)
      *

--- a/src/jorphan/src/test/groovy/org/apache/jorphan/util/ConverterSpec.groovy
+++ b/src/jorphan/src/test/groovy/org/apache/jorphan/util/ConverterSpec.groovy
@@ -144,4 +144,14 @@ class ConverterSpec extends Specification {
                 .parse(dateString)
         return DateFormat.getDateInstance(format).format(date)
     }
+    
+    def "line breaks should be replaced in '#source' to '#expected'"() {
+        expect:
+           Converter.insertLineBreaks(source, "foo") == expected
+        where:
+           source | expected
+           null   | ""
+           "bar"  | "bar"
+           "\nbar"| "foobar"
+    }
 }


### PR DESCRIPTION
## Description
Updated the consumers for several graph in the report generator to use a percentile rather than mean.

## Motivation and Context
The percentile is a much more useful metric than the mean when observing timings, so it is preferable to report them by default over a general mean average. The following graphs have been updated to use a percentile as defined by aggregate_rpt_pct2, or default to 95%-tile when that is not populated

ConnectTimeOverTimeGraph
LatencyOverTimeGraph
LatencyVSRequest
ResponseTimeOverTime
TimeVSThread

## How Has This Been Tested?
This is a rebase/refactor of https://github.com/apache/jmeter/pull/473, functional test evidence can be found there

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
