### PR TITLE
Add support for InfluxDB 2

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -68,6 +68,8 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
 
     private URL url;
 
+    private String token;
+
     private Future<HttpResponse> lastRequest;
 
     HttpMetricsSender() {
@@ -81,10 +83,12 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
      *
      * @param influxdbUrl
      *            example : http://localhost:8086/write?db=myd&rp=one_week
-     * @see org.apache.jmeter.visualizers.backend.influxdb.InfluxdbMetricsSender#setup(java.lang.String)
+     * @param influxDBToken
+     *            example: my-token
+     * @see InfluxdbMetricsSender#setup(String, String)
      */
     @Override
-    public void setup(String influxdbUrl) throws Exception {
+    public void setup(String influxdbUrl, String influxDBToken) throws Exception {
         // Create I/O reactor configuration
         IOReactorConfig ioReactorConfig = IOReactorConfig
                 .custom()
@@ -108,16 +112,18 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
                 .disableConnectionState()
                 .build();
         url = new URL(influxdbUrl);
-        httpRequest = createRequest(url);
+        token = influxDBToken;
+        httpRequest = createRequest(url, token);
         httpClient.start();
     }
 
     /**
      * @param url {@link URL} Influxdb Url
+     * @param token Influxdb 2.0 authorization token
      * @return {@link HttpPost}
      * @throws URISyntaxException
      */
-    private HttpPost createRequest(URL url) throws URISyntaxException {
+    private HttpPost createRequest(URL url, String token) throws URISyntaxException {
         RequestConfig defaultRequestConfig = RequestConfig.custom()
                 .setConnectTimeout(JMeterUtils.getPropDefault("backend_influxdb.connection_timeout", 1000))
                 .setSocketTimeout(JMeterUtils.getPropDefault("backend_influxdb.socket_timeout", 3000))
@@ -126,6 +132,9 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
 
         HttpPost currentHttpRequest = new HttpPost(url.toURI());
         currentHttpRequest.setConfig(defaultRequestConfig);
+        if (token != null) {
+            currentHttpRequest.setHeader("Authorization", "Token " + token);
+        }
         log.debug("Created InfluxDBMetricsSender with url: {}", url);
         return currentHttpRequest;
     }
@@ -154,7 +163,7 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
         if (!copyMetrics.isEmpty()) {
             try {
                 if(httpRequest == null) {
-                    httpRequest = createRequest(url);
+                    httpRequest = createRequest(url, token);
                 }
                 StringBuilder sb = new StringBuilder(copyMetrics.size()*35);
                 for (MetricTuple metric : copyMetrics) {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
@@ -57,6 +58,9 @@ import org.slf4j.LoggerFactory;
  */
 class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
     private static final Logger log = LoggerFactory.getLogger(HttpMetricsSender.class);
+
+    private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+    private static final String AUTHORIZATION_HEADER_VALUE = "Token ";
 
     private final Object lock = new Object();
 
@@ -132,8 +136,8 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
 
         HttpPost currentHttpRequest = new HttpPost(url.toURI());
         currentHttpRequest.setConfig(defaultRequestConfig);
-        if (token != null) {
-            currentHttpRequest.setHeader("Authorization", "Token " + token);
+        if (StringUtils.isNotBlank(token)) {
+            currentHttpRequest.setHeader(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE + token);
         }
         log.debug("Created InfluxDBMetricsSender with url: {}", url);
         return currentHttpRequest;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -316,6 +316,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
     public void setupTest(BackendListenerContext context) throws Exception {
         String influxdbMetricsSender = context.getParameter("influxdbMetricsSender");
         String influxdbUrl = context.getParameter("influxdbUrl");
+        String influxdbToken = context.getParameter("influxdbToken");
         summaryOnly = context.getBooleanParameter("summaryOnly", false);
         samplersRegex = context.getParameter("samplersRegex", "");
         application = AbstractInfluxdbMetricsSender.tagToStringValue(context.getParameter("application", ""));
@@ -366,7 +367,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
 
         Class<?> clazz = Class.forName(influxdbMetricsSender);
         this.influxdbMetricsManager = (InfluxdbMetricsSender) clazz.getDeclaredConstructor().newInstance();
-        influxdbMetricsManager.setup(influxdbUrl);
+        influxdbMetricsManager.setup(influxdbUrl, influxdbToken);
         samplersToFilter = Pattern.compile(samplersRegex);
         addAnnotation(true);
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbMetricsSender.java
@@ -57,9 +57,10 @@ interface InfluxdbMetricsSender {
     /**
      * Setup sender using influxDBUrl
      * @param influxDBUrl url pointing to influxdb
+     * @param influxDBToken authorization token to influxdb 2.0
      * @throws Exception when setup fails
      */
-    public void setup(String influxDBUrl) throws Exception; // NOSONAR
+    public void setup(String influxDBUrl, String influxDBToken) throws Exception; // NOSONAR
 
     /**
      * Destroy sender

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/UdpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/UdpMetricsSender.java
@@ -56,7 +56,7 @@ class UdpMetricsSender extends AbstractInfluxdbMetricsSender {
     }
 
     @Override
-    public void setup(String influxdbUrl) throws Exception {
+    public void setup(String influxdbUrl, String influxDBToken) throws Exception {
         try {
             log.debug("Setting up with url:{}", influxdbUrl);
             String[] urlComponents = influxdbUrl.split(":");

--- a/src/components/src/test/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSenderTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSenderTest.java
@@ -91,6 +91,40 @@ public class HttpMetricsSenderTest {
     }
 
     @Test
+    public void checkEmptyTokenDoesNotPresentInHeader() throws Exception {
+        String influxdbUrl = String.format("http://localhost:%s/api/v2/write", server.getLocalPort());
+        HttpMetricsSender metricsSender = new HttpMetricsSender();
+        metricsSender.setup(influxdbUrl, "");
+        metricsSender.addMetric("measurement", "location=west", "size=10");
+        metricsSender.writeAndSendMetrics();
+
+        do {
+            Thread.sleep(100);
+        } while (request == null);
+
+        assertNull(
+                "The authorization header shouldn't be defined.",
+                request.getFirstHeader("Authorization"));
+    }
+
+    @Test
+    public void checkEmptyOnlyWhitespaceTokenDoesNotPresentInHeader() throws Exception {
+        String influxdbUrl = String.format("http://localhost:%s/api/v2/write", server.getLocalPort());
+        HttpMetricsSender metricsSender = new HttpMetricsSender();
+        metricsSender.setup(influxdbUrl, "  ");
+        metricsSender.addMetric("measurement", "location=west", "size=10");
+        metricsSender.writeAndSendMetrics();
+
+        do {
+            Thread.sleep(100);
+        } while (request == null);
+
+        assertNull(
+                "The authorization header shouldn't be defined.",
+                request.getFirstHeader("Authorization"));
+    }
+
+    @Test
     public void checkTokenPresentInHeader() throws Exception {
         String influxdbUrl = String.format("http://localhost:%s/api/v2/write", server.getLocalPort());
         HttpMetricsSender metricsSender = new HttpMetricsSender();

--- a/src/components/src/test/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSenderTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSenderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.jmeter.visualizers.backend.influxdb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpMetricsSenderTest {
+
+    private HttpServer server;
+    private HttpRequest request;
+
+    @Before
+    public void startServer() throws IOException {
+        server = ServerBootstrap.bootstrap()
+                .setListenerPort(8183)
+                .registerHandler("*", (request, response, context) -> {
+                    HttpMetricsSenderTest.this.request = request;
+                    response.setStatusCode(HttpStatus.SC_NO_CONTENT);
+                })
+                .create();
+        server.start();
+    }
+
+    @After
+    public void stopServer() {
+        server.shutdown(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void checkTokenDoesNotPresentInHeader() throws Exception {
+        HttpMetricsSender metricsSender = new HttpMetricsSender();
+        metricsSender.setup("http://localhost:8183/api/v2/write", null);
+        metricsSender.addMetric("measurement", "location=west", "size=10");
+        metricsSender.writeAndSendMetrics();
+
+        do {
+            Thread.sleep(100);
+        } while (request == null);
+
+        assertNull(
+                "The authorization header shouldn't be defined.",
+                request.getFirstHeader("Authorization"));
+    }
+
+    @Test
+    public void checkTokenPresentInHeader() throws Exception {
+        HttpMetricsSender metricsSender = new HttpMetricsSender();
+        metricsSender.setup("http://localhost:8183", "my-token");
+        metricsSender.addMetric("measurement", "location=west", "size=10");
+        metricsSender.writeAndSendMetrics();
+
+        do {
+            Thread.sleep(100);
+        } while (request == null);
+
+        assertEquals(
+                "The authorization header should be: 'Token my-token'",
+                request.getFirstHeader("Authorization").getValue(),
+                "Token my-token");
+    }
+}

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -3395,6 +3395,7 @@ By default, a Graphite implementation is provided.
     <properties>
         <property name="influxdbMetricsSender" required="Yes"><code>org.apache.jmeter.visualizers.backend.influxdb.HttpMetricsSender</code></property>
         <property name="influxdbUrl" required="Yes">Influx URL (example : http://influxHost:8086/write?db=jmeter)</property>
+        <property name="influxdbToken" required="No">InfluxDB 2 <a href="https://v2.docs.influxdata.com/v2.0/security/">authentication token</a> (example : HE9yIdAPzWJDspH_tCc2UvdKZpX==); since 5.2.</property>
         <property name="application" required="Yes">Name of tested application. This value is stored in the 'events' measurement too as a tag named 'application' </property>
         <property name="measurement" required="Yes">Measurement as per <a href="https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_reference/">Influx Line Protocol Reference</a>. Defaults to "<code>jmeter</code>."</property>
         <property name="summaryOnly" required="Yes">Only send a summary with no detail. Defaults to <code>true</code>.</property>


### PR DESCRIPTION
## Description
This PR add support for InfluxDB 2 authentication token ([see documentation](https://v2.docs.influxdata.com/v2.0/security/)). 

The `InfluxdbBackendListenerClient` has new optional property: `influxdbToken` that is used as an `Authorization` header in Http request.
 

## Motivation and Context
Supporting InfluxDB 2.0

## How Has This Been Tested?
It was tested by [InfluxDB_Listener.jmx.zip](https://github.com/apache/jmeter/files/3568224/InfluxDB_Listener.jmx.zip) with InfluxDB 2 instance and also I added unit tests - [HttpMetricsSenderTest.java](https://github.com/apache/jmeter/blob/d2790912eeeaa0760bfba43f7bbd993ffb4e670a/src/components/src/test/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSenderTest.java).

## Screenshots (if appropriate):

![InfluxDB_Listener](https://user-images.githubusercontent.com/455137/64152239-85c9f980-ce2c-11e9-92d3-91eda032aac4.png)

## Types of changes
- New feature (non-breaking change which adds functionality)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines