### PR TITLE
Updated checkstyle and added MissingDeprecated check, also formatted

### DIFF
--- a/checksum.xml
+++ b/checksum.xml
@@ -22,6 +22,7 @@
     <trusted-key id='912d2c0eccda55c0' group='com.google.errorprone' />
     <trusted-key id='9a259c7ee636c5ed' group='com.google.errorprone' />
     <trusted-key id='bf935c771a8474f8' group='com.google.errorprone' />
+    <trusted-key id='912d2c0eccda55c0' group='com.google.errorprone' />
     <trusted-key id='9a259c7ee636c5ed' group='com.google.googlejavaformat' />
     <trusted-key id='abe9f3126bb741c1' group='com.google.guava' />
     <trusted-key id='f6d4a1d411e9d1ae' group='com.google.guava' />

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -71,7 +71,7 @@
   <module name="TreeWalker">
 
     <!-- Annotations -->
-    <!--<module name="MissingDeprecated"/>-->
+    <module name="MissingDeprecated"/>
     <module name="MissingOverride"/>
 
     <!-- Block checks -->

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -85,7 +85,7 @@
     <module name="NeedBraces"/>
 
     <!--Class Design-->
-    <!--<module name="FinalClass"/>-->
+    <module name="FinalClass"/>
     <!--<module name="HideUtilityClassConstructor"/>--> <!--need to change 25 class APIs-->
     <module name="InterfaceIsType"/> <!-- Interfaces must be types (not just constants) -->
     <module name="MutableException"/>

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathCache.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathCache.java
@@ -30,7 +30,7 @@ import io.burt.jmespath.RuntimeConfiguration;
 import io.burt.jmespath.function.FunctionRegistry;
 import io.burt.jmespath.jackson.JacksonRuntime;
 
-public class JMESPathCache {
+public final class JMESPathCache {
     private static final class JMESPathCacheLoader implements CacheLoader<String, Expression<JsonNode>> {
         final JmesPath<JsonNode> runtime;
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/SampleTimeout.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/SampleTimeout.java
@@ -51,10 +51,11 @@ public class SampleTimeout extends AbstractTestElement implements Serializable, 
 
     private final transient ScheduledExecutorService execService;
 
-    private static class TPOOLHolder {
+    private final static class TPOOLHolder {
         private TPOOLHolder() {
             // NOOP
         }
+
         static final ScheduledExecutorService EXEC_SERVICE =
                 Executors.newScheduledThreadPool(1,
                         (Runnable r) -> {

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -255,7 +255,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         stopThread.start();
     }
 
-    private class StopTest implements Runnable {
+    private final class StopTest implements Runnable {
         private final boolean now;
 
         private StopTest(boolean b) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
@@ -46,7 +46,7 @@ import org.xml.sax.SAXParseException;
  * Manages Test Plan templates
  * @since 2.10
  */
-public class TemplateManager {
+public final class TemplateManager {
     private static final String TEMPLATE_FILES = JMeterUtils.getPropDefault("template.files", // $NON-NLS-1$
             "/bin/templates/templates.xml");
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/CheckBoxPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/CheckBoxPanel.java
@@ -26,7 +26,7 @@ import javax.swing.JCheckBox;
  * See <a href="https://bz.apache.org/bugzilla/show_bug.cgi?id=58810">Bug 58810</a><br>
  * Note: using a JPanel affects the alignment within the container
  */
-public class CheckBoxPanel {
+public final class CheckBoxPanel {
 
     private CheckBoxPanel() {
         // not instantiable

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -138,12 +138,6 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
         return getInstance(rows, cols, false);
     }
 
-    @Deprecated
-    public JSyntaxTextArea() {
-        // For use by test code only
-        this(30, 50, false);
-    }
-
     // for use by headless tests only
     private JSyntaxTextArea(boolean dummy) {
         disableUndo = dummy;
@@ -260,7 +254,7 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
     }
 
 
-    private static final Theme initTheme() {
+    private static Theme initTheme() {
         try {
             return Theme.load(JSyntaxTextArea.class.getClassLoader().getResourceAsStream(
                     "org/apache/jmeter/gui/util/theme/darcula_theme.xml"));

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JTextScrollPane.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JTextScrollPane.java
@@ -19,7 +19,6 @@ package org.apache.jmeter.gui.util;
 
 import org.fife.ui.rtextarea.RTextScrollPane;
 
-
 /**
  * Utility class to handle RSyntaxTextArea code
  * It's not currently possible to instantiate the RTextScrollPane class when running headless.
@@ -29,9 +28,7 @@ public class JTextScrollPane extends RTextScrollPane {
 
     private static final long serialVersionUID = 210L;
 
-    @Deprecated
-    public JTextScrollPane() {
-        // for use by test code only
+    private JTextScrollPane() {
     }
 
     public static JTextScrollPane getInstance(JSyntaxTextArea scriptField, boolean foldIndicatorEnabled) {
@@ -68,8 +65,7 @@ public class JTextScrollPane extends RTextScrollPane {
     }
 
     /**
-     *
-     * @param scriptField syntax text are to wrap
+     * @param scriptField          syntax text are to wrap
      * @param foldIndicatorEnabled flag, whether fold indicator should be enabled
      * @deprecated use {@link #getInstance(JSyntaxTextArea, boolean)} instead
      */

--- a/src/core/src/main/java/org/apache/jmeter/report/config/ConfigurationUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/ConfigurationUtils.java
@@ -26,7 +26,7 @@ import org.apache.jmeter.report.core.Converters;
  *
  * @since 3.0
  */
-public class ConfigurationUtils {
+public final class ConfigurationUtils {
 
     private static final String NOT_SUPPORTED_CONVERSION_FMT = "Convert \"%s\" to \"%s\" is not supported";
 

--- a/src/core/src/main/java/org/apache/jmeter/report/utils/MetricUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/utils/MetricUtils.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * @since 5.0
  */
-public class MetricUtils {
+public final class MetricUtils {
     public static final String ASSERTION_FAILED = "Assertion failed"; //$NON-NLS-1$
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/samplers/AsynchSampleSender.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/AsynchSampleSender.java
@@ -127,7 +127,7 @@ public class AsynchSampleSender extends AbstractSampleSender implements Serializ
         }
     }
 
-    private static class Worker extends Thread {
+    private static final class Worker extends Thread {
 
         private final BlockingQueue<SampleEvent> queue;
 

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleSenderFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleSenderFactory.java
@@ -23,7 +23,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SampleSenderFactory {
+public final class SampleSenderFactory {
 
     private static final Logger log = LoggerFactory.getLogger(SampleSenderFactory.class);
 

--- a/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
+++ b/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * server has all support files in a relative-same location) and to package up
  * test plans to execute on unknown boxes that only have Java installed.
  */
-public class FileServer {
+public final class FileServer {
 
     private static final Logger log = LoggerFactory.getLogger(FileServer.class);
 

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
@@ -47,7 +47,6 @@ import org.apache.jmeter.util.JMeterUtils;
  * <li>The possibility to write your own value, unless the <b>noEdit</b>
  * property is set.
  * </ul>
- *
  */
 class ComboStringEditor extends PropertyEditorSupport implements ItemListener, ClearGui {
 
@@ -72,13 +71,13 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
      */
     private final Map<String, String> validTranslations;
 
-    private boolean startingEdit = false;
 
-    /*
+    /**
      * True iff we're currently processing an event triggered by the user
      * selecting the "Edit" option. Used to prevent reverting the combo to
      * non-editable during processing of secondary events.
      */
+    private boolean startingEdit = false;
 
     // Needs to be visible to test cases
     final Object UNDEFINED = new UniqueObject("property_undefined"); //$NON-NLS-1$
@@ -91,23 +90,18 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
     // The maximum index of the tags in the combo box
     private final int maxTagIndex;
 
-    @Deprecated // only for use from test code
-    ComboStringEditor() {
-        this(null, false, false);
-    }
-
     ComboStringEditor(PropertyDescriptor descriptor) {
-        this((String[])descriptor.getValue(GenericTestBeanCustomizer.TAGS),
-              GenericTestBeanCustomizer.notExpression(descriptor),
-              GenericTestBeanCustomizer.notNull(descriptor),
-              (ResourceBundle) descriptor.getValue(GenericTestBeanCustomizer.RESOURCE_BUNDLE));
+        this((String[]) descriptor.getValue(GenericTestBeanCustomizer.TAGS),
+                GenericTestBeanCustomizer.notExpression(descriptor),
+                GenericTestBeanCustomizer.notNull(descriptor),
+                (ResourceBundle) descriptor.getValue(GenericTestBeanCustomizer.RESOURCE_BUNDLE));
     }
 
-    ComboStringEditor(String []tags, boolean noEdit, boolean noUndefined) {
+    ComboStringEditor(String[] tags, boolean noEdit, boolean noUndefined) {
         this(tags, noEdit, noUndefined, null);
     }
 
-    ComboStringEditor(String []pTags, boolean noEdit, boolean noUndefined, ResourceBundle rb) {
+    ComboStringEditor(String[] pTags, boolean noEdit, boolean noUndefined, ResourceBundle rb) {
 
         tags = pTags == null ? ArrayUtils.EMPTY_STRING_ARRAY : pTags.clone();
 
@@ -119,7 +113,7 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
                 validTranslations.put(tag, rb.getString(tag));
             }
         } else {
-            validTranslations=null;
+            validTranslations = null;
         }
 
         if (!noUndefined) {
@@ -129,11 +123,11 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
             this.minTagIndex = Integer.MAX_VALUE;
             this.maxTagIndex = Integer.MIN_VALUE;
         } else {
-            this.minTagIndex=model.getSize(); // track where tags start ...
+            this.minTagIndex = model.getSize(); // track where tags start ...
             for (String tag : this.tags) {
                 model.addElement(translate(tag));
             }
-            this.maxTagIndex=model.getSize(); // ... and where they end
+            this.maxTagIndex = model.getSize(); // ... and where they end
         }
         if (!noEdit) {
             model.addElement(EDIT);
@@ -181,7 +175,7 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
         // Check if the entry index corresponds to a tag, if so return the tag
         // This also works if the tags were not translated
         if (item >= minTagIndex && item <= maxTagIndex) {
-            return tags[item-minTagIndex];
+            return tags[item - minTagIndex];
         }
         // Not a tag entry, return the original value
         return (String) value;

--- a/src/core/src/main/java/org/apache/jmeter/timers/TimerService.java
+++ b/src/core/src/main/java/org/apache/jmeter/timers/TimerService.java
@@ -24,7 +24,7 @@ import org.apache.jmeter.threads.JMeterThread;
  * Manages logic related to timers and pauses
  * @since 3.2
  */
-public class TimerService {
+public final class TimerService {
 
     private TimerService() {
         super();

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -87,7 +87,7 @@ public class JMeterUtils implements UnitTestManager {
 
     // Note: cannot use a static variable here, because that would be processed before the JMeter properties
     // have been defined (Bug 52783)
-    private static class LazyPatternCacheHolder {
+    private static final class LazyPatternCacheHolder {
         private LazyPatternCacheHolder() {
             super();
         }
@@ -1292,7 +1292,7 @@ public class JMeterUtils implements UnitTestManager {
     /**
      * @return {@link XStream} XStream instance following JMeter security policy
      */
-    public static final XStream createXStream() {
+    public static XStream createXStream() {
         XStream xstream = new XStream();
         JMeterUtils.setupXStreamSecurityPolicy(xstream);
         return xstream;

--- a/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
@@ -72,7 +72,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
     /**
      * Initialization On Demand Holder pattern
      */
-    private static class LazyHolder {
+    private static final class LazyHolder {
         private LazyHolder() {
             super();
         }

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -79,7 +79,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 /**
  * This class provides a few utility methods for dealing with XML/XPath.
  */
-public class XPathUtil {
+public final class XPathUtil {
 
     private static final Logger log = LoggerFactory.getLogger(XPathUtil.class);
 
@@ -90,9 +90,6 @@ public class XPathUtil {
         XPATH_CACHE = Caffeine.newBuilder().maximumSize(cacheSize).build(new XPathQueryCacheLoader());
     }
 
-    /**
-     *
-     */
     private static final Processor PROCESSOR = new Processor(false);
 
     private XPathUtil() {
@@ -115,9 +112,10 @@ public class XPathUtil {
      *
      * @return javax.xml.parsers.DocumentBuilderFactory
      */
-    private static synchronized DocumentBuilderFactory makeDocumentBuilderFactory(boolean validate, boolean whitespace,
-            boolean namespace) throws ParserConfigurationException {
-        if (XPathUtil.documentBuilderFactory == null || documentBuilderFactory.isValidating() != validate
+    private static synchronized DocumentBuilderFactory makeDocumentBuilderFactory(
+            boolean validate, boolean whitespace, boolean namespace) throws ParserConfigurationException  {
+        if (XPathUtil.documentBuilderFactory == null
+                || documentBuilderFactory.isValidating() != validate
                 || documentBuilderFactory.isNamespaceAware() != namespace
                 || documentBuilderFactory.isIgnoringElementContentWhitespace() != whitespace) {
             // configure the document builder factory

--- a/src/core/src/test/java/org/apache/jmeter/junit/JMeterTestUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/junit/JMeterTestUtils.java
@@ -22,7 +22,7 @@ import java.io.File;
 import org.apache.jmeter.testkit.ResourceLocator;
 import org.apache.jmeter.util.JMeterUtils;
 
-public class JMeterTestUtils {
+public final class JMeterTestUtils {
     // Used by findTestFile
     private static volatile String filePrefix;
     private JMeterTestUtils() {

--- a/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestComboStringEditor.java
+++ b/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestComboStringEditor.java
@@ -36,8 +36,7 @@ public class TestComboStringEditor {
 
     @Test
     public void testSetGet() throws Exception {
-        @SuppressWarnings("deprecation") // test code, intentional
-        ComboStringEditor e = new ComboStringEditor();
+        ComboStringEditor e = new ComboStringEditor(null, false, false);
 
         testSetGet(e, "any string");
         testSetGet(e, "");
@@ -47,8 +46,7 @@ public class TestComboStringEditor {
 
     @Test
     public void testSetGetAsText() throws Exception {
-        @SuppressWarnings("deprecation") // test code, intentional
-        ComboStringEditor e = new ComboStringEditor();
+        ComboStringEditor e = new ComboStringEditor(null, false, false);
 
         testSetGetAsText(e, "any string");
         testSetGetAsText(e, "");

--- a/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestFieldStringEditor.java
+++ b/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestFieldStringEditor.java
@@ -35,8 +35,7 @@ public class TestFieldStringEditor {
 
     @Test
     public void testSetGet() throws Exception {
-        @SuppressWarnings("deprecation") // test code, intentional
-        ComboStringEditor e = new ComboStringEditor();
+        ComboStringEditor e = new ComboStringEditor(null, false, false);
 
         testSetGet(e, "any string");
         testSetGet(e, "");
@@ -45,8 +44,7 @@ public class TestFieldStringEditor {
 
     @Test
     public void testSetGetAsText() throws Exception {
-        @SuppressWarnings("deprecation") // test code, intentional
-        ComboStringEditor e = new ComboStringEditor();
+        ComboStringEditor e = new ComboStringEditor(null, false, false);
 
         testSetGetAsText(e, "any string");
         testSetGetAsText(e, "");

--- a/src/jorphan/src/main/java/org/apache/jorphan/exec/KeyToolUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/exec/KeyToolUtils.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Utilities for working with Java keytool
  */
-public class KeyToolUtils {
+public final class KeyToolUtils {
     private static final Logger log = LoggerFactory.getLogger(KeyToolUtils.class);
 
     // The DNAME which is used if none is provided

--- a/src/jorphan/src/main/java/org/apache/jorphan/logging/Slf4jLogkitLogger.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/logging/Slf4jLogkitLogger.java
@@ -23,8 +23,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper, implementing <code>org.apache.log.Logger</code> and delegating to the internal SLF4J logger.
+ * @deprecated Logger & Priority will be dropped in 3.3; so should this class
  */
-@Deprecated // Logger & Priority will be dropped in 3.3; so will this class be
+@Deprecated
 class Slf4jLogkitLogger extends org.apache.log.Logger {
 
     private final Logger slf4jLogger;

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/HeapDumper.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/HeapDumper.java
@@ -34,7 +34,7 @@ import javax.management.RuntimeMBeanException;
  * Uses Reflection so that the code compiles on Java 1.5.
  * The code will only work on Sun Java 1.6+.
  */
-public class HeapDumper {
+public final class HeapDumper {
 
     // SingletonHolder idiom for lazy initialisation
     private static class DumperHolder {

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/ThreadDumper.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/ThreadDumper.java
@@ -34,7 +34,7 @@ import java.util.Date;
  * Utility class to create a Thread Dump
  * @since 3.2
  */
-public class ThreadDumper {
+public final class ThreadDumper {
 
     // Only invoked by IODH class
     private ThreadDumper() {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
@@ -40,7 +40,7 @@ public class JsoupBasedHtmlParser extends HTMLParser {
     /*
      * A dummy class to pass the pointer of URL.
      */
-    private static class URLPointer {
+    private static final class URLPointer {
         private URLPointer(URL newUrl) {
             url = newUrl;
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
@@ -52,7 +52,7 @@ public class LagartoBasedHtmlParser extends HTMLParser {
     /*
      * A dummy class to pass the pointer of URL.
      */
-    private static class URLPointer {
+    private static final class URLPointer {
         private URLPointer(URL newUrl) {
             url = newUrl;
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HttpClientDefaultParameters.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HttpClientDefaultParameters.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * @deprecated since 5.0
  */
 @Deprecated
-public class HttpClientDefaultParameters {
+public final class HttpClientDefaultParameters {
 
     private static final Logger log = LoggerFactory.getLogger(HttpClientDefaultParameters.class);
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/ResourcesDownloader.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/ResourcesDownloader.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  *  </ul>
  * @since 3.0
  */
-public class ResourcesDownloader {
+public final class ResourcesDownloader {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResourcesDownloader.class);
 

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -49,15 +49,15 @@ import junit.framework.TestSuite;
 public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
     private static final Logger log = LoggerFactory.getLogger(TestHTMLParser.class);
 
-    private static final String DEFAULT_UA  = "Apache-HttpClient/4.2.6";
-    private static final String UA_FF       = "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0";
-    private static final String UA_IE55     = "Mozilla/4.0 (compatible;MSIE 5.5; Windows 98)";
-    private static final String UA_IE6      = "Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 2.0.50727)";
-    private static final String UA_IE7      = "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)";
-    private static final String UA_IE8      = "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; "
+    private static final String DEFAULT_UA = "Apache-HttpClient/4.2.6";
+    private static final String UA_FF = "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0";
+    private static final String UA_IE55 = "Mozilla/4.0 (compatible;MSIE 5.5; Windows 98)";
+    private static final String UA_IE6 = "Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 2.0.50727)";
+    private static final String UA_IE7 = "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)";
+    private static final String UA_IE8 = "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; "
             + "GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)";
-    private static final String UA_IE9      = "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))";
-    private static final String UA_IE10     = "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)";
+    private static final String UA_IE9 = "Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))";
+    private static final String UA_IE10 = "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)";
 
     public TestHTMLParser(String arg0) {
         super(arg0);
@@ -84,7 +84,7 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
         return Description.createTestDescription(getClass(), getName() + " " + testNumber + " " + parserName);
     }
 
-    private static class StaticTestClass // Can't instantiate
+    private static final class StaticTestClass // Can't instantiate
     {
         private StaticTestClass() {
         }
@@ -108,22 +108,21 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
         public String userAgent;
 
         /**
-         *
          * @param htmlFileName HTML File with content
-         * @param baseUrl Base URL
-         * @param expectedSet Set of expected URLs
+         * @param baseUrl      Base URL
+         * @param expectedSet  Set of expected URLs
          * @param expectedList List of expected URLs
          */
         private TestData(String htmlFileName, String baseUrl, String expectedSet, String expectedList) {
             this(htmlFileName, baseUrl, expectedList, expectedList, DEFAULT_UA);
         }
+
         /**
-         *
          * @param htmlFileName HTML File with content
-         * @param baseUrl Base URL
-         * @param expectedSet Set of expected URLs
+         * @param baseUrl      Base URL
+         * @param expectedSet  Set of expected URLs
          * @param expectedList List of expected URLs
-         * @param userAgent User Agent
+         * @param userAgent    User Agent
          */
         private TestData(String htmlFileName, String baseUrl, String expectedSet, String expectedList, String userAgent) {
             this.fileName = htmlFileName;
@@ -140,13 +139,13 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
 
     // List of parsers to test. Should probably be derived automatically
     private static final String[] PARSERS = {
-        "org.apache.jmeter.protocol.http.parser.JTidyHTMLParser",
-        "org.apache.jmeter.protocol.http.parser.RegexpHTMLParser",
-        DEFAULT_JMETER_PARSER,
-        "org.apache.jmeter.protocol.http.parser.JsoupBasedHtmlParser"
-        };
+            "org.apache.jmeter.protocol.http.parser.JTidyHTMLParser",
+            "org.apache.jmeter.protocol.http.parser.RegexpHTMLParser",
+            DEFAULT_JMETER_PARSER,
+            "org.apache.jmeter.protocol.http.parser.JsoupBasedHtmlParser"
+    };
 
-    private static final TestData[] TESTS = new TestData[] {
+    private static final TestData[] TESTS = new TestData[]{
             new TestData("testfiles/HTMLParserTestCase.html",
                     "http://localhost/mydir/myfile.html",
                     "testfiles/HTMLParserTestCase.set",
@@ -157,8 +156,8 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
                     "testfiles/HTMLParserTestCaseBase.all"),
             new TestData("testfiles/HTMLParserTestCaseWithBaseHRef2.html",
                     "http://localhost/mydir/myfile.html",
-                     "testfiles/HTMLParserTestCaseBase.set",
-                     "testfiles/HTMLParserTestCaseBase.all"),
+                    "testfiles/HTMLParserTestCaseBase.set",
+                    "testfiles/HTMLParserTestCaseBase.all"),
             new TestData("testfiles/HTMLParserTestCaseWithMissingBaseHRef.html",
                     "http://localhost/mydir/images/myfile.html",
                     "testfiles/HTMLParserTestCaseBase.set",
@@ -184,78 +183,78 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
                     "file:HTMLParserTestFile_2.html",
                     "testfiles/HTMLParserTestFile_2.all",
                     "testfiles/HTMLParserTestFile_2.all"),
-                     };
+    };
 
 
-    private static final TestData[] SPECIFIC_PARSER_TESTS = new TestData[] {
-        new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional1_FF.all",
-                UA_FF),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional1_IE6.all",
-                UA_IE6),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional1_IE7.all",
-                UA_IE7),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional1_IE8.all",
-                UA_IE8),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional1_IE8.all",
-                UA_IE8),
+    private static final TestData[] SPECIFIC_PARSER_TESTS = new TestData[]{
+            new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional1_FF.all",
+                    UA_FF),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional1_IE6.all",
+                    UA_IE6),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional1_IE7.all",
+                    UA_IE7),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional1_IE8.all",
+                    UA_IE8),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional1.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional1_IE8.all",
+                    UA_IE8),
 
-        // FF gets mixed up by nested comments
-        new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional2_FF.all",
-                UA_FF),
+            // FF gets mixed up by nested comments
+            new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional2_FF.all",
+                    UA_FF),
 
-        new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional2_IE7.all",
-                UA_IE7),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional2_IE8.all",
-                UA_IE8),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional2_IE9.all",
-                UA_IE9),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional3_FF.all",
-                UA_FF),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional3_IE10.all",
-                UA_IE10),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional3_IE55.all",
-                UA_IE55),
-        new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
-                "http://localhost/mydir/myfile.html",
-                null,
-                "testfiles/HTMLParserTestCaseWithConditional3_IE6.all",
-                UA_IE6)
+            new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional2_IE7.all",
+                    UA_IE7),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional2_IE8.all",
+                    UA_IE8),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional2.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional2_IE9.all",
+                    UA_IE9),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional3_FF.all",
+                    UA_FF),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional3_IE10.all",
+                    UA_IE10),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional3_IE55.all",
+                    UA_IE55),
+            new TestData("testfiles/HTMLParserTestCaseWithConditional3.html",
+                    "http://localhost/mydir/myfile.html",
+                    null,
+                    "testfiles/HTMLParserTestCaseWithConditional3_IE6.all",
+                    UA_IE6)
     };
 
     public static junit.framework.Test suite() {
@@ -278,7 +277,7 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
             suite.addTest(ps);
         }
 
-        TestSuite ps = new TestSuite(DEFAULT_JMETER_PARSER+"_conditional_comments");// Identify subtests
+        TestSuite ps = new TestSuite(DEFAULT_JMETER_PARSER + "_conditional_comments");// Identify subtests
         for (int j = 0; j < SPECIFIC_PARSER_TESTS.length; j++) {
             TestSuite ts = new TestSuite(SPECIFIC_PARSER_TESTS[j].fileName);
             ts.addTest(new TestHTMLParser("testSpecificParserList", DEFAULT_JMETER_PARSER, j));
@@ -379,18 +378,18 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
 
 
     private static void filetest(HTMLParser p, String file, String url, String resultFile, Collection<URLString> c,
-            boolean orderMatters, // Does the order matter?
-            String userAgent)
+                                 boolean orderMatters, // Does the order matter?
+                                 String userAgent)
             throws Exception {
         String parserName = p.getClass().getName().substring("org.apache.jmeter.protocol.http.parser.".length());
-        String fname = file.substring(file.indexOf('/')+1);
+        String fname = file.substring(file.indexOf('/') + 1);
         log.debug("file   {}", file);
         byte[] buffer = IOUtils.toByteArray(getInputStream(file));
         Iterator<URL> result;
         if (c == null) {
             result = p.getEmbeddedResourceURLs(userAgent, buffer, new URL(url), System.getProperty("file.encoding"));
         } else {
-            result = p.getEmbeddedResourceURLs(userAgent, buffer, new URL(url), c,System.getProperty("file.encoding"));
+            result = p.getEmbeddedResourceURLs(userAgent, buffer, new URL(url), c, System.getProperty("file.encoding"));
         }
         /*
          * TODO: Exact ordering is only required for some tests; change the
@@ -416,14 +415,14 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
 
         while (expected.hasNext()) {
             Object next = expected.next();
-            assertTrue(userAgent+"::"+fname+"::"+parserName + "::Expecting another result " + next, result.hasNext());
+            assertTrue(userAgent + "::" + fname + "::" + parserName + "::Expecting another result " + next, result.hasNext());
             try {
-                assertEquals(userAgent+"::"+fname+"::"+parserName + "(next)", next, result.next().toString());
+                assertEquals(userAgent + "::" + fname + "::" + parserName + "(next)", next, result.next().toString());
             } catch (ClassCastException e) {
-                fail(userAgent+"::"+fname+"::"+parserName + "::Expected URL, but got " + e.toString());
+                fail(userAgent + "::" + fname + "::" + parserName + "::Expected URL, but got " + e.toString());
             }
         }
-        assertFalse(userAgent+"::"+fname+"::"+parserName + "::Should have reached the end of the results", result.hasNext());
+        assertFalse(userAgent + "::" + fname + "::" + parserName + "::Should have reached the end of the results", result.hasNext());
     }
 
     // Get expected results as a List

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -90,13 +90,13 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
         }
     }
 
-    private class TestClass // Can't instantiate
+    private final class TestClass // Can't instantiate
     {
         private TestClass() {
         }
     }
 
-    private static class TestData {
+    private static final class TestData {
         private String fileName;
 
         private String baseURL;
@@ -113,7 +113,6 @@ public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
          * @param baseUrl Base URL
          * @param expectedSet Set of expected URLs
          * @param expectedList List of expected URLs
-         * @param userAgent User Agent
          */
         private TestData(String htmlFileName, String baseUrl, String expectedSet, String expectedList) {
             this(htmlFileName, baseUrl, expectedList, expectedList, DEFAULT_UA);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import junit.framework.TestSuite;
 
-public class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
+public final class TestHTMLParser extends JMeterTestCaseJUnit implements Describable {
     private static final Logger log = LoggerFactory.getLogger(TestHTMLParser.class);
 
     private static final String DEFAULT_UA = "Apache-HttpClient/4.2.6";

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ClientPool.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ClientPool.java
@@ -33,7 +33,7 @@ import org.apache.jorphan.util.JOrphanUtils;
  * N.B. This class is thread safe as it is called from sample threads
  * and the thread that runs testEnded() methods.
  */
-public class ClientPool {
+public final class ClientPool {
 
     private static final List<Closeable> CLIENTS = Collections.synchronizedList(new ArrayList<>());
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/MessageAdmin.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/MessageAdmin.java
@@ -26,12 +26,10 @@ import javax.jms.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Administration of messages.
- *
  */
-public class MessageAdmin {
+public final class MessageAdmin {
 
     private static final class PlaceHolder {
         private final CountDownLatch latch;
@@ -96,13 +94,10 @@ public class MessageAdmin {
      * associated with this request and the waiting party can be signaled by
      * means of a {@link CountDownLatch}
      *
-     * @param id
-     *            id of the request
-     * @param request
-     *            request object to store under id
-     * @param latch
-     *            communication latch to signal when a reply for this request
-     *            was received
+     * @param id      id of the request
+     * @param request request object to store under id
+     * @param latch   communication latch to signal when a reply for this request
+     *                was received
      */
     public void putRequest(String id, Message request, CountDownLatch latch) {
         log.debug("REQ_ID [{}]", id);
@@ -114,10 +109,8 @@ public class MessageAdmin {
      * request is found, the owner of the request will be notified with the
      * registered {@link CountDownLatch}
      *
-     * @param id
-     *            id of the request
-     * @param reply
-     *            object with the reply
+     * @param id    id of the request
+     * @param reply object with the reply
      */
     public void putReply(String id, Message reply) {
         PlaceHolder holder = table.get(id);
@@ -125,11 +118,11 @@ public class MessageAdmin {
         if (holder != null) {
             holder.setReply(reply);
             CountDownLatch latch = holder.getLatch();
-            if(log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("{} releasing latch : {}", Thread.currentThread().getName(), latch);
             }
             latch.countDown();
-            if(log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("{} released latch : {}", Thread.currentThread().getName(), latch);
             }
         } else {
@@ -142,8 +135,7 @@ public class MessageAdmin {
     /**
      * Get the reply message.
      *
-     * @param id
-     *            the id of the message
+     * @param id the id of the message
      * @return the received message or <code>null</code>
      */
     public Message get(String id) {
@@ -152,6 +144,6 @@ public class MessageAdmin {
         if (holder == null || !holder.hasReply()) {
             log.debug("Message with {} not found.", id);
         }
-        return holder==null ? null : (Message) holder.getReply();
+        return holder == null ? null : (Message) holder.getReply();
     }
 }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LdapExtClient.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LdapExtClient.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * Based on the work of: author T.Elanjchezhiyan(chezhiyan@siptech.co.in)
  *
  */
-public class LdapExtClient {
+public final class LdapExtClient {
     private static final Logger log = LoggerFactory.getLogger(LdapExtClient.class);
 
     private static final String CONTEXT_IS_NULL = "Context is null";

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/BinaryTCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/BinaryTCPClientImpl.java
@@ -66,9 +66,10 @@ public class BinaryTCPClientImpl extends AbstractTCPClient {
             for (int i = 0; i < ba.length; i++) {
                 int nibble0 = Character.digit(sc[i * 2], 16);
                 int nibble1 = Character.digit(sc[i * 2 + 1], 16);
-                if (nibble0 == -1 || nibble1 == -1){
+                if (nibble0 == -1 || nibble1 == -1) {
                     throw new IllegalArgumentException(
-                    "Hex-encoded binary string contains an invalid hex digit in '"+sc[i * 2]+sc[i * 2 + 1]+"'");
+                            String.format("Hex-encoded binary string contains an invalid hex digit in '%s%s'",
+                                    sc[i * 2], sc[i * 2 + 1]));
                 }
                 ba[i] = (byte) ((nibble0 << 4) | nibble1);
             }
@@ -82,14 +83,15 @@ public class BinaryTCPClientImpl extends AbstractTCPClient {
 
     /**
      * Input (hex) string is converted to binary and written to the output stream.
-     * @param os output stream
+     *
+     * @param os               output stream
      * @param hexEncodedBinary hex-encoded binary
      */
     @Override
-    public void write(OutputStream os, String hexEncodedBinary) throws IOException{
+    public void write(OutputStream os, String hexEncodedBinary) throws IOException {
         os.write(hexStringToByteArray(hexEncodedBinary));
         os.flush();
-        if(log.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug("Wrote: " + hexEncodedBinary);
         }
     }
@@ -103,6 +105,9 @@ public class BinaryTCPClientImpl extends AbstractTCPClient {
                 "Method not supported for Length-Prefixed data.");
     }
 
+    /**
+     * @deprecated use {@link #read(InputStream, SampleResult)} instead
+     */
     @Deprecated
     public String read(InputStream is) throws ReadException {
         log.warn("Deprecated method, use read(is, sampleResult) instead");
@@ -114,6 +119,7 @@ public class BinaryTCPClientImpl extends AbstractTCPClient {
      * If there is no EOM byte defined, then reads until
      * the end of the stream is reached.
      * Response data is converted to hex-encoded binary
+     *
      * @return hex-encoded binary string
      * @throws ReadException when reading fails
      */
@@ -137,7 +143,7 @@ public class BinaryTCPClientImpl extends AbstractTCPClient {
 
             IOUtils.closeQuietly(w); // For completeness
             final String hexString = JOrphanUtils.baToHexString(w.toByteArray());
-            if(log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("Read: " + w.size() + "\n" + hexString);
             }
             return hexString;

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/LengthPrefixedBinaryTCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/LengthPrefixedBinaryTCPClientImpl.java
@@ -67,6 +67,9 @@ public class LengthPrefixedBinaryTCPClientImpl extends TCPClientDecorator {
         this.tcpClient.write(os, is);
     }
 
+    /**
+     * @deprecated use {@link #read(InputStream, SampleResult)} instead
+     */
     @Deprecated
     public String read(InputStream is) throws ReadException {
         log.warn("Deprecated method, use read(is, sampleResult) instead");

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
@@ -85,6 +85,9 @@ public class TCPClientImpl extends AbstractTCPClient {
         }
     }
 
+    /**
+     * @deprecated use {@link #read(InputStream, SampleResult)} instead.
+     */
     @Deprecated
     public String read(InputStream is) throws ReadException {
         return read(is, new SampleResult());


### PR DESCRIPTION
## Description
Added extra checkstyle rule and updated to 8.23 (8.24 is the current latest but it causes a lot more errors, especially usage of `<` and `>` in JavaDoc).

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
