### PR TITLE
Add Spotless for import order verification and formatting of the code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     checkstyle
     id("org.jetbrains.gradle.plugin.idea-ext") version "0.5" apply false
     id("org.nosphere.apache.rat") version "0.5.0"
+    id("com.diffplug.gradle.spotless") version "3.24.3"
     id("com.github.spotbugs") version "1.6.10"
     id("org.sonarqube") version "2.7.1"
     id("com.github.vlsi.crlf") version "1.17.0"
@@ -241,6 +242,7 @@ if (enableSpotBugs) {
     }
 }
 
+val licenseHeaderFile = file("config/license.header.java")
 allprojects {
     group = "org.apache.jmeter"
     // JMeter ClassFinder parses "class.path" and tries to find jar names there,
@@ -274,6 +276,29 @@ allprojects {
         spotbugs {
             toolVersion = "spotbugs".v
             isIgnoreFailures = ignoreSpotBugsFailures
+        }
+
+        apply(plugin = "com.diffplug.gradle.spotless")
+        spotless {
+            java {
+                licenseHeaderFile(licenseHeaderFile)
+                importOrder("static ", "java.", "javax", "org", "net", "com", "")
+                removeUnusedImports()
+                trimTrailingWhitespace()
+                indentWithSpaces(4)
+                endWithNewline()
+            }
+        }
+    }
+    plugins.withId("groovy") {
+        spotless {
+            groovy {
+                licenseHeaderFile(licenseHeaderFile)
+                importOrder("static ", "java.", "javax", "org", "net", "com", "")
+                trimTrailingWhitespace()
+                indentWithSpaces(4)
+                endWithNewline()
+            }
         }
     }
 

--- a/checksum.xml
+++ b/checksum.xml
@@ -4,24 +4,31 @@
   <ignored-keys />
   <trusted-keys>
     <trusted-key id='1c8d5ef0df2b70d4' group='cglib' />
+    <trusted-key id='379ce192d401ab61' group='com.diffplug.durian' />
+    <trusted-key id='379ce192d401ab61' group='com.diffplug.spotless' />
     <trusted-key id='c9fbaa83a8753994' group='com.fasterxml.jackson.core' />
     <trusted-key id='4c00043bec5cb7cb' group='com.fifesoft' />
     <trusted-key id='af10873874630863' group='com.flipkart.zjsonpatch' />
     <trusted-key id='3c0a8f4744f37328' group='com.github.ben-manes.caffeine' />
     <trusted-key id='8ea48d105232855d' group='com.github.jknack' />
+    <trusted-key id='461a804f2609fd89' group='com.github.shyiko.klob' />
     <trusted-key id='1756b920eecf0e90' group='com.github.spotbugs' />
     <trusted-key id='78fcd238c26ea995' group='com.github.tomakehurst' />
     <trusted-key id='59a252fb1199d873' group='com.google.code.findbugs' />
     <trusted-key id='7a01b0f236e5430f' group='com.google.code.gson' />
     <trusted-key id='9a259c7ee636c5ed' group='com.google.errorprone' />
     <trusted-key id='bf935c771a8474f8' group='com.google.errorprone' />
+    <trusted-key id='9a259c7ee636c5ed' group='com.google.googlejavaformat' />
     <trusted-key id='abe9f3126bb741c1' group='com.google.guava' />
     <trusted-key id='f6d4a1d411e9d1ae' group='com.google.guava' />
     <trusted-key id='29579f18fa8fd93b' group='com.google.j2objc' />
+    <trusted-key id='7eb97d110dfadd60' group='com.googlecode.concurrent-trees' />
     <trusted-key id='72475fd306b9cab7' group='com.googlecode.javaewah' />
     <trusted-key id='e57428da9e879e7d' group='com.helger' />
     <trusted-key id='3684155e9365c30e' group='com.jayway.jsonpath' />
     <trusted-key id='a50569c7ca7fa1f0' group='com.jcraft' />
+    <trusted-key id='aa49c633b4734832' group='com.pinterest' />
+    <trusted-key id='aa49c633b4734832' group='com.pinterest.ktlint' />
     <trusted-key id='1063fe98bcecb758' group='com.puppycrawl.tools' />
     <trusted-key id='6425559c47cc79c4' group='com.sun.activation' />
     <trusted-key id='602ec18d20c4661c' group='com.thoughtworks.xstream' />
@@ -62,6 +69,7 @@
     <trusted-key id='64a16faaec16a4be' group='org.apache.commons' />
     <trusted-key id='7a8860944fad5f62' group='org.apache.commons' />
     <trusted-key id='86fdc7e2a11262cb' group='org.apache.commons' />
+    <trusted-key id='9daadc1c9fcc82d0' group='org.apache.commons' />
     <trusted-key id='a2115ae15f6b8b72' group='org.apache.commons' />
     <trusted-key id='f513c419e4b9d0ac' group='org.apache.commons' />
     <trusted-key id='31474e5e7c6b7034' group='org.apache.ftpserver' />
@@ -69,6 +77,7 @@
     <trusted-key id='ecdfea3cb4493b94' group='org.apache.geronimo.specs' />
     <trusted-key id='7c25280eae63ebe5' group='org.apache.httpcomponents' />
     <trusted-key id='3595395eb3d8e1ba' group='org.apache.logging.log4j' />
+    <trusted-key id='c7bf26d0bb617866' group='org.apache.maven' />
     <trusted-key id='31474e5e7c6b7034' group='org.apache.mina' />
     <trusted-key id='9c8c892f91f8e6d1' group='org.apache.rat' />
     <trusted-key id='4a51a45b944ffd51' group='org.apache.tika' />
@@ -76,13 +85,16 @@
     <trusted-key id='a2e92e06ddb37997' group='org.apache.xbean' />
     <trusted-key id='5b93f1df7cdb6dea' group='org.apache.xmlgraphics' />
     <trusted-key id='85911f425ec61b51' group='org.apiguardian' />
+    <trusted-key id='e2b3d84202b812d9' group='org.assertj' />
     <trusted-key id='b341ddb020fcb6ab' group='org.bouncycastle' />
     <trusted-key id='be84d764623a3644' group='org.brotli' />
     <trusted-key id='b16698a4adf4d638' group='org.checkerframework' />
     <trusted-key id='41321490758aad6f' group='org.codehaus.groovy' />
     <trusted-key id='6525fd70cc303655' group='org.codehaus.mojo' />
     <trusted-key id='873a8e86b4372146' group='org.codehaus.mojo' />
+    <trusted-key id='466caed6e0747d50' group='org.codehaus.plexus' />
     <trusted-key id='79e193516be7998f' group='org.dom4j' />
+    <trusted-key id='c7bf26d0bb617866' group='org.eclipse.aether' />
     <trusted-key id='2d0e1fb8fe4b68b4' group='org.eclipse.jetty' />
     <trusted-key id='5b05ccde140c2876' group='org.eclipse.jgit' />
     <trusted-key id='8759d8f56d022006' group='org.exparity' />
@@ -94,6 +106,7 @@
     <trusted-key id='cb43338e060cf9fa' group='org.jacoco' />
     <trusted-key id='8799af90c06efbbd' group='org.jdom' />
     <trusted-key id='bcf4173966770193' group='org.jetbrains' />
+    <trusted-key id='379ce192d401ab61' group='org.jetbrains.intellij.deps' />
     <trusted-key id='98fe03a974ce0a0b' group='org.jetbrains.kotlin' />
     <trusted-key id='379ce192d401ab61' group='org.jetbrains.kotlinx' />
     <trusted-key id='91ae1504568ec4dd' group='org.jodd' />
@@ -194,6 +207,15 @@
     </dependency>
     <dependency group='org.ow2.asm' module='asm' version='7.1'>
       <sha512>7EBA7097109389F48FA9142BF22D225F5D3104D68013D3B8E0A6D4054A8CD0EF64614372BDCB38987D68ADB6D33A3804E98DDF112BA84DBB09D448CE702DACC4</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='jcl-over-slf4j' version='1.6.2'>
+      <sha512>3BA508C96EE0985865C9E86EBE803D1903835F7C198EB15723CDC86B028D6C82DBB7E96ECB01CEFAD7CC6EC7023155676D034B6B730A911D0FFE9F91FE532592</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='slf4j-api' version='1.6.2'>
+      <sha512>F520620AA2DF7856DEA11E8B310F5F48C7A53444867112F734FFEF6726DF6EB469BF068564AF79B7DE30845906E7B5772CA064A3CC0DA18918E6DE46BD02D6E6</sha512>
+    </dependency>
+    <dependency group='org.slf4j' module='slf4j-nop' version='1.6.2'>
+      <sha512>89F8559C281F6BCEA4EB193C49AA8C960A5FE6762DCA0198A7BB04B9D8A846AC52231F77EC16B2E9C0B48D0F6011517B641B5B93279B24EEF65EE22E2C1167F3</sha512>
     </dependency>
     <dependency group='oro' module='oro' version='2.0.8'>
       <sha512>9A98E493C4D771322B1331EC05AB0E363A83D8AC2AF8018D96A44DF2BF5BFC97D33EBE6F6F93E46AB10BF1536F0C29E9D9569318ED49BC18B4E96B1A8B476D37</sha512>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -131,6 +131,8 @@
       <property name="allowStaticMemberImports" value="false"/>
     </module>
     <module name="RedundantImport"/>
+    <!--
+      Note: Import order is moved to Spotless. See ./gradlew spotlessCheck; ./gradlew spotlessApply
     <module name="UnusedImports"/>
     <module name="ImportOrder">
       <property name="groups" value="/^java\./,javax,org,net,com"/>
@@ -139,6 +141,7 @@
       <property name="option" value="top"/>
      <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
+    -->
 
     <!-- JavaDocs -->
 <!--

--- a/config/license.header.java
+++ b/config/license.header.java
@@ -16,14 +16,3 @@
  *
  */
 
-package org.apache.jmeter.assertions;
-
-import org.apache.jmeter.util.BSFBeanInfoSupport;
-
-public class BSFAssertionBeanInfo extends BSFBeanInfoSupport {
-
-    public BSFAssertionBeanInfo() {
-        super(BSFAssertion.class);
-    }
-
-}

--- a/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions;
 
 import java.io.Serializable;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSR223AssertionBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSR223AssertionBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/assertions/MD5HexAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/MD5HexAssertion.java
@@ -16,13 +16,6 @@
  *
  */
 
-/**
- * MD5HexAssertion class creates an MD5 checksum from the response <br/>
- * and matches it with the MD5 hex provided.
- * The assertion will fail when the expected hex is different from the <br/>
- * one calculated from the response OR when the expected hex is left empty.
- *
- */
 package org.apache.jmeter.assertions;
 
 import java.io.Serializable;
@@ -38,6 +31,12 @@ import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * MD5HexAssertion class creates an MD5 checksum from the response
+ * and matches it with the MD5 hex provided.
+ * <p>The assertion will fail when the expected hex is different from the
+ * one calculated from the response OR when the expected hex is left empty.</p>
+ */
 public class MD5HexAssertion extends AbstractTestElement implements Serializable, Assertion {
 
     private static final long serialVersionUID = 241L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/XMLSchemaAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/XMLSchemaAssertion.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions;
 
 import java.io.IOException;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/XPath2Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/XPath2Assertion.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions;
 
 import java.io.Serializable;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/JSONPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/JSONPathAssertionGui.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions.gui;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
@@ -16,10 +16,6 @@
  *
  */
 
-/**
- * GUI class supporting the MD5Hex assertion functionality.
- *
- */
 package org.apache.jmeter.assertions.gui;
 
 import java.awt.BorderLayout;
@@ -34,6 +30,9 @@ import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+/**
+ * GUI class supporting the MD5Hex assertion functionality.
+ */
 public class MD5HexAssertionGUI extends AbstractAssertionGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions.jmespath;
 
 import java.io.Serializable;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGui.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions.jmespath.gui;
 
 import javax.swing.JCheckBox;

--- a/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfig.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfig.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfigBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfigBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/control/RandomOrderController.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/RandomOrderController.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.control;
 
 import java.io.Serializable;

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/RandomOrderControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/RandomOrderControllerGui.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.control.gui;
 
 import org.apache.jmeter.control.RandomOrderController;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/DebugPostProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/DebugPostProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/Extractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/Extractor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSoupExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSoupExtractor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JoddExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JoddExtractor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/XPath2Extractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/XPath2Extractor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor;
 
 import java.io.Serializable;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/XPathExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/XPathExtractor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor;
 
 import java.io.ByteArrayInputStream;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPath2ExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPath2ExtractorGui.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor.gui;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor.gui;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathCache.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathCache.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor.json.jmespath;
 
 import org.apache.jmeter.util.JMeterUtils;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathCacheLoader.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathCacheLoader.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor.json.jmespath;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathExtractor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor.json.jmespath;
 
 import java.io.IOException;

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessorBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessorBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/sampler/TestAction.java
+++ b/src/components/src/main/java/org/apache/jmeter/sampler/TestAction.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.sampler;
 
 import java.util.Arrays;

--- a/src/components/src/main/java/org/apache/jmeter/thinktime/DefaultThinkTimeCreator.java
+++ b/src/components/src/main/java/org/apache/jmeter/thinktime/DefaultThinkTimeCreator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.thinktime;
 
 import org.apache.jmeter.exceptions.IllegalUserActionException;

--- a/src/components/src/main/java/org/apache/jmeter/timers/BSFTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BSFTimer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/BSFTimerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BSFTimerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/JSR223TimerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/JSR223TimerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/SyncTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/SyncTimer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/SyncTimerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/SyncTimerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/AxisGraph.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/AxisGraph.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.Color;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListener.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListenerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListenerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BarGraph.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BarGraph.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListenerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListenerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/Graph.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/Graph.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223ListenerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223ListenerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/LineGraph.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/LineGraph.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.BasicStroke;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsBoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsBoundaryExtractor.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsCssJQuery.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsCssJQuery.java
@@ -9,17 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/**
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsDocument.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsDocument.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsHTML.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsHTML.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsHTMLFormatted.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsHTMLFormatted.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsHTMLWithEmbedded.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsHTMLWithEmbedded.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsJSON.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsJSON.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
@@ -9,17 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/**
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsText.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsText.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXML.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXML.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath.java
@@ -1,19 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath2.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath2.java
@@ -1,19 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RequestPanel.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RequestPanel.java
@@ -1,19 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RequestView.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RequestView.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RequestViewRaw.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RequestViewRaw.java
@@ -1,19 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphChart.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphChart.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphDataBean.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphDataBean.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphLineBean.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphLineBean.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -9,17 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/**
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ResultRenderer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ResultRenderer.java
@@ -9,17 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/**
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.Color;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTextExtension.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTextExtension.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphProperties.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphProperties.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -9,17 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/**
  *
  */
+
 package org.apache.jmeter.visualizers;
 
 import java.awt.BorderLayout;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/utils/Colors.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/utils/Colors.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.visualizers.utils;

--- a/src/components/src/test/groovy/org/apache/jmeter/assertions/CompareAssertionSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/assertions/CompareAssertionSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -13,16 +13,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.assertions
 
+import java.nio.charset.StandardCharsets
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.jmeter.samplers.SampleResult
+
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.nio.charset.StandardCharsets
 
 @Unroll
 class CompareAssertionSpec extends Specification {

--- a/src/components/src/test/groovy/org/apache/jmeter/assertions/MD5HexAssertionSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/assertions/MD5HexAssertionSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -13,16 +13,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.assertions
 
+import java.nio.charset.StandardCharsets
+
 import org.apache.commons.lang3.StringUtils
 import org.apache.jmeter.samplers.SampleResult
+
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.nio.charset.StandardCharsets
 
 @Unroll
 class MD5HexAssertionSpec extends Specification {

--- a/src/components/src/test/groovy/org/apache/jmeter/assertions/gui/AssertionGuiSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/assertions/gui/AssertionGuiSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.assertions.gui

--- a/src/components/src/test/groovy/org/apache/jmeter/control/RandomOrderControllerSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/control/RandomOrderControllerSpec.groovy
@@ -6,19 +6,21 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.control
 
 import org.apache.jmeter.junit.stubs.TestSampler
 import org.apache.jmeter.testelement.TestElement
+
 import spock.lang.Specification
 
 class RandomOrderControllerSpec extends Specification {

--- a/src/components/src/test/groovy/org/apache/jmeter/control/RunTimeSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/control/RunTimeSpec.groovy
@@ -13,12 +13,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.control
 
 import org.apache.jmeter.junit.stubs.TestSampler
 import org.apache.jmeter.samplers.Sampler
+
 import spock.lang.Specification
 
 class RunTimeSpec extends Specification {

--- a/src/components/src/test/groovy/org/apache/jmeter/control/ThroughputControllerSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/control/ThroughputControllerSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -19,6 +19,7 @@
 package org.apache.jmeter.control
 
 import org.apache.jmeter.junit.stubs.TestSampler
+
 import spock.lang.Specification
 
 class ThroughputControllerSpec extends Specification {

--- a/src/components/src/test/groovy/org/apache/jmeter/extractor/BoundaryExtractorSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/extractor/BoundaryExtractorSpec.groovy
@@ -13,18 +13,20 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
- package org.apache.jmeter.extractor
+package org.apache.jmeter.extractor
+
+import java.util.stream.Stream
 
 import org.apache.jmeter.samplers.SampleResult
 import org.apache.jmeter.threads.JMeterContext
 import org.apache.jmeter.threads.JMeterContextService
 import org.apache.jmeter.threads.JMeterVariables
+
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.util.stream.Stream
 
 @Unroll
 class BoundaryExtractorSpec extends Specification {

--- a/src/components/src/test/groovy/org/apache/jmeter/extractor/JoddExtractorSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/extractor/JoddExtractorSpec.groovy
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.extractor
 
 import spock.lang.Specification

--- a/src/components/src/test/groovy/org/apache/jmeter/extractor/json/render/RenderAsJmesPathRendererSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/extractor/json/render/RenderAsJmesPathRendererSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -13,17 +13,20 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.extractor.json.render
 
-import org.apache.jmeter.samplers.SampleResult
-import org.apache.jmeter.extractor.json.render.RenderAsJmesPathRenderer
-import org.apache.jmeter.junit.spock.JMeterSpec
-import org.apache.jmeter.util.JMeterUtils
 import javax.swing.JTabbedPane
+
+import org.apache.jmeter.extractor.json.render.RenderAsJmesPathRenderer
 import org.apache.jmeter.junit.categories.NeedGuiTests
+import org.apache.jmeter.junit.spock.JMeterSpec
+import org.apache.jmeter.samplers.SampleResult
+import org.apache.jmeter.util.JMeterUtils
 import org.junit.experimental.categories.Category
+
 import spock.lang.IgnoreIf
 
 class RenderAsJmesPathRendererSpec extends JMeterSpec {

--- a/src/components/src/test/groovy/org/apache/jmeter/extractor/json/render/RenderAsJsonRendererSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/extractor/json/render/RenderAsJsonRendererSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -13,17 +13,20 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.extractor.json.render
 
-import org.apache.jmeter.samplers.SampleResult
-import org.apache.jmeter.extractor.json.render.RenderAsJsonRenderer
-import org.apache.jmeter.junit.spock.JMeterSpec
-import org.apache.jmeter.util.JMeterUtils
 import javax.swing.JTabbedPane
+
+import org.apache.jmeter.extractor.json.render.RenderAsJsonRenderer
 import org.apache.jmeter.junit.categories.NeedGuiTests
+import org.apache.jmeter.junit.spock.JMeterSpec
+import org.apache.jmeter.samplers.SampleResult
+import org.apache.jmeter.util.JMeterUtils
 import org.junit.experimental.categories.Category
+
 import spock.lang.IgnoreIf
 
 class RenderAsJsonRendererSpec extends JMeterSpec {

--- a/src/components/src/test/groovy/org/apache/jmeter/timers/UniformRandomTimerSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/timers/UniformRandomTimerSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.timers

--- a/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/graphite/PickleGraphiteMetricsSenderSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/graphite/PickleGraphiteMetricsSenderSpec.groovy
@@ -18,10 +18,11 @@
 
 package org.apache.jmeter.visualizers.backend.graphite
 
-import org.apache.commons.pool2.impl.GenericKeyedObjectPool
-import spock.lang.Specification
-
 import java.time.Instant
+
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool
+
+import spock.lang.Specification
 
 class PickleGraphiteMetricsSenderSpec extends Specification {
 

--- a/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/graphite/TextGraphiteMetricsSenderSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/graphite/TextGraphiteMetricsSenderSpec.groovy
@@ -19,6 +19,7 @@
 package org.apache.jmeter.visualizers.backend.graphite
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool
+
 import spock.lang.Specification
 
 class TextGraphiteMetricsSenderSpec extends Specification {

--- a/src/components/src/test/java/org/apache/jmeter/assertions/TestJSONPathAssertion.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/TestJSONPathAssertion.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions;
 
 import static org.junit.Assert.assertEquals;

--- a/src/components/src/test/java/org/apache/jmeter/assertions/gui/TestJSONPathAssertionGui.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/gui/TestJSONPathAssertionGui.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions.gui;
 
 import org.apache.jmeter.assertions.JSONPathAssertion;

--- a/src/components/src/test/java/org/apache/jmeter/assertions/jmespath/TestJMESPathAssertion.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/jmespath/TestJMESPathAssertion.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions.jmespath;
 
 import static org.junit.Assert.assertEquals;

--- a/src/components/src/test/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGuiTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGuiTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.assertions.jmespath.gui;
 
 import org.apache.jmeter.assertions.jmespath.JMESPathAssertion;

--- a/src/components/src/test/java/org/apache/jmeter/config/TestRandomVariableConfig.java
+++ b/src/components/src/test/java/org/apache/jmeter/config/TestRandomVariableConfig.java
@@ -16,10 +16,6 @@
  *
  */
 
-/**
- * Package to test FileServer methods
- */
-
 package org.apache.jmeter.config;
 
 import java.util.Locale;

--- a/src/components/src/test/java/org/apache/jmeter/control/TestRandomController.java
+++ b/src/components/src/test/java/org/apache/jmeter/control/TestRandomController.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.control;
 
 import static org.junit.Assert.assertEquals;

--- a/src/components/src/test/java/org/apache/jmeter/extractor/json/jmespath/TestJMESPathExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/json/jmespath/TestJMESPathExtractor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor.json.jmespath;
 
 import static org.junit.Assert.assertThat;

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ObsoleteGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ObsoleteGui.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/SimpleConfigGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/SimpleConfigGui.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/control/NextIsNullException.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/NextIsNullException.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on Apr 30, 2003
- */
 package org.apache.jmeter.control;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/control/TransactionSampler.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/TransactionSampler.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- *  N.B. Although this is a type of sampler, it is only used by the transaction controller,
- *  and so is in the control package
-*/
 package org.apache.jmeter.control;
 
 

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/AbstractTransformer.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/AbstractTransformer.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on May 4, 2003
- */
 package org.apache.jmeter.engine.util;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/FunctionParser.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/FunctionParser.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on Jul 25, 2003
- */
 package org.apache.jmeter.engine.util;
 
 import java.io.IOException;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/NoConfigMerge.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/NoConfigMerge.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.engine.util;
 
 import org.apache.jmeter.threads.TestCompiler;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/NoThreadClone.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/NoThreadClone.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on Apr 23, 2003
- */
 package org.apache.jmeter.engine.util;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on May 4, 2003
- */
 package org.apache.jmeter.engine.util;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceStringWithFunctions.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceStringWithFunctions.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on May 4, 2003
- */
 package org.apache.jmeter.engine.util;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/UndoVariableReplacement.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/UndoVariableReplacement.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on May 4, 2003
- */
 package org.apache.jmeter.engine.util;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ValueTransformer.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ValueTransformer.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on May 4, 2003
- */
 package org.apache.jmeter.engine.util;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/gui/GUIMenuSortOrder.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GUIMenuSortOrder.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.gui;

--- a/src/core/src/main/java/org/apache/jmeter/gui/SavePropertyDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/SavePropertyDialog.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 15, 2004
- */
 package org.apache.jmeter.gui;
 
 import java.awt.BorderLayout;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/ActionRouter.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/ActionRouter.java
@@ -393,4 +393,3 @@ public final class ActionRouter implements ActionListener {
         return INSTANCE;
     }
 }
-

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Copy.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Copy.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.action;
 
 import java.awt.Toolkit;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Duplicate.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Duplicate.java
@@ -16,11 +16,6 @@
  *
  */
 
-/*
- * Created on Apr 9, 2003
- *
- * Clones a JMeterTreeNode
- */
 package org.apache.jmeter.gui.action;
 
 import java.awt.event.ActionEvent;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Restart.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Restart.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.action;
 
 import java.awt.event.ActionEvent;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SaveGraphics.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SaveGraphics.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/TreeNodeNamingPolicy.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/TreeNodeNamingPolicy.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.action;
 
 import org.apache.jmeter.gui.tree.JMeterTreeNode;

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventAppender.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventAppender.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.logging;
 
 import java.io.Serializable;

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventBus.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventBus.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.logging;
 
 import java.util.ArrayList;

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventListener.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventListener.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.logging;
 
 import java.util.EventListener;

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/LogEventObject.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/LogEventObject.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.logging;
 
 import java.util.EventObject;

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeModel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeModel.java
@@ -35,7 +35,7 @@ import org.apache.jmeter.gui.JMeterGUIComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestPlan;
-import org.apache.jmeter.testelement.WorkBench; // NOSONAR We need this for backward compatibility
+import org.apache.jmeter.testelement.WorkBench;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.collections.ListedHashTree;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/CheckBoxPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/CheckBoxPanel.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.util;
 
 import javax.swing.Box;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/HorizontalPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/HorizontalPanel.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Created on Apr 25, 2003
- *
- */
 package org.apache.jmeter.gui.util;
 
 import java.awt.BorderLayout;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/IconToolbarBean.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/IconToolbarBean.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.gui.util;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.gui.util;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.gui.util;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/MenuSeparatorInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/MenuSeparatorInfo.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.gui.util;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextBoxDialoger.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextBoxDialoger.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.gui.util;

--- a/src/core/src/main/java/org/apache/jmeter/report/config/ConfigurationException.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/ConfigurationException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.config;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/config/ConfigurationUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/ConfigurationUtils.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.config;
 
 import org.apache.jmeter.report.core.ConvertException;

--- a/src/core/src/main/java/org/apache/jmeter/report/config/ExporterConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/ExporterConfiguration.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.config;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/config/GraphConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/GraphConfiguration.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.config;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/config/InstanceConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/InstanceConfiguration.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.config;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/config/SubConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/SubConfiguration.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.config;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/AbstractSampleWriter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/AbstractSampleWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.io.BufferedWriter;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/ControllerSamplePredicate.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/ControllerSamplePredicate.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/ConvertException.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/ConvertException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/Converters.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/Converters.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvFile.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvFile.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleReader.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleReader.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.io.BufferedReader;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleWriter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/DataContext.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/DataContext.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.util.TreeMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/JsonUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/JsonUtil.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/Sample.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/Sample.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleBuilder.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleBuilder.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.math.RoundingMode;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleComparator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleComparator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleException.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetaDataParser.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetaDataParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.util.regex.Pattern;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetadata.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetadata.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.util.ArrayList;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SamplePredicate.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SamplePredicate.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleWriter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.io.Closeable;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/StringConverter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/StringConverter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/TimeHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/TimeHelper.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import java.text.SimpleDateFormat;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/AbstractDataExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/AbstractDataExporter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/DataExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/DataExporter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ExportException.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ExportException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/GenerationException.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/GenerationException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/JsonizerVisitor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/JsonizerVisitor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/TemplateVisitor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/TemplateVisitor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.dashboard;
 
 import java.io.BufferedWriter;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleProcessor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleProcessor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.ArrayList;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleSource.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.List;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSummaryConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AggregateConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AggregateConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.commons.lang3.Validate;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/Aggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/Aggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.commons.lang3.ObjectUtils;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexThresholdsInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexThresholdsInfo.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ChannelContext.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ChannelContext.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.TreeMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ErrorsSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ErrorsSummaryConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ExternalSampleSorter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ExternalSampleSorter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/FieldSampleComparator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/FieldSampleComparator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/FilterConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/FilterConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/Job.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/Job.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ListResultData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ListResultData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.ArrayList;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MapResultData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MapResultData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MaxAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MaxAggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MaxAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MaxAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MeanAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MeanAggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.commons.math3.stat.descriptive.moment.Mean;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MeanAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MeanAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MedianAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MedianAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MinAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MinAggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MinAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MinAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/NormalizerSampleConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/NormalizerSampleConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.text.SimpleDateFormat;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/PercentileAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/PercentileAggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/PercentileAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/PercentileAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/RequestsSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/RequestsSummaryConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ResultData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ResultData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ResultDataVisitor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ResultDataVisitor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleContext.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleContext.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleIndexer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleIndexer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleProcessor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleProcessor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleProducer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleProducer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleSource.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.List;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleWriterConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleWriterConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SumAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SumAggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SumAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SumAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/TaggerConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/TaggerConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.ArrayList;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ThresholdSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ThresholdSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/TimeRateAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/TimeRateAggregator.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/TimeRateAggregatorFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/TimeRateAggregatorFactory.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsBySamplerConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsBySamplerConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsSummaryData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsSummaryData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ValueResultData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ValueResultData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.control.TransactionController;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractOverTimeGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.Map;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractSeriesSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractVersusRequestsGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractVersusRequestsGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/CodeSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/CodeSeriesSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/ConnectTimeValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/ConnectTimeValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/CountValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/CountValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.control.TransactionController;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/ElapsedTimeValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/ElapsedTimeValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.control.TransactionController;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GraphKeysSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GraphKeysSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.SampleSelector;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GraphSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GraphSeriesSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.SampleSelector;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GraphValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GraphValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GroupData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GroupData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GroupInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/GroupInfo.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.processor.AggregatorFactory;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/IndexedNameSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/IndexedNameSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.LinkedList;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/LatencyValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/LatencyValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/NameSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/NameSeriesSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/SeriesData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/SeriesData.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/StaticSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/StaticSeriesSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/StatusSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/StatusSeriesSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/SuccessfulElapsedTimeValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/SuccessfulElapsedTimeValueSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/TimeStampKeysSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/TimeStampKeysSelector.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ActiveThreadsGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ActiveThreadsGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.Collections;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/BytesThroughputGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/BytesThroughputGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CodesPerSecondGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CodesPerSecondGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ConnectTimeOverTimeGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.Collections;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CustomGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CustomGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/HitsPerSecondGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/HitsPerSecondGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyOverTimeGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/LatencyVSRequestGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseCustomGraphGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseCustomGraphGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeDistributionGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeDistributionGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeOverTimeGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePerSampleGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePerSampleGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesOverTimeGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimeVSRequestGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/SyntheticResponseTimeDistributionGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/SyntheticResponseTimeDistributionGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.text.MessageFormat;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TimeVSThreadGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.HashMap;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TotalTPSGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TotalTPSGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TransactionsPerSecondGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TransactionsPerSecondGraphConsumer.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import java.util.Arrays;

--- a/src/core/src/main/java/org/apache/jmeter/report/utils/MetricUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/utils/MetricUtils.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.utils;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/core/src/main/java/org/apache/jmeter/rmi/AliasKeyManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/rmi/AliasKeyManager.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.rmi;
 
 import java.net.Socket;

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleSaveConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleSaveConfiguration.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 7, 2004
- */
 package org.apache.jmeter.samplers;
 
 import java.io.Serializable;

--- a/src/core/src/main/java/org/apache/jmeter/save/SaveGraphicsService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/SaveGraphicsService.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.save;
 
 import java.awt.Dimension;

--- a/src/core/src/main/java/org/apache/jmeter/save/TestResultWrapper.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/TestResultWrapper.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 6, 2004
- */
 package org.apache.jmeter.save;
 
 import java.util.Collection;

--- a/src/core/src/main/java/org/apache/jmeter/save/converters/ConversionHelp.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/converters/ConversionHelp.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Jul 27, 2004
- */
 package org.apache.jmeter.save.converters;
 
 import java.io.UnsupportedEncodingException;

--- a/src/core/src/main/java/org/apache/jmeter/save/converters/TestResultWrapperConverter.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/converters/TestResultWrapperConverter.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 7, 2004
- */
 package org.apache.jmeter.save.converters;
 
 import java.util.ArrayList;

--- a/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
+++ b/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/BeanInfoSupport.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/BeanInfoSupport.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans;
 
 import java.awt.Image;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/TestBean.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/TestBean.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 21, 2004
- */
 package org.apache.jmeter.testbeans;
 
 /**

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanBeanInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanBeanInfo.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans;
 
 import java.awt.Image;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanHelper.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans;
 
 import java.beans.BeanInfo;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/EnumEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/EnumEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FieldStringEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FieldStringEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FileEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FileEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.BorderLayout;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/PasswordEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/PasswordEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/SharedCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/SharedCustomizer.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.beans.Customizer;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.BorderLayout;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TextAreaEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TextAreaEditor.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 21, 2004
- */
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/WrapperEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/WrapperEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.awt.Component;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElementBeanInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElementBeanInfo.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testelement;
 
 import java.awt.Image;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/NonTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/NonTestElement.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.testelement;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/OnErrorTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/OnErrorTestElement.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Created on Dec 9, 2003
- *
- */
 package org.apache.jmeter.testelement;
 
 import org.apache.jmeter.testelement.property.IntegerProperty;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestCloneable.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestCloneable.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 28, 2004
- */
 package org.apache.jmeter.testelement;
 
 public interface TestCloneable extends Cloneable {

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/AbstractProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/AbstractProperty.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/FunctionProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/FunctionProperty.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/NumberProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/NumberProperty.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on May 5, 2003
- */
 package org.apache.jmeter.testelement.property;
 
 public abstract class NumberProperty extends AbstractProperty {

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/ObjectProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/ObjectProperty.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 16, 2004
- */
 package org.apache.jmeter.testelement.property;
 
 import java.util.Objects;

--- a/src/core/src/main/java/org/apache/jmeter/threads/ListenerNotifier.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ListenerNotifier.java
@@ -16,17 +16,6 @@
  *
  */
 
-/////////////////////////////////////////
-////////
-//////// This code is mostly unused at present
-//////// it seems that only notifyListeners()
-//////// is used.
-////////
-//////// However, it does look useful.
-//////// And it may one day be used...
-////////
-/////////////////////////////////////////
-
 package org.apache.jmeter.threads;
 
 import java.io.Serializable;

--- a/src/core/src/main/java/org/apache/jmeter/util/BSFJavaScriptEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/BSFJavaScriptEngine.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/util/BSFTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/BSFTestElement.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/util/BeanShellTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/BeanShellTestElement.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/util/CustomX509TrustManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/CustomX509TrustManager.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.util;

--- a/src/core/src/main/java/org/apache/jmeter/util/Document.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/Document.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.util;

--- a/src/core/src/main/java/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.util;

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterTreeNodeTransferable.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterTreeNodeTransferable.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.util;

--- a/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/main/java/org/apache/jmeter/util/NameUpdater.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/NameUpdater.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on Jun 13, 2003
- */
 package org.apache.jmeter.util;
 
 import java.io.File;

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.util;
 
 import java.util.HashMap;

--- a/src/core/src/test/groovy/org/apache/jmeter/junit/spock/JMeterSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/junit/spock/JMeterSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -13,16 +13,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.junit.spock
 
+import java.nio.charset.Charset
+
 import org.apache.jmeter.junit.JMeterTestCaseJUnit
 import org.apache.jmeter.junit.JMeterTestUtils
 import org.apache.jmeter.util.JMeterUtils
-import spock.lang.Specification
 
-import java.nio.charset.Charset
+import spock.lang.Specification
 
 /**
  * Common setup for Spock test cases.

--- a/src/core/src/test/groovy/org/apache/jmeter/report/core/ConvertersSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/core/ConvertersSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.report.core
@@ -60,4 +61,3 @@ class ConvertersSpec extends Specification {
      "ä"         | char.class          | 'ä'
     }
 }
-

--- a/src/core/src/test/groovy/org/apache/jmeter/report/core/SampleMetadataParserSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/core/SampleMetadataParserSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.report.core

--- a/src/core/src/test/groovy/org/apache/jmeter/report/processor/ApdexSummaryConsumerSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/processor/ApdexSummaryConsumerSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.report.processor

--- a/src/core/src/test/groovy/org/apache/jmeter/report/processor/FieldSampleComparatorSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/processor/FieldSampleComparatorSpec.groovy
@@ -15,10 +15,12 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor
 
 import org.apache.jmeter.report.core.Sample
 import org.apache.jmeter.report.core.SampleMetadata
+
 import spock.lang.Specification
 
 class FieldSampleComparatorSpec extends Specification {

--- a/src/core/src/test/groovy/org/apache/jmeter/report/processor/ListResultDataSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/processor/ListResultDataSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.report.processor

--- a/src/core/src/test/groovy/org/apache/jmeter/report/processor/Top5ErrorsBySamplerConsumerSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/processor/Top5ErrorsBySamplerConsumerSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.report.processor
@@ -20,6 +21,7 @@ package org.apache.jmeter.report.processor
 
 import org.apache.jmeter.report.core.Sample
 import org.apache.jmeter.report.utils.MetricUtils
+
 import spock.lang.Specification
 
 class Top5ErrorsBySamplerConsumerSpec extends Specification {

--- a/src/core/src/test/groovy/org/apache/jmeter/report/processor/Top5ErrorsSummaryDataSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/processor/Top5ErrorsSummaryDataSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.report.processor

--- a/src/core/src/test/groovy/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesOverTimeGraphConsumerSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesOverTimeGraphConsumerSpec.groovy
@@ -13,13 +13,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
- package org.apache.jmeter.report.processor.graph.impl
-
-import org.apache.jmeter.junit.spock.JMeterSpec
+package org.apache.jmeter.report.processor.graph.impl
 
 import java.util.stream.Collectors
+
+import org.apache.jmeter.junit.spock.JMeterSpec
 
 class ResponseTimePercentilesOverTimeGraphConsumerSpec extends JMeterSpec {
 

--- a/src/core/src/test/groovy/org/apache/jmeter/services/FileServerSpec.groovy
+++ b/src/core/src/test/groovy/org/apache/jmeter/services/FileServerSpec.groovy
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.services

--- a/src/core/src/test/java/org/apache/jmeter/JMeterTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/JMeterTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter;
 
 import static org.junit.Assert.assertTrue;

--- a/src/core/src/test/java/org/apache/jmeter/report/core/SampleMetadataTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/report/core/SampleMetadataTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import static org.junit.Assert.assertEquals;

--- a/src/core/src/test/java/org/apache/jmeter/report/core/TestCsvSampleWriter.java
+++ b/src/core/src/test/java/org/apache/jmeter/report/core/TestCsvSampleWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.core;
 
 import static org.junit.Assert.assertEquals;

--- a/src/core/src/test/java/org/apache/jmeter/report/processor/ErrorsSummaryConsumerTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/report/processor/ErrorsSummaryConsumerTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor;
 
 import org.apache.jmeter.report.core.Sample;

--- a/src/core/src/test/java/org/apache/jmeter/report/processor/graph/impl/CustomGraphConsumerTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/report/processor/graph/impl/CustomGraphConsumerTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.report.processor.graph.impl;
 
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleResult.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleResult.java
@@ -383,4 +383,3 @@ public class TestSampleResult implements JMeterSerialTest {
             assertTrue("Expected true on second call of markFile with null", secondResult.markFile(null));
         }
 }
-

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
@@ -188,4 +188,3 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
     }
 
  }
-

--- a/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestBooleanPropertyEditor.java
+++ b/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestBooleanPropertyEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import static org.junit.Assert.assertEquals;

--- a/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestComboStringEditor.java
+++ b/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestComboStringEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import static org.junit.Assert.assertEquals;

--- a/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestFieldStringEditor.java
+++ b/src/core/src/test/java/org/apache/jmeter/testbeans/gui/TestFieldStringEditor.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import static org.junit.Assert.assertEquals;

--- a/src/core/src/test/java/org/apache/jmeter/testelement/property/AbstractPropertyTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/testelement/property/AbstractPropertyTest.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.testelement.property;
 
 import static org.junit.Assert.assertThat;

--- a/src/core/src/test/java/org/apache/jmeter/threads/JMeterContextServiceHelper.java
+++ b/src/core/src/test/java/org/apache/jmeter/threads/JMeterContextServiceHelper.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.threads;

--- a/src/core/src/test/java/org/apache/jmeter/util/JSR223TestElementTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/JSR223TestElementTest.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/test/java/org/apache/jmeter/util/LogRecord.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/LogRecord.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.util;
 
 import org.slf4j.Marker;

--- a/src/core/src/test/java/org/apache/jmeter/util/LogRecordingDelegatingLogger.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/LogRecordingDelegatingLogger.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.util;
 
 import java.util.Collection;

--- a/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
@@ -16,10 +16,6 @@
  *
  */
 
-/**
- * Package to test JMeterUtils methods
- */
-
 package org.apache.jmeter.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/core/src/test/java/org/apache/jorphan/test/AllTests.java
+++ b/src/core/src/test/java/org/apache/jorphan/test/AllTests.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jorphan.test;

--- a/src/dist-check/src/test/groovy/org/apache/jmeter/engine/util/PackageSpec.groovy
+++ b/src/dist-check/src/test/groovy/org/apache/jmeter/engine/util/PackageSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.engine.util
@@ -22,6 +23,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty
 import org.apache.jmeter.testelement.property.StringProperty
 import org.apache.jmeter.threads.JMeterContextService
 import org.apache.jmeter.threads.JMeterVariables
+
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/src/dist-check/src/test/groovy/org/apache/jmeter/gui/action/HtmlReportGeneratorSpec.groovy
+++ b/src/dist-check/src/test/groovy/org/apache/jmeter/gui/action/HtmlReportGeneratorSpec.groovy
@@ -18,8 +18,8 @@
 
 package org.apache.jmeter.gui.action
 
+import java.net.URL
 import java.nio.file.Paths
-import java.net.URL;
 import java.text.MessageFormat
 
 import org.apache.commons.io.FileUtils

--- a/src/dist-check/src/test/groovy/org/apache/jmeter/gui/util/MenuFactorySpec.groovy
+++ b/src/dist-check/src/test/groovy/org/apache/jmeter/gui/util/MenuFactorySpec.groovy
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.gui.util
 
 import org.apache.jmeter.junit.spock.JMeterSpec
@@ -31,4 +33,3 @@ class MenuFactorySpec extends JMeterSpec {
             MenuFactory.createDefaultAddMenu().itemCount == 6 + 3 // items + separators
     }
 }
-

--- a/src/dist-check/src/test/groovy/org/apache/jmeter/report/dashboard/ReportGeneratorSpec.groovy
+++ b/src/dist-check/src/test/groovy/org/apache/jmeter/report/dashboard/ReportGeneratorSpec.groovy
@@ -18,8 +18,8 @@
 
 package org.apache.jmeter.report.dashboard
 
+import java.net.URL
 import java.nio.file.Paths
-import java.net.URL;
 
 import org.apache.commons.io.FileUtils
 import org.apache.jmeter.junit.spock.JMeterSpec

--- a/src/dist-check/src/test/java/org/apache/jmeter/testbeans/gui/PackageTest.java
+++ b/src/dist-check/src/test/java/org/apache/jmeter/testbeans/gui/PackageTest.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.testbeans.gui;
 
 import java.beans.BeanInfo;

--- a/src/dist-check/src/test/java/org/apache/jorphan/reflect/TestClassFinder.java
+++ b/src/dist-check/src/test/java/org/apache/jorphan/reflect/TestClassFinder.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 package org.apache.jorphan.reflect;
 

--- a/src/examples/src/main/java/org/apache/jmeter/examples/sampler/gui/ExampleSamplerGui.java
+++ b/src/examples/src/main/java/org/apache/jmeter/examples/sampler/gui/ExampleSamplerGui.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Example Sampler GUI (non-beans version)
- */
-
 package org.apache.jmeter.examples.sampler.gui;
 
 import java.awt.BorderLayout;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/Jexl2Function.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/Jexl2Function.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.functions;
 
 import java.util.Collection;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/Jexl3Function.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/Jexl3Function.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.functions;
 
 import java.util.Collection;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/StringToFile.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.functions;
 
 import java.io.File;

--- a/src/functions/src/test/groovy/org/apache/jmeter/functions/ChangeCaseSpec.groovy
+++ b/src/functions/src/test/groovy/org/apache/jmeter/functions/ChangeCaseSpec.groovy
@@ -13,14 +13,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.functions
 
-import org.apache.jmeter.engine.util.CompoundVariable;
-import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jmeter.threads.JMeterContextService;
-import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.engine.util.CompoundVariable
+import org.apache.jmeter.samplers.SampleResult
+import org.apache.jmeter.threads.JMeterContextService
+import org.apache.jmeter.threads.JMeterVariables
 
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/src/functions/src/test/groovy/org/apache/jmeter/functions/IterationCounterSpec.groovy
+++ b/src/functions/src/test/groovy/org/apache/jmeter/functions/IterationCounterSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.functions;
@@ -20,7 +21,7 @@ package org.apache.jmeter.functions;
 import java.util.concurrent.CountDownLatch
 
 import org.apache.jmeter.engine.util.CompoundVariable
-import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterContextService
 import org.apache.jmeter.threads.JMeterVariables
 
 import spock.lang.Specification

--- a/src/functions/src/test/groovy/org/apache/jmeter/functions/gui/FunctionHelperSpec.groovy
+++ b/src/functions/src/test/groovy/org/apache/jmeter/functions/gui/FunctionHelperSpec.groovy
@@ -13,12 +13,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.functions.gui
 
 import org.apache.jmeter.config.Argument
 import org.apache.jmeter.config.Arguments
+
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -48,4 +50,3 @@ class FunctionHelperSpec extends Specification {
             "fname"      | ["a,\${f(b,\${g(c,d)},e)},f", "h"] | "\${fname(a\\,\${f(b,\${g(c,d)},e)}\\,f,h)}"
     }
 }
-

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestStringtoFile.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestStringtoFile.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.functions;
 
 import java.io.File;

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/AbstractParserControl.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/AbstractParserControl.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 /**

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLArgsParser.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLArgsParser.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 import java.text.ParseException;

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLOption.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLOption.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 import java.util.Arrays;

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLOptionDescriptor.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLOptionDescriptor.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 /**

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLUtil.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLUtil.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 /**

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/ParserControl.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/ParserControl.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 /**

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/Token.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/Token.java
@@ -9,13 +9,13 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 /**

--- a/src/jorphan/src/main/java/org/apache/jorphan/documentation/VisibleForTesting.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/documentation/VisibleForTesting.java
@@ -1,4 +1,4 @@
- /*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jorphan.gui;

--- a/src/jorphan/src/main/java/org/apache/jorphan/math/NumberComparator.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/math/NumberComparator.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 25, 2004
- */
 package org.apache.jorphan.math;
 
 import java.io.Serializable;

--- a/src/jorphan/src/main/java/org/apache/jorphan/reflect/Functor.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/reflect/Functor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/Converter.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/Converter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jorphan.util;
 
 import java.io.File;

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/HeapDumper.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/HeapDumper.java
@@ -201,4 +201,3 @@ public class HeapDumper {
         }
     }
 }
-

--- a/src/jorphan/src/main/java/org/apache/log/ContextMap.java
+++ b/src/jorphan/src/main/java/org/apache/log/ContextMap.java
@@ -6,14 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.log;
 
 import java.io.Serializable;

--- a/src/jorphan/src/main/java/org/apache/log/LogEvent.java
+++ b/src/jorphan/src/main/java/org/apache/log/LogEvent.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.log;

--- a/src/jorphan/src/main/java/org/apache/log/LogTarget.java
+++ b/src/jorphan/src/main/java/org/apache/log/LogTarget.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.log;

--- a/src/jorphan/src/main/java/org/apache/log/Logger.java
+++ b/src/jorphan/src/main/java/org/apache/log/Logger.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.log;

--- a/src/jorphan/src/main/java/org/apache/log/Priority.java
+++ b/src/jorphan/src/main/java/org/apache/log/Priority.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.log;

--- a/src/jorphan/src/test/groovy/org/apache/jorphan/io/TextFileSpec.groovy
+++ b/src/jorphan/src/test/groovy/org/apache/jorphan/io/TextFileSpec.groovy
@@ -9,21 +9,22 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
-package org.apache.jorphan.io
 
-import org.apache.commons.io.FileUtils
-import spock.lang.Specification
-import spock.lang.Unroll
+package org.apache.jorphan.io
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
+
+import org.apache.commons.io.FileUtils
+
+import spock.lang.Specification
+import spock.lang.Unroll
 
 @Unroll
 class TextFileSpec extends Specification {

--- a/src/jorphan/src/test/groovy/org/apache/jorphan/util/ConverterSpec.groovy
+++ b/src/jorphan/src/test/groovy/org/apache/jorphan/util/ConverterSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jorphan.util

--- a/src/jorphan/src/test/java/org/apache/commons/cli/avalon/ClutilTestCase.java
+++ b/src/jorphan/src/test/java/org/apache/commons/cli/avalon/ClutilTestCase.java
@@ -9,20 +9,18 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.commons.cli.avalon;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
-// Renamed from org.apache.avalon.excalibur.cli
 
 import java.util.List;
 

--- a/src/jorphan/src/test/java/org/apache/jorphan/exec/TestKeyToolUtils.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/exec/TestKeyToolUtils.java
@@ -16,9 +16,6 @@
  *
  */
 
-/**
- * Package to test JOrphanUtils methods
- */
 package org.apache.jorphan.exec;
 
 import static org.junit.Assert.fail;

--- a/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableModelTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableModelTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jorphan.gui;

--- a/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableSorterTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableSorterTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jorphan.gui;

--- a/src/jorphan/src/test/java/org/apache/jorphan/gui/TableModelEventBacker.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/gui/TableModelEventBacker.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jorphan.gui;

--- a/src/jorphan/src/test/java/org/apache/jorphan/reflect/TestClassTools.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/reflect/TestClassTools.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jorphan.reflect;
 
 import static org.junit.Assert.assertEquals;

--- a/src/jorphan/src/test/java/org/apache/jorphan/util/TestJorphanUtils.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/util/TestJorphanUtils.java
@@ -16,10 +16,6 @@
  *
  */
 
-/**
- * Package to test JOrphanUtils methods
- */
-
 package org.apache.jorphan.util;
 
 import static org.junit.Assert.assertEquals;

--- a/src/launcher/src/main/java/org/apache/jmeter/DynamicClassLoader.java
+++ b/src/launcher/src/main/java/org/apache/jmeter/DynamicClassLoader.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter;
 
 import java.net.URL;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CookieManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CookieManager.java
@@ -16,8 +16,6 @@
  *
  */
 
-// For unit tests @see TestCookieManager
-
 package org.apache.jmeter.protocol.http.control;
 
 import java.io.BufferedReader;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
@@ -1,18 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.control;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
@@ -9,12 +9,11 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed  under the  License is distributed on an "AS IS" BASIS,
- * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
- * implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.control;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/StaticHost.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/StaticHost.java
@@ -1,18 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.control;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.control.gui;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -1,18 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.gui;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.gui.action;
 
 import java.awt.BorderLayout;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParseException.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParseException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.parser;
 
 /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSamplerBeanInfo.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSamplerBeanInfo.java
@@ -6,20 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 24, 2004
- *
- */
 package org.apache.jmeter.protocol.http.sampler;
 
 import java.beans.PropertyDescriptor;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.http.sampler;
 
 import java.io.BufferedInputStream;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.http.sampler;
 
 import java.io.BufferedInputStream;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSampler.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.http.sampler;
 
 import org.apache.jmeter.samplers.Interruptible;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.http.sampler;
 
 import java.io.ByteArrayOutputStream;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseBeanInfo.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseBeanInfo.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 24, 2004
- */
 package org.apache.jmeter.protocol.http.sampler;
 
 import org.apache.jmeter.testelement.AbstractTestElementBeanInfo;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseConverter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseConverter.java
@@ -6,20 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 14, 2004
- *
- */
 package org.apache.jmeter.protocol.http.sampler;
 
 import org.apache.jmeter.save.converters.TestElementConverter;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HttpClientDefaultParameters.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HttpClientDefaultParameters.java
@@ -6,13 +6,14 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.sampler;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/DirectAccessByteArrayOutputStream.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/DirectAccessByteArrayOutputStream.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.http.util;
 
 import java.io.ByteArrayOutputStream;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
@@ -1,10 +1,10 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPResultConverter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPResultConverter.java
@@ -6,20 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on Sep 14, 2004
- *
- */
 package org.apache.jmeter.protocol.http.util;
 
 import java.net.URL;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.util.accesslog;
 
 import java.io.Serializable;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -1,19 +1,19 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this
- * work for additional information regarding copyright ownership. The ASF
- * licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.visualizers;

--- a/src/protocol/http/src/test/groovy/org/apache/jmeter/protocol/http/control/DNSCacheManagerSpec.groovy
+++ b/src/protocol/http/src/test/groovy/org/apache/jmeter/protocol/http/control/DNSCacheManagerSpec.groovy
@@ -3,7 +3,7 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License") you may not use this file except in compliance with
+ * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0

--- a/src/protocol/http/src/test/groovy/org/apache/jmeter/protocol/http/util/HTTPUtilsSpec.groovy
+++ b/src/protocol/http/src/test/groovy/org/apache/jmeter/protocol/http/util/HTTPUtilsSpec.groovy
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.http.util

--- a/src/protocol/http/src/test/java/org/apache/jmeter/gui/action/ParseCurlCommandActionTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/gui/action/ParseCurlCommandActionTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.gui.action;
 
 import static org.junit.Assert.assertEquals;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestAuthManagerThreadIteration.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestAuthManagerThreadIteration.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.control;
 
 import static org.junit.Assert.assertNotNull;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestCookieManagerThreadIteration.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestCookieManagerThreadIteration.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.control;
 
 import static org.junit.Assert.assertEquals;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/NotReusableParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/NotReusableParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.parser;
 
 import java.net.URL;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/ReusableParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/ReusableParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.parser;
 
 import java.net.URL;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestBaseParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestBaseParser.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.parser;
 
 import static org.junit.Assert.assertNotSame;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestCssParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestCssParser.java
@@ -79,4 +79,3 @@ public class TestCssParser extends JMeterTestCase {
         return result;
     }
 }
-

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/proxy/NonGuiProxySample.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/proxy/NonGuiProxySample.java
@@ -84,4 +84,3 @@ public class NonGuiProxySample {
 
     }
 }
-

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/HTTPSampler3.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/HTTPSampler3.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.http.sampler;
 
 import org.apache.jmeter.engine.event.LoopIterationEvent;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/PackageTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/PackageTest.java
@@ -16,9 +16,6 @@
  *
  */
 
-/*
- * Created on Jul 16, 2003
- */
 package org.apache.jmeter.protocol.http.sampler;
 
 import static org.junit.Assert.assertEquals;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPHC4Impl.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPHC4Impl.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.sampler;
 
 import static org.junit.Assert.assertFalse;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/accesslog/TestSessionFilter.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/accesslog/TestSessionFilter.java
@@ -6,15 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.http.util.accesslog;
 
 import static org.junit.Assert.assertSame;

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BSFSamplerBeanInfo.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BSFSamplerBeanInfo.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/SleepTest.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/SleepTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.java.test;
 
 import java.io.Serializable;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElement.java
@@ -13,7 +13,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
 package org.apache.jmeter.protocol.jdbc.config;
 
 import java.sql.Connection;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
@@ -6,19 +6,16 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 
-/*
- * Created on May 15, 2004
- */
 package org.apache.jmeter.protocol.jdbc.config;
 
 import java.beans.PropertyDescriptor;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPostProcessorBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPostProcessorBeanInfo.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Created on May 16, 2004
- *
- */
 package org.apache.jmeter.protocol.jdbc.processor;
 
 import org.apache.jmeter.protocol.jdbc.JDBCTestElementBeanInfoSupport;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPreProcessorBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPreProcessorBeanInfo.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Created on May 16, 2004
- *
- */
 package org.apache.jmeter.protocol.jdbc.processor;
 
 import org.apache.jmeter.protocol.jdbc.JDBCTestElementBeanInfoSupport;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSamplerBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSamplerBeanInfo.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Created on May 16, 2004
- *
- */
 package org.apache.jmeter.protocol.jdbc.sampler;
 
 import org.apache.jmeter.protocol.jdbc.JDBCTestElementBeanInfoSupport;

--- a/src/protocol/jdbc/src/test/groovy/org/apache/jmeter/protocol/jdbc/sampler/JDBCSamplerSpec.groovy
+++ b/src/protocol/jdbc/src/test/groovy/org/apache/jmeter/protocol/jdbc/sampler/JDBCSamplerSpec.groovy
@@ -13,21 +13,23 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jdbc.sampler
-
-import org.apache.jmeter.config.ConfigTestElement
-import org.apache.jmeter.samplers.SampleResult
-import org.apache.jmeter.testelement.property.JMeterProperty
-import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.sql.Connection
 import java.sql.ResultSet
 import java.sql.ResultSetMetaData
 import java.sql.SQLException
 import java.sql.Statement
+
+import org.apache.jmeter.config.ConfigTestElement
+import org.apache.jmeter.samplers.SampleResult
+import org.apache.jmeter.testelement.property.JMeterProperty
+
+import spock.lang.Specification
+import spock.lang.Unroll
 
 @Unroll
 class JDBCSamplerSpec extends Specification {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ClientPool.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ClientPool.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.client;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/BaseJMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/BaseJMSSampler.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/PublisherSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/PublisherSampler.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/SubscriberSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/SubscriberSampler.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/TimeoutEnabledQueueRequestor.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/TimeoutEnabledQueueRequestor.java
@@ -6,13 +6,13 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRenderer.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/FileKey.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/FileKey.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/MapMessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/MapMessageRenderer.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/MessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/MessageRenderer.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRenderer.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/RendererFactory.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/RendererFactory.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/Renderers.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/Renderers.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRenderer.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/PublisherSamplerTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/PublisherSamplerTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler;

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRendererTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRendererTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/MessageRendererTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/MessageRendererTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRendererTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/ObjectMessageRendererTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/Person.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/Person.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRendererTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/render/TextMessageRendererTest.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.protocol.jms.sampler.render;

--- a/src/protocol/junit-sample/src/main/java/test/DummyAnnotatedTest.java
+++ b/src/protocol/junit-sample/src/main/java/test/DummyAnnotatedTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 package test;
 

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/ClassFilter.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/ClassFilter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.java.control.gui;
 
 import java.util.ArrayList;

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 package org.apache.jmeter.protocol.java.control.gui;
 
@@ -448,4 +448,3 @@ implements ChangeListener, ActionListener, ItemListener
         }
     }
 }
-

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.java.sampler;
 
 import java.lang.annotation.Annotation;

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/MailReaderSampler.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/MailReaderSampler.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.mail.sampler;
 
 import java.io.ByteArrayOutputStream;

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.mail.sampler.gui;
 
 import java.awt.BorderLayout;

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpSamplerGui.java
@@ -16,7 +16,6 @@
  *
  */
 
-
 package org.apache.jmeter.protocol.smtp.sampler.gui;
 
 import java.awt.BorderLayout;

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/BinaryTCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/BinaryTCPClientImpl.java
@@ -16,12 +16,6 @@
  *
  */
 
-/*
- * TCP Sampler Client implementation which reads and writes binary data.
- *
- * Input/Output strings are passed as hex-encoded binary strings.
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import java.io.ByteArrayOutputStream;
@@ -43,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * the end of the stream is reached.
  * The EOM byte is defined by the property "tcp.BinaryTCPClient.eomByte".
  *
- * Input data is assumed to be in hex, and is converted to binary
+ * <p>Input/Output strings are passed as hex-encoded binary strings.</p>
  */
 public class BinaryTCPClientImpl extends AbstractTCPClient {
     private static final Logger log = LoggerFactory.getLogger(BinaryTCPClientImpl.class);

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/LengthPrefixedBinaryTCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/LengthPrefixedBinaryTCPClientImpl.java
@@ -16,16 +16,6 @@
  *
  */
 
-/*
- * TCP Sampler Client implementation which reads and writes length-prefixed binary data.
- *
- * Input/Output strings are passed as hex-encoded binary strings.
- *
- * 2-Byte or 4-Byte length prefixes are supported.
- *
- * Length prefix is binary of length specified by property "tcp.length.prefix.length".
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import java.io.IOException;
@@ -40,7 +30,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implements binary length-prefixed binary data.
- * This is used in ISO8583 for example.
+ * <p>This is used in ISO8583 for example.
+ * Input/Output strings are passed as hex-encoded binary strings.</p>
+ *
+ * <p>2-Byte or 4-Byte length prefixes are supported.</p>
+ *
+ * <p>Length prefix is binary of length specified by property "tcp.length.prefix.length".</p>
  */
 public class LengthPrefixedBinaryTCPClientImpl extends TCPClientDecorator {
     private static final Logger log = LoggerFactory.getLogger(LengthPrefixedBinaryTCPClientImpl.class);

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/ReadException.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/ReadException.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.protocol.tcp.sampler;
 
 /**

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClient.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClient.java
@@ -16,12 +16,6 @@
  *
  */
 
-/*
- * Created on 24-Sep-2003
- *
- * Interface for generic TCP protocol handler
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import java.io.IOException;

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientDecorator.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientDecorator.java
@@ -16,13 +16,12 @@
  *
  */
 
-/*
- * TCP Sampler Client decorator to permit wrapping base client implementations with length prefixes.
- * For example, character data or binary data with character length or binary length
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
+/**
+ * TCP Sampler Client decorator to permit wrapping base client implementations with length prefixes.
+ * <p>For example, character data or binary data with character length or binary length.</p>
+ */
 public abstract class TCPClientDecorator extends AbstractTCPClient {
 
     protected final TCPClient tcpClient; // the data implementation

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
@@ -16,14 +16,6 @@
  *
  */
 
-/*
- * Basic TCP Sampler Client class
- *
- * Can be used to test the TCP Sampler against an HTTP server
- *
- * The protocol handler class name is defined by the property tcp.handler
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import java.io.ByteArrayOutputStream;

--- a/src/protocol/tcp/src/test/java/org/apache/jmeter/protocol/tcp/sampler/BinaryTCPClientImplTest.java
+++ b/src/protocol/tcp/src/test/java/org/apache/jmeter/protocol/tcp/sampler/BinaryTCPClientImplTest.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Test class for BinaryTCPClientImpl utility methods.
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import static org.junit.Assert.assertEquals;

--- a/src/protocol/tcp/src/test/java/org/apache/jmeter/protocol/tcp/sampler/LengthPrefixedBinaryTCPClientImplTest.java
+++ b/src/protocol/tcp/src/test/java/org/apache/jmeter/protocol/tcp/sampler/LengthPrefixedBinaryTCPClientImplTest.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Test class for BinaryTCPClientImpl utility methods.
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import static org.junit.Assert.assertEquals;

--- a/src/protocol/tcp/src/test/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientDecoratorTest.java
+++ b/src/protocol/tcp/src/test/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientDecoratorTest.java
@@ -16,10 +16,6 @@
  *
  */
 
-/*
- * Test class for TCPClientDecorator utility methods.
- *
- */
 package org.apache.jmeter.protocol.tcp.sampler;
 
 import static org.junit.Assert.assertEquals;

--- a/src/testkit/src/main/java/org/apache/jmeter/testkit/ResourceLocator.java
+++ b/src/testkit/src/main/java/org/apache/jmeter/testkit/ResourceLocator.java
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.jmeter.testkit;


### PR DESCRIPTION
Implemented rules:
* import order
* unused imports
* trim whitespace at end of line
* ensure newline at end of file
* tabs -> spaces for formatting

```bash
./gradlew spotlessCheck # verifies the code
./gradlew spotlessApply # formats it
```
