### PR TITLE
Bug 63775

### DIFF
--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -123,6 +123,7 @@ to view the last release notes of version 5.1.1.
       if none is given explicitly. Reported by Havlicek Honza (havlicek.honza at gmail.com)</li>
   <li><bug>63727</bug>New <code>JMESPath Extractor</code> element to ease extraction from JSON using <a href="http://jmespath.org">JMESPath</a> technology. Contributed by Ubik Load Pack (support at ubikloadpack.com)</li>
   <li><bug>63763</bug>New <code>JMESPath Assertion</code> element to ease assertion on JSON using <a href="http://jmespath.org">JMESPath</a> technology. Contributed by Ubik Load Pack (support at ubikloadpack.com)</li>
+  <li><bug>63775</bug>Allow Boundary Extractor to accept empty boundaries</li>
 </ul>
 
 <h3>Functions</h3>


### PR DESCRIPTION
Bug 63775 - Allow Boundary Extractor to accept empty boundaries

## Description
Allow Boundary Extractor to accept empty left or right boundary text

## Motivation and Context
Allow fast text extraction than regular expression 
Allow to include text from the start and until the end of text

## How Has This Been Tested?
Tested with GUI

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
