### PR TITLE
Bug 63775

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Extracts Strings from a text response between a start and end boundary.
- * @see org.apache.jmeter.extractor.TestBoundaryExtractor for unit tests
  */
 public class BoundaryExtractor extends AbstractScopedTestElement implements PostProcessor, Serializable {
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -93,7 +93,7 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         if (log.isDebugEnabled()) {
             log.debug("Boundary Extractor {}: processing result", getName());
         }
-        if (StringUtils.isAnyEmpty(getLeftBoundary(), getRightBoundary(), getRefName())) {
+        if (StringUtils.isEmpty(getRefName())) {
             throw new IllegalArgumentException(
                     "One of the mandatory properties is missing in Boundary Extractor:" + getName());
         }
@@ -243,9 +243,23 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         if (StringUtils.isBlank(inputString)) {
             return Collections.emptyList();
         }
-        Objects.requireNonNull(leftBoundary);
-        Objects.requireNonNull(rightBoundary);
-
+		boolean isEmptyLeftBoundary = StringUtils.isEmpty(leftBoundary);
+		boolean isEmptyRightBoundary = StringUtils.isEmpty(rightBoundary);
+		if (isEmptyLeftBoundary && isEmptyRightBoundary) {
+			return Collections.singletonList(inputString);
+		}
+		if (isEmptyLeftBoundary) {
+			int rightBoundaryIndex = inputString.indexOf(rightBoundary);
+			if (rightBoundaryIndex != -1) {
+				return Collections.singletonList(inputString.substring(0, rightBoundaryIndex));
+			}
+		}
+		if (isEmptyRightBoundary) {
+			int leftBoundaryIndex = inputString.indexOf(leftBoundary);
+			if (leftBoundaryIndex != -1) {
+				return Collections.singletonList(inputString.substring(leftBoundaryIndex + leftBoundary.length()));
+			}
+		}
         List<String> matches = new ArrayList<>();
         int leftBoundaryLen = leftBoundary.length();
         boolean collectAll = matchNumber <= 0;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Extracts Strings from a text response between a start and end boundary.
+ * @see org.apache.jmeter.extractor.TestBoundaryExtractor for unit tests
  */
 public class BoundaryExtractor extends AbstractScopedTestElement implements PostProcessor, Serializable {
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -243,23 +243,23 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         if (StringUtils.isBlank(inputString)) {
             return Collections.emptyList();
         }
-		boolean isEmptyLeftBoundary = StringUtils.isEmpty(leftBoundary);
-		boolean isEmptyRightBoundary = StringUtils.isEmpty(rightBoundary);
-		if (isEmptyLeftBoundary && isEmptyRightBoundary) {
-			return Collections.singletonList(inputString);
-		}
-		if (isEmptyLeftBoundary) {
-			int rightBoundaryIndex = inputString.indexOf(rightBoundary);
-			if (rightBoundaryIndex != -1) {
-				return Collections.singletonList(inputString.substring(0, rightBoundaryIndex));
-			}
-		}
-		if (isEmptyRightBoundary) {
-			int leftBoundaryIndex = inputString.indexOf(leftBoundary);
-			if (leftBoundaryIndex != -1) {
-				return Collections.singletonList(inputString.substring(leftBoundaryIndex + leftBoundary.length()));
-			}
-		}
+        boolean isEmptyLeftBoundary = StringUtils.isEmpty(leftBoundary);
+        boolean isEmptyRightBoundary = StringUtils.isEmpty(rightBoundary);
+        if (isEmptyLeftBoundary && isEmptyRightBoundary) {
+            return Collections.singletonList(inputString);
+        }
+        if (isEmptyLeftBoundary) {
+            int rightBoundaryIndex = inputString.indexOf(rightBoundary);
+            if (rightBoundaryIndex != -1) {
+                return Collections.singletonList(inputString.substring(0, rightBoundaryIndex));
+            }
+        }
+        if (isEmptyRightBoundary) {
+            int leftBoundaryIndex = inputString.indexOf(leftBoundary);
+            if (leftBoundaryIndex != -1) {
+                return Collections.singletonList(inputString.substring(leftBoundaryIndex + leftBoundary.length()));
+            }
+        }
         List<String> matches = new ArrayList<>();
         int leftBoundaryLen = leftBoundary.length();
         boolean collectAll = matchNumber <= 0;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/components/src/test/groovy/org/apache/jmeter/extractor/BoundaryExtractorSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/extractor/BoundaryExtractorSpec.groovy
@@ -127,9 +127,6 @@ class BoundaryExtractorSpec extends Specification {
         then:
             thrown(IllegalArgumentException)
         where:
-            lb   | rb   | name
-            null | "r"  | "name"
-            "l"  | null | "name"
             "l"  | "r"  | null
     }
 

--- a/src/components/src/test/groovy/org/apache/jmeter/extractor/BoundaryExtractorSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/extractor/BoundaryExtractorSpec.groovy
@@ -117,7 +117,7 @@ class BoundaryExtractorSpec extends Specification {
             matchNumber << [-1, 0, 1, 2, 100]
     }
 
-    def "IllegalArgumentException when one of left (#lb), right (#rb), name (#name) are null"() {
+    def "IllegalArgumentException when name (#name) is null"() {
         given:
             sut.setLeftBoundary(lb)
             sut.setRightBoundary(rb)
@@ -128,8 +128,6 @@ class BoundaryExtractorSpec extends Specification {
             thrown(IllegalArgumentException)
         where:
             lb   | rb   | name
-            null | "r"  | "name"
-            "l"  | null | "name"
             "l"  | "r"  | null
     }
 

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
@@ -54,7 +54,7 @@ public class TestBoundaryExtractor {
         jmctx.setVariables(vars);
         jmctx.setPreviousResult(result);
     }
-    
+
     @Test
     public void testNoBoundaries() {
         vars.put("content", "one");

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
@@ -73,7 +73,7 @@ public class TestBoundaryExtractor {
         vars.put("content", "one");
         extractor.setLeftBoundary("o");
         extractor.setMatchNumber(-1);
-        extractor.setRefName("varname"); 
+        extractor.setRefName("varname");
         extractor.setScopeVariable("content");
         extractor.setThreadContext(jmctx);
         extractor.process();
@@ -87,7 +87,7 @@ public class TestBoundaryExtractor {
         vars.put("content", "one");
         extractor.setRightBoundary("e");
         extractor.setMatchNumber(-1);
-        extractor.setRefName("varname"); 
+        extractor.setRefName("varname");
         extractor.setScopeVariable("content");
         extractor.setThreadContext(jmctx);
         extractor.process();

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.jmeter.extractor;
+
+import static org.junit.Assert.assertThat;
+
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestBoundaryExtractor {
+
+    private BoundaryExtractor extractor;
+
+    private SampleResult result;
+
+    private JMeterVariables vars;
+
+    private JMeterContext jmctx;
+
+    @Before
+    public void setUp() {
+        jmctx = JMeterContextService.getContext();
+        extractor = new BoundaryExtractor();
+        extractor.setThreadContext(jmctx);
+        extractor.setRefName("regVal");
+        result = new SampleResult();
+        String data = "<company-xmlext-query-ret>" + "<row>" + "<value field=\"RetCode\">LIS_OK</value>"
+                + "<value field=\"RetCodeExtension\"></value>" + "<value field=\"alias\"></value>"
+                + "<value field=\"positioncount\"></value>" + "<value field=\"invalidpincount\">0</value>"
+                + "<value field=\"pinposition1\">1</value>" + "<value field=\"pinpositionvalue1\"></value>"
+                + "<value field=\"pinposition2\">5</value>" + "<value field=\"pinpositionvalue2\"></value>"
+                + "<value field=\"pinposition3\">6</value>" + "<value field=\"pinpositionvalue3\"></value>"
+                + "</row>" + "</company-xmlext-query-ret>";
+        result.setResponseData(data, null);
+        result.setResponseHeaders("Header1: Value1\nHeader2: Value2");
+        result.setResponseCode("abcd");
+        result.setResponseMessage("The quick brown fox");
+        vars = new JMeterVariables();
+        jmctx.setVariables(vars);
+        jmctx.setPreviousResult(result);
+    }
+    
+    @Test
+    public void testNoBoundaries() {
+        vars.put("content", "one");
+        extractor.setMatchNumber(-1);
+        extractor.setRefName("varname");        
+        extractor.setScopeVariable("content");
+        extractor.setThreadContext(jmctx);        
+        extractor.process();
+        assertThat(vars.get("varname"), CoreMatchers.is(CoreMatchers.nullValue()));
+        assertThat(vars.get("varname_1"), CoreMatchers.is("one"));
+        assertThat(vars.get("varname_matchNr"), CoreMatchers.is("1"));
+    }
+
+    @Test
+    public void testOnlyLeftBoundary() {
+        vars.put("content", "one");
+        extractor.setLeftBoundary("o");
+        extractor.setMatchNumber(-1);
+        extractor.setRefName("varname");        
+        extractor.setScopeVariable("content");
+        extractor.setThreadContext(jmctx);        
+        extractor.process();
+        assertThat(vars.get("varname"), CoreMatchers.is(CoreMatchers.nullValue()));
+        assertThat(vars.get("varname_1"), CoreMatchers.is("ne"));
+        assertThat(vars.get("varname_matchNr"), CoreMatchers.is("1"));
+    }
+
+    @Test
+    public void testOnlyRightBoundary() {
+        vars.put("content", "one");
+        extractor.setRightBoundary("e");
+        extractor.setMatchNumber(-1);
+        extractor.setRefName("varname");        
+        extractor.setScopeVariable("content");
+        extractor.setThreadContext(jmctx);        
+        extractor.process();
+        assertThat(vars.get("varname"), CoreMatchers.is(CoreMatchers.nullValue()));
+        assertThat(vars.get("varname_1"), CoreMatchers.is("on"));
+        assertThat(vars.get("varname_matchNr"), CoreMatchers.is("1"));
+    }
+
+}

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
@@ -44,13 +44,7 @@ public class TestBoundaryExtractor {
         extractor.setThreadContext(jmctx);
         extractor.setRefName("regVal");
         result = new SampleResult();
-        String data = "<company-xmlext-query-ret>" + "<row>" + "<value field=\"RetCode\">LIS_OK</value>"
-                + "<value field=\"RetCodeExtension\"></value>" + "<value field=\"alias\"></value>"
-                + "<value field=\"positioncount\"></value>" + "<value field=\"invalidpincount\">0</value>"
-                + "<value field=\"pinposition1\">1</value>" + "<value field=\"pinpositionvalue1\"></value>"
-                + "<value field=\"pinposition2\">5</value>" + "<value field=\"pinpositionvalue2\"></value>"
-                + "<value field=\"pinposition3\">6</value>" + "<value field=\"pinpositionvalue3\"></value>"
-                + "</row>" + "</company-xmlext-query-ret>";
+        String data = "<company-xmlext-query-ret><row></row></company-xmlext-query-ret>";
         result.setResponseData(data, null);
         result.setResponseHeaders("Header1: Value1\nHeader2: Value2");
         result.setResponseCode("abcd");

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
@@ -44,13 +44,7 @@ public class TestBoundaryExtractor {
         extractor.setThreadContext(jmctx);
         extractor.setRefName("regVal");
         result = new SampleResult();
-        String data = "<company-xmlext-query-ret>" + "<row>" + "<value field=\"RetCode\">LIS_OK</value>"
-                + "<value field=\"RetCodeExtension\"></value>" + "<value field=\"alias\"></value>"
-                + "<value field=\"positioncount\"></value>" + "<value field=\"invalidpincount\">0</value>"
-                + "<value field=\"pinposition1\">1</value>" + "<value field=\"pinpositionvalue1\"></value>"
-                + "<value field=\"pinposition2\">5</value>" + "<value field=\"pinpositionvalue2\"></value>"
-                + "<value field=\"pinposition3\">6</value>" + "<value field=\"pinpositionvalue3\"></value>"
-                + "</row>" + "</company-xmlext-query-ret>";
+        String data = "<company-xmlext-query-ret><row></row></company-xmlext-query-ret>";
         result.setResponseData(data, null);
         result.setResponseHeaders("Header1: Value1\nHeader2: Value2");
         result.setResponseCode("abcd");
@@ -64,9 +58,9 @@ public class TestBoundaryExtractor {
     public void testNoBoundaries() {
         vars.put("content", "one");
         extractor.setMatchNumber(-1);
-        extractor.setRefName("varname");        
+        extractor.setRefName("varname");
         extractor.setScopeVariable("content");
-        extractor.setThreadContext(jmctx);        
+        extractor.setThreadContext(jmctx);
         extractor.process();
         assertThat(vars.get("varname"), CoreMatchers.is(CoreMatchers.nullValue()));
         assertThat(vars.get("varname_1"), CoreMatchers.is("one"));
@@ -78,9 +72,9 @@ public class TestBoundaryExtractor {
         vars.put("content", "one");
         extractor.setLeftBoundary("o");
         extractor.setMatchNumber(-1);
-        extractor.setRefName("varname");        
+        extractor.setRefName("varname"); 
         extractor.setScopeVariable("content");
-        extractor.setThreadContext(jmctx);        
+        extractor.setThreadContext(jmctx);
         extractor.process();
         assertThat(vars.get("varname"), CoreMatchers.is(CoreMatchers.nullValue()));
         assertThat(vars.get("varname_1"), CoreMatchers.is("ne"));
@@ -92,9 +86,9 @@ public class TestBoundaryExtractor {
         vars.put("content", "one");
         extractor.setRightBoundary("e");
         extractor.setMatchNumber(-1);
-        extractor.setRefName("varname");        
+        extractor.setRefName("varname"); 
         extractor.setScopeVariable("content");
-        extractor.setThreadContext(jmctx);        
+        extractor.setThreadContext(jmctx);
         extractor.process();
         assertThat(vars.get("varname"), CoreMatchers.is(CoreMatchers.nullValue()));
         assertThat(vars.get("varname_1"), CoreMatchers.is("on"));

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestBoundaryExtractor.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+
 package org.apache.jmeter.extractor;
 
 import static org.junit.Assert.assertThat;

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -123,6 +123,7 @@ to view the last release notes of version 5.1.1.
       if none is given explicitly. Reported by Havlicek Honza (havlicek.honza at gmail.com)</li>
   <li><bug>63727</bug>New <code>JMESPath Extractor</code> element to ease extraction from JSON using <a href="http://jmespath.org">JMESPath</a> technology. Contributed by Ubik Load Pack (support at ubikloadpack.com)</li>
   <li><bug>63763</bug>New <code>JMESPath Assertion</code> element to ease assertion on JSON using <a href="http://jmespath.org">JMESPath</a> technology. Contributed by Ubik Load Pack (support at ubikloadpack.com)</li>
+  <li><bug>63775</bug>Allow Boundary Extractor to accept empty boundaries</li>
 </ul>
 
 <h3>Functions</h3>

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6244,8 +6244,8 @@ generate the template string, and store the result into the given variable name.
         Headers can be useful for HTTP samples; it may not be present for other sample types.
         </property>
         <property name="Name of created variable" required="Yes">The name of the JMeter variable in which to store the result.  Also note that each group is stored as <code>[refname]_g#</code>, where <code>[refname]</code> is the string you entered as the reference name, and <code>#</code> is the group number, where group <code>0</code> is the entire match, group <code>1</code> is the match from the first set of parentheses, etc.</property>
-        <property name="Left Boundary" required="Yes">Left boundary of value to find</property>
-        <property name="Right Boundary" required="Yes">Right boundary of value to find</property>
+        <property name="Left Boundary" required="No">Left boundary of value to find</property>
+        <property name="Right Boundary" required="No">Right boundary of value to find</property>
         <property name="Match No. (0 for Random)" required="Yes">Indicates which match to use.  The boundaries may match multiple times.  
             <ul>
                 <li>Use a value of zero to indicate JMeter should choose a match at random.</li>


### PR DESCRIPTION
Bug 63775 - Allow Boundary Extractor to accept empty boundaries

## Description
Allow Boundary Extractor to accept empty left or right boundary text

## Motivation and Context
Allow fast text extraction than regular expression 
Allow to include text from the start and until the end of text

## How Has This Been Tested?
Tested with GUI

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
