### PR TITLE
Groovy Eclipse Formatter with Spotless

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,6 +262,7 @@ if (enableSpotBugs) {
 }
 
 val licenseHeaderFile = file("config/license.header.java")
+val grEclipseConfFile = file("config/greclipse.properties")
 allprojects {
     group = "org.apache.jmeter"
     // JMeter ClassFinder parses "class.path" and tries to find jar names there,
@@ -367,6 +368,7 @@ allprojects {
                     trimTrailingWhitespace()
                     indentWithSpaces(4)
                     endWithNewline()
+                    greclipse().configFile(grEclipseConfFile)
                 }
             }
         }

--- a/checksum.xml
+++ b/checksum.xml
@@ -15,6 +15,7 @@
     <trusted-key id='1756b920eecf0e90' group='com.github.spotbugs' />
     <trusted-key id='78fcd238c26ea995' group='com.github.tomakehurst' />
     <trusted-key id='59a252fb1199d873' group='com.google.code.findbugs' />
+    <trusted-key id='353a436e043e3145' group='com.google.code.findbugs' />
     <trusted-key id='7a01b0f236e5430f' group='com.google.code.gson' />
     <trusted-key id='9a259c7ee636c5ed' group='com.google.errorprone' />
     <trusted-key id='bf935c771a8474f8' group='com.google.errorprone' />
@@ -99,6 +100,7 @@
     <trusted-key id='c7bf26d0bb617866' group='org.eclipse.aether' />
     <trusted-key id='2d0e1fb8fe4b68b4' group='org.eclipse.jetty' />
     <trusted-key id='5b05ccde140c2876' group='org.eclipse.jgit' />
+    <trusted-key id='700e4f39bc05364b' group='org.eclipse.platform' />
     <trusted-key id='8759d8f56d022006' group='org.exparity' />
     <trusted-key id='1939a2520bab1d90' group='org.freemarker' />
     <trusted-key id='9ff25980f5ba7e4f' group='org.fusesource.hawtbuf' />

--- a/config/greclipse.properties
+++ b/config/greclipse.properties
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# Whether to use 'space', 'tab' or 'mixed' (both) characters for indentation.
+# The default value is 'tab'.
+org.eclipse.jdt.core.formatter.tabulation.char=space
+
+# Number of spaces used for indentation in case 'space' characters
+# have been selected. The default value is 4.
+org.eclipse.jdt.core.formatter.tabulation.size=4
+
+# Number of spaces used for indentation in case 'mixed' characters
+# have been selected. The default value is 4.
+org.eclipse.jdt.core.formatter.indentation.size=4
+
+# Whether or not indentation characters are inserted into empty lines.
+# The default value is 'true'.
+org.eclipse.jdt.core.formatter.indent_empty_lines=false
+
+# Number of spaces used for multiline indentation.
+# The default value is 2.
+groovy.formatter.multiline.indentation=2
+
+# Length after which list are considered too long. These will be wrapped.
+# The default value is 30.
+groovy.formatter.longListLength=30
+
+# Whether opening braces position shall be the next line.
+# The default value is 'same'.
+groovy.formatter.braces.start=same
+
+# Whether closing braces position shall be the next line.
+# The default value is 'next'.
+groovy.formatter.braces.end=next
+
+# Remove unnecessary semicolons. The default value is 'false'.
+groovy.formatter.remove.unnecessary.semicolons=true


### PR DESCRIPTION
I've tried to implement some more rules with Spotless i.e. `remove.unnecessary.semicolons`, however it doesn't seem to be able to parse the Spock tests. I've created this draft PR in case anyone has some time to look into it. I'm going to go back to JUnit5 migration.