### PR TITLE
Bug 61801 HEX and Base64 function

### DIFF
--- a/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
@@ -33,8 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Encode Decode Function  
- * Supports Hex and Base64 methods 
+ * Encode Decode Function
+ * Supports Hex and Base64 methods
  *
  * @since 5.2
  */

--- a/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
@@ -22,9 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
-
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
@@ -64,7 +64,7 @@ public class EncodeDecodeFunction extends AbstractFunction {
     }
 
     private CompoundVariable[] values;
-        
+
     @Override
     public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
         String digestAlgorithm = values[0].execute();

--- a/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.jmeter.functions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.binary.Base64;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.util.JMeterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Encode Decode Function  
+ * Supports Hex and Base64 methods 
+ *
+ * @since 5.2
+ */
+public class EncodeDecodeFunction extends AbstractFunction {
+
+	private static final Logger log = LoggerFactory.getLogger(EncodeDecodeFunction.class);
+
+	/**
+	 * The algorithm names in this section can be specified when generating an
+	 * instance of MessageDigest: MD5 SHA-1 SHA-256 SHA-384 SHA-512
+	 */
+	private static final List<String> desc = new LinkedList<>();
+	private static final String KEY = "__encodeDecode";//NOSONAR
+	private static final String BASE64_ENCODE = "BASE64_ENCODE";//NOSONAR
+	private static final String BASE64_DECODE = "BASE64_DECODE";//NOSONAR
+	private static final String HEX_ENCODE = "HEX_ENCODE";//NOSONAR
+	private static final String HEX_DECODE = "HEX_DECODE";//NOSONAR
+
+	// Number of parameters expected - used to reject invalid calls
+	private static final int MIN_PARAMETER_COUNT = 2;
+	private static final int MAX_PARAMETER_COUNT = 3;
+
+	static {
+		desc.add(JMeterUtils.getResString("algorithm_string"));//NOSONAR
+		desc.add(JMeterUtils.getResString("sha_string"));//NOSONAR
+		desc.add(JMeterUtils.getResString("function_name_paropt"));//NOSONAR
+	}
+
+	private CompoundVariable[] values;
+
+	@Override
+	public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
+		String digestAlgorithm = values[0].execute();
+		String stringToEncode = values[1].execute();
+		String encodedString = null;
+		try {
+			switch (digestAlgorithm) {
+			case BASE64_ENCODE:
+				encodedString = Base64.encodeBase64String(stringToEncode.getBytes(StandardCharsets.UTF_8.name()));
+				break;
+			case BASE64_DECODE:
+				encodedString = new String(Base64.decodeBase64(stringToEncode), StandardCharsets.UTF_8.name());
+				break;
+			case HEX_DECODE:
+				encodedString = new String(Hex.decodeHex(stringToEncode), StandardCharsets.UTF_8.name());
+				break;
+			case HEX_ENCODE:
+				encodedString = Hex.encodeHexString(stringToEncode.getBytes(StandardCharsets.UTF_8.name()));
+				break;
+			default:
+				throw new InvalidVariableException("Invalid algorithm, suppprt only: BASE64_ENCODE,BASE64_DECODE,HEX_ENCODE,HEX_DECODE");//NOSONAR
+			}
+			addVariableValue(encodedString, values, 2);
+		} catch (Exception e) {
+			log.error("Error calling {} function with value {}, digest algorithm {}, ", KEY, stringToEncode, digestAlgorithm, e);//NOSONAR
+		}
+		return encodedString;
+	}
+
+	@Override
+	public void setParameters(Collection<CompoundVariable> parameters) throws InvalidVariableException {
+		checkParameterCount(parameters, MIN_PARAMETER_COUNT, MAX_PARAMETER_COUNT);
+		values = parameters.toArray(new CompoundVariable[parameters.size()]);
+	}
+
+	@Override
+	public String getReferenceKey() {
+		return KEY;
+	}
+
+	@Override
+	public List<String> getArgumentDesc() {
+		return desc;
+	}
+}

--- a/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
@@ -40,73 +40,73 @@ import org.slf4j.LoggerFactory;
  */
 public class EncodeDecodeFunction extends AbstractFunction {
 
-	private static final Logger log = LoggerFactory.getLogger(EncodeDecodeFunction.class);
+    private static final Logger log = LoggerFactory.getLogger(EncodeDecodeFunction.class);
 
-	/**
-	 * The algorithm names in this section can be specified when generating an
-	 * instance of MessageDigest: MD5 SHA-1 SHA-256 SHA-384 SHA-512
-	 */
-	private static final List<String> desc = new LinkedList<>();
-	private static final String KEY = "__encodeDecode";//NOSONAR
-	private static final String BASE64_ENCODE = "BASE64_ENCODE";//NOSONAR
-	private static final String BASE64_DECODE = "BASE64_DECODE";//NOSONAR
-	private static final String HEX_ENCODE = "HEX_ENCODE";//NOSONAR
-	private static final String HEX_DECODE = "HEX_DECODE";//NOSONAR
+    /**
+     * The algorithm names in this section can be specified when generating an
+     * instance of MessageDigest: MD5 SHA-1 SHA-256 SHA-384 SHA-512
+     */
+    private static final List<String> desc = new LinkedList<>();
+    private static final String KEY = "__encodeDecode";//NOSONAR
+    private static final String BASE64_ENCODE = "BASE64_ENCODE";//NOSONAR
+    private static final String BASE64_DECODE = "BASE64_DECODE";//NOSONAR
+    private static final String HEX_ENCODE = "HEX_ENCODE";//NOSONAR
+    private static final String HEX_DECODE = "HEX_DECODE";//NOSONAR
 
-	// Number of parameters expected - used to reject invalid calls
-	private static final int MIN_PARAMETER_COUNT = 2;
-	private static final int MAX_PARAMETER_COUNT = 3;
+    // Number of parameters expected - used to reject invalid calls
+    private static final int MIN_PARAMETER_COUNT = 2;
+    private static final int MAX_PARAMETER_COUNT = 3;
 
-	static {
-		desc.add(JMeterUtils.getResString("algorithm_string"));//NOSONAR
-		desc.add(JMeterUtils.getResString("sha_string"));//NOSONAR
-		desc.add(JMeterUtils.getResString("function_name_paropt"));//NOSONAR
-	}
+    static {
+        desc.add(JMeterUtils.getResString("algorithm_string"));//NOSONAR
+        desc.add(JMeterUtils.getResString("sha_string"));//NOSONAR
+        desc.add(JMeterUtils.getResString("function_name_paropt"));//NOSONAR
+    }
 
-	private CompoundVariable[] values;
+    private CompoundVariable[] values;
+        
+    @Override
+    public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
+        String digestAlgorithm = values[0].execute();
+        String stringToEncode = values[1].execute();
+        String encodedString = null;
+        try {
+            switch (digestAlgorithm) {
+            case BASE64_ENCODE:
+                encodedString = Base64.encodeBase64String(stringToEncode.getBytes(StandardCharsets.UTF_8.name()));
+                break;
+            case BASE64_DECODE:
+                encodedString = new String(Base64.decodeBase64(stringToEncode), StandardCharsets.UTF_8.name());
+                break;
+            case HEX_DECODE:
+                encodedString = new String(Hex.decodeHex(stringToEncode), StandardCharsets.UTF_8.name());
+                break;
+            case HEX_ENCODE:
+                encodedString = Hex.encodeHexString(stringToEncode.getBytes(StandardCharsets.UTF_8.name()));
+                break;
+            default:
+                throw new InvalidVariableException("Invalid algorithm, suppprt only: BASE64_ENCODE,BASE64_DECODE,HEX_ENCODE,HEX_DECODE");//NOSONAR
+            }
+            addVariableValue(encodedString, values, 2);
+        } catch (Exception e) {
+            log.error("Error calling {} function with value {}, digest algorithm {}, ", KEY, stringToEncode, digestAlgorithm, e);//NOSONAR
+        }
+        return encodedString;
+    }
 
-	@Override
-	public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
-		String digestAlgorithm = values[0].execute();
-		String stringToEncode = values[1].execute();
-		String encodedString = null;
-		try {
-			switch (digestAlgorithm) {
-			case BASE64_ENCODE:
-				encodedString = Base64.encodeBase64String(stringToEncode.getBytes(StandardCharsets.UTF_8.name()));
-				break;
-			case BASE64_DECODE:
-				encodedString = new String(Base64.decodeBase64(stringToEncode), StandardCharsets.UTF_8.name());
-				break;
-			case HEX_DECODE:
-				encodedString = new String(Hex.decodeHex(stringToEncode), StandardCharsets.UTF_8.name());
-				break;
-			case HEX_ENCODE:
-				encodedString = Hex.encodeHexString(stringToEncode.getBytes(StandardCharsets.UTF_8.name()));
-				break;
-			default:
-				throw new InvalidVariableException("Invalid algorithm, suppprt only: BASE64_ENCODE,BASE64_DECODE,HEX_ENCODE,HEX_DECODE");//NOSONAR
-			}
-			addVariableValue(encodedString, values, 2);
-		} catch (Exception e) {
-			log.error("Error calling {} function with value {}, digest algorithm {}, ", KEY, stringToEncode, digestAlgorithm, e);//NOSONAR
-		}
-		return encodedString;
-	}
+    @Override
+    public void setParameters(Collection<CompoundVariable> parameters) throws InvalidVariableException {
+        checkParameterCount(parameters, MIN_PARAMETER_COUNT, MAX_PARAMETER_COUNT);
+        values = parameters.toArray(new CompoundVariable[parameters.size()]);
+    }
 
-	@Override
-	public void setParameters(Collection<CompoundVariable> parameters) throws InvalidVariableException {
-		checkParameterCount(parameters, MIN_PARAMETER_COUNT, MAX_PARAMETER_COUNT);
-		values = parameters.toArray(new CompoundVariable[parameters.size()]);
-	}
+    @Override
+    public String getReferenceKey() {
+        return KEY;
+    }
 
-	@Override
-	public String getReferenceKey() {
-		return KEY;
-	}
-
-	@Override
-	public List<String> getArgumentDesc() {
-		return desc;
-	}
+    @Override
+    public List<String> getArgumentDesc() {
+        return desc;
+    }
 }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/EncodeDecodeFunction.java
@@ -22,8 +22,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
 
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -78,7 +78,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
     @Test
     public void testHex() throws Exception {
         params.add(new CompoundVariable("HEX_ENCODE"));
-        params.add(new CompoundVariable("I am a string"));        
+        params.add(new CompoundVariable("I am a string"));
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals("4920616d206120737472696e67", returnValue);
@@ -96,7 +96,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
     @Test
     public void testInvalid() throws Exception {
         params.add(new CompoundVariable(null));
-        params.add(new CompoundVariable("I am a string"));        
+        params.add(new CompoundVariable("I am a string"));
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals(null, returnValue);

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.jmeter.functions;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jmeter.threads.JMeterVariables;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestEncodeDecode extends JMeterTestCase  {
+    protected AbstractFunction encodeDecode;
+
+    private SampleResult result;
+
+    private Collection<CompoundVariable> params;
+
+    private JMeterVariables vars;
+
+    private JMeterContext jmctx;
+    @Before
+    public void setUp() {
+        encodeDecode = new EncodeDecodeFunction();
+        result = new SampleResult();
+        jmctx = JMeterContextService.getContext();
+        String data = "dummy data";
+        result.setResponseData(data, null);
+        vars = new JMeterVariables();
+        jmctx.setVariables(vars);
+        jmctx.setPreviousResult(result);
+        params = new LinkedList<>();
+    }
+
+    @Test
+    public void testParameterCount512() throws Exception {
+        checkInvalidParameterCounts(encodeDecode, 2, 3);
+    }
+
+    @Test
+    public void testBase64() throws Exception {
+        params.add(new CompoundVariable("BASE64_ENCODE"));
+        params.add(new CompoundVariable("I am a string"));
+        params.add(new CompoundVariable("salt"));
+        encodeDecode.setParameters(params);
+        String returnValue = encodeDecode.execute(result, null);
+        assertEquals(
+                "SSBhbSBhIHN0cmluZw==",
+                returnValue);
+    }
+    
+    @Test
+    public void testDecodeBase64() throws Exception {
+    	params.add(new CompoundVariable("BASE64_DECODE"));
+    	params.add(new CompoundVariable("SSBhbSBhIHN0cmluZw=="));
+    	encodeDecode.setParameters(params);
+    	String returnValue = encodeDecode.execute(result, null);
+    	assertEquals(
+    			"I am a string",
+    			returnValue);
+    }
+    
+    @Test
+    public void testHex() throws Exception {
+    	params.add(new CompoundVariable("HEX_ENCODE"));
+    	params.add(new CompoundVariable("I am a string"));
+    	
+    	encodeDecode.setParameters(params);
+    	String returnValue = encodeDecode.execute(result, null);
+    	assertEquals(
+    			"4920616d206120737472696e67",
+    			returnValue);
+    }
+    
+    @Test
+    public void testDecodeHex() throws Exception {
+    	params.add(new CompoundVariable("HEX_DECODE"));
+    	params.add(new CompoundVariable("4920616d206120737472696e67"));
+    	
+    	encodeDecode.setParameters(params);
+    	String returnValue = encodeDecode.execute(result, null);
+    	assertEquals(
+    			"I am a string",
+    			returnValue);
+    }
+    
+    @Test
+    public void testInvalid() throws Exception {
+    	params.add(new CompoundVariable(null));
+    	params.add(new CompoundVariable("I am a string"));
+    	
+    	encodeDecode.setParameters(params);
+    	String returnValue = encodeDecode.execute(result, null);
+    	assertEquals(
+    			null,
+    			returnValue);
+    }
+    
+}

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -26,7 +26,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
-import static org.junit.Assert.assertEquals;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,7 +62,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         params.add(new CompoundVariable("salt"));
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals("SSBhbSBhIHN0cmluZw==", returnValue);
+        Assert.assertEquals("SSBhbSBhIHN0cmluZw==", returnValue);
     }
     
     @Test
@@ -71,7 +71,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         params.add(new CompoundVariable("SSBhbSBhIHN0cmluZw=="));
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals("I am a string", returnValue);
+        Assert.assertEquals("I am a string", returnValue);
     }
     
     @Test
@@ -80,7 +80,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         params.add(new CompoundVariable("I am a string"));        
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals("4920616d206120737472696e67", returnValue);
+        Assert.assertEquals("4920616d206120737472696e67", returnValue);
     }
     
     @Test
@@ -89,7 +89,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         params.add(new CompoundVariable("4920616d206120737472696e67"));
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals("I am a string", returnValue);
+        Assert.assertEquals("I am a string", returnValue);
     }
     
     @Test
@@ -98,7 +98,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         params.add(new CompoundVariable("I am a string"));        
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals(null, returnValue);
+        Assert.assertEquals(null, returnValue);
     }
     
 }

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -66,56 +66,48 @@ public class TestEncodeDecode extends JMeterTestCase  {
         params.add(new CompoundVariable("salt"));
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals(
-                "SSBhbSBhIHN0cmluZw==",
-                returnValue);
+        assertEquals("SSBhbSBhIHN0cmluZw==", returnValue);
     }
     
     @Test
     public void testDecodeBase64() throws Exception {
-    	params.add(new CompoundVariable("BASE64_DECODE"));
-    	params.add(new CompoundVariable("SSBhbSBhIHN0cmluZw=="));
-    	encodeDecode.setParameters(params);
-    	String returnValue = encodeDecode.execute(result, null);
-    	assertEquals(
-    			"I am a string",
-    			returnValue);
+        params.add(new CompoundVariable("BASE64_DECODE"));
+        params.add(new CompoundVariable("SSBhbSBhIHN0cmluZw=="));
+        encodeDecode.setParameters(params);
+        String returnValue = encodeDecode.execute(result, null);
+        assertEquals("I am a string", returnValue);
     }
     
     @Test
     public void testHex() throws Exception {
-    	params.add(new CompoundVariable("HEX_ENCODE"));
-    	params.add(new CompoundVariable("I am a string"));
-    	
-    	encodeDecode.setParameters(params);
-    	String returnValue = encodeDecode.execute(result, null);
-    	assertEquals(
-    			"4920616d206120737472696e67",
-    			returnValue);
+        params.add(new CompoundVariable("HEX_ENCODE"));
+        params.add(new CompoundVariable("I am a string"));
+        
+        encodeDecode.setParameters(params);
+        String returnValue = encodeDecode.execute(result, null);
+        assertEquals("4920616d206120737472696e67", returnValue);
     }
     
     @Test
     public void testDecodeHex() throws Exception {
-    	params.add(new CompoundVariable("HEX_DECODE"));
-    	params.add(new CompoundVariable("4920616d206120737472696e67"));
-    	
-    	encodeDecode.setParameters(params);
-    	String returnValue = encodeDecode.execute(result, null);
-    	assertEquals(
-    			"I am a string",
-    			returnValue);
+        params.add(new CompoundVariable("HEX_DECODE"));
+        params.add(new CompoundVariable("4920616d206120737472696e67"));
+        
+        encodeDecode.setParameters(params);
+        String returnValue = encodeDecode.execute(result, null);
+        assertEquals("I am a string", returnValue);
     }
     
     @Test
     public void testInvalid() throws Exception {
-    	params.add(new CompoundVariable(null));
-    	params.add(new CompoundVariable("I am a string"));
-    	
-    	encodeDecode.setParameters(params);
-    	String returnValue = encodeDecode.execute(result, null);
-    	assertEquals(
-    			null,
-    			returnValue);
+        params.add(new CompoundVariable(null));
+        params.add(new CompoundVariable("I am a string"));
+        
+        encodeDecode.setParameters(params);
+        String returnValue = encodeDecode.execute(result, null);
+        assertEquals(
+                null,
+                returnValue);
     }
     
 }

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.functions;
 
 import java.util.Collection;
 import java.util.LinkedList;
+
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jmeter.samplers.SampleResult;
@@ -36,7 +37,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
     private Collection<CompoundVariable> params;
     private JMeterVariables vars;
     private JMeterContext jmctx;
-    
+
     @Before
     public void setUp() {
         encodeDecode = new EncodeDecodeFunction();
@@ -64,7 +65,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals("SSBhbSBhIHN0cmluZw==", returnValue);
     }
-    
+
     @Test
     public void testDecodeBase64() throws Exception {
         params.add(new CompoundVariable("BASE64_DECODE"));
@@ -73,7 +74,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals("I am a string", returnValue);
     }
-    
+
     @Test
     public void testHex() throws Exception {
         params.add(new CompoundVariable("HEX_ENCODE"));
@@ -82,7 +83,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals("4920616d206120737472696e67", returnValue);
     }
-    
+
     @Test
     public void testDecodeHex() throws Exception {
         params.add(new CompoundVariable("HEX_DECODE"));
@@ -91,7 +92,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals("I am a string", returnValue);
     }
-    
+
     @Test
     public void testInvalid() throws Exception {
         params.add(new CompoundVariable(null));

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -101,5 +101,5 @@ public class TestEncodeDecode extends JMeterTestCase  {
         String returnValue = encodeDecode.execute(result, null);
         Assert.assertEquals(null, returnValue);
     }
-    
+
 }

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestEncodeDecode.java
@@ -15,32 +15,28 @@
  * limitations under the License.
  *
  */
-package org.apache.jmeter.functions;
 
-import static org.junit.Assert.assertEquals;
+package org.apache.jmeter.functions;
 
 import java.util.Collection;
 import java.util.LinkedList;
-
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestEncodeDecode extends JMeterTestCase  {
     protected AbstractFunction encodeDecode;
-
     private SampleResult result;
-
     private Collection<CompoundVariable> params;
-
     private JMeterVariables vars;
-
     private JMeterContext jmctx;
+    
     @Before
     public void setUp() {
         encodeDecode = new EncodeDecodeFunction();
@@ -81,8 +77,7 @@ public class TestEncodeDecode extends JMeterTestCase  {
     @Test
     public void testHex() throws Exception {
         params.add(new CompoundVariable("HEX_ENCODE"));
-        params.add(new CompoundVariable("I am a string"));
-        
+        params.add(new CompoundVariable("I am a string"));        
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
         assertEquals("4920616d206120737472696e67", returnValue);
@@ -92,7 +87,6 @@ public class TestEncodeDecode extends JMeterTestCase  {
     public void testDecodeHex() throws Exception {
         params.add(new CompoundVariable("HEX_DECODE"));
         params.add(new CompoundVariable("4920616d206120737472696e67"));
-        
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
         assertEquals("I am a string", returnValue);
@@ -101,13 +95,10 @@ public class TestEncodeDecode extends JMeterTestCase  {
     @Test
     public void testInvalid() throws Exception {
         params.add(new CompoundVariable(null));
-        params.add(new CompoundVariable("I am a string"));
-        
+        params.add(new CompoundVariable("I am a string"));        
         encodeDecode.setParameters(params);
         String returnValue = encodeDecode.execute(result, null);
-        assertEquals(
-                null,
-                returnValue);
+        assertEquals(null, returnValue);
     }
     
 }


### PR DESCRIPTION
## Description
New function : Allow easy HEX and Base64 encode / Decode
_encodeDecode(string, mode,output variable) where mode is:
BASE64_ENCODE
BASE64_DECODE
HEX_ENCODE
HEX_DECODE

## Motivation and Context
Bug 61801 - New function : Allow easy HEX and Base64 encode / Decode

## How Has This Been Tested?
Java JUnit tests

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
