### PR TITLE
Remove old instructions valid for ant only from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,20 +153,6 @@ systemProp.https.proxyUser=your_user_name
 systemProp.https.proxyPassword=your_password
 ```
 
-You might also want to skip some tests - that are failing without proper access to the internet - by adding some more
-properties into `build-local.properties`:
-
-```properties
-skip.bug52310=true
-skip.bug60607=true
-skip.batchtest_Http4ImplPreemptiveBasicAuth=true
-skip.batchtest_SlowCharsFeature=true
-skip.batchtest_TestKeepAlive=true
-skip.batchtest_ResponseDecompression=true
-skip.test_http=true
-skip.test_TestDNSCacheManager.testWithCustomResolverAnd1Server=true
-```
-
 ### Test builds
 
 JMeter is built using Gradle.


### PR DESCRIPTION
## Description
Remove left overs from the old ant based setup description

## Motivation and Context
We are using Gradle now

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
