### PR TITLE
HTTP Request's Path isn't required

### DIFF
--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -275,7 +275,7 @@ https.default.protocol=SSLv3
         When using <code>multipart/form-data</code>, this suppresses the <code>Content-Type</code> and
         <code>Content-Transfer-Encoding</code> headers; only the <code>Content-Disposition</code> header is sent.
         </property>
-        <property name="Path" required="Yes">The path to resource (for example, <code>/servlets/myServlet</code>). If the
+        <property name="Path" required="No">The path to resource (for example, <code>/servlets/myServlet</code>). If the
 resource requires query string parameters, add them below in the
 "Send Parameters With the Request" section.
 <note>


### PR DESCRIPTION
Update documentation HTTP Request's Path isn't required, you can send requests without path (e.g. Server Name jmeter.apache.org)

## Description
Update documentation for HTTP Request
Path field isn't required as documented, you can send requests without path 
For example if setting only Server Name as jmeter.apache.org

## Motivation and Context
Fixing wrong documentation

## How Has This Been Tested?
Sent HTTP request with Path field

## Screenshots (if appropriate):

## Types of changes
No code change
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
