### PR TITLE
Use Assumptions.assume(condition) rather than if (condition) { Assumptions for readability

### DIFF
--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/ParallelResourcesAndIpSource.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/ParallelResourcesAndIpSource.java
@@ -170,18 +170,14 @@ public class ParallelResourcesAndIpSource {
             if (HTTPSamplerFactory.IMPL_JAVA.equals(httpImplementation)) {
                 // Java implementation is known to ignore source IP, so it should connect anyway
                 // pass to "successful" assertion below
-                if (result.getResponseDataAsString().contains("SocketException: Protocol family unavailable")) {
-                    //noinspection ConstantConditions
-                    Assumptions.assumeTrue(false,
-                            "Java implementation might throw 'SocketException: Protocol family unavailable'" +
-                                    " in case it connects from the wrong source IP");
-                }
-                if (result.getResponseDataAsString().contains("BindException: Cannot assign requested address")) {
-                    //noinspection ConstantConditions
-                    Assumptions.assumeTrue(false,
-                            "Java implementation might throw 'BindException: Cannot assign requested address'" +
-                                    " in case it connects from the wrong source IP");
-                }
+                Assumptions.assumeFalse(
+                        result.getResponseDataAsString().contains("SocketException: Protocol family unavailable"),
+                        "Java implementation might throw 'SocketException: Protocol family unavailable'"
+                                + " in case it connects from the wrong source IP");
+                Assumptions.assumeFalse(
+                        result.getResponseDataAsString().contains("BindException: Cannot assign requested address"),
+                        "Java implementation might throw 'BindException: Cannot assign requested address'"
+                                + " in case it connects from the wrong source IP");
             } else if (result.isSuccessful() || result.isResponseCodeOK() ||
                     !(result.getResponseDataAsString().contains("ConnectException") ||
                             result.getResponseDataAsString().contains("BindException") ||


### PR DESCRIPTION
## Description
By moving the result of the expression in the if statement into the assumption,
we are using the assumption call as intended and there is no need for `noinspect`
anymore.

## Motivation and Context
Get rid of `noinspect` comments, when possible
 
## How Has This Been Tested?
Ran the tests

## Screenshots (if appropriate):

## Types of changes
- code-cosmetic change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
