### PR TITLE
Use full name for Apache Groovy in documentation

### DIFF
--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -131,7 +131,7 @@ Alternatively, just use <code>/</code> instead for the path separator - e.g. <co
         <tr><td>Calculation</td><td> <a href="#__RandomFromMultipleVars">RandomFromMultipleVars</a></td><td>extracts an element from the values of a set of variables separated by <code>|</code></td><td>3.1</td></tr>
         <tr><td>Calculation</td><td> <a href="#__RandomString">RandomString</a></td><td>generate a random string</td><td>2.6</td></tr>
         <tr><td>Calculation</td><td> <a href="#__UUID">UUID</a></td><td>generate a random type 4 UUID</td><td>2.9</td></tr>
-        <tr><td>Scripting</td><td> <a href="#__groovy">groovy</a></td><td>run a Groovy script</td><td>3.1</td></tr>
+        <tr><td>Scripting</td><td> <a href="#__groovy">groovy</a></td><td>run an Apache Groovy script</td><td>3.1</td></tr>
         <tr><td>Scripting</td><td> <a href="#__BeanShell">BeanShell</a></td><td>run a BeanShell script</td><td>1.X</td></tr>
         <tr><td>Scripting</td><td> <a href="#__javaScript">javaScript</a></td><td>process JavaScript (Nashorn)</td><td>1.9</td></tr>
         <tr><td>Scripting</td><td> <a href="#__jexl2">jexl2</a></td><td>evaluate a Commons Jexl2 expression</td><td>jexl2(2.1.1)</td></tr>
@@ -1009,7 +1009,7 @@ Instead do the following, which can be cached: <source>${__groovy(vars.get("myVa
 </description>
 
 <properties>
-        <property name="Expression to evaluate" required="Yes">A groovy script (not a file name)
+        <property name="Expression to evaluate" required="Yes">An Apache Groovy script (not a file name)
         <note>Argument values that themselves contain commas should be escaped as necessary.
         If you need to include a comma in your parameter value, escape it like this: '<code>\,</code>'</note>
         </property>

--- a/xdocs/usermanual/hints_and_tips.xml
+++ b/xdocs/usermanual/hints_and_tips.xml
@@ -65,7 +65,7 @@ You can use these to determine the correct property setting to change the loggin
 
 <p>
 It is sometimes very useful to see Log messages to debug dynamic scripting languages like BeanShell or
-groovy used in JMeter.
+Apache Groovy used in JMeter.
 You can view log messages directly in JMeter GUI, to do so:</p>
 <ul>
 <li>use menu <menuchoice><guimenuitem>Options</guimenuitem><guimenuitem>Log Viewer</guimenuitem></menuchoice>,


### PR DESCRIPTION
## Motivation and Context
As Vladimir noted, the language Apache Groovy should be referenced
using its full name.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Documentation

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
