### PR TITLE
Grammar fixes for - Informations

### DIFF
--- a/bin/report-template/content/pages/CustomsGraphs.html.fmkr
+++ b/bin/report-template/content/pages/CustomsGraphs.html.fmkr
@@ -112,7 +112,7 @@
                 <div class="col-lg-12">
                      <div class="panel panel-default" >
                         <div class="panel-heading" style="text-align:center;">
-                           <p class="dashboard-title">Test and Report informations</p>
+                           <p class="dashboard-title">Test and Report information</p>
                         </div>
                         <div class="panel-body">
                             <table id="generalInfos" class="table table-bordered table-condensed " >

--- a/bin/report-template/content/pages/OverTime.html.fmkr
+++ b/bin/report-template/content/pages/OverTime.html.fmkr
@@ -150,7 +150,7 @@
                 <div class="col-lg-12">
                      <div class="panel panel-default" >
                         <div class="panel-heading" style="text-align:center;">
-                           <p class="dashboard-title">Test and Report informations</p>
+                           <p class="dashboard-title">Test and Report information</p>
                         </div>
                         <div class="panel-body">
                         <table id="generalInfos" class="table table-bordered table-condensed " >

--- a/bin/report-template/content/pages/ResponseTimes.html.fmkr
+++ b/bin/report-template/content/pages/ResponseTimes.html.fmkr
@@ -119,7 +119,7 @@
                 <div class="col-lg-12">
                      <div class="panel panel-default" >
                         <div class="panel-heading" style="text-align:center;">
-                           <p class="dashboard-title">Test and Report informations</p>
+                           <p class="dashboard-title">Test and Report information</p>
                         </div>
                         <div class="panel-body">
                         <table id="generalInfos" class="table table-bordered table-condensed " >

--- a/bin/report-template/content/pages/Throughput.html.fmkr
+++ b/bin/report-template/content/pages/Throughput.html.fmkr
@@ -119,7 +119,7 @@
                 <div class="col-lg-12">
                      <div class="panel panel-default">
                         <div class="panel-heading" style="text-align:center;">
-                           <p class="dashboard-title">Test and Report informations</p>
+                           <p class="dashboard-title">Test and Report information</p>
                         </div>
                         <div class="panel-body">
                         <table id="generalInfos" class="table table-bordered table-condensed " >

--- a/bin/report-template/index.html.fmkr
+++ b/bin/report-template/index.html.fmkr
@@ -84,7 +84,7 @@
                 <div class="col-lg-12">
                      <div class="panel panel-default" >
                         <div class="panel-heading" style="text-align:center;">
-                           <p class="dashboard-title">Test and Report informations</p>
+                           <p class="dashboard-title">Test and Report information</p>
                         </div>
                         <div class="panel-body">
                         <table id="generalInfos" class="table table-bordered table-condensed " >

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
@@ -108,7 +108,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
     }
 
     /**
-     * Clears any stored sampling-informations.
+     * Clears any stored sampling-information.
      */
     @Override
     public synchronized void clearData() {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -122,7 +122,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
     }
 
     /**
-     * Compute sampler informations from Request Header
+     * Compute sampler information from Request Header
      * @param sampler {@link HTTPSamplerBase}
      * @param request {@link HttpRequestHdr}
      * @param pageEncodings Map of page encodings
@@ -149,7 +149,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
     }
 
     /**
-     * Compute sampler informations from Request Header
+     * Compute sampler information from Request Header
      * @param sampler {@link HTTPSamplerBase}
      * @param request {@link HttpRequestHdr}
      * @throws Exception when something fails

--- a/xdocs/creating-templates.xml
+++ b/xdocs/creating-templates.xml
@@ -44,7 +44,7 @@
                         <figure image="templates/templates_xml.png">Figure 2 - recording template declaration</figure>
                         A template declaration is made as follow :<br/>
                         <ul>
-                            <li><code>template</code> element which contains the informations described in the followings tags</li>
+                            <li><code>template</code> element which contains the information described in the following tags</li>
                             <li><code>name</code> element which contains the template name the user will see</li>
                             <li><code>fileName</code> element which contains the relative path of the template.</li>
                             <li><code>description</code> element which uses html to describe the template</li>

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -5946,7 +5946,7 @@ extracting the node as text or attribute value and store the result into the giv
      <dt><code>compare(/book[1]/page[2],/book[2]/page[2])</code></dt>
     <dd>return Integer value equal 0 to if the 2<sup>nd</sup> page of the first book is equal to the 2<sup>nd</sup> page of the 2<sup>nd</sup> book, else return -1.</dd>
  </dl>
- <p>To see more informations about thoses fuctions, please check <a href="http://saxon.sourceforge.net/saxon7.9.1/functions.html">xPath2 functions</a></p>
+ <p>To see more information about these functions, please check <a href="http://saxon.sourceforge.net/saxon7.9.1/functions.html">xPath2 functions</a></p>
 </component>
 
 <component name="XPath Extractor" index="&sect-num;.8.3"  width="729" height="317" screenshot="xpath_extractor.png">


### PR DESCRIPTION
## Description
* Grammar fixes for the word "informations"
* "functions" was misspelled

## Motivation and Context
Apache JMeter Dashboard - Test and Report informations
^
This is wrong. Information never has a "s" on the end.

## How Has This Been Tested?
🇺🇸 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
