### PR TITLE
Add default append value to __StringToFile

### DIFF
--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -1730,7 +1730,7 @@ returns:
     </property>
     <property name="Append to file?" required="No">
     The way to write the string, <code>true</code> means append, <code>false</code>
-    means overwrite.
+    means overwrite. If not specified, the default append is <code>true</code>.
     </property>
     <property name="File encoding if not UTF-8" required="No">
     The encoding to be used to write to the file. If not specified, the default encoding is <code>UTF-8</code>.


### PR DESCRIPTION
## Description
Documentation missing default append value in new __StringToFile function

## Motivation and Context
Add default append value to __StringToFile documentation

## How Has This Been Tested?
The default value for append is true
## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
