### PR TITLE
Add BackendListener that sends "raw" results to InfluxDB

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
@@ -95,14 +95,6 @@ public abstract class AbstractBackendListenerClient implements BackendListenerCl
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SampleResult createSampleResult(BackendListenerContext context, SampleResult result) {
-        return result;
-    }
-
-    /**
      * @param sampleLabel Name of sample used as key
      * @return {@link SamplerMetric}
      */

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.jmeter.config.Arguments;
-import org.apache.jmeter.samplers.SampleResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
@@ -23,10 +23,11 @@ import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
 
 /**
- * This interface defines the interactions between the BackendListener and external
- * Java programs which can be executed by JMeter. Any Java class which wants to
- * be executed using the BackendListener test element must implement this interface (either directly
- * or preferably indirectly through AbstractBackendListenerClient).
+ * This interface defines the interactions between the {@link BackendListener}
+ * and external Java programs which can be executed by JMeter. Any Java class
+ * which wants to be executed using the {@link BackendListener} test element
+ * must implement this interface (either directly or through
+ * {@link AbstractBackendListenerClient}).
  * <p>
  * JMeter will create one instance of a BackendListenerClient implementation for
  * each user/thread in the test. Additional instances may be created for
@@ -34,21 +35,24 @@ import org.apache.jmeter.samplers.SampleResult;
  * supported by the client).
  * <p>
  * When the test is started, setupTest() will be called on each thread's
- * BackendListenerClient instance to initialize the client. Then handleSampleResult() will be
- * called for each SampleResult notification. Finally, teardownTest() will be called
- * to allow the client to do any necessary clean-up.
+ * BackendListenerClient instance to initialize the client.
+ * Then {@link #handleSampleResults(List, BackendListenerContext)} will be
+ * called for each {@link SampleResult} notification. Finally,
+ * {@link #teardownTest(BackendListenerContext)}
+ * will be called to allow the client to do any necessary clean-up.
  * <p>
- * The JMeter BackendListener GUI allows a list of parameters to be defined for the
- * test. These are passed to the various test methods through the
+ * The JMeter BackendListener GUI allows a list of parameters to be defined for
+ * the test. These are passed to the various test methods through the
  * {@link BackendListenerContext}. A list of default parameters can be defined
- * through the getDefaultParameters() method. These parameters and any default
- * values associated with them will be shown in the GUI. Users can add other
- * parameters as well.
+ * through the {@link #getDefaultParameters()} method. These parameters and any
+ * default values associated with them will be shown in the GUI. Users can add
+ * other parameters as well.
  * <p>
- * When possible, Listeners should extend {@link AbstractBackendListenerClient
- * AbstractBackendListenerClient} rather than implementing BackendListenerClient
- * directly. This should protect your tests from future changes to the
- * interface. While it may be necessary to make changes to the BackendListenerClient
+ * Listeners should extend {@link AbstractBackendListenerClient}
+ * rather than implementing {@link BackendListenerClient} directly to protect
+ * your code from future changes to the interface.
+ * <p>
+ * While it may be necessary to make changes to the {@link BackendListenerClient}
  * interface from time to time (therefore requiring changes to any
  * implementations of this interface), we intend to make this abstract class
  * provide reasonable default implementations of any new methods so that
@@ -63,14 +67,11 @@ public interface BackendListenerClient {
 
     /**
      * Do any initialization required by this client. It is generally
-     * recommended to do any initialization such as getting parameter values in
-     * the setupTest method rather than the runTest method in order to add as
-     * little overhead as possible to the test.
+     * recommended to do any initialization such as getting parameter values
+     * here rather than {@link #handleSampleResults(List, BackendListenerContext)}
+     * in order to add as little overhead as possible to the test.
      *
-     * @param context
-     *            the context to run with. This provides access to
-     *            initialization parameters.
-     *            Context is readonly
+     * @param context provides access to initialization parameters.
      * @throws Exception when setup fails
      */
     void setupTest(BackendListenerContext context) throws Exception; // NOSONAR
@@ -79,23 +80,19 @@ public interface BackendListenerClient {
      * Handle sampleResults, this can be done in many ways:
      * <ul>
      * <li>Write to a file</li>
-     * <li>Write to a distant server</li>
+     * <li>Write to a remote server</li>
      * <li>...</li>
      * </ul>
-     * @param sampleResults List of {@link SampleResult}
-     * @param context
-     *            the context to run with. This provides access to
-     *            initialization parameters.
      *
+     * @param sampleResults List of {@link SampleResult}
+     * @param context       provides access to initialization parameters.
      */
     void handleSampleResults(List<SampleResult> sampleResults, BackendListenerContext context);
 
     /**
      * Do any clean-up required at the end of a test run.
      *
-     * @param context
-     *            the context to run with. This provides access to
-     *            initialization parameters.
+     * @param context provides access to initialization parameters.
      * @throws Exception when tear down fails
      */
     void teardownTest(BackendListenerContext context) throws Exception; // NOSONAR
@@ -110,7 +107,7 @@ public interface BackendListenerClient {
      * empty value.
      *
      * @return a specification of the parameters used by this test which should
-     *         be listed in the GUI, or null if no parameters should be listed.
+     * be listed in the GUI, or null if no parameters should be listed.
      */
     default Arguments getDefaultParameters() {
         return null;
@@ -121,8 +118,9 @@ public interface BackendListenerClient {
      * what is kept in the copy, for example copy could remove some useless fields.
      * Note that if it returns null, the sample result is not put in the queue.
      * Defaults to returning result.
+     *
      * @param context {@link BackendListenerContext}
-     * @param result {@link SampleResult}
+     * @param result  {@link SampleResult}
      * @return {@link SampleResult}
      */
     default SampleResult createSampleResult(

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
@@ -112,7 +112,9 @@ public interface BackendListenerClient {
      * @return a specification of the parameters used by this test which should
      *         be listed in the GUI, or null if no parameters should be listed.
      */
-    Arguments getDefaultParameters();
+    default Arguments getDefaultParameters() {
+        return null;
+    }
 
     /**
      * Create a copy of SampleResult, this method is here to allow customizing

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
@@ -122,6 +122,8 @@ public interface BackendListenerClient {
      * @param result {@link SampleResult}
      * @return {@link SampleResult}
      */
-    SampleResult createSampleResult(
-            BackendListenerContext context, SampleResult result);
+    default SampleResult createSampleResult(
+            BackendListenerContext context, SampleResult result) {
+        return result;
+    }
 }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerClient.java
@@ -60,6 +60,7 @@ import org.apache.jmeter.samplers.SampleResult;
  * @since 2.13
  */
 public interface BackendListenerClient {
+
     /**
      * Do any initialization required by this client. It is generally
      * recommended to do any initialization such as getting parameter values in

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -149,9 +149,14 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
     }
 
     @Override
-    public void addMetric(String mesurement, String tag, String field) {
+    public void addMetric(String measurement, String tag, String field) {
+        addMetric(measurement, tag, field, System.currentTimeMillis());
+    }
+
+    @Override
+    public void addMetric(String measurement, String tag, String field, long timestamp) {
         synchronized (lock) {
-            metrics.add(new MetricTuple(mesurement, tag, field, System.currentTimeMillis()));
+            metrics.add(new MetricTuple(measurement, tag, field, timestamp));
         }
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -127,8 +127,8 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
     }
 
     /**
-     * @param url   {@link URL} Influxdb Url
-     * @param token Influxdb 2.0 authorization token
+     * @param url   {@link URL} InfluxDB Url
+     * @param token InfluxDB 2.0 authorization token
      * @return {@link HttpPost}
      * @throws URISyntaxException
      */

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
@@ -80,8 +80,9 @@ public class InfluxDBRawBackendListenerClient implements BackendListenerClient {
     }
 
     private void initInfluxDBMetricsManager(BackendListenerContext context) throws Exception {
-        influxDBMetricsManager = (InfluxdbMetricsSender) Class
+        influxDBMetricsManager = Class
                 .forName(context.getParameter("influxdbMetricsSender"))
+                .asSubclass(InfluxdbMetricsSender.class)
                 .getDeclaredConstructor()
                 .newInstance();
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.visualizers.backend.influxdb;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.visualizers.backend.BackendListenerClient;
+import org.apache.jmeter.visualizers.backend.BackendListenerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link BackendListenerClient} to write the response times
+ * of every sample to InfluxDB. If more "raw" information is required in InfluxDB
+ * then this class can be extended or another BackendListener
+ * {@link InfluxdbBackendListenerClient} can be used to send aggregate information
+ * to InfluxDB.
+ *
+ * @since 5.3
+ */
+public class InfluxDBRawBackendListenerClient implements BackendListenerClient {
+
+    private static final Logger log = LoggerFactory.getLogger(InfluxDBRawBackendListenerClient.class);
+
+    private static final Object LOCK = new Object();
+
+    private static final String TAG_OK = "ok";
+    private static final String TAG_KO = "ko";
+    private static final String DEFAULT_MEASUREMENT = "jmeter";
+
+    private static final Map<String, String> DEFAULT_ARGS = new LinkedHashMap<>();
+
+    static {
+        DEFAULT_ARGS.put("influxdbMetricsSender", HttpMetricsSender.class.getName());
+        DEFAULT_ARGS.put("influxdbUrl", "http://host_to_change:8086/write?db=jmeter");
+        DEFAULT_ARGS.put("influxdbToken", "");
+        DEFAULT_ARGS.put("measurement", DEFAULT_MEASUREMENT);
+    }
+
+    private InfluxdbMetricsSender influxDBMetricsManager;
+    private String measurement;
+
+    public InfluxDBRawBackendListenerClient() {
+        // default constructor
+    }
+
+    /**
+     * Used for testing.
+     *
+     * @param sender the {@link InfluxdbMetricsSender} to use
+     */
+    public InfluxDBRawBackendListenerClient(InfluxdbMetricsSender sender) {
+        influxDBMetricsManager = sender;
+    }
+
+    @Override
+    public void setupTest(BackendListenerContext context) throws Exception {
+        initInfluxDBMetricsManager(context);
+        measurement = context.getParameter("measurement", DEFAULT_MEASUREMENT);
+    }
+
+    private void initInfluxDBMetricsManager(BackendListenerContext context) throws Exception {
+        influxDBMetricsManager = (InfluxdbMetricsSender) Class
+                .forName(context.getParameter("influxdbMetricsSender"))
+                .getDeclaredConstructor()
+                .newInstance();
+
+        influxDBMetricsManager.setup(
+                context.getParameter("influxdbUrl"),
+                context.getParameter("influxdbToken"));
+    }
+
+    @Override
+    public void teardownTest(BackendListenerContext context) {
+        influxDBMetricsManager.destroy();
+    }
+
+    @Override
+    public void handleSampleResults(
+            List<SampleResult> sampleResults, BackendListenerContext context) {
+        log.debug("Handling {} sample results", sampleResults.size());
+        synchronized (LOCK) {
+            for (SampleResult sampleResult : sampleResults) {
+                addMetricFromSampleResult(sampleResult);
+            }
+            influxDBMetricsManager.writeAndSendMetrics();
+        }
+    }
+
+    private void addMetricFromSampleResult(SampleResult sampleResult) {
+        String tags = "," + createTags(sampleResult);
+        String fields = createFields(sampleResult);
+        long timestamp = sampleResult.getTimeStamp();
+
+        influxDBMetricsManager.addMetric(measurement, tags, fields, timestamp);
+    }
+
+    private String createTags(SampleResult sampleResult) {
+        boolean isError = sampleResult.getErrorCount() != 0;
+        String status = isError ? TAG_KO : TAG_OK;
+        // remove surrounding quotes and spaces from sample label
+        String label = StringUtils.strip(sampleResult.getSampleLabel(), "\" ");
+        String transaction = AbstractInfluxdbMetricsSender.tagToStringValue(label);
+        return "status=" + status
+                + ",transaction=" + transaction;
+    }
+
+    private String createFields(SampleResult sampleResult) {
+        long duration = sampleResult.getTime();
+        long latency = sampleResult.getLatency();
+        long connectTime = sampleResult.getConnectTime();
+        return "duration=" + duration
+                + ",ttfb=" + latency
+                + ",connectTime=" + connectTime;
+    }
+
+    @Override
+    public Arguments getDefaultParameters() {
+        Arguments arguments = new Arguments();
+        DEFAULT_ARGS.forEach(arguments::addArgument);
+        return arguments;
+    }
+}

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -44,8 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implementation of {@link AbstractBackendListenerClient} to write in an InfluxDB using
- * custom schema; since JMeter 5.2, this also support the InfluxDB v2.
+ * Implementation of {@link AbstractBackendListenerClient} to write to InfluxDB
+ * using a custom schema; since JMeter 5.2, this also support the InfluxDB v2.
  *
  * @since 3.2
  */

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -414,7 +414,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         addAnnotation(false);
 
         // Send last set of data before ending
-        log.info("Sending last metrics");
+        log.info("Sending last metrics to InfluxDB");
         sendMetrics();
 
         influxdbMetricsManager.destroy();
@@ -424,10 +424,10 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
     /**
      * Add Annotation at start or end of the run ( useful with Grafana )
      * Grafana will let you send HTML in the "Text" such as a link to the release notes
-     * Tags are separated by spaces in grafana
+     * Tags are separated by spaces in Grafana
      * Tags is put as InfluxdbTag for better query performance on it
-     * Never double or single quotes in influxdb except for string field
-     * see : https://docs.influxdata.com/influxdb/v1.1/write_protocols/line_protocol_reference/#quoting-special-characters-and-additional-naming-guidelines
+     * Never double or single quotes in InfluxDB except for string field
+     * see : https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_reference/#quoting-special-characters-and-additional-naming-guidelines
      *
      * @param isStartOfTest boolean true for start, false for end
      */

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbMetricsSender.java
@@ -19,8 +19,8 @@ package org.apache.jmeter.visualizers.backend.influxdb;
 
 /**
  * InfluxDB Sender interface
- * @since 3.2
  *
+ * @since 3.2
  */
 interface InfluxdbMetricsSender {
 
@@ -42,14 +42,22 @@ interface InfluxdbMetricsSender {
     }
 
     /**
-     * @param measurement name of the influxdb measurement
-     * @param tag tag set for influxdb
-     * @param field field set for influxdb
+     * @param measurement name of the InfluxDB measurement
+     * @param tag         tag set for InfluxDB (N.B. Needs to start with a comma)
+     * @param field       field set for InfluxDB
      */
     public void addMetric(String measurement, String tag, String field);
 
     /**
-     * Write metrics to Influxdb with HTTP API with InfluxDB's Line Protocol
+     * @param measurement name of the InfluxDB measurement
+     * @param tag         tag set for InfluxDB (N.B. Needs to start with a comma)
+     * @param field       field set for InfluxDB
+     * @param timestamp   timestamp for InfluxDB
+     */
+    public void addMetric(String measurement, String tag, String field, long timestamp);
+
+    /**
+     * Write metrics to InfluxDB with HTTP API with InfluxDB's Line Protocol
      */
     public void writeAndSendMetrics();
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbMetricsSender.java
@@ -63,8 +63,9 @@ interface InfluxdbMetricsSender {
 
     /**
      * Setup sender using influxDBUrl
-     * @param influxDBUrl url pointing to influxdb
-     * @param influxDBToken authorization token to influxdb 2.0
+     *
+     * @param influxDBUrl   url pointing to InfluxDB
+     * @param influxDBToken authorization token to InfluxDB 2.0
      * @throws Exception when setup fails
      */
     public void setup(String influxDBUrl, String influxDBToken) throws Exception; // NOSONAR

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/UdpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/UdpMetricsSender.java
@@ -72,9 +72,14 @@ class UdpMetricsSender extends AbstractInfluxdbMetricsSender {
     }
 
     @Override
-    public void addMetric(String mesurement, String tag, String field) {
+    public void addMetric(String measurement, String tag, String field) {
+        addMetric(measurement, tag, field, System.currentTimeMillis());
+    }
+
+    @Override
+    public void addMetric(String measurement, String tag, String field, long timestamp) {
         synchronized (lock) {
-            metrics.add(new MetricTuple(mesurement, tag, field, System.currentTimeMillis()));
+            metrics.add(new MetricTuple(measurement, tag, field, timestamp));
         }
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/UdpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/UdpMetricsSender.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Influxdb sender base on The Line Protocol. <br>
+ * InfluxDB sender base on The Line Protocol. <br>
  * The Line Protocol is a text based format for writing points to InfluxDB. <br>
  * Syntax : <br>
  * <code>
@@ -39,9 +39,9 @@ import org.slf4j.LoggerFactory;
  * </code><br>
  * Each line, separated by the newline character, represents a single point in InfluxDB.<br>
  * Line Protocol is whitespace sensitive.
- *
  */
 class UdpMetricsSender extends AbstractInfluxdbMetricsSender {
+
     private static final Logger log = LoggerFactory.getLogger(UdpMetricsSender.class);
 
     private final Object lock = new Object();
@@ -64,10 +64,12 @@ class UdpMetricsSender extends AbstractInfluxdbMetricsSender {
                 hostAddress = InetAddress.getByName(urlComponents[0]);
                 udpPort = Integer.parseInt(urlComponents[1]);
             } else {
-                throw new IllegalArgumentException("Influxdb url '"+influxdbUrl+"' is wrong. The format shoule be <host/ip>:<port>");
+                throw new IllegalArgumentException(
+                        "InfluxDB url '"+influxdbUrl+"' is wrong. The format should be <host/ip>:<port>");
             }
         } catch (Exception e) {
-            throw new IllegalArgumentException("Influxdb url '"+influxdbUrl+"' is wrong. The format shoule be <host/ip>:<port>", e);
+            throw new IllegalArgumentException(
+                    "InfluxDB url '"+influxdbUrl+"' is wrong. The format should be <host/ip>:<port>", e);
         }
     }
 

--- a/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClientSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClientSpec.groovy
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.visualizers.backend.influxdb
+
+import org.apache.jmeter.samplers.SampleResult
+import org.apache.jmeter.visualizers.backend.BackendListenerContext
+
+import spock.lang.Specification
+
+class InfluxDBRawBackendListenerClientSpec extends Specification {
+
+    def sut = new InfluxDBRawBackendListenerClient()
+    def defaultContext = new BackendListenerContext(sut.getDefaultParameters())
+
+    def createOkSample() {
+        def now = System.currentTimeMillis()
+        def okSample = SampleResult.createTestSample(now - 100, now)
+        okSample.setLatency(42)
+        okSample.setConnectTime(7)
+        okSample.setSampleLabel("myLabel")
+        okSample.setResponseOK()
+        return okSample
+    }
+
+    def "Default parameters contain minimum required options"() {
+        expect:
+            sut.getDefaultParameters()
+                    .getArgumentsAsMap()
+                    .keySet()
+                    .containsAll([
+                            "influxdbMetricsSender", "influxdbUrl",
+                            "influxdbToken", "measurement"])
+    }
+
+    def "Provided args are used during setup"() {
+        when:
+            sut.setupTest(defaultContext)
+        then:
+            sut.measurement == sut.DEFAULT_MEASUREMENT
+            sut.influxDBMetricsManager.class.isAssignableFrom(HttpMetricsSender.class)
+    }
+
+    def "OK sample data is mapped correctly to InfluxDB tags and fields"() {
+        given:
+            def okSample = createOkSample()
+        when:
+            def tags = sut.createTags(okSample)
+            def fields = sut.createFields(okSample)
+        then:
+            tags == "status=ok,transaction=myLabel"
+            fields == "duration=100,ttfb=42,connectTime=7"
+    }
+
+    def "Failed sample data is mapped correctly to InfluxDB tags and fields"() {
+        given:
+            def koSample = new SampleResult()
+            koSample.setSampleLabel("myLabel")
+        expect:
+            sut.createTags(koSample) == "status=ko,transaction=myLabel"
+    }
+
+    def "Upon handling sample result data is added to influxDBMetricsManager and written"() {
+        given:
+            def mockSender = Mock(InfluxdbMetricsSender)
+            def sut = new InfluxDBRawBackendListenerClient(mockSender)
+        when:
+            sut.handleSampleResults([createOkSample()], defaultContext)
+        then:
+            1 * mockSender.addMetric(_, _, _, _)
+            1 * mockSender.writeAndSendMetrics()
+    }
+
+    def "teardownTest calls destroy on influxDBMetricsManager"() {
+        given:
+            def mockSender = Mock(InfluxdbMetricsSender)
+            def sut = new InfluxDBRawBackendListenerClient(mockSender)
+        when:
+            sut.teardownTest()
+        then:
+            1 * mockSender.destroy()
+    }
+}

--- a/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClientSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClientSpec.groovy
@@ -28,8 +28,8 @@ class InfluxDBRawBackendListenerClientSpec extends Specification {
     def defaultContext = new BackendListenerContext(sut.getDefaultParameters())
 
     def createOkSample() {
-        def now = System.currentTimeMillis()
-        def okSample = SampleResult.createTestSample(now - 100, now)
+        def t = 1600123456789
+        def okSample = SampleResult.createTestSample(t - 100, t)
         okSample.setLatency(42)
         okSample.setConnectTime(7)
         okSample.setSampleLabel("myLabel")

--- a/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClientSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClientSpec.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 class InfluxdbBackendListenerClientSpec extends Specification {
 
     def sut = new InfluxdbBackendListenerClient()
-    def defaultContext = new BackendListenerContext(InfluxdbBackendListenerClient.DEFAULT_ARGS)
+    def defaultContext = new BackendListenerContext(sut.getDefaultParameters())
 
     def "setupTest with default config does not raise an exception"() {
         when:

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -3444,8 +3444,7 @@ By default, a Graphite implementation is provided.
  <property name="Parameters" required="Yes">Parameters of the <code>BackendListenerClient</code> implementation.</property>
  </properties>
 
-
-     <p>The following parameters apply to the <apilink href="org/apache/jmeter/visualizers/backend/graphite/GraphiteBackendListenerClient.html">GraphiteBackendListenerClient</apilink> implementation:</p>
+    <p>The following parameters apply to the <apilink href="org/apache/jmeter/visualizers/backend/graphite/GraphiteBackendListenerClient.html">GraphiteBackendListenerClient</apilink> implementation:</p>
 
     <properties>
         <property name="graphiteMetricsSender" required="Yes"><code>org.apache.jmeter.visualizers.backend.graphite.TextGraphiteMetricsSender</code> or <code>org.apache.jmeter.visualizers.backend.graphite.PickleGraphiteMetricsSender</code></property>
@@ -3467,8 +3466,11 @@ By default, a Graphite implementation is provided.
     <figure width="1265" height="581" image="grafana_dashboard.png">Grafana dashboard</figure>
 
 
-    <p>Since JMeter 3.2, a new implementation has been added that allows writing directly in InfluxDB with a custom schema, it is called <code>InfluxdbBackendListenerClient</code>. Since JMeter 5.2, <code>InfluxdbBackendListenerClient</code> supports both InfluxDB v1 and v2.</p>
-    <p>The following parameters apply to the <apilink href="org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.html">InfluxdbBackendListenerClient</apilink> implementation:</p>
+    <p>
+        Since JMeter 3.2, an implementation that allows writing directly in InfluxDB with a custom schema.
+        It is called <code>InfluxdbBackendListenerClient</code>. The following parameters apply to the
+        <apilink href="org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.html">InfluxdbBackendListenerClient</apilink> implementation:
+    </p>
 
     <properties>
         <property name="influxdbMetricsSender" required="Yes"><code>org.apache.jmeter.visualizers.backend.influxdb.HttpMetricsSender</code></property>
@@ -3489,6 +3491,26 @@ By default, a Graphite implementation is provided.
     <p>See also <a href="realtime-results.html" >Real-time results</a> and <a href="http://docs.grafana.org/reference/annotations/#influxdb-annotations">Influxdb annotations in Grafana</a> for more details.
         There is also a <a href="realtime-results.html#influxdb_v2">subsection on configuring the listener for InfluxDB v2</a>.
     </p>
+
+    <p>
+      Since JMeter 5.4, an implementation that writes all sample results directly to InfluxDB.
+      It is called <code>InfluxDBRawBackendListenerClient</code>. It is worth noting that this will use more resources
+      than the <code>InfluxdbBackendListenerClient</code> both in JMeter while running a load test and also InfluxDB
+      due to the increase writes and data. The following parameters apply to the
+      <a href="../api/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.html">InfluxDBRawBackendListenerClient</a> implementation:
+    </p>
+
+    <properties>
+      <property name="influxdbMetricsSender" required="Yes"><code>org.apache.jmeter.visualizers.backend.influxdb.HttpMetricsSender</code></property>
+      <property name="influxdbUrl" required="Yes">Influx URL (e.g. http://influxHost:8086/write?db=jmeter)</property>
+      <property name="influxdbToken" required="No">
+        InfluxDB 2 <a href="https://v2.docs.influxdata.com/v2.0/security/">authentication token</a> (e.g. HE9yIdAPzWJDspH_tCc2UvdKZpX==)
+      </property>
+      <property name="measurement" required="Yes">
+        Measurement as per <a href="https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_reference/">Influx Line Protocol Reference</a>.
+        Defaults to "<code>jmeter</code>."
+      </property>
+    </properties>
 </component>
 
 <a href="#">^</a>

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -3493,16 +3493,21 @@ By default, a Graphite implementation is provided.
     </p>
 
     <p>
-      Since JMeter 5.4, an implementation that writes all sample results directly to InfluxDB.
-      It is called <code>InfluxDBRawBackendListenerClient</code>. It is worth noting that this will use more resources
-      than the <code>InfluxdbBackendListenerClient</code> both in JMeter while running a load test and also InfluxDB
-      due to the increase writes and data. The following parameters apply to the
-      <a href="../api/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.html">InfluxDBRawBackendListenerClient</a> implementation:
+      Since JMeter 5.4, an implementation that writes all sample results to InfluxDB.
+      It is called <code>InfluxDBRawBackendListenerClient</code>.
+      It is worth noting that this will use more resources than the
+      <code>InfluxdbBackendListenerClient</code>, both by JMeter and InfluxDB
+      due to the increase in data and individual writes.
+      The following parameters apply to the
+      <a href="../api/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.html">InfluxDBRawBackendListenerClient</a>
+      implementation:
     </p>
 
     <properties>
       <property name="influxdbMetricsSender" required="Yes"><code>org.apache.jmeter.visualizers.backend.influxdb.HttpMetricsSender</code></property>
-      <property name="influxdbUrl" required="Yes">Influx URL (e.g. http://influxHost:8086/write?db=jmeter)</property>
+      <property name="influxdbUrl" required="Yes">
+        Influx URL (e.g. http://influxHost:8086/write?db=jmeter or, for the cloud, https://eu-central-1-1.aws.cloud2.influxdata.com/api/v2/write?org=org-id&amp;bucket=jmeter)
+      </property>
       <property name="influxdbToken" required="No">
         InfluxDB 2 <a href="https://v2.docs.influxdata.com/v2.0/security/">authentication token</a> (e.g. HE9yIdAPzWJDspH_tCc2UvdKZpX==)
       </property>

--- a/xdocs/usermanual/realtime-results.xml
+++ b/xdocs/usermanual/realtime-results.xml
@@ -124,7 +124,7 @@ In this document we will present the configuration setup to graph and historize 
     i.e. the 3 percentiles 90%, 95% and 99%.
     </p>
     <p>
-    The <a href="http://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy">Graphite naming hierarchy</a>
+    The <a href="https://graphite.readthedocs.io/en/latest/feeding-carbon.html#step-1-plan-a-naming-hierarchy">Graphite naming hierarchy</a>
     uses dot (".") to separate elements. This could be confused with decimal percentile values.
     JMeter converts any such values, replacing dot (".") with underscore ("-").
     For example, "<code>99.9</code>" becomes "<code>99_9</code>"
@@ -179,8 +179,8 @@ InfluxDB data can be easily viewed in a browser through <a href="http://grafana.
 <subsection name="&sect-num;.4 Grafana configuration" anchor="grafana_configuration">
     <p>
     Installing grafana<br/>
-    Read <a href="http://docs.grafana.org/" target="_blank">documentation</a> for more details.
-    Add the <a href="http://docs.grafana.org/features/datasources/influxdb/" target="_blank">datasource</a><br/>
+    Read <a href="https://docs.grafana.org/" target="_blank">documentation</a> for more details.
+    Add the <a href="https://docs.grafana.org/features/datasources/influxdb/" target="_blank">datasource</a><br/>
     </p>
     Here is the kind of dashboard that you could obtain:
     <figure width="1265" height="581" image="grafana_dashboard.png">Grafana dashboard</figure>
@@ -189,7 +189,6 @@ InfluxDB data can be easily viewed in a browser through <a href="http://grafana.
 <subsection name="&sect-num;.5 Graphite" anchor="graphite">
 <p>HELP WELCOME for this section, see <a href="../building.html" >Contributing documentation</a></p>
 </subsection>
-
 
 </section>
 

--- a/xdocs/usermanual/realtime-results.xml
+++ b/xdocs/usermanual/realtime-results.xml
@@ -149,6 +149,8 @@ In this document we will present the configuration setup to graph and historize 
         <li>For InfluxDB 2 setup, create a <code>jmeter</code> <a href="https://v2.docs.influxdata.com/v2.0/organizations/buckets/create-bucket/" target="_blank">bucket</a></li>
         <li>For InfluxDB 1.x setup, create a <code>jmeter</code> database using the <a href="https://docs.influxdata.com/influxdb/v1.8/introduction/get-started/" target="_blank">Influx CLI</a></li>
     </ul>
+    You can also use the HTTP API i.e.
+        <code>curl -i -XPOST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE jmeter"</code>
     </p>
 
 <subsection name="&sect-num;.3.1 InfluxDB setup for InfluxDBBackendListenerClient" anchor="influxdb">


### PR DESCRIPTION
## Description

Add `BackendListener` that sends "raw" results to InfluxDB.
Instead of summarised statistics this listener sends the raw results for each sample to InfluxDB.

In its current form it sends connect time, ttfb (latency) and duration.
Are there other metrics that would be essential to send?

Added extra method to `InfluxdbMetricsSender`: `public void addMetric(String measurement, String tag, String field, long timestamp)`.

This is a draft PR to start a discussion about what more needs to be done or could be done before including.

## Motivation and Context

As can be seen from the below graphs, in a low TPS situation the current InfluxDB listener has a misleading max value and you lose a lot of detail with avg etc.

![Grafana-JMeter-InfluxDB-Listeners-low-tps](https://user-images.githubusercontent.com/3393038/68526774-3ba33f80-02d7-11ea-8dd2-8240aa7f1a53.png)

In a slightly higher TPS test you can see that the time is slightly off (due to the listener using `System.currentTimeMillis()` instead of the sample end (or start) time) and also interesting details are lost due to the summary nature of the listener.

![Grafana-JMeter-InfluxDB-Listeners](https://user-images.githubusercontent.com/3393038/68526814-963c9b80-02d7-11ea-8393-3c3691d597c3.png)

## How Has This Been Tested?
Tested with a few simple test plans against a local InxlufDB and Grafana, and also the Influx cloud 2.0.0.

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
