### PR TITLE
Add Travis CI job to test JMeter with IBM s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
   allow_failures:
     # j-m-p does not seem to download all the dependencies: https://github.com/jmeter-maven-plugin/jmeter-maven-plugin/issues/187
     - name: jmeter-maven-plugin tests
+    - name: jmeter-maven-plugin tests on s390x
   include:
     - name: Tests with OpenJDK 8 + code coverage
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,20 @@ matrix:
         # This job verifies headless mode to ensure Apache JMeter is workable in headless as well
         # Spotless and Checksyle are skipped here to save some time. They are verified anyway in Java 8 and Java 13 builds, so skipping them for Java 11 does not harm
         - ./gradlew build -Djava.awt.headless=true -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
+    - name: Tests with OpenJDK 11 on s390x 
+      os: linux  
+      arch: s390x  
+      dist: bionic 
+      jdk: openjdk11 
+      addons: 
+        apt: 
+          packages: 
+            - language-pack-fr 
+      script: 
+        - sudo apt-get install -y openjdk-11-jdk  
+        - export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-s390x/  
+        - export PATH=$JAVA_HOME/bin:$PATH   
+        - ./gradlew build -Djava.awt.headless=true -PskipCheckstyle -PskipSpotless $SKIP_TAR
     # Java 12 is not here because it has been superceeded by Java 13
     # Tests with Java 12 do not surface much new, so Java 11 (LTS) and Java 13 (non-LTS) are enough for "post Java 9" testing
     - name: Tests with OpenJDK 13
@@ -68,4 +82,17 @@ matrix:
         - cd ..
         - git clone --depth 100 https://github.com/jmeter-maven-plugin/jmeter-maven-plugin.git
         - cd jmeter-maven-plugin
+        - mvn verify -Djmeter.version=42.0-SNAPSHOT
+    - name: jmeter-maven-plugin tests on s390x
+      os: linux  
+      arch: s390x  
+      jdk: openjdk8 
+      script: 
+        - wget http://www.eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz  
+        - tar -xvzf apache-maven-3.6.3-bin.tar.gz  
+        - export PATH=`pwd`/apache-maven-3.6.3/bin/:$PATH  
+        - ./gradlew -PskipJavadoc publishToMavenLocal -Pjmeter.version=42.0 -PchecksumIgnore 
+        - cd .. 
+        - git clone --depth 100 https://github.com/jmeter-maven-plugin/jmeter-maven-plugin.git 
+        - cd jmeter-maven-plugin 
         - mvn verify -Djmeter.version=42.0-SNAPSHOT

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
     - name: jmeter-maven-plugin tests on s390x
       os: linux  
       arch: s390x  
-      jdk: openjdk8 
+      jdk: openjdk11 
       script: 
         - wget http://www.eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz  
         - tar -xvzf apache-maven-3.6.3-bin.tar.gz  


### PR DESCRIPTION
## Motivation and Context
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.

## How Has This Been Tested?
Travis job passes

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
