### PR TITLE
Bug 64142 - Use gray icons for disabled elements in the tree

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
@@ -18,8 +18,12 @@
 package org.apache.jmeter.gui.action;
 
 import java.awt.event.ActionEvent;
+import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.swing.tree.TreeNode;
 
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
@@ -50,12 +54,15 @@ public class EnableComponent extends AbstractAction {
         if (e.getActionCommand().equals(ActionNames.ENABLE)) {
             log.debug("enabling currently selected gui objects");
             enableComponents(nodes, true);
+            triggerChildrenRender(nodes);
         } else if (e.getActionCommand().equals(ActionNames.DISABLE)) {
             log.debug("disabling currently selected gui objects");
             enableComponents(nodes, false);
+            triggerChildrenRender(nodes);
         } else if (e.getActionCommand().equals(ActionNames.TOGGLE)) {
             log.debug("toggling currently selected gui objects");
             toggleComponents(nodes);
+            triggerChildrenRender(nodes);
         }
     }
 
@@ -73,6 +80,24 @@ public class EnableComponent extends AbstractAction {
             boolean enable = !node.isEnabled();
             node.setEnabled(enable);
             pack.getGui(node.getTestElement()).setEnabled(enable);
+        }
+    }
+
+    private void triggerChildrenRender(JMeterTreeNode[] nodes) {
+        Set<TreeNode> visited = new HashSet<>();
+        ArrayDeque<TreeNode> queue = new ArrayDeque<>(Arrays.asList(nodes));
+        while (!queue.isEmpty()) {
+            final TreeNode next = queue.poll();
+            if (!visited.add(next)) {
+                continue;
+            }
+            if (next instanceof JMeterTreeNode) {
+                // Trigger render
+                ((JMeterTreeNode) next).nameChanged();
+            }
+            for (int i = 0; i < next.getChildCount(); i++) {
+                queue.add(next.getChildAt(i));
+            }
         }
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
@@ -25,6 +25,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JTree;
 import javax.swing.border.Border;
 import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JOrphanUtils;
@@ -52,6 +53,13 @@ public class JMeterCellRenderer extends DefaultTreeCellRenderer {
                 JOrphanUtils.isBlank(node.getName()) ? BLANK : node.getName(),
                         sel, expanded, leaf, row, p_hasFocus);
         boolean enabled = node.isEnabled();
+        // Even in case the node itself is not disabled, we render it as disabled if
+        // one of its parents is in fact disabled.
+        for (TreeNode parent = node.getParent(); parent != null && enabled; parent = parent.getParent()) {
+            if (parent instanceof JMeterTreeNode) {
+                enabled = ((JMeterTreeNode) parent).isEnabled();
+            }
+        }
         ImageIcon ic = node.getIcon(enabled);
         if (ic != null) {
             if (enabled) {

--- a/src/core/src/main/java/org/apache/jmeter/plugin/PluginManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/plugin/PluginManager.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.plugin;
 
 import java.net.URL;
 
+import javax.swing.GrayFilter;
 import javax.swing.ImageIcon;
 
 import org.apache.jmeter.gui.GUIFactory;
@@ -57,14 +58,24 @@ public final class PluginManager {
             if (resource == null) {
                 log.warn("Can't find icon for {} - {}", icon[0], icon[1]);
             } else {
-                GUIFactory.registerIcon(icon[0], new ImageIcon(resource));
+                final ImageIcon regularIcon = new ImageIcon(resource);
+                GUIFactory.registerIcon(icon[0], regularIcon);
+                ImageIcon disabledIcon = null;
                 if (icon.length > 2 && icon[2] != null) {
                     URL resource2 = classloader.getResource(icon[2].trim());
                     if (resource2 == null) {
                         log.info("Can't find disabled icon for {} - {}", icon[0], icon[2]);
                     } else {
-                        GUIFactory.registerDisabledIcon(icon[0], new ImageIcon(resource2));
+                        disabledIcon = new ImageIcon(resource2);
                     }
+                } else {
+                    // Second icon is not specified, create disabled one automatically
+                    disabledIcon = new ImageIcon(
+                            GrayFilter.createDisabledImage(regularIcon.getImage())
+                    );
+                }
+                if (disabledIcon != null) {
+                    GUIFactory.registerDisabledIcon(icon[0], disabledIcon);
                 }
             }
         }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -120,6 +120,7 @@ to view the last release notes of version 5.2.1.
 <ul>
   <li><bug>63458</bug><pr>551</pr>Add new template "Functional Testing Test Plan [01]". Contributed by Sebastian Boga (sebastian.boga at endava.com)</li>
   <li><bug>64119</bug>Use first renderer from <code>view.results.tree.renderers_order</code> property as default in View Results Tree</li>
+  <li><bug>64148</bug>Use gray icons for disabled elements in the tree, display subtree as gray</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
## Description

a) Automatic generation of gray icons.
b) When an element is disabled, full subtree is rendered in gray. It does not impact execution, however, it makes it easier to understand what is disabled.

## Screenshots (if appropriate):

https://recordit.co/Rz6E81R8hp

<img src="http://g.recordit.co/Rz6E81R8hp.gif">

