### PR TITLE
Add ExecutionMode.SAME_THREAD to JMeterSerialTest to ensure the tests are not executed concurrently

### DIFF
--- a/src/core/src/test/java/org/apache/jorphan/test/JMeterSerialTest.java
+++ b/src/core/src/test/java/org/apache/jorphan/test/JMeterSerialTest.java
@@ -17,9 +17,13 @@
 
 package org.apache.jorphan.test;
 
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 /**
  * Used to tag tests which need to be run on their own (in serial) because
  * either, they cause other tests to fail, or they fail when run in parallel.
  */
+@Execution(ExecutionMode.SAME_THREAD)
 public interface JMeterSerialTest {
 }


### PR DESCRIPTION
See https://github.com/junit-team/junit5/issues/2142