### PR TITLE
Show context menu for the full row, not just for the tree label

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
@@ -17,6 +17,7 @@
 
 package org.apache.jmeter.gui.tree;
 
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -167,12 +168,19 @@ public class JMeterTreeListener implements TreeSelectionListener, MouseListener,
         MainFrame mainFrame = GuiPackage.getInstance().getMainFrame();
         // Close any Main Menu that is open
         mainFrame.closeMenu();
-        int selRow = tree.getRowForLocation(e.getX(), e.getY());
-        if (tree.getPathForLocation(e.getX(), e.getY()) != null) {
-            log.debug("mouse pressed, updating currentPath");
-            currentPath = tree.getPathForLocation(e.getX(), e.getY());
+        TreePath closestPath = tree.getClosestPathForLocation(e.getX(), e.getY());
+        if (closestPath == null) {
+            log.debug("ClosestPathForLocation is not found for x={}, y={}", e.getX(), e.getY());
+            return;
         }
-        if (selRow != -1 && isRightClick(e)) {
+        Rectangle bounds = tree.getPathBounds(closestPath);
+        if (bounds == null || bounds.y > e.getY() || e.getY() > bounds.y + bounds.height) {
+            log.debug("Mouse click was outside of node {}. bounds={}, event.x={}, event.y={}",
+                    closestPath, bounds, e.getX(), e.getY());
+            return;
+        }
+        currentPath = closestPath;
+        if (isRightClick(e)) {
             if (tree.getSelectionCount() < 2) {
                 tree.setSelectionPath(currentPath);
             }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -89,6 +89,7 @@ are gray. It is purely a UI change, and the behavior is not altered.
 <p>Use <keycombo><keysym>CTRL</keysym><keysym>ALT</keysym><keysym>wheel</keysym></keycombo> for zooming
     fonts. Previous shortcut was <keycombo><keysym>CTRL</keysym><keysym>SHIFT</keysym><keysym>wheel</keysym></keycombo>,
     however, it conflicted with horizontal scrolling.</p>
+<p>Tree context menu is shown for the full row, not for the label only</p>
 <!--
 <ch_title>Functions</ch_title>
 -->


### PR DESCRIPTION
This enables to show the menu in case Y coordinate is ok.
Previously JMeter required to click on the label which is not really convenient, especially when the label is small.

<img width="408" alt="Снимок экрана 2020-03-16 в 0 31 44" src="https://user-images.githubusercontent.com/213894/76711053-887fa280-671d-11ea-9596-b1c79b3c8e97.png">
