### PR TITLE
On the fly look and feel updates, change zoom hotkey to ctrl+alt+wheel

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -184,10 +184,15 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
      * @return a JLabel which subclasses can add to their GUI
      */
     protected Component createTitleLabel() {
-        JLabel titleLabel = new JLabel(getStaticLabel());
-        Font curFont = titleLabel.getFont();
-        titleLabel.setFont(curFont.deriveFont((float) curFont.getSize() + 4));
-        return titleLabel;
+        return new JLabel(getStaticLabel()) {
+            @Override
+            public void updateUI() {
+                super.updateUI();
+                // Setting the font in updateUI reduces UI jumps when look and feel changes
+                Font curFont = getFont();
+                setFont(curFont.deriveFont((float) curFont.getSize() + 4));
+            }
+        };
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -232,8 +232,8 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
         initTopLevelDndHandler();
         setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
 
-        int ctrlShiftMask = (IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK) |
-                InputEvent.SHIFT_DOWN_MASK;
+        int ctrlAltMask = (IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK) |
+                InputEvent.ALT_DOWN_MASK;
 
         addMouseWheelListener(e -> {
             if (e.getWheelRotation() == 0) {
@@ -243,7 +243,8 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
                 // See https://github.com/JetBrains/intellij-community/blob/21c99af7c78fc82aefc4d05646389f4991b08b38/bin/idea.properties#L133-L156
                 return;
             }
-            if ((e.getModifiersEx() & ctrlShiftMask) == ctrlShiftMask) {
+            // Shift down means "horizontal scrolling" on macOS, and we need only vertical one
+            if ((e.getModifiersEx() & (ctrlAltMask | InputEvent.SHIFT_DOWN_MASK)) == ctrlAltMask) {
                 final float scale = 1.1f;
                 int rotation = e.getWheelRotation();
                 if (rotation > 0) { // DOWN

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/LookAndFeelCommand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/LookAndFeelCommand.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.prefs.Preferences;
 
-import javax.swing.JOptionPane;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
@@ -212,6 +211,7 @@ public class LookAndFeelCommand extends AbstractAction {
             } else {
                 UIManager.setLookAndFeel(className);
                 UIManager.put("Button.defaultButtonFollowsFocus", false);
+                LafManager.updateLaf();
             }
             PREFS.put(USER_PREFS_KEY, item.command);
         } catch (UnsupportedLookAndFeelException
@@ -230,14 +230,7 @@ public class LookAndFeelCommand extends AbstractAction {
     public void doAction(ActionEvent ev) {
         try {
             activateLookAndFeel(ev.getActionCommand());
-            JMeterUtils.refreshUI();
-            int chosenOption = JOptionPane.showConfirmDialog(GuiPackage.getInstance().getMainFrame(), JMeterUtils
-                    .getResString("laf_quit_after_change"), // $NON-NLS-1$
-                    JMeterUtils.getResString("exit"), // $NON-NLS-1$
-                    JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
-            if (chosenOption == JOptionPane.YES_OPTION) {
-                ActionRouter.getInstance().doActionNow(new ActionEvent(ev.getSource(), ev.getID(), ActionNames.RESTART));
-            }
+            GuiPackage.getInstance().invalidateCachedUi();
         } catch (IllegalArgumentException e) {
             JMeterUtils.reportErrorToUser(e.getMessage(), e);
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
@@ -39,6 +39,8 @@ import org.apache.jmeter.util.LocaleChangeListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.weisj.darklaf.ui.button.DarkButtonUI;
+
 /**
  * The JMeter main toolbar class
  *
@@ -126,7 +128,18 @@ public class JMeterToolBar extends JToolBar implements LocaleChangeListener {
         if (imageURL == null) {
             throw new Exception("No icon for: " + iconBean.getActionName());
         }
-        JButton button = new JButton(new ImageIcon(imageURL));
+        JButton button = new JButton(new ImageIcon(imageURL)) {
+            @Override
+            public void updateUI() {
+                super.updateUI();
+                // Certain LaFs might alter button configuration, so we revert it to the way we want
+                // For instance, https://github.com/weisJ/darklaf/issues/84
+                setFocusable(false);
+                setRolloverEnabled(true);
+                putClientProperty(DarkButtonUI.KEY_VARIANT, DarkButtonUI.VARIANT_SHADOW);
+                putClientProperty(DarkButtonUI.KEY_THIN, true);
+            }
+        };
         button.setToolTipText(JMeterUtils.getResString(iconBean.getI18nKey()));
         final URL imageURLPressed = JMeterUtils.class.getClassLoader().getResource(iconBean.getIconPathPressed());
         button.setPressedIcon(new ImageIcon(imageURLPressed));

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -18,11 +18,8 @@
 package org.apache.jmeter.util;
 
 import java.awt.Component;
-import java.awt.Dialog;
 import java.awt.Font;
-import java.awt.Frame;
 import java.awt.HeadlessException;
-import java.awt.Window;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -73,6 +70,7 @@ import org.apache.oro.text.regex.Perl5Matcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.weisj.darklaf.LafManager;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.security.AnyTypePermission;
 import com.thoughtworks.xstream.security.NoTypePermission;
@@ -1267,15 +1265,7 @@ public class JMeterUtils implements UnitTestManager {
      * Refresh UI after LAF change or resizing
      */
     public static final void refreshUI() {
-        for (Window w : Window.getWindows()) {
-            SwingUtilities.updateComponentTreeUI(w);
-            if (w.isDisplayable() &&
-                (w instanceof Frame ? !((Frame)w).isResizable() :
-                w instanceof Dialog ? !((Dialog)w).isResizable() :
-                true)) {
-                w.pack();
-            }
-        }
+        LafManager.updateLaf();
     }
 
     /**

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -83,6 +83,8 @@ are gray. It is purely a UI change, and the behavior is not altered.
 
 <p>Tree context menu is shown even in case the node selection is changed. Previously
     the popup did disappear and it was required to select a node first and only then launch popup.</p>
+
+<p>Update look and feel without restart</p>
 <!--
 <ch_title>Functions</ch_title>
 -->

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -85,6 +85,10 @@ are gray. It is purely a UI change, and the behavior is not altered.
     the popup did disappear and it was required to select a node first and only then launch popup.</p>
 
 <p>Update look and feel without restart</p>
+
+<p>Use <keycombo><keysym>CTRL</keysym><keysym>ALT</keysym><keysym>wheel</keysym></keycombo> for zooming
+    fonts. Previous shortcut was <keycombo><keysym>CTRL</keysym><keysym>SHIFT</keysym><keysym>wheel</keysym></keycombo>,
+    however, it conflicted with horizontal scrolling.</p>
 <!--
 <ch_title>Functions</ch_title>
 -->


### PR DESCRIPTION
## Description

Look and feel can now be updated without JMeter restart.

## Motivation and Context

Having to restart is really painful.

## How Has This Been Tested?

Works on my macOS machine :)

Here's how it looks like. All the themes can be switched without a restart.


intellij:
<img width="1152" alt="intellij" src="https://user-images.githubusercontent.com/213894/76844869-0394a600-684f-11ea-9999-96f07fa1697b.png">

darcula:
<img width="1152" alt="darcula" src="https://user-images.githubusercontent.com/213894/76844904-127b5880-684f-11ea-9299-9dd32935b374.png">

solarized dark:
<img width="1152" alt="solarized dark" src="https://user-images.githubusercontent.com/213894/76844930-17d8a300-684f-11ea-8476-c09b0a029933.png">

nimbus:
<img width="1152" alt="nimbus" src="https://user-images.githubusercontent.com/213894/76844945-1dce8400-684f-11ea-88bc-a136fd4249c7.png">

metal:
<img width="1152" alt="metal" src="https://user-images.githubusercontent.com/213894/76844958-23c46500-684f-11ea-8ba7-dc9276b5cf4d.png">
