### PR TITLE
Improve toolbar border

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -56,7 +56,6 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.DropMode;
 import javax.swing.ImageIcon;
 import javax.swing.InputMap;
@@ -585,12 +584,11 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
      * @return a panel containing the running indicator
      */
     private Component createToolBar() {
-        Box toolPanel = new Box(BoxLayout.X_AXIS);
+        JMeterToolBar toolPanel = JMeterToolBar.createToolbar(true);
         // add the toolbar
-        this.toolbar = JMeterToolBar.createToolbar(true);
+        this.toolbar = toolPanel;
         GuiPackage guiInstance = GuiPackage.getInstance();
         guiInstance.setMainToolbar(toolbar);
-        toolPanel.add(toolbar);
 
         toolPanel.add(Box.createRigidArea(new Dimension(5, 15)));
         toolPanel.add(Box.createGlue());


### PR DESCRIPTION
## Description
Change the container of the toolbar from `Box` to `JToolBar` and use an empty border for the toolbar itself.

## Motivation and Context
1. Generally toolbars are placed in a component that uses `BorderLayout`. When doing so it gives the LaF more context on how to paint the toolbar.
2. With the toolbar being placed in a `Box` container the toolbar only paints it border along the space it consumes resulting in an odd visual e.g.

    - On Metal the background is different midway through the topbar (zoom in to see it).
      ![metal_before](https://user-images.githubusercontent.com/31143295/77070769-1e9c1d00-69eb-11ea-8d6f-3a4a94033238.png)

    - On Nimbus the border stops midway.
       ![nimbus_before](https://user-images.githubusercontent.com/31143295/77070782-2956b200-69eb-11ea-828b-8fded0815114.png)


3. `JToolBar` uses the exact same layoutmanager as `Box` resulting in the same layout as before.
4. By giving the actual toolbar portion an `EmptyBorder` doubly painted borders are avoided.

## How Has This Been Tested?
Layout has not been affected. See screenshots

## Screenshots (if appropriate):
IntelliJ (Looks the same on the other darklaf themes):
![intellij](https://user-images.githubusercontent.com/31143295/77070366-62425700-69ea-11ea-8ffb-8ab11cdf3964.png)

Motif:
![motif](https://user-images.githubusercontent.com/31143295/77070400-70907300-69ea-11ea-9c58-29b4c443e526.png)

Metal:
![metal](https://user-images.githubusercontent.com/31143295/77070413-79814480-69ea-11ea-8be1-98cc30e17eb4.png)

Nimbus:
![nimbus](https://user-images.githubusercontent.com/31143295/77070421-7be39e80-69ea-11ea-9798-0a894d8e1e91.png)

Windows:
![windows](https://user-images.githubusercontent.com/31143295/77070425-7ede8f00-69ea-11ea-9fbf-27565743d2a7.png)

Windows Classic:
![windows_classic](https://user-images.githubusercontent.com/31143295/77070432-8140e900-69ea-11ea-932a-53d79cc44d08.png)

## Types of changes
- Visual improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] ~~I have updated the documentation accordingly.~~ Not needed.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
