### PR TITLE
Remove etched borders.

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/DurationAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/DurationAssertionGui.java
@@ -104,8 +104,7 @@ public class DurationAssertionGui extends AbstractAssertionGui {
 
         // USER_INPUT
         VerticalPanel durationPanel = new VerticalPanel();
-        durationPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
-                getDurationAttributesTitle()));
+        durationPanel.setBorder(BorderFactory.createTitledBorder(getDurationAttributesTitle()));
 
         JPanel labelPanel = new JPanel(new BorderLayout(5, 0));
         JLabel durationLabel =

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/HTMLAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/HTMLAssertionGui.java
@@ -207,7 +207,7 @@ public class HTMLAssertionGui extends AbstractAssertionGui implements KeyListene
 
         // USER_INPUT
         VerticalPanel assertionPanel = new VerticalPanel();
-        assertionPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Tidy Settings"));
+        assertionPanel.setBorder(BorderFactory.createTitledBorder("Tidy Settings"));
 
         // doctype
         HorizontalPanel docTypePanel = new HorizontalPanel();
@@ -218,7 +218,7 @@ public class HTMLAssertionGui extends AbstractAssertionGui implements KeyListene
 
         // format (HTML, XHTML, XML)
         VerticalPanel formatPanel = new VerticalPanel();
-        formatPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Format"));
+        formatPanel.setBorder(BorderFactory.createTitledBorder("Format"));
         htmlRadioButton = new JRadioButton("HTML", true); //$NON-NLS-1$
         xhtmlRadioButton = new JRadioButton("XHTML", false); //$NON-NLS-1$
         xmlRadioButton = new JRadioButton("XML", false); //$NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
@@ -53,7 +53,7 @@ public class MD5HexAssertionGUI extends AbstractAssertionGui {
 
         // USER_INPUT
         HorizontalPanel md5HexPanel = new HorizontalPanel();
-        md5HexPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        md5HexPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("md5hex_assertion_md5hex_test"))); // $NON-NLS-1$
 
         md5HexPanel.add(new JLabel(JMeterUtils.getResString("md5hex_assertion_label"))); //$NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/SizeAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/SizeAssertionGui.java
@@ -222,7 +222,7 @@ public class SizeAssertionGui extends AbstractAssertionGui implements ActionList
 
         // USER_INPUT
         JPanel sizePanel = new JPanel();
-        sizePanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        sizePanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("size_assertion_size_test"))); //$NON-NLS-1$
 
         sizePanel.add(new JLabel(JMeterUtils.getResString("size_assertion_label"))); //$NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLConfPanel.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLConfPanel.java
@@ -62,14 +62,14 @@ public class XMLConfPanel extends JPanel {
         tolerant.addActionListener(e -> tolerant());
         downloadDTDs = new JCheckBox(JMeterUtils.getResString("xml_download_dtds")); //$NON-NLS-1$
         Box tidyOptions = Box.createHorizontalBox();
-        tidyOptions.setBorder(BorderFactory.createEtchedBorder());
+        tidyOptions.setBorder(BorderFactory.createTitledBorder(""));
         tidyOptions.add(tolerant);
         tidyOptions.add(quiet);
         tidyOptions.add(reportErrors);
         tidyOptions.add(showWarnings);
 
         Box untidyOptions = Box.createHorizontalBox();
-        untidyOptions.setBorder(BorderFactory.createEtchedBorder());
+        untidyOptions.setBorder(BorderFactory.createTitledBorder(""));
         untidyOptions.add(namespace);
         untidyOptions.add(validate);
         untidyOptions.add(whitespace);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLSchemaAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLSchemaAssertionGUI.java
@@ -120,7 +120,7 @@ public class XMLSchemaAssertionGUI extends AbstractAssertionGui {
 
         // USER_INPUT
         VerticalPanel assertionPanel = new VerticalPanel();
-        assertionPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "XML Schema"));
+        assertionPanel.setBorder(BorderFactory.createTitledBorder("XML Schema"));
 
         // doctype
         HorizontalPanel xmlSchemaPanel = new HorizontalPanel();

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2AssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2AssertionGui.java
@@ -86,8 +86,7 @@ public class XPath2AssertionGui extends AbstractAssertionGui { // $NOSONAR
         // USER_INPUT
         JPanel sizePanel = new JPanel(new BorderLayout());
         sizePanel.setBorder(BorderFactory.createEmptyBorder(0, 10, 10, 10));
-        sizePanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
-                getXPathAttributesTitle()));
+        sizePanel.setBorder(BorderFactory.createTitledBorder(getXPathAttributesTitle()));
         xpath = new XPath2Panel();
         sizePanel.add(xpath);
         add(sizePanel, BorderLayout.CENTER);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPathAssertionGui.java
@@ -84,8 +84,8 @@ public class XPathAssertionGui extends AbstractAssertionGui {
         topBox.add(createScopePanel(true));
 
         xml = new XMLConfPanel();
-        xml.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("xpath_assertion_option"))); //$NON-NLS-1$
+        xml.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("xpath_assertion_option"))); //$NON-NLS-1$
         topBox.add(xml);
 
         add(topBox, BorderLayout.NORTH);
@@ -93,8 +93,7 @@ public class XPathAssertionGui extends AbstractAssertionGui {
         // USER_INPUT
         JPanel sizePanel = new JPanel(new BorderLayout());
         sizePanel.setBorder(BorderFactory.createEmptyBorder(0, 10, 10, 10));
-        sizePanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
-                getXPathAttributesTitle()));
+        sizePanel.setBorder(BorderFactory.createTitledBorder(getXPathAttributesTitle()));
         xpath = new XPathPanel();
         sizePanel.add(xpath);
         add(sizePanel, BorderLayout.CENTER);

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
@@ -126,8 +126,8 @@ public class XPathExtractorGui extends AbstractPostProcessorGui {
         Box box = Box.createVerticalBox();
         box.add(makeTitlePanel());
         box.add(createScopePanel(true, true, true));
-        xml.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("xpath_assertion_option"))); //$NON-NLS-1$
+        xml.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("xpath_assertion_option"))); //$NON-NLS-1$
         box.add(xml);
         box.add(getFragment);
         box.add(makeParameterPanel());

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
@@ -149,7 +149,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
         mainPanel.add(makeTitlePanel());
 
         JPanel attributePane = new VerticalPanel();
-        attributePane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        attributePane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("mailer_title_settings"))); // $NON-NLS-1$
 
         // Settings panes
@@ -179,7 +179,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
 
     private JPanel createMailingSettings() {
         JPanel settingsPane = new JPanel(new BorderLayout());
-        settingsPane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        settingsPane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("mailer_title_message"))); // $NON-NLS-1$
 
         JPanel headerPane = new JPanel(new BorderLayout());
@@ -239,7 +239,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
 
     private JPanel createSmtpSettings() {
         JPanel settingsPane = new JPanel(new BorderLayout());
-        settingsPane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        settingsPane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("mailer_title_smtpserver"))); // $NON-NLS-1$
 
         JPanel hostPane = new JPanel(new BorderLayout());

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -748,7 +748,6 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
     private JPanel createGraphSettingsPane() {
         JPanel settingsPane = new JPanel(new BorderLayout());
         settingsPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("graph_resp_time_settings_pane"))); // $NON-NLS-1$
 
         JPanel intervalPane = new JPanel();
@@ -816,7 +815,7 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         titleFontStyleList.setSelectedIndex(DEFAULT_TITLE_FONT_STYLE);
 
         JPanel titlePane = new JPanel(new BorderLayout());
-        titlePane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        titlePane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("aggregate_graph_title_group"))); // $NON-NLS-1$
         titlePane.add(titleNamePane, BorderLayout.NORTH);
         titlePane.add(titleStylePane, BorderLayout.SOUTH);
@@ -827,7 +826,6 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         JPanel lineStylePane = new JPanel();
         lineStylePane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         lineStylePane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("graph_resp_time_settings_line"))); // $NON-NLS-1$
         lineStylePane.add(GuiUtils.createLabelCombo(JMeterUtils.getResString("graph_resp_time_stroke_width"), //$NON-NLS-1$
                 strokeWidthList));
@@ -842,7 +840,6 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         JPanel dimensionPane = new JPanel();
         dimensionPane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         dimensionPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_dimension"))); // $NON-NLS-1$
 
         dimensionPane.add(dynamicGraphSize);
@@ -865,7 +862,6 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         JPanel xAxisPane = new JPanel();
         xAxisPane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         xAxisPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_xaxis_group"))); // $NON-NLS-1$
         xAxisTimeFormat.setText(DEFAULT_XAXIS_TIME_FORMAT); // $NON-NLS-1$
         xAxisPane.add(xAxisTimeFormat);
@@ -880,7 +876,6 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         JPanel yAxisPane = new JPanel();
         yAxisPane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         yAxisPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_yaxis_group"))); // $NON-NLS-1$
         yAxisPane.add(maxValueYAxisLabel);
         yAxisPane.add(incrScaleYAxis);
@@ -896,7 +891,6 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         JPanel legendPanel = new JPanel();
         legendPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         legendPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_legend"))); // $NON-NLS-1$
 
         legendPanel.add(GuiUtils.createLabelCombo(JMeterUtils.getResString("aggregate_graph_legend_placement"), //$NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -877,7 +877,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         barPane.add(optionsPanel, BorderLayout.SOUTH);
 
         JPanel columnPane = new JPanel(new BorderLayout());
-        columnPane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        columnPane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("aggregate_graph_column_settings"))); // $NON-NLS-1$
         columnPane.add(barPane, BorderLayout.NORTH);
         columnPane.add(Box.createRigidArea(new Dimension(0,3)), BorderLayout.CENTER);
@@ -945,7 +945,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         titleFontStyleList.setSelectedItem(JMeterUtils.getResString("fontstyle.bold"));  // $NON-NLS-1$ // default: bold
 
         JPanel titlePane = new JPanel(new BorderLayout());
-        titlePane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        titlePane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("aggregate_graph_title_group"))); // $NON-NLS-1$
         titlePane.add(titleNamePane, BorderLayout.NORTH);
         titlePane.add(titleStylePane, BorderLayout.SOUTH);
@@ -972,7 +972,6 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         JPanel dimensionPane = new JPanel();
         dimensionPane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         dimensionPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_dimension"))); // $NON-NLS-1$
 
         dimensionPane.add(dynamicGraphSize);
@@ -995,7 +994,6 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         JPanel xAxisPane = new JPanel();
         xAxisPane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         xAxisPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_xaxis_group"))); // $NON-NLS-1$
         xAxisPane.add(maxLengthXAxisLabel);
         return xAxisPane;
@@ -1009,7 +1007,6 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         JPanel yAxisPane = new JPanel();
         yAxisPane.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         yAxisPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_yaxis_group"))); // $NON-NLS-1$
         yAxisPane.add(maxValueYAxisLabel);
         return yAxisPane;
@@ -1023,7 +1020,6 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         JPanel legendPanel = new JPanel();
         legendPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
         legendPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("aggregate_graph_legend"))); // $NON-NLS-1$
 
         legendPanel.add(GuiUtils.createLabelCombo(JMeterUtils.getResString("aggregate_graph_legend_placement"), //$NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/gui/ServerPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/ServerPanel.java
@@ -102,7 +102,7 @@ public class ServerPanel extends JPanel {
         setLayout(new BorderLayout(5, 0));
         // Target server panel
         JPanel webServerPanel = new HorizontalPanel();
-        webServerPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        webServerPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("target_server"))); // $NON-NLS-1$
         final JPanel domainPanel = getDomainPanel();
         final JPanel portPanel = getPortPanel();
@@ -110,7 +110,7 @@ public class ServerPanel extends JPanel {
         webServerPanel.add(portPanel, BorderLayout.EAST);
 
         JPanel timeOut = new HorizontalPanel();
-        timeOut.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        timeOut.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_server_timeout_title"))); // $NON-NLS-1$
         final JPanel connPanel = getConnectTimeOutPanel();
         final JPanel reqPanel = getResponseTimeOutPanel();

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -571,8 +571,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
                 }
                 currentGroup = g;
                 currentPanel = new JPanel(new GridBagLayout());
-                currentPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
-                        groupDisplayName(g)));
+                currentPanel.setBorder(BorderFactory.createTitledBorder(groupDisplayName(g)));
                 cp.weighty = 0.0;
                 y = 0;
             }

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
@@ -181,7 +181,7 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
     private void init() { // WARNING: called from ctor so must not be overridden (i.e. must be private or final)
         // THREAD PROPERTIES
         JPanel threadPropsPanel = new JPanel(new MigLayout("fillx, wrap 2", "[][fill,grow]"));
-        threadPropsPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        threadPropsPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("thread_properties"))); // $NON-NLS-1$
 
         // NUMBER OF THREADS

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -245,7 +245,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
 
     private JPanel getTimeOutPanel() {
         JPanel timeOut = new HorizontalPanel();
-        timeOut.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        timeOut.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_server_timeout_title"))); // $NON-NLS-1$
         final JPanel connPanel = getConnectTimeOutPanel();
         final JPanel reqPanel = getResponseTimeOutPanel();
@@ -299,8 +299,8 @@ public class HttpDefaultsGui extends AbstractConfigGui {
         concurrentPool.setMaximumSize(new Dimension(30, (int) concurrentPool.getPreferredSize().getHeight()));
 
         final JPanel embeddedRsrcPanel = new HorizontalPanel();
-        embeddedRsrcPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("web_testing_retrieve_title"))); // $NON-NLS-1$
+        embeddedRsrcPanel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("web_testing_retrieve_title"))); // $NON-NLS-1$
         embeddedRsrcPanel.add(retrieveEmbeddedResources);
         embeddedRsrcPanel.add(concurrentDwn);
         embeddedRsrcPanel.add(concurrentPool);
@@ -314,8 +314,8 @@ public class HttpDefaultsGui extends AbstractConfigGui {
 
     protected JPanel createSourceAddrPanel() {
         final JPanel sourceAddrPanel = new HorizontalPanel();
-        sourceAddrPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("web_testing_source_ip"))); // $NON-NLS-1$
+        sourceAddrPanel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("web_testing_source_ip"))); // $NON-NLS-1$
 
         sourceIpType.setSelectedIndex(HTTPSamplerBase.SourceType.HOSTNAME.ordinal()); //default: IP/Hostname
         sourceAddrPanel.add(sourceIpType);
@@ -328,8 +328,8 @@ public class HttpDefaultsGui extends AbstractConfigGui {
     protected JPanel createOptionalTasksPanel() {
         // OPTIONAL TASKS
         final JPanel checkBoxPanel = new VerticalPanel();
-        checkBoxPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("optional_tasks"))); // $NON-NLS-1$
+        checkBoxPanel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("optional_tasks"))); // $NON-NLS-1$
 
         // Use MD5
         useMD5 = new JCheckBox(JMeterUtils.getResString("response_save_as_md5")); // $NON-NLS-1$
@@ -365,7 +365,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
      */
     protected final JPanel getImplementationPanel(){
         JPanel implPanel = new HorizontalPanel();
-        implPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        implPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_server_client"))); // $NON-NLS-1$
         implPanel.add(new JLabel(JMeterUtils.getResString("http_implementation"))); // $NON-NLS-1$
         httpImplementation.addItem("");// $NON-NLS-1$
@@ -389,7 +389,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
         proxyLogin.add(getProxyPassPanel());
 
         JPanel proxyServerPanel = new HorizontalPanel();
-        proxyServerPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        proxyServerPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_proxy_server_title"))); // $NON-NLS-1$
         proxyServerPanel.add(proxyServer);
         proxyServerPanel.add(proxyLogin);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
@@ -318,7 +318,7 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
         // WEB REQUEST PANEL
         JPanel webRequestPanel = new JPanel();
         webRequestPanel.setLayout(new BorderLayout());
-        webRequestPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        webRequestPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_request"))); // $NON-NLS-1$
 
         webRequestPanel.add(getPathPanel(), BorderLayout.NORTH);
@@ -340,7 +340,7 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
         domain = new JLabeledTextField(JMeterUtils.getResString("web_server_domain"), 40); // $NON-NLS-1$
 
         JPanel webServerPanel = new HorizontalPanel();
-        webServerPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        webServerPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_server"))); // $NON-NLS-1$
         webServerPanel.add(protocol);
         webServerPanel.add(domain);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpMirrorControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpMirrorControlGui.java
@@ -191,7 +191,7 @@ public class HttpMirrorControlGui extends LogicControllerGui
         mqsLabel.setLabelFor(maxQueueSizeField);
 
         HorizontalPanel panel = new HorizontalPanel();
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("httpmirror_settings"))); // $NON-NLS-1$
 
         panel.add(label);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -200,7 +200,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
 
     private JPanel getTimeOutPanel() {
         JPanel timeOut = new HorizontalPanel();
-        timeOut.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        timeOut.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_server_timeout_title"))); // $NON-NLS-1$
         final JPanel connPanel = getConnectTimeOutPanel();
         final JPanel reqPanel = getResponseTimeOutPanel();
@@ -254,8 +254,8 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         concurrentPool.setMaximumSize(new Dimension(30, (int) concurrentPool.getPreferredSize().getHeight()));
 
         final JPanel embeddedRsrcPanel = new HorizontalPanel();
-        embeddedRsrcPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("web_testing_retrieve_title"))); // $NON-NLS-1$
+        embeddedRsrcPanel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("web_testing_retrieve_title"))); // $NON-NLS-1$
         embeddedRsrcPanel.add(retrieveEmbeddedResources);
         embeddedRsrcPanel.add(concurrentDwn);
         embeddedRsrcPanel.add(concurrentPool);
@@ -274,7 +274,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
      */
     protected final JPanel getImplementationPanel(){
         JPanel implPanel = new HorizontalPanel();
-        implPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        implPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_server_client"))); // $NON-NLS-1$
         implPanel.add(new JLabel(JMeterUtils.getResString("http_implementation"))); // $NON-NLS-1$
         httpImplementation.addItem("");// $NON-NLS-1$
@@ -285,8 +285,8 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
     protected JPanel createOptionalTasksPanel() {
         // OPTIONAL TASKS
         final JPanel checkBoxPanel = new VerticalPanel();
-        checkBoxPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("optional_tasks"))); // $NON-NLS-1$
+        checkBoxPanel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("optional_tasks"))); // $NON-NLS-1$
 
         // Use MD5
         useMD5 = new JCheckBox(JMeterUtils.getResString("response_save_as_md5")); // $NON-NLS-1$
@@ -297,8 +297,8 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
 
     protected JPanel createSourceAddrPanel() {
         final JPanel sourceAddrPanel = new HorizontalPanel();
-        sourceAddrPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("web_testing_source_ip"))); // $NON-NLS-1$
+        sourceAddrPanel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("web_testing_source_ip"))); // $NON-NLS-1$
 
         // Add a new field source ip address (for HC implementations only)
         sourceIpType.setSelectedIndex(HTTPSamplerBase.SourceType.HOSTNAME.ordinal()); //default: IP/Hostname
@@ -375,7 +375,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         proxyLogin.add(getProxyPassPanel());
 
         JPanel proxyServerPanel = new HorizontalPanel();
-        proxyServerPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        proxyServerPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("web_proxy_server_title"))); // $NON-NLS-1$
         proxyServerPanel.add(proxyServer);
         proxyServerPanel.add(proxyLogin);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
@@ -168,7 +168,6 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
 
         JPanel optionsPane = new JPanel();
         optionsPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("auth_manager_options"))); // $NON-NLS-1$
         optionsPane.setLayout(new VerticalLayout(5, VerticalLayout.BOTH));
         clearEachIteration =
@@ -294,7 +293,7 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
         mechanismColumn.setCellEditor(new MechanismCellEditor());
 
         JPanel panel = new JPanel(new BorderLayout(0, 5));
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("auths_stored"))); //$NON-NLS-1$
         panel.add(new JScrollPane(authTable));
         panel.add(createButtonPanel(), BorderLayout.SOUTH);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
@@ -296,7 +296,6 @@ public class CookiePanel extends AbstractConfigGui implements ActionListener {
         northPanel.add(makeTitlePanel());
         JPanel optionsPane = new JPanel();
         optionsPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("cookie_options"))); // $NON-NLS-1$
         optionsPane.setLayout(new VerticalLayout(5, VerticalLayout.BOTH));
         optionsPane.add(clearEachIteration);
@@ -321,8 +320,8 @@ public class CookiePanel extends AbstractConfigGui implements ActionListener {
         JPanel buttonPanel = createButtonPanel();
 
         JPanel panel = new JPanel(new BorderLayout(0, 5));
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("cookies_stored"))); //$NON-NLS-1$
+        panel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("cookies_stored"))); //$NON-NLS-1$
 
         panel.add(GuiUtils.emptyBorder(new JScrollPane(cookieTable)), BorderLayout.CENTER);
         panel.add(buttonPanel, BorderLayout.SOUTH);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -222,7 +222,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         northPanel.setLayout(new VerticalLayout(5, VerticalLayout.BOTH));
         northPanel.add(makeTitlePanel());
         JPanel optionsPane = new JPanel();
-        optionsPane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), OPTIONS)); // $NON-NLS-1$
+        optionsPane.setBorder(BorderFactory.createTitledBorder(OPTIONS)); // $NON-NLS-1$
         optionsPane.setLayout(new VerticalLayout(5, VerticalLayout.BOTH));
         optionsPane.add(clearEachIteration, BorderLayout.WEST);
         optionsPane.add(createChooseResPanel(), BorderLayout.SOUTH);
@@ -248,7 +248,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         dnsServersTable.setPreferredScrollableViewportSize(new Dimension(400, 100));
 
         JPanel panel = new JPanel(new BorderLayout(0, 5));
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("dns_servers"))); // $NON-NLS-1$
         JScrollPane dnsServScrollPane = GuiUtils.emptyBorder(new JScrollPane(dnsServersTable));
         panel.add(dnsServScrollPane, BorderLayout.CENTER);
@@ -265,7 +265,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         dnsHostsTable.setPreferredScrollableViewportSize(new Dimension(400, 100));
 
         JPanel panel = new JPanel(new BorderLayout(0, 5));
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("dns_hosts"))); // $NON-NLS-1$
         JScrollPane dnsHostsScrollPane = GuiUtils.emptyBorder(new JScrollPane(dnsHostsTable));
         panel.add(dnsHostsScrollPane, BorderLayout.CENTER);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
@@ -274,7 +274,7 @@ public class HeaderPanel extends AbstractConfigGui implements ActionListener {
         headerTable.setPreferredScrollableViewportSize(new Dimension(100, 70));
 
         JPanel panel = new JPanel(new BorderLayout(0, 5));
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("headers_stored"))); // $NON-NLS-1$
         panel.add(GuiUtils.emptyBorder(new JScrollPane(headerTable)), BorderLayout.CENTER);
         panel.add(createButtonPanel(), BorderLayout.SOUTH);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -781,7 +781,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         restart.setEnabled(false);
 
         JPanel panel = new JPanel();
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("proxy_general_lifecycle"))); // $NON-NLS-1$
         panel.add(start);
         panel.add(Box.createHorizontalStrut(10));
@@ -837,7 +837,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         gbc.weighty = 1;
 
         JPanel gPane = new JPanel(gridBagLayout);
-        gPane.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        gPane.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("proxy_general_settings"))); // $NON-NLS-1$
         gPane.add(panel, gbc.clone());
         gbc.gridx++;
@@ -864,7 +864,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         regexMatch.setActionCommand(ENABLE_RESTART);
 
         VerticalPanel mainPanel = new VerticalPanel();
-        mainPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        mainPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("proxy_test_plan_content"))); // $NON-NLS-1$
 
         HorizontalPanel nodeCreationPanel = new HorizontalPanel();
@@ -948,7 +948,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         gbc.weightx = 1;
         gbc.weighty = 1;
         JPanel panel = new JPanel(gridBagLayout);
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("proxy_sampler_settings"))); // $NON-NLS-1$
         panel.add(httpSampleNamingMode, gbc.clone());
         gbc.gridx++;
@@ -1073,7 +1073,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         contentTypeExclude.setText(JMeterUtils.getProperty("proxy.content_type_exclude")); // $NON-NLS-1$
 
         HorizontalPanel panel = new HorizontalPanel();
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("proxy_content_type_filter"))); // $NON-NLS-1$
         panel.add(labelInclude);
         panel.add(contentTypeInclude);
@@ -1091,8 +1091,8 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         includeTable.setPreferredScrollableViewportSize(new Dimension(80, 80));
 
         JPanel panel = new JPanel(new BorderLayout());
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("patterns_to_include"))); // $NON-NLS-1$
+        panel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("patterns_to_include"))); // $NON-NLS-1$
 
         panel.add(GuiUtils.emptyBorder(new JScrollPane(includeTable)), BorderLayout.CENTER);
         panel.add(createTableButtonPanel(ADD_INCLUDE, DELETE_INCLUDE, ADD_TO_INCLUDE_FROM_CLIPBOARD, null), BorderLayout.SOUTH);
@@ -1108,8 +1108,8 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         excludeTable.setPreferredScrollableViewportSize(new Dimension(80, 80));
 
         JPanel panel = new JPanel(new BorderLayout());
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("patterns_to_exclude"))); // $NON-NLS-1$
+        panel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("patterns_to_exclude"))); // $NON-NLS-1$
 
         panel.add(GuiUtils.emptyBorder(new JScrollPane(excludeTable)), BorderLayout.CENTER);
         panel.add(createTableButtonPanel(ADD_EXCLUDE, DELETE_EXCLUDE, ADD_TO_EXCLUDE_FROM_CLIPBOARD, ADD_SUGGESTED_EXCLUDES), BorderLayout.SOUTH);
@@ -1119,8 +1119,8 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
 
     private JPanel createNotifyListenersPanel() {
         JPanel panel = new JPanel();
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), JMeterUtils
-                .getResString("notify_child_listeners_fr"))); // $NON-NLS-1$
+        panel.setBorder(BorderFactory.createTitledBorder(
+                JMeterUtils.getResString("notify_child_listeners_fr"))); // $NON-NLS-1$
 
         notifyChildSamplerListenerOfFilteredSamplersCB = new JCheckBox(JMeterUtils.getResString("notify_child_listeners_fr")); // $NON-NLS-1$
         notifyChildSamplerListenerOfFilteredSamplersCB.setSelected(false);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/RecorderDialog.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/RecorderDialog.java
@@ -147,7 +147,7 @@ public class RecorderDialog extends JDialog implements ItemListener, KeyListener
         gbc.weightx = 1;
         gbc.weighty = 1;
         JPanel panel = new JPanel(gridBagLayout);
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("proxy_sampler_settings"))); // $NON-NLS-1$
         panel.add(httpSampleNamingMode, gbc.clone());
         gbc.gridx++;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
@@ -194,7 +194,7 @@ public class JMSPropertiesPanel extends JPanel implements ActionListener {
         mechanismColumn.setCellEditor(new TypeCellEditor());
 
         JPanel panel = new JPanel(new BorderLayout(0, 5));
-        panel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("jms_props"))); //$NON-NLS-1$
         panel.add(GuiUtils.emptyBorder(new JScrollPane(jmsPropertiesTable)));
         panel.add(createButtonPanel(), BorderLayout.SOUTH);

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
@@ -218,7 +218,7 @@ public class JMSSamplerGui extends AbstractSamplerGui {
         add(makeTitlePanel(), BorderLayout.NORTH);
 
         JPanel jmsQueueingPanel = new JPanel(new BorderLayout());
-        jmsQueueingPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        jmsQueueingPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("jms_queueing"))); //$NON-NLS-1$
 
         JPanel qcfPanel = new JPanel(new BorderLayout(5, 0));
@@ -236,11 +236,11 @@ public class JMSSamplerGui extends AbstractSamplerGui {
         jmsQueueingPanel.add(receiveQueuePanel, BorderLayout.SOUTH);
 
         JPanel messagePanel = new JPanel(new BorderLayout());
-        messagePanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        messagePanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("jms_message_title"))); //$NON-NLS-1$
 
         JPanel correlationPanel = new HorizontalPanel();
-        correlationPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        correlationPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("jms_correlation_title"))); //$NON-NLS-1$
 
         useReqMsgIdAsCorrelId = new JCheckBox(JMeterUtils.getResString("jms_use_req_msgid_as_correlid"), false); //$NON-NLS-1$
@@ -291,7 +291,7 @@ public class JMSSamplerGui extends AbstractSamplerGui {
      */
     private JPanel createJNDIPanel() {
         JPanel jndiPanel = new JPanel(new BorderLayout());
-        jndiPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        jndiPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("jms_jndi_props"))); //$NON-NLS-1$
 
         JPanel contextPanel = new JPanel(new BorderLayout(10, 0));

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SecuritySettingsPanel.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SecuritySettingsPanel.java
@@ -79,7 +79,6 @@ public class SecuritySettingsPanel extends JPanel{
     private void init(){ // WARNING: called from ctor so must not be overridden (i.e. must be private or final)
         this.setLayout(new GridBagLayout());
         this.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("smtp_security_settings"))); // $NON-NLS-1$
 
         GridBagConstraints gridBagConstraints = new GridBagConstraints();

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
@@ -584,7 +584,7 @@ public class SmtpPanel extends JPanel {
          * Server Settings
          */
         JPanel panelServerSettings = new VerticalPanel();
-        panelServerSettings.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panelServerSettings.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("smtp_server_settings"))); // $NON-NLS-1$
 
         JPanel panelMailServer = new JPanel(new BorderLayout(5, 0));
@@ -599,7 +599,7 @@ public class SmtpPanel extends JPanel {
         panelServerSettings.add(panelMailServerPort, BorderLayout.SOUTH);
 
         JPanel panelServerTimeoutsSettings = new VerticalPanel();
-        panelServerTimeoutsSettings.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(),
+        panelServerTimeoutsSettings.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("smtp_server_timeouts_settings"))); // $NON-NLS-1$
 
         JPanel panelMailServerConnectionTimeout = new JPanel(new BorderLayout(5, 0));
@@ -625,7 +625,6 @@ public class SmtpPanel extends JPanel {
          */
         JPanel panelMailSettings = new JPanel(new GridBagLayout());
         panelMailSettings.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("smtp_mail_settings"))); // $NON-NLS-1$
 
         gridBagConstraints.gridx = 0;
@@ -677,7 +676,6 @@ public class SmtpPanel extends JPanel {
          */
         JPanel panelAuthSettings = new JPanel(new GridBagLayout());
         panelAuthSettings.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("smtp_auth_settings"))); // $NON-NLS-1$
 
         cbUseAuth.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
@@ -730,7 +728,6 @@ public class SmtpPanel extends JPanel {
          */
         JPanel panelMessageSettings = new JPanel(new GridBagLayout());
         panelMessageSettings.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("smtp_message_settings"))); // $NON-NLS-1$
 
         gridBagConstraints.gridx = 0;
@@ -852,7 +849,6 @@ public class SmtpPanel extends JPanel {
          */
         JPanel panelAdditionalSettings = new JPanel(new GridBagLayout());
         panelAdditionalSettings.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("smtp_additional_settings"))); // $NON-NLS-1$
 
         cbMessageSizeStats.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));

--- a/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
+++ b/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
@@ -164,7 +164,6 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
         panel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("return_code_config_box_title"))); // $NON-NLS-1$
         checkReturnCode = new JCheckBox(JMeterUtils.getResString("check_return_code_title")); // $NON-NLS-1$
         checkReturnCode.addItemListener(this);
@@ -184,7 +183,6 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
         panel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("timeout_config_box_title"))); // $NON-NLS-1$
         timeout = new JLabeledTextField(JMeterUtils.getResString("timeout_title")); // $NON-NLS-1$
         timeout.setSize(timeout.getSize().height, 30);
@@ -206,7 +204,6 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
 
         JPanel panel = new VerticalPanel();
         panel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("command_config_box_title"))); // $NON-NLS-1$
         panel.add(cmdPanel, BorderLayout.NORTH);
         panel.add(makeArgumentsPanel(), BorderLayout.CENTER);
@@ -244,7 +241,6 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
     private JPanel makeStreamsPanel() {
         JPanel stdPane = new JPanel(new BorderLayout());
         stdPane.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEtchedBorder(),
                 JMeterUtils.getResString("command_config_std_streams_title"))); // $NON-NLS-1$
         stdPane.add(stdin, BorderLayout.NORTH);
         stdPane.add(stdout, BorderLayout.CENTER);

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
@@ -219,7 +219,7 @@ public class TCPConfigGui extends AbstractConfigGui {
         reqLabel.setLabelFor(requestData);
 
         JPanel reqDataPanel = new JPanel(new BorderLayout(5, 0));
-        reqDataPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder()));
+        reqDataPanel.setBorder(BorderFactory.createTitledBorder(""));
 
         reqDataPanel.add(reqLabel, BorderLayout.WEST);
         reqDataPanel.add(JTextScrollPane.getInstance(requestData), BorderLayout.CENTER);
@@ -242,7 +242,7 @@ public class TCPConfigGui extends AbstractConfigGui {
         mainPanel.add(serverPanel);
 
         HorizontalPanel optionsPanel = new HorizontalPanel();
-        optionsPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder()));
+        optionsPanel.setBorder(BorderFactory.createTitledBorder(""));
         optionsPanel.add(createClosePortPanel());
         optionsPanel.add(createCloseConnectionPanel());
         optionsPanel.add(createNoDelayPanel());


### PR DESCRIPTION
## Description
Remove the usage of  `BorderFactory#createEtchedBorder`.

## Motivation and Context
Currently `EtchedBorder` is used for almost (but weirdly not all) titled borders.
They are undesirable for multiple reasons:
1. The Laf can't provide a custom etched border. Instead:
2. Etched borders simply use a lighter and darker version of the background colour, which most of the time looks out of place (especially with regards to "newer" design standards).

When using `BorderFactory#createTitledBorder` without specifying the border explicitly the a LaF-provided border is used. Because it can provide a border which looks good together with the rest of the LaF the result looks a lot more consistent.

At the places where simply `BorderFactory#createEtchedBorder` is used it is replaced by `BorderFactory.createLineBorder("")` which simply uses an unmodified version of the border provided by the laf.

## How Has This Been Tested?
See screenshots. Only visuals are updated.

## Screenshots (if appropriate):
All other lafs not shown look the same as before, because they use an `EtchedBorder` by default.

### Before:
#### Metal
![metal_before](https://user-images.githubusercontent.com/31143295/77077058-fe715b80-69f4-11ea-9372-3e305a90eff7.png)

#### Nimbus
![nimbus_before](https://user-images.githubusercontent.com/31143295/77077094-0cbf7780-69f5-11ea-87d6-642e61be1860.png)

#### IntelliJ
![intellij_before](https://user-images.githubusercontent.com/31143295/77077105-0f21d180-69f5-11ea-89d6-64b06f420850.png)

### After:
#### Metal
![metal](https://user-images.githubusercontent.com/31143295/77077357-688a0080-69f5-11ea-9af1-3cd1a79c81c7.png)

#### Nimbus
![nimbus](https://user-images.githubusercontent.com/31143295/77077362-6a53c400-69f5-11ea-8be3-3488076128a0.png)

#### IntelliJ
![intellij](https://user-images.githubusercontent.com/31143295/77077367-6d4eb480-69f5-11ea-9247-9eb09a84fcd7.png)


## Types of changes
- UI improvements.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] ~~I have updated the documentation accordingly.~~ Not needed.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
