### PR TITLE
Improve the startup time: skip test plan UI initialization

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.AbstractTestElement;
@@ -31,6 +32,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.oro.text.regex.StringSubstitution;
 import org.apache.oro.text.regex.Util;
 
+@TestElementMetadata(labelResource = "displayName")
 public class CompareAssertion extends AbstractTestElement implements Assertion, TestBean, Serializable,
         LoopIterationListener {
 

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
@@ -24,6 +24,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.util.JSR223TestElement;
@@ -31,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "displayName")
 public class JSR223Assertion extends JSR223TestElement implements Cloneable, Assertion, TestBean
 {
     private static final Logger log = LoggerFactory.getLogger(JSR223Assertion.class);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/AssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/AssertionGui.java
@@ -42,6 +42,7 @@ import javax.swing.ListSelectionModel;
 import org.apache.jmeter.assertions.ResponseAssertion;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
@@ -58,6 +59,7 @@ import org.apache.jorphan.gui.GuiUtils;
  * GUI interface for a {@link ResponseAssertion}.
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "assertion_title")
 public class AssertionGui extends AbstractAssertionGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/BeanShellAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/BeanShellAssertionGui.java
@@ -28,6 +28,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.BeanShellAssertion;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanelEntry;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
@@ -36,6 +37,7 @@ import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.util.JMeterUtils;
 
 @GUIMenuSortOrder(Integer.MAX_VALUE)
+@TestElementMetadata(labelResource = "bsh_assertion_title")
 public class BeanShellAssertionGui extends AbstractAssertionGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/DurationAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/DurationAssertionGui.java
@@ -25,6 +25,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.DurationAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -32,6 +33,7 @@ import org.apache.jmeter.util.JMeterUtils;
 /**
  * GUI for {@link DurationAssertion}
  */
+@TestElementMetadata(labelResource = "duration_assertion_title")
 public class DurationAssertionGui extends AbstractAssertionGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/HTMLAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/HTMLAssertionGui.java
@@ -34,6 +34,7 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.HTMLAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanel;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
 /**
  * GUI for HTMLAssertion
  */
+@TestElementMetadata(labelResource = "html_assertion_title")
 public class HTMLAssertionGui extends AbstractAssertionGui implements KeyListener, ActionListener {
 
     private static final Logger log = LoggerFactory.getLogger(HTMLAssertionGui.class);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/JSONPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/JSONPathAssertionGui.java
@@ -26,6 +26,7 @@ import javax.swing.event.ChangeListener;
 
 import org.apache.jmeter.assertions.JSONPathAssertion;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -37,6 +38,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * @since 4.0
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "json_assertion_title")
 public class JSONPathAssertionGui extends AbstractAssertionGui implements ChangeListener {
 
     private static final long serialVersionUID = -6008018002423594040L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
@@ -25,6 +25,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.MD5HexAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -32,6 +33,7 @@ import org.apache.jmeter.util.JMeterUtils;
 /**
  * GUI class supporting the MD5Hex assertion functionality.
  */
+@TestElementMetadata(labelResource = "md5hex_assertion_title")
 public class MD5HexAssertionGUI extends AbstractAssertionGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/SMIMEAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/SMIMEAssertionGui.java
@@ -29,10 +29,12 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.SMIMEAssertionTestElement;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "smime_assertion_title")
  public class SMIMEAssertionGui extends AbstractAssertionGui {
 
     private static final long serialVersionUID = 1L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/SizeAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/SizeAssertionGui.java
@@ -30,6 +30,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.SizeAssertion;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
@@ -38,6 +39,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
  * GUI for {@link SizeAssertion}
  */
 @GUIMenuSortOrder(3)
+@TestElementMetadata(labelResource = "size_assertion_title")
 public class SizeAssertionGui extends AbstractAssertionGui implements ActionListener {
 
     private static final long serialVersionUID = 241L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLAssertionGui.java
@@ -18,9 +18,11 @@
 package org.apache.jmeter.assertions.gui;
 
 import org.apache.jmeter.assertions.XMLAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "xml_assertion_title")
 public class XMLAssertionGui extends AbstractAssertionGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLSchemaAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLSchemaAssertionGUI.java
@@ -26,6 +26,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.assertions.XMLSchemaAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * XMLSchemaAssertionGUI.java
  *
  */
+@TestElementMetadata(labelResource = "xmlschema_assertion_title")
 public class XMLSchemaAssertionGUI extends AbstractAssertionGui {
     // class attributes
      private static final Logger log = LoggerFactory.getLogger(XMLSchemaAssertionGUI.class);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2AssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2AssertionGui.java
@@ -25,10 +25,12 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.assertions.XPath2Assertion;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
 @GUIMenuSortOrder(50)
+@TestElementMetadata(labelResource = "xpath2_assertion_title")
 public class XPath2AssertionGui extends AbstractAssertionGui { // $NOSONAR
 
     private static final long serialVersionUID = 240L;// $NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPathAssertionGui.java
@@ -24,9 +24,11 @@ import javax.swing.Box;
 import javax.swing.JPanel;
 
 import org.apache.jmeter.assertions.XPathAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "xpath_assertion_title")
 public class XPathAssertionGui extends AbstractAssertionGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGui.java
@@ -21,6 +21,7 @@ import javax.swing.JCheckBox;
 
 import org.apache.jmeter.assertions.gui.JSONPathAssertionGui;
 import org.apache.jmeter.assertions.jmespath.JMESPathAssertion;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextArea;
@@ -35,6 +36,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  *
  * @since 5.2
  */
+@TestElementMetadata(labelResource = "jmespath_assertion_title")
 public class JMESPathAssertionGui extends JSONPathAssertionGui {
     private static final long serialVersionUID = 3719848809836264945L;
 

--- a/src/components/src/main/java/org/apache/jmeter/config/CSVDataSet.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/CSVDataSet.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.engine.util.NoConfigMerge;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testbeans.TestBean;
@@ -68,6 +69,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "displayName")
 public class CSVDataSet extends ConfigTestElement
     implements TestBean, LoopIterationListener, NoConfigMerge {
     private static final Logger log = LoggerFactory.getLogger(CSVDataSet.class);

--- a/src/components/src/main/java/org/apache/jmeter/config/KeystoreConfig.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/KeystoreConfig.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.config;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.util.JMeterUtils;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Configure Keystore
  */
+@TestElementMetadata(labelResource = "displayName")
 public class KeystoreConfig extends ConfigTestElement implements TestBean, TestStateListener {
 
     private static final long serialVersionUID = 1L;

--- a/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfig.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfig.java
@@ -25,6 +25,7 @@ import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.engine.util.NoConfigMerge;
 import org.apache.jmeter.engine.util.NoThreadClone;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.threads.JMeterContextService;
@@ -32,6 +33,7 @@ import org.apache.jmeter.threads.JMeterVariables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@TestElementMetadata(labelResource = "displayName")
 public class RandomVariableConfig extends ConfigTestElement
     implements TestBean, LoopIterationListener, NoThreadClone, NoConfigMerge, ThreadListener
 {

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/CriticalSectionControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/CriticalSectionControllerGui.java
@@ -25,6 +25,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.control.CriticalSectionController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -35,6 +36,7 @@ import org.apache.jmeter.util.JMeterUtils;
  *
  * @since 2.12
  */
+@TestElementMetadata(labelResource = "critical_section_controller_title")
 public class CriticalSectionControllerGui extends AbstractControllerGui {
 
     /**

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ForeachControlPanel.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ForeachControlPanel.java
@@ -25,6 +25,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.control.ForeachController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -34,6 +35,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * sub-components should be executed some number of times in a loop. This
  * component can be used standalone or embedded into some other component.
  */
+@TestElementMetadata(labelResource = "foreach_controller_title")
 public class ForeachControlPanel extends AbstractControllerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/IncludeControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/IncludeControllerGui.java
@@ -20,12 +20,14 @@ package org.apache.jmeter.control.gui;
 import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.control.IncludeController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanel;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "include_controller")
 public class IncludeControllerGui extends AbstractControllerGui
 {
 

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/InterleaveControlGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/InterleaveControlGui.java
@@ -20,11 +20,13 @@ package org.apache.jmeter.control.gui;
 import javax.swing.JCheckBox;
 
 import org.apache.jmeter.control.InterleaveControl;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "interleave_control_title")
 public class InterleaveControlGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ModuleControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ModuleControllerGui.java
@@ -47,6 +47,7 @@ import org.apache.jmeter.control.ModuleController;
 import org.apache.jmeter.control.TestFragmentController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.gui.util.MenuInfo;
@@ -69,6 +70,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
  *
  */
 @GUIMenuSortOrder(MenuInfo.SORT_ORDER_DEFAULT+2)
+@TestElementMetadata(labelResource = "module_controller_title")
 public class ModuleControllerGui extends AbstractControllerGui implements ActionListener { // NOSONAR Ignore parent warning
     private static final long serialVersionUID = -4195441608252523573L;
 

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/OnceOnlyControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/OnceOnlyControllerGui.java
@@ -18,9 +18,11 @@
 package org.apache.jmeter.control.gui;
 
 import org.apache.jmeter.control.OnceOnlyController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "once_only_controller_title")
 public class OnceOnlyControllerGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/RandomControlGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/RandomControlGui.java
@@ -21,11 +21,13 @@ import javax.swing.JCheckBox;
 
 import org.apache.jmeter.control.InterleaveControl;
 import org.apache.jmeter.control.RandomController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "random_control_title")
 public class RandomControlGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/RandomOrderControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/RandomOrderControllerGui.java
@@ -18,12 +18,14 @@
 package org.apache.jmeter.control.gui;
 
 import org.apache.jmeter.control.RandomOrderController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 
 /**
  * GUI for RandomOrderController.
  *
  */
+@TestElementMetadata(labelResource = "random_order_control_title")
 public class RandomOrderControllerGui extends LogicControllerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/SwitchControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/SwitchControllerGui.java
@@ -25,11 +25,13 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.control.SwitchController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.MenuInfo;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
 @GUIMenuSortOrder(MenuInfo.SORT_ORDER_DEFAULT+2)
+@TestElementMetadata(labelResource = "switch_controller_title")
 public class SwitchControllerGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ThroughputControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ThroughputControllerGui.java
@@ -28,6 +28,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.control.ThroughputController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.gui.util.MenuInfo;
 import org.apache.jmeter.testelement.TestElement;
@@ -35,6 +36,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
 @GUIMenuSortOrder(MenuInfo.SORT_ORDER_DEFAULT+1)
+@TestElementMetadata(labelResource = "throughput_control_title")
 public class ThroughputControllerGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.extractor;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testbeans.TestBean;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(Integer.MAX_VALUE)
+@TestElementMetadata(labelResource = "displayName")
 public class BeanShellPostProcessor extends BeanShellTestElement
     implements Cloneable, PostProcessor, TestBean
 {

--- a/src/components/src/main/java/org/apache/jmeter/extractor/DebugPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/DebugPostProcessor.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testbeans.TestBean;
@@ -36,6 +37,7 @@ import org.apache.jmeter.util.JMeterUtils;
 /**
  * Debugging Post-Processor: creates a subSample containing the variables defined in the previous sampler.
  */
+@TestElementMetadata(labelResource = "displayName")
 public class DebugPostProcessor extends AbstractTestElement implements PostProcessor, TestBean {
 
     private static final long serialVersionUID = 260L;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
@@ -23,6 +23,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.util.JSR223TestElement;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(5)
+@TestElementMetadata(labelResource = "displayName")
 public class JSR223PostProcessor extends JSR223TestElement implements Cloneable, PostProcessor, TestBean
 {
     private static final Logger log = LoggerFactory.getLogger(JSR223PostProcessor.class);

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/BoundaryExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/BoundaryExtractorGui.java
@@ -33,6 +33,7 @@ import javax.swing.JRadioButton;
 import org.apache.jmeter.extractor.BoundaryExtractor;
 import org.apache.jmeter.extractor.RegexExtractor;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.AbstractScopedTestElement;
 import org.apache.jmeter.testelement.TestElement;
@@ -44,6 +45,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * @since 4.0
  */
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "boundaryextractor_title")
 public class BoundaryExtractorGui extends AbstractPostProcessorGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/HtmlExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/HtmlExtractorGui.java
@@ -34,6 +34,7 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.extractor.HtmlExtractor;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.AbstractScopedTestElement;
@@ -46,6 +47,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * @since 2.9
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "html_extractor_title")
 public class HtmlExtractorGui extends AbstractPostProcessorGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
@@ -32,6 +32,7 @@ import javax.swing.JRadioButton;
 
 import org.apache.jmeter.extractor.RegexExtractor;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.AbstractScopedTestElement;
 import org.apache.jmeter.testelement.TestElement;
@@ -42,6 +43,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * Regular Expression Extractor Post-Processor GUI
  */
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "regex_extractor_title")
 public class RegexExtractorGui extends AbstractPostProcessorGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPath2ExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPath2ExtractorGui.java
@@ -29,6 +29,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.apache.jmeter.extractor.XPath2Extractor;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
@@ -40,6 +41,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * GUI for XPath2Extractor class.
  * @since 5.0
  */
+@TestElementMetadata(labelResource = "xpath2_extractor_title")
 public class XPath2ExtractorGui extends AbstractPostProcessorGui{ // NOSONAR Ignore parents warning
 
     private static final long serialVersionUID = 1L;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
@@ -30,6 +30,7 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.assertions.gui.XMLConfPanel;
 import org.apache.jmeter.extractor.XPathExtractor;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -37,6 +38,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
 /**
  * GUI for XPathExtractor class.
  */
+@TestElementMetadata(labelResource = "xpath_extractor_title")
 public class XPathExtractorGui extends AbstractPostProcessorGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/gui/JMESPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/gui/JMESPathExtractorGui.java
@@ -28,6 +28,7 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.extractor.json.jmespath.JMESPathExtractor;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -39,6 +40,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * @since 5.2
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "jmes_extractor_title")
 public class JMESPathExtractorGui extends AbstractPostProcessorGui {
 
     private static final long serialVersionUID = -4825532539405119033L;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/gui/JSONPostProcessorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/gui/JSONPostProcessorGui.java
@@ -30,6 +30,7 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.extractor.json.jsonpath.JSONPostProcessor;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -40,6 +41,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * @since 3.0
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "json_post_processor_title")
 public class JSONPostProcessorGui extends AbstractPostProcessorGui {
 
     private static final long serialVersionUID = -2845056031828291476L;

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.modifiers;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PreProcessor;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(Integer.MAX_VALUE)
+@TestElementMetadata(labelResource = "displayName")
 public class BeanShellPreProcessor extends BeanShellTestElement
     implements Cloneable, PreProcessor, TestBean
 {

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
@@ -23,6 +23,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PreProcessor;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.util.JSR223TestElement;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "displayName")
 public class JSR223PreProcessor extends JSR223TestElement implements Cloneable, PreProcessor, TestBean
 {
     private static final Logger log = LoggerFactory.getLogger(JSR223PreProcessor.class);

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/CounterConfigGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/CounterConfigGui.java
@@ -23,6 +23,7 @@ import java.awt.event.ActionListener;
 import javax.swing.JCheckBox;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.modifiers.CounterConfig;
 import org.apache.jmeter.testelement.TestElement;
@@ -30,6 +31,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
+@TestElementMetadata(labelResource = "counter_config_title")
 public class CounterConfigGui extends AbstractConfigGui implements ActionListener {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/SampleTimeoutGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/SampleTimeoutGui.java
@@ -23,6 +23,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.modifiers.SampleTimeout;
 import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
@@ -32,6 +33,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
 /**
  * The GUI for SampleTimeout.
  */
+@TestElementMetadata(labelResource = "sample_timeout_title")
 public class SampleTimeoutGui extends AbstractPreProcessorGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
@@ -41,6 +41,7 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.gui.util.VerticalPanel;
@@ -55,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(5)
+@TestElementMetadata(labelResource = "user_parameters_title")
 public class UserParametersGui extends AbstractPreProcessorGui {
 
     private static final long serialVersionUID = 241L;

--- a/src/components/src/main/java/org/apache/jmeter/sampler/DebugSampler.java
+++ b/src/components/src/main/java/org/apache/jmeter/sampler/DebugSampler.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
@@ -38,6 +39,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * The Debug Sampler can be used to "sample" JMeter variables, JMeter properties and System Properties.
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "displayName")
 public class DebugSampler extends AbstractSampler implements TestBean {
 
     private static final long serialVersionUID = 232L;

--- a/src/components/src/main/java/org/apache/jmeter/sampler/gui/TestActionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/sampler/gui/TestActionGui.java
@@ -28,6 +28,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.sampler.TestAction;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
@@ -36,6 +37,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "test_action_title")
 public class TestActionGui extends AbstractSamplerGui { // NOSONAR Ignore hierarchy error
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.timers;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.BeanShellTestElement;
@@ -26,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(Integer.MAX_VALUE)
+@TestElementMetadata(labelResource = "displayName")
 public class BeanShellTimer extends BeanShellTestElement implements Cloneable, Timer, TestBean {
     private static final Logger log = LoggerFactory.getLogger(BeanShellTimer.class);
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/ConstantThroughputTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/ConstantThroughputTimer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testbeans.gui.GenericTestBeanCustomizer;
 import org.apache.jmeter.testelement.AbstractTestElement;
@@ -47,6 +48,7 @@ import org.slf4j.LoggerFactory;
  * - delay each thread according to when any thread last ran
  */
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "displayName")
 public class ConstantThroughputTimer extends AbstractTestElement implements Timer, TestStateListener, TestBean {
     private static final long serialVersionUID = 4;
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
@@ -22,11 +22,13 @@ import java.io.IOException;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.util.JSR223TestElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@TestElementMetadata(labelResource = "displayName")
 public class JSR223Timer extends JSR223TestElement implements Cloneable, Timer, TestBean {
     private static final Logger log = LoggerFactory.getLogger(JSR223Timer.class);
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/SyncTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/SyncTimer.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestStateListener;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  * thus create large instant loads at various points of the test plan.
  *
  */
+@TestElementMetadata(labelResource = "displayName")
 public class SyncTimer extends AbstractTestElement implements Timer, Serializable, TestBean, TestStateListener, ThreadListener {
     private static final Logger log = LoggerFactory.getLogger(SyncTimer.class);
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/ConstantTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/ConstantTimerGui.java
@@ -24,6 +24,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.timers.ConstantTimer;
 import org.apache.jmeter.util.JMeterUtils;
@@ -33,6 +34,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
  * The GUI for ConstantTimer.
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "constant_timer_title")
 public class ConstantTimerGui extends AbstractTimerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/GaussianRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/GaussianRandomTimerGui.java
@@ -17,6 +17,7 @@
 
 package org.apache.jmeter.timers.gui;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.timers.GaussianRandomTimer;
 import org.apache.jmeter.timers.RandomTimer;
 import org.apache.jmeter.util.JMeterUtils;
@@ -24,6 +25,7 @@ import org.apache.jmeter.util.JMeterUtils;
 /**
  * Implementation of a gaussian random timer.
  */
+@TestElementMetadata(labelResource = "gaussian_timer_title")
 public class GaussianRandomTimerGui extends AbstractRandomTimerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/PoissonRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/PoissonRandomTimerGui.java
@@ -17,6 +17,7 @@
 
 package org.apache.jmeter.timers.gui;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.timers.PoissonRandomTimer;
 import org.apache.jmeter.timers.RandomTimer;
 import org.apache.jmeter.util.JMeterUtils;
@@ -24,6 +25,7 @@ import org.apache.jmeter.util.JMeterUtils;
 /**
  * Implementation of a Poisson random timer.
  */
+@TestElementMetadata(labelResource = "poisson_timer_title")
 public class PoissonRandomTimerGui extends AbstractRandomTimerGui {
 
     private static final long serialVersionUID = -3218002787832805275L;

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/UniformRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/UniformRandomTimerGui.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.timers.gui;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.timers.RandomTimer;
 import org.apache.jmeter.timers.UniformRandomTimer;
 import org.apache.jmeter.util.JMeterUtils;
@@ -26,6 +27,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * Implementation of a uniform random timer.
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "uniform_timer_title")
 public class UniformRandomTimerGui extends AbstractRandomTimerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/timers/poissonarrivals/PreciseThroughputTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/poissonarrivals/PreciseThroughputTimer.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestStateListener;
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
  * @since 4.0
  */
 @GUIMenuSortOrder(3)
+@TestElementMetadata(labelResource = "displayName")
 public class PreciseThroughputTimer extends AbstractTestElement implements Cloneable, Timer, TestStateListener, TestBean, ThroughputProvider, DurationProvider {
     private static final Logger log = LoggerFactory.getLogger(PreciseThroughputTimer.class);
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/AssertionVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/AssertionVisualizer.java
@@ -29,11 +29,13 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
 import org.apache.jmeter.assertions.AssertionResult;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 
+@TestElementMetadata(labelResource = "assertion_visualizer_title")
 public class AssertionVisualizer extends AbstractVisualizer implements Clearable {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListener.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.visualizers;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.UnsharedComponent;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleListener;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @GUIMenuSortOrder(Integer.MAX_VALUE)
+@TestElementMetadata(labelResource = "displayName")
 public class BeanShellListener extends BeanShellTestElement
     implements Cloneable, SampleListener, TestBean, Visualizer, UnsharedComponent  {
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ComparisonVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ComparisonVisualizer.java
@@ -36,11 +36,13 @@ import javax.swing.tree.TreeSelectionModel;
 
 import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.assertions.CompareAssertionResult;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 
+@TestElementMetadata(labelResource = "comparison_visualizer_title")
 public class ComparisonVisualizer extends AbstractVisualizer implements Clearable {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/GraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/GraphVisualizer.java
@@ -42,6 +42,7 @@ import javax.swing.Timer;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.JMeterColor;
 import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
@@ -54,6 +55,7 @@ import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
  * autoscaling plots.
  *
  */
+@TestElementMetadata(labelResource = "graph_results_title")
 public class GraphVisualizer extends AbstractVisualizer implements ImageVisualizer, ItemListener, Clearable {
 
     private static final long serialVersionUID = 240L;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
@@ -23,6 +23,7 @@ import javax.script.Bindings;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleListener;
 import org.apache.jmeter.samplers.SampleResult;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
  * Needs to implement Visualizer so that TestBeanGUI can find the correct GUI class
  *
  */
+@TestElementMetadata(labelResource = "displayName")
 public class JSR223Listener extends JSR223TestElement
     implements Cloneable, SampleListener, TestBean, Visualizer {
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
@@ -39,6 +39,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.reporters.MailerModel;
 import org.apache.jmeter.reporters.MailerResultCollector;
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory;
  * This class implements a visualizer that mails a message when an error occurs.
  *
  */
+@TestElementMetadata(labelResource = "mailer_visualizer_title")
 public class MailerVisualizer extends AbstractVisualizer implements ActionListener, Clearable, ChangeListener {
     private static final long serialVersionUID = 241L;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/PropertyControlGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/PropertyControlGui.java
@@ -41,6 +41,7 @@ import javax.swing.ListSelectionModel;
 
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.UnsharedComponent;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.gui.util.MenuFactory;
@@ -49,6 +50,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
 
+@TestElementMetadata(labelResource = "property_visualiser_title", actionGroups = MenuFactory.NON_TEST_ELEMENTS)
 public class PropertyControlGui extends AbstractConfigGui implements
         ActionListener, UnsharedComponent {
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -51,6 +51,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeListener;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
 import org.apache.jmeter.gui.action.SaveGraphics;
@@ -69,6 +70,7 @@ import org.apache.jorphan.math.StatCalculatorLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@TestElementMetadata(labelResource = "graph_resp_time_title")
 public class RespTimeGraphVisualizer extends AbstractVisualizer implements ActionListener, Clearable {
 
     private static final long serialVersionUID = 281L;
@@ -512,14 +514,14 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
             try {
                 ActionRouter.getInstance().getAction(
                         ActionNames.SAVE_GRAPHICS,SaveGraphics.class.getName()).doAction(
-                                new ActionEvent(this,event.getID(),ActionNames.SAVE_GRAPHICS));
+                        new ActionEvent(this,event.getID(),ActionNames.SAVE_GRAPHICS));
             } catch (Exception e) {
                 log.error(e.getMessage());
             }
         } else if (eventSource == syncWithName) {
             graphTitle.setText(getName());
         } else if (eventSource == dynamicGraphSize) {
-                enableDynamicGraph(dynamicGraphSize.isSelected());
+            enableDynamicGraph(dynamicGraphSize.isSelected());
         } else if (eventSource == samplerSelection) {
             enableSamplerSelection(samplerSelection.isSelected());
             if (!samplerSelection.isSelected()) {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SimpleDataWriter.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SimpleDataWriter.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.visualizers;
 
 import java.awt.BorderLayout;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 
@@ -26,6 +27,7 @@ import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
  * This listener can record results to a file but not to the UI. It is meant to
  * provide an efficient means of recording data by eliminating GUI overhead.
  */
+@TestElementMetadata(labelResource = "simple_data_writer_title")
 public class SimpleDataWriter extends AbstractVisualizer {
     private static final long serialVersionUID = 240L;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -65,6 +65,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
 import org.apache.jmeter.gui.action.SaveGraphics;
@@ -96,6 +97,7 @@ import org.slf4j.LoggerFactory;
  * you!
  *
  */
+@TestElementMetadata(labelResource = "aggregate_graph_title")
 public class StatGraphVisualizer extends AbstractVisualizer implements Clearable, ActionListener {
     private static final long serialVersionUID = 242L;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
@@ -42,6 +42,7 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRendererWrapper;
 import org.apache.jmeter.samplers.Clearable;
@@ -58,6 +59,7 @@ import org.apache.jorphan.gui.RendererUtils;
  * Aggregate Table-Based Reporting Visualizer for JMeter.
  */
 @GUIMenuSortOrder(3)
+@TestElementMetadata(labelResource = "aggregate_report")
 public class StatVisualizer extends AbstractVisualizer implements Clearable, ActionListener {
 
     private static final long serialVersionUID = 242L;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
@@ -45,6 +45,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRendererWrapper;
 import org.apache.jmeter.samplers.Clearable;
@@ -67,6 +68,7 @@ import org.apache.jorphan.reflect.Functor;
  * Excludes the Median and 90% columns, which are expensive in memory terms
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "summary_report")
 public class SummaryReport extends AbstractVisualizer implements Clearable, ActionListener {
 
     private static final long serialVersionUID = 241L;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/TableVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/TableVisualizer.java
@@ -40,6 +40,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
 
 import org.apache.jmeter.JMeter;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRendererWrapper;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.samplers.Clearable;
@@ -60,6 +61,7 @@ import org.apache.jorphan.reflect.Functor;
  * in a JTable, and the statistics are displayed at the bottom of the table.
  *
  */
+@TestElementMetadata(labelResource = "view_results_in_table")
 public class TableVisualizer extends AbstractVisualizer implements Clearable {
 
     private static final long serialVersionUID = 241L;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -67,6 +67,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.JMeter;
 import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
@@ -80,6 +81,7 @@ import org.slf4j.LoggerFactory;
  * Base for ViewResults
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "view_results_tree_title")
 public class ViewResultsFullVisualizer extends AbstractVisualizer
 implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -39,6 +39,7 @@ import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
@@ -54,6 +55,7 @@ import org.slf4j.LoggerFactory;
  * @since 2.13
  */
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "backend_listener")
 public class BackendListenerGui extends AbstractListenerGui implements ActionListener {
 
     private static final long serialVersionUID = 1L;

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/LoginConfigGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/LoginConfigGui.java
@@ -25,6 +25,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.config.ConfigTestElement;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.StringProperty;
@@ -35,6 +36,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * login.
  *
  */
+@TestElementMetadata(labelResource = "login_config_element")
 public class LoginConfigGui extends AbstractConfigGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ObsoleteGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ObsoleteGui.java
@@ -25,12 +25,14 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
 /**
  * Default config gui for Configuration Element.
  */
+@TestElementMetadata(labelResource = "obsolete_test_element", actionGroups = "")
 public class ObsoleteGui extends AbstractJMeterGuiComponent {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/SimpleConfigGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/SimpleConfigGui.java
@@ -29,6 +29,7 @@ import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 
 import org.apache.jmeter.config.ConfigTestElement;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.testelement.TestElement;
@@ -42,6 +43,7 @@ import org.apache.jorphan.gui.GuiUtils;
 /**
  * Default config gui for Configuration Element.
  */
+@TestElementMetadata(labelResource = "simple_config_element")
 public class SimpleConfigGui extends AbstractConfigGui implements ActionListener {
     /* This class created for enhancement Bug ID 9101. */
 

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/IfControllerPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/IfControllerPanel.java
@@ -30,6 +30,7 @@ import javax.swing.event.ChangeListener;
 
 import org.apache.jmeter.control.IfController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.testelement.TestElement;
@@ -44,6 +45,7 @@ import org.apache.jorphan.gui.JMeterUIDefaults;
  *
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "if_controller_title")
 public class IfControllerPanel extends AbstractControllerGui implements ChangeListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/LogicControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/LogicControllerGui.java
@@ -20,12 +20,14 @@ package org.apache.jmeter.control.gui;
 import java.awt.BorderLayout;
 
 import org.apache.jmeter.control.GenericController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 
 /**
  * A generic controller component.
  *
  */
+@TestElementMetadata(labelResource = "logic_controller_title")
 public class LogicControllerGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/LoopControlPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/LoopControlPanel.java
@@ -29,6 +29,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.control.LoopController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FocusRequester;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -41,6 +42,7 @@ import org.apiguardian.api.API;
  *
  */
 @GUIMenuSortOrder(3)
+@TestElementMetadata(labelResource = "loop_controller_title")
 public class LoopControlPanel extends AbstractControllerGui implements ActionListener {
     private static final long serialVersionUID = 241L;
 

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/RunTimeGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/RunTimeGui.java
@@ -27,6 +27,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.control.RunTime;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -36,7 +37,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * used standalone or embedded into some other component.
  *
  */
-
+@TestElementMetadata(labelResource = "runtime_controller_title")
 public class RunTimeGui extends AbstractControllerGui implements ActionListener {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TestFragmentControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TestFragmentControllerGui.java
@@ -25,6 +25,7 @@ import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.control.TestFragmentController;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
@@ -35,7 +36,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * to allow for a non-execution part of the Test Plan that can be saved and referenced
  * by a Module or Include Controller.
  */
-
+@TestElementMetadata(labelResource = "test_fragment_title", actionGroups = MenuFactory.FRAGMENTS)
 public class TestFragmentControllerGui extends AbstractControllerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TestPlanGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TestPlanGui.java
@@ -29,6 +29,7 @@ import javax.swing.JPopupMenu;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.util.FileListPanel;
 import org.apache.jmeter.gui.util.MenuFactory;
@@ -42,6 +43,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * JMeter GUI component representing the test plan which will be executed when
  * the test is run.
  */
+@TestElementMetadata(labelResource = "test_plan", actionGroups = "")
 public class TestPlanGui extends AbstractJMeterGuiComponent {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TransactionControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TransactionControllerGui.java
@@ -21,6 +21,7 @@ import javax.swing.JCheckBox;
 
 import org.apache.jmeter.control.TransactionController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -30,6 +31,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
  * A Transaction controller component.
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "transaction_controller_title")
 public class TransactionControllerGui extends AbstractControllerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/WhileControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/WhileControllerGui.java
@@ -25,12 +25,14 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.control.WhileController;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "while_controller_title")
 public class WhileControllerGui extends AbstractControllerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/WorkBenchGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/WorkBenchGui.java
@@ -25,6 +25,7 @@ import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.gui.util.VerticalPanel;
@@ -38,6 +39,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * @deprecated since 4.0 Non Test Elements are now children of Test Plan
  */
 @Deprecated
+@TestElementMetadata(labelResource = "workbench_title", actionGroups = MenuFactory.NON_TEST_ELEMENTS)
 public class WorkBenchGui extends AbstractJMeterGuiComponent {
     private static final long serialVersionUID = 240L;
     // This check-box defines whether to save  WorkBench content or not

--- a/src/core/src/main/java/org/apache/jmeter/gui/TestElementMetadata.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/TestElementMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apiguardian.api.API;
+
+/**
+ * Enables to get component information (e.g. title, group in menu) at the startup.
+ * <p>Historically JMeter was creating component classes which initializes GUI elements.
+ * The idea here is to enable access to the metadata without instantiating GUI classes.</p>
+ * <p>This annotation is not meant to be used by the third-party plugins,
+ * and it might be removed as better alternatives are implemented.</p>
+ * @since 5.3
+ * @see org.apache.jmeter.gui.util.MenuFactory
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@API(since = "5.3", status = API.Status.INTERNAL)
+public @interface TestElementMetadata {
+    String labelResource();
+    String resourceBundle() default "";
+    String[] actionGroups() default {};
+}

--- a/src/core/src/main/java/org/apache/jmeter/gui/menu/StaticJMeterGUIComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/menu/StaticJMeterGUIComponent.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui.menu;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import javax.swing.JPopupMenu;
+
+import org.apache.jmeter.assertions.Assertion;
+import org.apache.jmeter.assertions.gui.AbstractAssertionGui;
+import org.apache.jmeter.config.ConfigElement;
+import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.control.Controller;
+import org.apache.jmeter.control.gui.AbstractControllerGui;
+import org.apache.jmeter.gui.JMeterGUIComponent;
+import org.apache.jmeter.gui.TestElementMetadata;
+import org.apache.jmeter.gui.util.MenuFactory;
+import org.apache.jmeter.processor.PostProcessor;
+import org.apache.jmeter.processor.PreProcessor;
+import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
+import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
+import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.threads.gui.AbstractThreadGroupGui;
+import org.apache.jmeter.timers.Timer;
+import org.apache.jmeter.timers.gui.AbstractTimerGui;
+import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.visualizers.Visualizer;
+import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
+import org.apiguardian.api.API;
+
+/**
+ * Internal class to speedup the startup time.
+ * <p>JMeter needs component names to create menus, however, default GUIComponent implementations
+ * create UI elements in their constructors. This class implements just the minimal subset of the
+ * methods to make menu factory happy.</p>
+ */
+@API(since = "5.3", status = API.Status.INTERNAL)
+public class StaticJMeterGUIComponent implements JMeterGUIComponent {
+    private final String labelResource;
+    private final ResourceBundle resourceBundle;
+    private final Collection<String> groups;
+
+    public StaticJMeterGUIComponent(Class<?> c, TestElementMetadata metadata) {
+        this.labelResource = metadata.labelResource();
+        String resourceBundle = metadata.resourceBundle();
+        if (!resourceBundle.isEmpty()) {
+            this.resourceBundle = ResourceBundle.getBundle(c.getName() + "Resources");
+        } else if (labelResource.equals("displayName")) {
+            this.resourceBundle = ResourceBundle.getBundle(c.getName() + "Resources");
+        } else {
+            this.resourceBundle = null;
+        }
+        this.groups = getGroups(c, metadata);
+    }
+
+    private List<String> getGroups(Class<?> c, TestElementMetadata metadata) {
+        String[] groups = metadata.actionGroups();
+        if (groups.length == 1 && groups[0].equals("")) {
+            // Annotations can't hold null values, so we use empty string instead
+            return null;
+        }
+        if (groups.length != 0) {
+            return Collections.unmodifiableList(Arrays.asList(groups));
+        }
+        String group;
+        if (Assertion.class.isAssignableFrom(c) || AbstractAssertionGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.ASSERTIONS;
+        } else if (ConfigElement.class.isAssignableFrom(c) || AbstractConfigGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.CONFIG_ELEMENTS;
+        } else if (Controller.class.isAssignableFrom(c) || AbstractControllerGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.CONTROLLERS;
+        } else if (Visualizer.class.isAssignableFrom(c) || AbstractListenerGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.LISTENERS;
+        } else if (PostProcessor.class.isAssignableFrom(c) || AbstractPostProcessorGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.POST_PROCESSORS;
+        } else if (PreProcessor.class.isAssignableFrom(c) || AbstractPreProcessorGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.PRE_PROCESSORS;
+        } else if (Sampler.class.isAssignableFrom(c) || AbstractSamplerGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.SAMPLERS;
+        } else if (Timer.class.isAssignableFrom(c) || AbstractTimerGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.TIMERS;
+        } else if (AbstractThreadGroupGui.class.isAssignableFrom(c) || AbstractThreadGroupGui.class.isAssignableFrom(c)) {
+            group = MenuFactory.THREADS;
+        } else {
+            throw new IllegalArgumentException("Unknown group for class " + c);
+        }
+        return Collections.singletonList(group);
+    }
+
+    @Override
+    public String getLabelResource() {
+        return labelResource;
+    }
+
+    @Override
+    public String getStaticLabel() {
+        String labelResource = getLabelResource();
+        if (resourceBundle == null) {
+            return JMeterUtils.getResString(labelResource);
+        }
+        return resourceBundle.getString(labelResource);
+    }
+
+    @Override
+    public Collection<String> getMenuCategories() {
+        return groups;
+    }
+
+    // The rest throws UnsupportedOperationException since the methods are not intended to be used
+
+    @Override
+    public void setName(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getDocAnchor() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TestElement createTestElement() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void modifyTestElement(TestElement element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JPopupMenu createPopupMenu() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void configure(TestElement element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clearGui() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/MenuInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/MenuInfo.java
@@ -49,7 +49,7 @@ public class MenuInfo {
 
     private int getSortOrderFromName(String classFullName) {
         try {
-            GUIMenuSortOrder menuSortOrder = Class.forName(classFullName)
+            GUIMenuSortOrder menuSortOrder = Class.forName(classFullName, false, MenuInfo.class.getClassLoader())
                     .getDeclaredAnnotation(GUIMenuSortOrder.class);
             if (menuSortOrder != null) {
                 return menuSortOrder.value();

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultActionGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultActionGui.java
@@ -22,6 +22,7 @@ import java.awt.BorderLayout;
 import javax.swing.Box;
 
 import org.apache.jmeter.gui.OnErrorPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.reporters.ResultAction;
 import org.apache.jmeter.testelement.OnErrorTestElement;
@@ -30,6 +31,7 @@ import org.apache.jmeter.testelement.TestElement;
 /**
  * Create a Result Action Test Element
  */
+@TestElementMetadata(labelResource = "resultaction_title")
 public class ResultActionGui extends AbstractPostProcessorGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultSaverGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultSaverGui.java
@@ -29,6 +29,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.reporters.ResultSaver;
 import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.testelement.TestElement;
@@ -41,6 +42,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * of files
  *
  */
+@TestElementMetadata(labelResource = "resultsaver_title")
 public class ResultSaverGui extends AbstractListenerGui implements Clearable { // NOSONAR Ignore inheritance rule
 
     private static final long serialVersionUID = 241L;

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/SummariserGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/SummariserGui.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.reporters.gui;
 
 import java.awt.BorderLayout;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.reporters.Summariser;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
@@ -27,6 +28,7 @@ import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
  * Create a summariser test element GUI.
  *
  */
+@TestElementMetadata(labelResource = "summariser_title")
 public class SummariserGui extends AbstractListenerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/PostThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/PostThreadGroupGui.java
@@ -19,9 +19,11 @@ package org.apache.jmeter.threads.gui;
 
 import java.awt.event.ItemListener;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.PostThreadGroup;
 
+@TestElementMetadata(labelResource = "post_thread_group_title")
 public class PostThreadGroupGui extends ThreadGroupGui implements ItemListener {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/SetupThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/SetupThreadGroupGui.java
@@ -19,9 +19,11 @@ package org.apache.jmeter.threads.gui;
 
 import java.awt.event.ItemListener;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.SetupThreadGroup;
 
+@TestElementMetadata(labelResource = "setup_thread_group_title")
 public class SetupThreadGroupGui extends ThreadGroupGui implements ItemListener {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
@@ -31,6 +31,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.control.LoopController;
 import org.apache.jmeter.control.gui.LoopControlPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.threads.AbstractThreadGroup;
@@ -39,6 +40,7 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+@TestElementMetadata(labelResource = "threadgroup")
 public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListener {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElement.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/config/BoltConnectionElement.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.protocol.bolt.config;
 
 import org.apache.jmeter.config.ConfigElement;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.testelement.AbstractTestElement;
@@ -30,6 +31,7 @@ import org.neo4j.driver.v1.GraphDatabase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@TestElementMetadata(labelResource = "displayName")
 public class BoltConnectionElement extends AbstractTestElement
         implements ConfigElement, TestStateListener, TestBean {
 

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.util.ConfigMergabilityIndicator;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.bolt.config.BoltConnectionElement;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
@@ -45,12 +46,16 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
+@TestElementMetadata(labelResource = "displayName")
 public class BoltSampler extends AbstractBoltTestElement implements Sampler, TestBean, ConfigMergabilityIndicator {
 
     private static final Set<String> APPLICABLE_CONFIG_CLASSES = new HashSet<>(
             Collections.singletonList("org.apache.jmeter.config.gui.SimpleConfigGui")); // $NON-NLS-1$
 
-    private static final ObjectReader objectMapper = new ObjectMapper().readerFor(new TypeReference<HashMap<String, Object>>() {});
+    // Enables to initialize object mapper on demand
+    private static class Holder {
+        private static final ObjectReader OBJECT_READER = new ObjectMapper().readerFor(new TypeReference<HashMap<String, Object>>() {});
+    }
 
     @Override
     public SampleResult sample(Entry e) {
@@ -116,7 +121,7 @@ public class BoltSampler extends AbstractBoltTestElement implements Sampler, Tes
 
     private Map<String, Object> getParamsAsMap() throws IOException {
         if (getParams() != null && getParams().length() > 0) {
-            return objectMapper.readValue(getParams());
+            return Holder.OBJECT_READER.readValue(getParams());
         } else {
             return Collections.emptyMap();
         }

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/config/gui/FtpConfigGui.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/config/gui/FtpConfigGui.java
@@ -29,12 +29,14 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.ftp.sampler.FTPSampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "ftp_sample_title")
 public class FtpConfigGui extends AbstractConfigGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/control/gui/FtpTestSamplerGui.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/control/gui/FtpTestSamplerGui.java
@@ -22,6 +22,7 @@ import java.awt.BorderLayout;
 import javax.swing.BorderFactory;
 
 import org.apache.jmeter.config.gui.LoginConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.ftp.config.gui.FtpConfigGui;
 import org.apache.jmeter.protocol.ftp.sampler.FTPSampler;
@@ -29,6 +30,7 @@ import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "ftp_testing_title")
 public class FtpTestSamplerGui extends AbstractSamplerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
@@ -51,6 +52,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * GUI for Http Request defaults
  */
 @GUIMenuSortOrder(5)
+@TestElementMetadata(labelResource = "url_config_title")
 public class HttpDefaultsGui extends AbstractConfigGui {
 
     private static final long serialVersionUID = 241L;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
@@ -17,10 +17,12 @@
 
 package org.apache.jmeter.protocol.http.control.gui;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.sampler.AjpSampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "ajp_sampler_title")
 public class AjpSamplerGui extends HttpTestSampleGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpMirrorControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpMirrorControlGui.java
@@ -33,6 +33,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.control.gui.LogicControllerGui;
 import org.apache.jmeter.gui.JMeterGUIComponent;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.UnsharedComponent;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.MenuFactory;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
  * GUI of Mirror Server Test element
  *
  */
+@TestElementMetadata(labelResource = "httpmirror_title", actionGroups = MenuFactory.NON_TEST_ELEMENTS)
 public class HttpMirrorControlGui extends LogicControllerGui
     implements JMeterGUIComponent, ActionListener, UnsharedComponent {
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -32,6 +32,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.http.config.gui.UrlConfigGui;
@@ -48,6 +49,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * HTTP Sampler GUI
  */
 @GUIMenuSortOrder(1)
+@TestElementMetadata(labelResource = "web_testing_title")
 public class HttpTestSampleGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 241L;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/RecordController.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/RecordController.java
@@ -27,6 +27,7 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.control.gui.LogicControllerGui;
 import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.tree.JMeterTreeModel;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.protocol.http.control.RecordingController;
@@ -35,6 +36,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@TestElementMetadata(labelResource = "record_controller_title")
 public class RecordController extends LogicControllerGui implements ActionListener {
     private static final long serialVersionUID = 241L;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
@@ -42,6 +42,7 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.protocol.http.control.AuthManager;
@@ -59,6 +60,7 @@ import org.slf4j.LoggerFactory;
  * Sampler. It also understands how to get AuthManagers for the files that the
  * user selects.
  */
+@TestElementMetadata(labelResource = "auth_manager_title")
 public class AuthPanel extends AbstractConfigGui implements ActionListener {
     private static final long serialVersionUID = -378312656300713635L;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CacheManagerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CacheManagerGui.java
@@ -28,6 +28,7 @@ import javax.swing.JTextField;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.control.CacheManager;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
@@ -37,6 +38,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
  * The GUI for the HTTP Cache Manager {@link CacheManager}
  */
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "cache_manager_title")
 public class CacheManagerGui extends AbstractConfigGui implements ActionListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
@@ -35,6 +35,7 @@ import javax.swing.ListSelectionModel;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.gui.util.PowerTableModel;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * for this service.
  */
 @GUIMenuSortOrder(3)
+@TestElementMetadata(labelResource = "cookie_manager_title")
 public class CookiePanel extends AbstractConfigGui implements ActionListener {
 
     private static final long serialVersionUID = 241L;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -34,6 +34,7 @@ import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.PowerTableModel;
 import org.apache.jmeter.protocol.http.control.DNSCacheManager;
 import org.apache.jmeter.protocol.http.control.StaticHost;
@@ -56,6 +57,7 @@ import org.slf4j.LoggerFactory;
  *
  * @since 2.12
  */
+@TestElementMetadata(labelResource = "dns_cache_manager_title")
 public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DNSCachePanel.class);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
@@ -41,6 +42,7 @@ import org.apache.jorphan.reflect.Functor;
  * These have names and values, as well as check-boxes to determine whether or not to
  * include the "=" sign in the output and whether or not to encode the output.
  */
+@TestElementMetadata(labelResource = "user_defined_variables")
 public class HTTPArgumentsPanel extends ArgumentsPanel {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
@@ -37,6 +37,7 @@ import javax.swing.table.AbstractTableModel;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.protocol.http.control.Header;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * parameters for this service.
  */
 @GUIMenuSortOrder(2)
+@TestElementMetadata(labelResource = "header_manager_title")
 public class HeaderPanel extends AbstractConfigGui implements ActionListener {
 
     private static final Logger log = LoggerFactory.getLogger(HeaderPanel.class);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/AnchorModifierGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/AnchorModifierGui.java
@@ -19,10 +19,12 @@ package org.apache.jmeter.protocol.http.modifier.gui;
 
 import java.awt.BorderLayout;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
 import org.apache.jmeter.protocol.http.modifier.AnchorModifier;
 import org.apache.jmeter.testelement.TestElement;
 
+@TestElementMetadata(labelResource = "anchor_modifier_title")
 public class AnchorModifierGui extends AbstractPreProcessorGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/RegExUserParametersGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/RegExUserParametersGui.java
@@ -26,6 +26,7 @@ import javax.swing.Box;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
 import org.apache.jmeter.protocol.http.modifier.RegExUserParameters;
 import org.apache.jmeter.testelement.TestElement;
@@ -35,6 +36,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
 /**
  * GUI for {@link RegExUserParameters}
  */
+@TestElementMetadata(labelResource = "regex_params_title")
 public class RegExUserParametersGui extends AbstractPreProcessorGui {
 
     /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/URLRewritingModifierGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/URLRewritingModifierGui.java
@@ -21,6 +21,7 @@ import java.awt.BorderLayout;
 
 import javax.swing.JCheckBox;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
 import org.apache.jmeter.protocol.http.modifier.URLRewritingModifier;
@@ -28,6 +29,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 
+@TestElementMetadata(labelResource = "http_url_rewriting_modifier_title")
 public class URLRewritingModifierGui extends AbstractPreProcessorGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -68,6 +68,7 @@ import org.apache.jmeter.engine.util.ValueReplacer;
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.JMeterGUIComponent;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.UnsharedComponent;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
@@ -94,6 +95,10 @@ import org.slf4j.LoggerFactory;
  * GUI of HTTP(s) Test Script Recorder
  *
  */
+@TestElementMetadata(
+        labelResource = "proxy_title",
+        actionGroups = MenuFactory.NON_TEST_ELEMENTS
+)
 public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComponent, ActionListener, ItemListener,
         KeyListener, UnsharedComponent {
     private static final Logger log = LoggerFactory.getLogger(ProxyControlGui.class);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.protocol.http.sampler;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.control.CookieManager;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.accesslog.Filter;
@@ -63,6 +64,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  */
+@TestElementMetadata(labelResource = "displayName")
 public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadListener {
     private static final Logger log = LoggerFactory.getLogger(AccessLogSampler.class);
 

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
@@ -37,6 +37,7 @@ import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.java.config.JavaConfig;
 import org.apache.jmeter.protocol.java.sampler.JavaSampler;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
  * {@link JavaConfig} object.
  *
  */
+@TestElementMetadata(labelResource = "java_request_defaults")
 public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
     private static final long serialVersionUID = 241L;
 

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
@@ -26,6 +26,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanelEntry;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
@@ -35,6 +36,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "bsh_sampler_title")
 public class BeanShellSamplerGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/JavaTestSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/JavaTestSamplerGui.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.protocol.java.control.gui;
 
 import java.awt.BorderLayout;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.java.config.JavaConfig;
 import org.apache.jmeter.protocol.java.config.gui.JavaConfigGui;
 import org.apache.jmeter.protocol.java.sampler.JavaSampler;
@@ -30,6 +31,7 @@ import org.apache.jmeter.testelement.TestElement;
  * the {@link JavaSampler}.
  *
  */
+@TestElementMetadata(labelResource = "java_request")
 public class JavaTestSamplerGui extends AbstractSamplerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -29,6 +29,7 @@ import javax.script.ScriptException;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.util.ConfigMergabilityIndicator;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
@@ -39,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @GUIMenuSortOrder(4)
+@TestElementMetadata(labelResource = "displayName")
 public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampler, TestBean, ConfigMergabilityIndicator {
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
             Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElement.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigElement;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.testelement.AbstractTestElement;
@@ -39,6 +40,7 @@ import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@TestElementMetadata(labelResource = "displayName")
 public class DataSourceElement extends AbstractTestElement
     implements ConfigElement, TestStateListener, TestBean {
     private static final Logger log = LoggerFactory.getLogger(DataSourceElement.class);

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPostProcessor.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPostProcessor.java
@@ -17,12 +17,14 @@
 
 package org.apache.jmeter.protocol.jdbc.processor;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testbeans.TestBean;
 
 /**
  * Post processor handling JDBC Requests
  */
+@TestElementMetadata(labelResource = "displayName")
 public class JDBCPostProcessor extends AbstractJDBCProcessor implements TestBean, PostProcessor {
 
     private static final long serialVersionUID = 1L;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPreProcessor.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/JDBCPreProcessor.java
@@ -17,12 +17,14 @@
 
 package org.apache.jmeter.protocol.jdbc.processor;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.PreProcessor;
 import org.apache.jmeter.testbeans.TestBean;
 
 /**
  * Preprocessor handling JDBC Requests
  */
+@TestElementMetadata(labelResource = "displayName")
 public class JDBCPreProcessor extends AbstractJDBCProcessor implements TestBean, PreProcessor {
 
     private static final long serialVersionUID = 1L;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.util.ConfigMergabilityIndicator;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement;
 import org.apache.jmeter.protocol.jdbc.config.DataSourceElement;
 import org.apache.jmeter.samplers.Entry;
@@ -39,6 +40,7 @@ import org.apache.jorphan.util.JOrphanUtils;
  * A sampler which understands JDBC database requests.
  *
  */
+@TestElementMetadata(labelResource = "displayName")
 public class JDBCSampler extends AbstractJDBCTestElement implements Sampler, TestBean, ConfigMergabilityIndicator {
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
             Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPublisherGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPublisherGui.java
@@ -27,6 +27,7 @@ import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanel;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.JLabeledRadioI18N;
@@ -45,6 +46,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
 /**
  * This is the GUI for JMS Publisher
  */
+@TestElementMetadata(labelResource = "jms_publisher")
 public class JMSPublisherGui extends AbstractSamplerGui implements ChangeListener {
 
     private static final long serialVersionUID = 241L;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
@@ -27,6 +27,7 @@ import javax.swing.JPanel;
 
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
@@ -44,6 +45,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
 /**
  * Configuration screen for Java Messaging Point-to-Point requests.
  */
+@TestElementMetadata(labelResource = "jms_point_to_point")
 public class JMSSamplerGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSubscriberGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSubscriberGui.java
@@ -26,6 +26,7 @@ import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.JLabeledRadioI18N;
 import org.apache.jmeter.gui.util.VerticalPanel;
@@ -40,6 +41,7 @@ import org.apache.jorphan.gui.JLabeledTextField;
  * This is the GUI for JMS Subscriber <br>
  *
  */
+@TestElementMetadata(labelResource = "jms_subscriber_title")
 public class JMSSubscriberGui extends AbstractSamplerGui implements ChangeListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
@@ -36,6 +36,7 @@ import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.java.sampler.JUnitSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
@@ -57,6 +58,7 @@ import junit.framework.TestCase;
  * for the {@link JUnitSampler}.
  *
  */
+@TestElementMetadata(labelResource = "junit_request")
 public class JUnitTestSamplerGui extends AbstractSamplerGui
 implements ChangeListener, ActionListener, ItemListener
 {

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
@@ -34,6 +34,7 @@ import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 
 import org.apache.jmeter.config.gui.AbstractConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.PropertyIterator;
@@ -48,6 +49,7 @@ import org.apache.jorphan.reflect.Functor;
  * for some other component.
  *
  */
+@TestElementMetadata(labelResource = "ldapext_sample_title", actionGroups = "")
 public class LDAPArgumentsPanel extends AbstractConfigGui implements ActionListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
@@ -33,6 +33,7 @@ import javax.swing.JTextField;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.ldap.sampler.LDAPSampler;
 import org.apache.jmeter.testelement.TestElement;
@@ -48,6 +49,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * Created Apr 29 2003 11:45 AM
  *
  */
+@TestElementMetadata(labelResource = "ldap_sample_title")
 public class LdapConfigGui extends AbstractConfigGui implements ItemListener {
 
     private static final long serialVersionUID = 241L;

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
@@ -34,6 +34,7 @@ import javax.swing.JTextField;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.ldap.sampler.LDAPExtSampler;
 import org.apache.jmeter.testelement.TestElement;
@@ -52,6 +53,7 @@ import org.apache.jorphan.gui.JLabeledChoice;
  * Based on the work of: author T.Elanjchezhiyan(chezhiyan@siptech.co.in)
  * created Apr 29 2003 11:00 AM company Sip Technologies and Exports Ltd.
  ******************************************************************************/
+@TestElementMetadata(labelResource = "ldapext_sample_title")
 public class LdapExtConfigGui extends AbstractConfigGui implements ItemListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapExtTestSamplerGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapExtTestSamplerGui.java
@@ -21,6 +21,7 @@ import java.awt.BorderLayout;
 
 import javax.swing.JPanel;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.ldap.config.gui.LdapExtConfigGui;
 import org.apache.jmeter.protocol.ldap.sampler.LDAPExtSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
@@ -35,6 +36,7 @@ import org.apache.jmeter.testelement.TestElement;
  * created Apr 29 2003 11:00 AM company Sip Technologies and Exports Ltd.
  *
  ******************************************************************************/
+@TestElementMetadata(labelResource = "ldapext_testing_title")
 public class LdapExtTestSamplerGui extends AbstractSamplerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapTestSamplerGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapTestSamplerGui.java
@@ -22,6 +22,7 @@ import java.awt.BorderLayout;
 import javax.swing.BorderFactory;
 
 import org.apache.jmeter.config.gui.LoginConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.ldap.config.gui.LdapConfigGui;
 import org.apache.jmeter.protocol.ldap.sampler.LDAPSampler;
@@ -29,6 +30,7 @@ import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "ldap_testing_title")
 public class LdapTestSamplerGui extends AbstractSamplerGui {
     private static final long serialVersionUID = 240L;
 

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
@@ -35,6 +35,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.mail.sampler.MailReaderSampler;
@@ -43,6 +44,7 @@ import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "mail_reader_title")
 public class MailReaderSamplerGui extends AbstractSamplerGui implements ActionListener, FocusListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpSamplerGui.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.protocol.smtp.sampler.gui;
 import java.awt.BorderLayout;
 import java.awt.Component;
 
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.smtp.sampler.SmtpSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
@@ -30,6 +31,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
  * Class to build superstructure-gui for SMTP-panel, sets/gets value for a JMeter's testElement-object (i.e. also for save/load-purposes).
  * This class extends AbstractSamplerGui, therefor most implemented methods are defined by JMeter's structure.
  */
+@TestElementMetadata(labelResource = "smtp_sampler_title")
 public class SmtpSamplerGui extends AbstractSamplerGui {
 
     /**

--- a/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
+++ b/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanelEntry;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.system.SystemSampler;
@@ -46,6 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * GUI for {@link SystemSampler}
  */
+@TestElementMetadata(labelResource = "system_sampler_title")
 public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener {
     private static final Logger log = LoggerFactory.getLogger(SystemSamplerGui.class);
 

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
@@ -31,6 +31,7 @@ import javax.swing.JTextField;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.gui.ServerPanel;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
@@ -41,6 +42,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 
+@TestElementMetadata(labelResource = "tcp_config_title")
 public class TCPConfigGui extends AbstractConfigGui {
 
     private static final long serialVersionUID = 240L;

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/control/gui/TCPSamplerGui.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/control/gui/TCPSamplerGui.java
@@ -22,6 +22,7 @@ import java.awt.BorderLayout;
 import javax.swing.BorderFactory;
 
 import org.apache.jmeter.config.gui.LoginConfigGui;
+import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.tcp.config.gui.TCPConfigGui;
 import org.apache.jmeter.protocol.tcp.sampler.TCPSampler;
@@ -29,6 +30,7 @@ import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
+@TestElementMetadata(labelResource = "tcp_sample_title")
 public class TCPSamplerGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 240L;


### PR DESCRIPTION
On my machine menu initialization takes 2-3 seconds (2.6GHz, SSD, fully cached).
Most of the cases the time is spent in creating Swing components, however, that work is not needed to get the label for the menu.

Even though the proper approach would be to split metadata from the UI components, I think it is fine to have an intermediate solution.
Note: `TestBeanGui` does not initialize UI elements, however, full bean metadata initialization still takes time (e.g. JSR223 elements query ScriptEngine for the list of available languages)
