### PR TITLE
Removed the http4client.retain_max_body_size property mentions

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -435,10 +435,6 @@ remote_hosts=127.0.0.1
 # No matter what, the connection will not be re-used beyond its TTL.
 #httpclient4.time_to_live=60000
 
-# Max size in bytes of PUT body to retain in result sampler.
-# Bigger results will be clipped.
-#httpclient4.max_body_retain_size=32768
-
 # Ignore EOFException that some edgy application may emit to signal end of GZIP stream
 # Defaults to false
 #httpclient4.gzip_relax_mode=false

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -532,11 +532,6 @@ JMETER-SERVER</source>
     No matter what, the connection will not be re-used beyond its TTL.<br/>
     Defaults to: <code>60000</code>
 </property>
-<property name="httpclient4.max_body_retain_size">
-    Max size in bytes of <code>PUT</code> body to retain in result sampler.
-    Bigger results will be clipped.<br/>
-    Defaults to: <code>327678</code> (bytes)
-</property>
 <property name="httpclient4.deflate_relax_mode">
     Ignore EOFException that some edgy application may emit to signal end of Deflated stream.<br/>
     Defaults to: <code>false</code>


### PR DESCRIPTION
## Description
I've removed the http4client.retain_max_body_size  property mentions from documentation and jmeter.properties file.

## Motivation and Context
The property is not used anymore and just confuses users.

## How Has This Been Tested?
No need to test, only text files modified`

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.
