### PR TITLE
UI improvements.

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -162,17 +162,20 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
 
     private void init() {// called from ctor, so must not be overridable
         setLayout(new BorderLayout(0, 5));
-        setBorder(makeBorder());
+        setBorder(BorderFactory.createEmptyBorder());
 
         // URL CONFIG
         urlConfigGui = new UrlConfigGui(true, true, true);
+        urlConfigGui.setBorder(makeBorder());
 
         // HTTP request options
         JPanel httpOptions = new HorizontalPanel();
         httpOptions.add(getImplementationPanel());
         httpOptions.add(getTimeOutPanel());
+
         // AdvancedPanel (embedded resources, source address and optional tasks)
         JPanel advancedPanel = new VerticalPanel();
+        advancedPanel.setBorder(makeBorder());
         if (!isAJP) {
             advancedPanel.add(httpOptions);
         }
@@ -190,7 +193,11 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         tabbedPane.add(JMeterUtils
                 .getResString("web_testing_advanced"), advancedPanel);
 
-        JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, makeTitlePanel(), tabbedPane);
+        JPanel wrapper = new JPanel(new BorderLayout());
+        wrapper.setBorder(makeBorder());
+        wrapper.add(makeTitlePanel(), BorderLayout.CENTER);
+
+        JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, wrapper, tabbedPane);
         splitPane.setBorder(BorderFactory.createEmptyBorder());
         splitPane.setOneTouchExpandable(true);
         add(splitPane);

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
@@ -122,7 +122,7 @@ public class JMSPropertiesPanel extends JPanel implements ActionListener {
      */
     private void init() {// called from ctor, so must not be overridable
         setLayout(new BorderLayout());
-        setBorder(BorderFactory.createEmptyBorder(10, 10, 5, 10));
+        setBorder(BorderFactory.createEmptyBorder(10, 0, 5, 0));
         add(createPropertiesPanel(), BorderLayout.CENTER);
     }
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
@@ -17,7 +17,7 @@
 
 package org.apache.jmeter.protocol.jms.control.gui;
 
-import java.awt.BorderLayout;
+import java.awt.*;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -41,6 +41,7 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.gui.JLabeledTextField;
+
 
 /**
  * Configuration screen for Java Messaging Point-to-Point requests.
@@ -252,9 +253,12 @@ public class JMSSamplerGui extends AbstractSamplerGui {
         correlationPanel.add(useReqMsgIdAsCorrelId);
         correlationPanel.add(useResMsgIdAsCorrelId);
 
+        JPanel communicationStylePanel = new JPanel();
+        communicationStylePanel.add(jmsCommunicationStyle);
+
         JPanel messageNorthPanel = new JPanel(new BorderLayout());
         JPanel onewayPanel = new HorizontalPanel();
-        onewayPanel.add(jmsCommunicationStyle);
+        onewayPanel.add(communicationStylePanel);
         onewayPanel.add(correlationPanel);
         messageNorthPanel.add(onewayPanel, BorderLayout.NORTH);
 

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SecuritySettingsPanel.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SecuritySettingsPanel.java
@@ -123,8 +123,6 @@ public class SecuritySettingsPanel extends JPanel{
         rbUseSSL.addItemListener(this::rbSecuritySettingsItemStateChanged);
         rbUseStartTLS.addItemListener(this::rbSecuritySettingsItemStateChanged);
 
-        cbTrustAllCerts.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
-        cbTrustAllCerts.setMargin(new java.awt.Insets(0, 0, 0, 0));
         cbTrustAllCerts.setEnabled(false);
         cbTrustAllCerts.setToolTipText(JMeterUtils.getResString("smtp_trustall_tooltip")); // $NON-NLS-1$
         cbTrustAllCerts.addActionListener(this::cbTrustAllCertsActionPerformed);
@@ -133,8 +131,6 @@ public class SecuritySettingsPanel extends JPanel{
         gridBagConstraints.gridy = 1;
         this.add(cbTrustAllCerts, gridBagConstraints);
 
-        cbEnforceStartTLS.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
-        cbEnforceStartTLS.setMargin(new java.awt.Insets(0, 0, 0, 0));
         cbEnforceStartTLS.setEnabled(false);
         cbEnforceStartTLS.addActionListener(this::cbEnforceStartTLSActionPerformed);
         cbEnforceStartTLS.setToolTipText(JMeterUtils.getResString("smtp_enforcestarttls_tooltip")); // $NON-NLS-1$
@@ -143,8 +139,6 @@ public class SecuritySettingsPanel extends JPanel{
         gridBagConstraints.gridy = 1;
         this.add(cbEnforceStartTLS, gridBagConstraints);
 
-        cbUseLocalTrustStore.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
-        cbUseLocalTrustStore.setMargin(new java.awt.Insets(0, 0, 0, 0));
         cbUseLocalTrustStore.setEnabled(false);
         cbUseLocalTrustStore.addActionListener(this::cbUseLocalTrustStoreActionPerformed);
 

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
@@ -787,7 +787,6 @@ public class SmtpPanel extends JPanel {
         gridBagConstraints.gridy = 3;
         panelMessageSettings.add(jlMessage, gridBagConstraints);
 
-        taMessage.setBorder(BorderFactory.createBevelBorder(1));
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 3;
         gridBagConstraints.fill = GridBagConstraints.BOTH;


### PR DESCRIPTION
## Description
Fixes the empty border around the vertical split pane in the http sampler.
Adds some missing borders around some syntax text areas (There are some other places where the text fields don't have a border but couldn't find the according source file).
Fixes misaligned radio buttons in security settings panel.

## Motivation and Context
The empty border looked weird as the split pane dividers weren't flush.

## How Has This Been Tested?
See screenshots.

## Screenshots (if appropriate):
| Old | New |
|:----:|:-----:|
|![http_request_old](https://user-images.githubusercontent.com/31143295/78662803-5fdc6a00-78d1-11ea-958c-5a9b9976bc2c.png)|![http_request_new](https://user-images.githubusercontent.com/31143295/78662815-64a11e00-78d1-11ea-9ff6-4bab230f62f3.png)|
|![jms_table_border_old](https://user-images.githubusercontent.com/31143295/78662838-6ec31c80-78d1-11ea-9380-e7182b254a0c.png)|![jms_table_border_new](https://user-images.githubusercontent.com/31143295/78662854-74206700-78d1-11ea-8022-973c8e4a2f10.png)|
|![smtp_old](https://user-images.githubusercontent.com/31143295/78662885-813d5600-78d1-11ea-84a3-0c91c37c5d6d.png)|![smtp_new](https://user-images.githubusercontent.com/31143295/78662910-87cbcd80-78d1-11ea-9caf-9929cd19ba1f.png)|
|![text_area_old](https://user-images.githubusercontent.com/31143295/78662920-8d291800-78d1-11ea-8b8b-e07eabd75bb7.png)|![text_area_new](https://user-images.githubusercontent.com/31143295/78662929-91edcc00-78d1-11ea-8939-a150f4f465b3.png)|

## Types of changes
- UI improvements.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] ~~I have updated the documentation accordingly.~~ not needed.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
