### PR TITLE
Added JEXL3 as a syntax alias for JSyntaxTextArea

### DIFF
--- a/src/core/src/main/resources/org/apache/jmeter/gui/util/textarea.properties
+++ b/src/core/src/main/resources/org/apache/jmeter/gui/util/textarea.properties
@@ -33,6 +33,7 @@ javaclass = text/java
 javascript = text/javascript
 jexl = text/java
 jexl2 = text/java
+jexl3 = text/java
 jpython = text/python
 js = text/javascript
 jscript = text/javascript


### PR DESCRIPTION
## Description
Added jexl3 as a language alias for text/java, for use with JSyntaxTextArea:
Add: jexl3=text/java to textarea.properties

## Motivation and Context
The JSR223 and other similar components that use JSyntaxTextArea may set the language to JEXL3, which is a perfecly valid scripting language name, but the syntax highlighter won't recognize and and won't enable the highlighting. By adding this alias, the issue is resolved. Considering that an alias already existed for jexl2, it makes sense that jexl3 be added.

## How Has This Been Tested?
The change was tested in a custom build. Because of the nature of the change (adding a property mapping) there is no risk of breakage. Furthermore, the value of the property mapping is verified to be good (same as is used in other mappings, i.e. for jexl2).

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
