### PR TITLE
Fix to Bug 64480

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
@@ -100,7 +100,7 @@ public class HTTPArgumentsPanel extends ArgumentsPanel {
     public HTTPArgumentsPanel() {
         super(JMeterUtils.getResString("paramtable")); //$NON-NLS-1$
         init();
-        clearBorderForMainPanel();
+        //clearBorderForMainPanel();
     }
 
     @Override


### PR DESCRIPTION
## Description
User defined variables in the config element is duplicated in the Jmeter-5.3

The root cause of that is the introduction of clearing border function in HTTPArgumentsPanel

## Motivation and Context
This will resolve the duplicated entry of User defined variables in the config element 

https://bz.apache.org/bugzilla/show_bug.cgi?id=64480

## How Has This Been Tested?
Tested a patch locally.. All test passed and the duplicated entry has been removed. no other functionality brroken
