### PR TITLE
Ensure all buttons added to the toolbar behave/look consistently.

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
@@ -91,6 +91,22 @@ public class JMeterToolBar extends JToolBar implements LocaleChangeListener {
         return toolBar;
     }
 
+    @Override
+    protected void addImpl(Component comp, Object constraints, int index) {
+        super.addImpl(comp, constraints, index);
+        if (comp instanceof JButton) {
+            // Ensure buttons added to the toolbar have the same style.
+            JButton b = (JButton) comp;
+            b.setFocusable(false);
+            if (b.isBorderPainted() && (b.getText() == null || b.getText().isEmpty())) {
+                b.setRolloverEnabled(true);
+                b.putClientProperty(DarkButtonUI.KEY_VARIANT, DarkButtonUI.VARIANT_BORDERLESS);
+                b.putClientProperty(DarkButtonUI.KEY_THIN, true);
+                b.putClientProperty(DarkButtonUI.KEY_SQUARE, true);
+            }
+        }
+    }
+
     /**
      * Setup toolbar content
      * @param toolBar {@link JMeterToolBar}
@@ -128,18 +144,7 @@ public class JMeterToolBar extends JToolBar implements LocaleChangeListener {
      * @return a button for toolbar
      */
     private static JButton makeButtonItemRes(IconToolbarBean iconBean) throws Exception {
-        JButton button = new JButton(loadIcon(iconBean, iconBean.getIconPath())) {
-            @Override
-            public void updateUI() {
-                super.updateUI();
-                // Certain LaFs might alter button configuration, so we revert it to the way we want
-                // For instance, https://github.com/weisJ/darklaf/issues/84
-                setFocusable(false);
-                setRolloverEnabled(true);
-                putClientProperty(DarkButtonUI.KEY_VARIANT, DarkButtonUI.VARIANT_BORDERLESS);
-                putClientProperty(DarkButtonUI.KEY_THIN, true);
-            }
-        };
+        JButton button = new JButton(loadIcon(iconBean, iconBean.getIconPath()));
         button.setToolTipText(JMeterUtils.getResString(iconBean.getI18nKey()));
         if (!iconBean.getIconPathPressed().equals(iconBean.getIconPath())) {
             button.setPressedIcon(loadIcon(iconBean, iconBean.getIconPathPressed()));


### PR DESCRIPTION
## Description
Ensure all buttons added to the toolbar behave and look consistently.

## Motivation and Context
Some plugins add own buttons to the toolbar e.g. JMeter Plugin.
Because those most likely aren't configured the same way the other buttons are they look/feel out of place.
This PR ensures that buttons in the toolbar are
1. Non focusable.
2. If a Darklaf theme is selected have their client properties set accordingly.

Ideally there should be an API for plugin developers to add own buttons to the toolbar (Is there already?). Right now the icons are located at the end of the toolbar instead of the designated button area.

## How Has This Been Tested?
See screenshots.

## Screenshots (if appropriate):
Visually this only makes a difference with Darklaf.

Before:
![toolbar_old](https://user-images.githubusercontent.com/31143295/85273933-8cd6fc80-b47e-11ea-824a-c76d320586e1.png)

After:
![toolbar_new](https://user-images.githubusercontent.com/31143295/85273943-8fd1ed00-b47e-11ea-8670-8a4b818cfa5f.png)

## Types of changes
- Visual changes.

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
