### PR TITLE
Set JMSType header field through JMSProperties.

### DIFF
--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/Utils.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/Utils.java
@@ -235,7 +235,7 @@ public final class Utils {
                 msg.setJMSCorrelationID((String)value);
             } else if ("JMSType".equalsIgnoreCase(name)) { // $NON-NLS-1$
                 msg.setJMSType((String)value);
-        } else {
+            } else {
                 msg.setObjectProperty(name, value);
             }
         }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/Utils.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/Utils.java
@@ -229,10 +229,13 @@ public final class Utils {
                 log.debug("Adding property [" + name + "=" + value + "]");
             }
 
-            // WebsphereMQ does not allow corr. id. to be set using setStringProperty()
+            // Some JMS implemenations do not allow certain header fields to be set using properties
+            // e.g.: WebsphereMQ does not allow corr. id. to be set using setStringProperty()
             if ("JMSCorrelationID".equalsIgnoreCase(name)) { // $NON-NLS-1$
                 msg.setJMSCorrelationID((String)value);
-            } else {
+            } else if ("JMSType".equalsIgnoreCase(name)) { // $NON-NLS-1$
+                msg.setJMSType((String)value);
+        } else {
                 msg.setObjectProperty(name, value);
             }
         }


### PR DESCRIPTION
## Description
Allow the JMSType header field to be set using the JMSProperties.

## Motivation and Context
JMeter seems to assume that all JMS implementations support setting the JMSType header field of a Message through the JMSProperties. This is not necessarily the case. The proprietary JMS implementation I use at our company does not support this and requires the JMSType header field to be set using Message.setJMSType. The JMS spec does not seem to require implementations to set the header fields through the message properties. It does state that JMSCorrelationId, JMSType and JMSReplyTo should be set by the client.
Since there already is a similar fix in place for WebSphereMQ where the JMSCorrelationId is set explicitly when a property with that name is set, it seemed only logical to do the same for JMSType.

## How Has This Been Tested?
Ran all unit tests, no test failures so this change does not seem to affect existing code.
Using our proprietary JMS implementation, added message property "JMSType" to a message. Send message, check request headers.
Prior to change: JMSType header field remained empty. A property with the name "JMSType" appeared under "Properties" containing the value.
After change: JMSType header field is set to expected value. No separate property, see screenshot.

## Screenshots (if appropriate):
When setting JMSType through properties, the JMSType would end up empty in the request header and a separate "JMSType" property would end up under "Properties:". After this change, the result looks as expected.
![image(10)](https://user-images.githubusercontent.com/67269601/85286002-278d0680-b492-11ea-8fe9-8a60a9318c39.png)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.
note: since there does not seem to be any documentation for the existing CorrelationId fix, I have not added any documentation for this change.

