### PR TITLE
Bug 64558 - Improve performances and throughput of Sample Results (more than 35%) by lifting contention on writing

### DIFF
--- a/checksum.xml
+++ b/checksum.xml
@@ -31,6 +31,7 @@
     <trusted-key id='e57428da9e879e7d' group='com.helger' />
     <trusted-key id='3684155e9365c30e' group='com.jayway.jsonpath' />
     <trusted-key id='a50569c7ca7fa1f0' group='com.jcraft' />
+    <trusted-key id='bffa420097f49c8a' group='com.lmax' />
     <trusted-key id='0a36eef644cff773' group='com.metsci.ext.com.kitfox.svg' />
     <trusted-key id='db45d3a62a183ce2' group='com.miglayout' />
     <trusted-key id='aa49c633b4734832' group='com.pinterest' />

--- a/src/core/build.gradle.kts
+++ b/src/core/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation("org.jodd:jodd-props")
     implementation("org.mozilla:rhino")
     implementation("org.slf4j:jcl-over-slf4j")
+    implementation("com.lmax:disruptor:3.4.2")
     // TODO: JMeter bundles Xerces, however the reason is unknown
     runtimeOnly("xerces:xercesImpl")
     runtimeOnly("xml-apis:xml-apis")

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultCollector.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultCollector.java
@@ -127,23 +127,23 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
     /** AutoFlush on each line */
     private static final boolean SAVING_AUTOFLUSH = JMeterUtils.getPropDefault("jmeter.save.saveservice.autoflush", false); //$NON-NLS-1$
 
-	private static final int DEFAULT_RING_BUFFER_SIZE = 0;
-	private static final int RING_BUFFER_SIZE = JMeterUtils.getPropDefault("jmeter.save.disruptor.ringbuffer.size",
-			DEFAULT_RING_BUFFER_SIZE);
+    private static final int DEFAULT_RING_BUFFER_SIZE = 0;
+    private static final int RING_BUFFER_SIZE = JMeterUtils.getPropDefault("jmeter.save.disruptor.ringbuffer.size",
+            DEFAULT_RING_BUFFER_SIZE);
 
-	private enum WaitingStrategy {
-		BlockingWaitStrategy, SleepingWaitStrategy, YieldingWaitStrategy, BusySpinWaitStrategy;
-		// LiteBlockingWaitStrategy experimental
-		// LiteTimeoutBlockingWaitStrategy undocumented
-		// PhasedBackoffWaitStrategy undocumented
-		// TimeoutBlockingWaitStrategy undocumented
-	}
+    private enum WaitingStrategy {
+        BlockingWaitStrategy, SleepingWaitStrategy, YieldingWaitStrategy, BusySpinWaitStrategy;
+        // LiteBlockingWaitStrategy experimental
+        // LiteTimeoutBlockingWaitStrategy undocumented
+        // PhasedBackoffWaitStrategy undocumented
+        // TimeoutBlockingWaitStrategy undocumented
+    }
 
-	private static final WaitingStrategy DEFAULT_WAIT_STRATEGY = WaitingStrategy.BlockingWaitStrategy;
-	private static final String WAIT_STRATEGY_STR = JMeterUtils.getPropDefault("jmeter.save.disruptor.wait-strategy",
-			DEFAULT_WAIT_STRATEGY.name());
-	
-	// Static variables
+    private static final WaitingStrategy DEFAULT_WAIT_STRATEGY = WaitingStrategy.BlockingWaitStrategy;
+    private static final String WAIT_STRATEGY_STR = JMeterUtils.getPropDefault("jmeter.save.disruptor.wait-strategy",
+            DEFAULT_WAIT_STRATEGY.name());
+
+    // Static variables
 
     // Lock used to guard static mutable variables
     private static final Object LOCK = new Object();
@@ -166,20 +166,20 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
     // Instance variables (guarded by volatile)
     private transient volatile PrintWriter out;
 
-	private transient volatile Disruptor<ResultCollectorEvent> disruptor;
+    private transient volatile Disruptor<ResultCollectorEvent> disruptor;
 
-	private static class ResultCollectorEvent {
-		private SampleEvent sampleEvent;
+    private static class ResultCollectorEvent {
+        private SampleEvent sampleEvent;
 
-		public SampleEvent getSampleEvent() {
-			return sampleEvent;
-		}
+        public SampleEvent getSampleEvent() {
+            return sampleEvent;
+        }
 
-		public void setSampleEvent(SampleEvent sampleEvent) {
-			this.sampleEvent = sampleEvent;
-		}
-	}
-	
+        public void setSampleEvent(SampleEvent sampleEvent) {
+            this.sampleEvent = sampleEvent;
+        }
+    }
+
     /**
      * Is a test running ?
      */
@@ -329,12 +329,12 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
     @Override
     public void testEnded(String host) {
         synchronized(LOCK){
-        	
-			if (disruptor != null) {
-				log.info("Shutdown disruptor of ResultCollector '{}'", getName());
-				disruptor.shutdown();
-				log.info("Disruptor of ResultCollector '{}' stopped", getName());
-			}
+
+            if (disruptor != null) {
+                log.info("Shutdown disruptor of ResultCollector '{}'", getName());
+                disruptor.shutdown();
+                log.info("Disruptor of ResultCollector '{}' stopped", getName());
+            }
 
             instanceCount--;
             if (instanceCount <= 0) {
@@ -356,36 +356,36 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
         }
     }
 
-	private void saveSampleEvent(SampleEvent event, SampleSaveConfiguration saveConfig) {
-		try {
-			if (saveConfig.saveAsXml()) {
-				SaveService.saveSampleResult(event, out);
-			} else { // !saveAsXml
-				CSVSaveService.saveSampleResult(event, out);
-			}
-		} catch (Exception err) {
-			log.error("Error trying to record a sample", err); // should throw exception back to caller
-		}
-	}
+    private void saveSampleEvent(SampleEvent event, SampleSaveConfiguration saveConfig) {
+        try {
+            if (saveConfig.saveAsXml()) {
+                SaveService.saveSampleResult(event, out);
+            } else { // !saveAsXml
+                CSVSaveService.saveSampleResult(event, out);
+            }
+        } catch (Exception err) {
+            log.error("Error trying to record a sample", err); // should throw exception back to caller
+        }
+    }
 
-	private WaitStrategy buildWaitStrategy(WaitingStrategy strategy) {
-		WaitStrategy result;
-		switch (strategy) {
-		case BusySpinWaitStrategy:
-			result = new BusySpinWaitStrategy();
-			break;
-		case SleepingWaitStrategy:
-			result = new SleepingWaitStrategy();
-			break;
-		case YieldingWaitStrategy:
-			result = new YieldingWaitStrategy();
-			break;
-		default:
-			result = new BlockingWaitStrategy();
-			break;
-		}
-		return result;
-	}
+    private WaitStrategy buildWaitStrategy(WaitingStrategy strategy) {
+        WaitStrategy result;
+        switch (strategy) {
+        case BusySpinWaitStrategy:
+            result = new BusySpinWaitStrategy();
+            break;
+        case SleepingWaitStrategy:
+            result = new SleepingWaitStrategy();
+            break;
+        case YieldingWaitStrategy:
+            result = new YieldingWaitStrategy();
+            break;
+        default:
+            result = new BlockingWaitStrategy();
+            break;
+        }
+        return result;
+    }
 
     @Override
     public void testStarted(String host) {
@@ -411,22 +411,22 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
                 log.error("Exception occurred while initializing file output.", e);
             }
 
-			if (RING_BUFFER_SIZE > 0) {
-				int ringBufferSize = JMeterUtils.ceilingNextPowerOfTwo(RING_BUFFER_SIZE);
-				log.info("Computed for result collector {} a ringBufferSize:{} from property:{} with value:{}", getName(),
-						ringBufferSize, "jmeter.save.disruptor.ringbuffer.size", RING_BUFFER_SIZE);
-				WaitingStrategy waitingStrategy = WaitingStrategy.valueOf(WAIT_STRATEGY_STR);
-				log.info("Initializing disruptor for result collector '{}' with ring buffer size: {} and wait strategy: {} ", getName(),
-						ringBufferSize, waitingStrategy);
-				disruptor = new Disruptor<>(ResultCollectorEvent::new, ringBufferSize, DaemonThreadFactory.INSTANCE,
-						ProducerType.MULTI, buildWaitStrategy(waitingStrategy));
-				disruptor.handleEventsWith((event, sequence, endOfBatch) -> {
-					saveSampleEvent(event.getSampleEvent(), getSaveConfig());
-				});
-				disruptor.start();
-			} else {
-				log.info("Ring buffer is not enabled, will use legacy synchronized saving of SampleResuls");
-			}
+            if (RING_BUFFER_SIZE > 0) {
+                int ringBufferSize = JMeterUtils.ceilingNextPowerOfTwo(RING_BUFFER_SIZE);
+                log.info("Computed for result collector {} a ringBufferSize:{} from property:{} with value:{}", getName(),
+                        ringBufferSize, "jmeter.save.disruptor.ringbuffer.size", RING_BUFFER_SIZE);
+                WaitingStrategy waitingStrategy = WaitingStrategy.valueOf(WAIT_STRATEGY_STR);
+                log.info("Initializing disruptor for result collector '{}' with ring buffer size: {} and wait strategy: {} ", getName(),
+                        ringBufferSize, waitingStrategy);
+                disruptor = new Disruptor<>(ResultCollectorEvent::new, ringBufferSize, DaemonThreadFactory.INSTANCE,
+                        ProducerType.MULTI, buildWaitStrategy(waitingStrategy));
+                disruptor.handleEventsWith((event, sequence, endOfBatch) -> {
+                    saveSampleEvent(event.getSampleEvent(), getSaveConfig());
+                });
+                disruptor.start();
+            } else {
+                log.info("Ring buffer is not enabled, will use legacy synchronized saving of SampleResuls");
+            }
 
         }
         inTest = true;
@@ -645,14 +645,14 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
                 SampleSaveConfiguration config = getSaveConfig();
                 result.setSaveConfig(config);
 
-				if (disruptor != null) {
-					RingBuffer<ResultCollectorEvent> ringBuffer = disruptor.getRingBuffer();
-					ringBuffer.publishEvent((rbEvent, seq, sampleEvent) -> {
-						rbEvent.setSampleEvent(sampleEvent);
-					}, event);
-				} else {
-					saveSampleEvent(event, config);
-				}
+                if (disruptor != null) {
+                    RingBuffer<ResultCollectorEvent> ringBuffer = disruptor.getRingBuffer();
+                    ringBuffer.publishEvent((rbEvent, seq, sampleEvent) -> {
+                        rbEvent.setSampleEvent(sampleEvent);
+                    }, event);
+                } else {
+                    saveSampleEvent(event, config);
+                }
             }
         }
 

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -79,6 +79,7 @@ import com.thoughtworks.xstream.security.NoTypePermission;
 public class JMeterUtils implements UnitTestManager {
     private static final Logger log = LoggerFactory.getLogger(JMeterUtils.class);
 
+    private static final int BITS_PER_INT = 32;
     private static final String JMETER_VARS_PREFIX = "__jm__";
     public static final String THREAD_GROUP_DISTRIBUTED_PREFIX_PROPERTY_NAME = "__jm.D_TG";
 
@@ -1310,5 +1311,17 @@ public class JMeterUtils implements UnitTestManager {
         XStream xstream = new XStream();
         JMeterUtils.setupXStreamSecurityPolicy(xstream);
         return xstream;
+    }
+    
+    /**
+     * Calculate the next power of 2, greater than or equal to x.
+     * <p>
+     * From Hacker's Delight, Chapter 3, Harry S. Warren Jr.
+     *
+     * @param x Value to round up
+     * @return The next power of 2 from x inclusive
+     */
+    public static int ceilingNextPowerOfTwo(final int x) {
+        return 1 << (BITS_PER_INT - Integer.numberOfLeadingZeros(x - 1));
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -1312,7 +1312,7 @@ public class JMeterUtils implements UnitTestManager {
         JMeterUtils.setupXStreamSecurityPolicy(xstream);
         return xstream;
     }
-    
+
     /**
      * Calculate the next power of 2, greater than or equal to x.
      * <p>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -596,6 +596,17 @@ JMETER-SERVER</source>
     Only <code>xml</code> and <code>csv</code> are currently supported.<br/>
     Defaults to: <code>csv</code>
 </property>
+<property name="jmeter.save.disruptor.ringbuffer.size">
+	Size of the Ring Buffer of <a href="https://lmax-exchange.github.io/disruptor/">LMAX Disruptor</a> used to store SampleResults that are delivered to ResultCollector (Default listener in CLI mode, View Results Tree...).<br/>
+    <note>Integer value that should be a power of 2 (but JMeter will adjust). Ensure it is large enough based on the type of test you run.</note><br/>
+    Defaults to: <code>0</code> meaning it is disabled.
+</property>
+<property name="jmeter.save.disruptor.wait-strategy">
+	RingBuffer wait strategy for storing SampleResults when Ring Buffer is enable (jmeter.save.disruptor.ringbuffer.size>0)<br/>
+    Defaults to: <code>BlockingWaitStrategy</code><br/>
+    Legitimate values: <code>BlockingWaitStrategy</code>, <code>SleepingWaitStrategy</code>, <code>, YieldingWaitStrategy</code>, <code>BusySpinWaitStrategy</code>.<br/>
+    See <a href="https://lmax-exchange.github.io/disruptor/docs/com/lmax/disruptor/WaitStrategy.html">WaitStrategy javadocs</a> 
+</property>
 <property name="jmeter.save.saveservice.assertion_results_failure_message">
     <code>true</code> when field should be saved; <code>false</code> otherwise.<br/>
     <code>assertion_results_failure_message</code> only affects CSV output.<br/>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -605,7 +605,7 @@ JMETER-SERVER</source>
 	RingBuffer wait strategy for storing SampleResults when Ring Buffer is enable (jmeter.save.disruptor.ringbuffer.size>0)<br/>
     Defaults to: <code>BlockingWaitStrategy</code><br/>
     Legitimate values: <code>BlockingWaitStrategy</code>, <code>SleepingWaitStrategy</code>, <code>, YieldingWaitStrategy</code>, <code>BusySpinWaitStrategy</code>.<br/>
-    See <a href="https://lmax-exchange.github.io/disruptor/docs/com/lmax/disruptor/WaitStrategy.html">WaitStrategy javadocs</a> 
+    See <a href="https://lmax-exchange.github.io/disruptor/docs/com/lmax/disruptor/WaitStrategy.html">WaitStrategy javadocs</a>
 </property>
 <property name="jmeter.save.saveservice.assertion_results_failure_message">
     <code>true</code> when field should be saved; <code>false</code> otherwise.<br/>


### PR DESCRIPTION
## Description

Hello Team,
We have noticed a major contention in JMeter that becomes a major problem at high scale.
The issue is related to the PrintWriter in ResultCollector.
In tests with high throughput (> 100 req/s), the lock taken by PrintWriter#println() will lead many threads to block waiting for the lock to be released (even with the underlying buffering).

We implemented a fix based on LMAX-Disruptor library:

- https://github.com/LMAX-Exchange/disruptor


You'll find an ODS document showing some results:

- https://github.com/ubikloadpack/jmeter/pull/61/files?w=1

The best ones made with dev/test_bug_64558.jmx being :

```
BlockingWaitStrategy 	
Threads \ Ring buffer size	0 	1024 		65536 		131072 		262144 		524288 		Max. gain
90 			131580918 	144970934 	161682916 	178337178 	N/A 		N/A 		35.53 %
500 			129404418 	8589281 	186455414 	183922157 	N/A 		N/A 		44.09 %
3000 			125778729 	23311727 	11658406 	25689004 	174138609 	174434147 	38.68 %
```

Please note it is critical to disable the Summariser during the test as it degrades throughput (we'll provide a future patch for this), using:

-     -Jsummariser.name=

Contributed by UbikLoadPack Team:

- Florent
- Benoit
- Philippe

Website:  https://ubikloadpack.com
Twitter: @ubikloadpack 

Files:

[test_bug_64558.jmx.txt](https://github.com/apache/jmeter/files/4826480/test_bug_64558.jmx.txt)

## Motivation and Context

See:

https://bz.apache.org/bugzilla/show_bug.cgi?id=64558

## How Has This Been Tested?

Benchmark :

jmeter -Jsummary= -n -t test_bug_64558.jmx -l results.csv 

Results in stats.ods

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
