### PR TITLE
Bug 64558 - Improve performances and throughput of Sample Results by lifting contention on writing

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -1034,6 +1034,7 @@ public class JMeter implements JMeterPlugin {
             ResultCollector resultCollector = null;
             if (logFile != null) {
                 resultCollector = new ResultCollector(summariser);
+                resultCollector.setName("DefaultResultCollector");
                 resultCollector.setFilename(logFile);
                 clonedTree.add(clonedTree.getArray()[0], resultCollector);
             }

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultCollector.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultCollector.java
@@ -163,17 +163,17 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
     /**
      * We cache the property value to avoid contention point at high throughput
      */
-	private transient boolean errorOnlyCached;
+    private transient boolean errorOnlyCached;
 
     /**
      * We cache the property value to avoid contention point at high throughput
      */
-	private transient boolean successOnlyCached;
-	
+    private transient boolean successOnlyCached;
+
     /**
      * We cache the property value to avoid contention point at high throughput
      */
-	private transient String fileNameCached;
+    private transient String fileNameCached;
 
     /**
      * No-arg constructor.
@@ -323,14 +323,14 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
                 }
                 if (QUEUE_SIZE > 0) {
                     log.info("Interrupting queueConsumer of {}", getName());
-	                queueConsumer.interrupt();
-	                SampleEvent event = null;
-	                log.info("Emptying the queue of {} which has {} elements", getName(), queue.size());
-	                SampleSaveConfiguration config = getSaveConfig();
-	                while((event = queue.poll()) != null) {
-	                	event.getResult().setSaveConfig(config);
-	                	saveSampleEvent(event, getSaveConfig());
-	                }
+                    queueConsumer.interrupt();
+                    SampleEvent event = null;
+                    log.info("Emptying the queue of {} which has {} elements", getName(), queue.size());
+                    SampleSaveConfiguration config = getSaveConfig();
+                    while((event = queue.poll()) != null) {
+                        event.getResult().setSaveConfig(config);
+                        saveSampleEvent(event, getSaveConfig());
+                    }
                 }
                 finalizeFileOutput();
                 out = null;
@@ -368,11 +368,11 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
             }
 
             if (QUEUE_SIZE > 0) {
-            	log.info("Configuring queue for {} of size:{}", getName(), QUEUE_SIZE);
-            	queue = new ArrayBlockingQueue<SampleEvent>(QUEUE_SIZE);
-            	queueConsumer = new Thread(new SampleEventConsumer(), getName() + "-QueueConsumer");
-            	queueConsumer.setDaemon(true);
-            	queueConsumer.start();
+                log.info("Configuring queue for {} of size:{}", getName(), QUEUE_SIZE);
+                queue = new ArrayBlockingQueue<SampleEvent>(QUEUE_SIZE);
+                queueConsumer = new Thread(new SampleEventConsumer(), getName() + "-QueueConsumer");
+                queueConsumer.setDaemon(true);
+                queueConsumer.start();
             }
         }
         inTest = true;
@@ -386,19 +386,19 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
     }
 
     private class SampleEventConsumer implements Runnable {
-		@Override
-		public void run() {
-			SampleEvent event;
-			try {
-				SampleSaveConfiguration config = getSaveConfig();
-				while ((event = queue.take()) != null) {
-					event.getResult().setSaveConfig(config);
-					saveSampleEvent(event, getSaveConfig());
-				}
-			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
-		}
+        @Override
+        public void run() {
+            SampleEvent event;
+            try {
+                SampleSaveConfiguration config = getSaveConfig();
+                while ((event = queue.take()) != null) {
+                    event.getResult().setSaveConfig(config);
+                    saveSampleEvent(event, getSaveConfig());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private void saveSampleEvent(SampleEvent event, SampleSaveConfiguration saveConfig) {
@@ -620,13 +620,13 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
             sendToVisualizer(result);
             if (out != null && !isResultMarked(result) && !this.isStats) {
                 try {
-                	if (QUEUE_SIZE > 0) {
-	                	queue.put(event);
-                	} else {
+                    if (QUEUE_SIZE > 0) {
+                        queue.put(event);
+                    } else {
                         SampleSaveConfiguration config = getSaveConfig();
                         result.setSaveConfig(config);
-                		saveSampleEvent(event, config);
-                	}
+                        saveSampleEvent(event, config);
+                    }
                 } catch (Exception err) {
                     log.error("Error trying to record a sample", err); // should throw exception back to caller
                 }

--- a/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
@@ -93,6 +93,11 @@ public class ThreadGroup extends AbstractThreadGroup {
     private ListedHashTree threadGroupTree;
 
     /**
+     * We cache thread group name for performance otherwise it's a contention point
+     */
+	private transient String cachedName;
+
+    /**
      * No-arg constructor.
      */
     public ThreadGroup() {
@@ -212,6 +217,7 @@ public class ThreadGroup extends AbstractThreadGroup {
         this.groupNumber = groupNum;
         this.notifier = notifier;
         this.threadGroupTree = threadGroupTree;
+        this.cachedName = super.getName();
         int numThreads = getNumThreads();
         int rampUpPeriodInSeconds = getRampUp();
         boolean isSameUserOnNextIteration = isSameUserOnNextIteration();
@@ -631,4 +637,12 @@ public class ThreadGroup extends AbstractThreadGroup {
             }
         }
     }
+
+	@Override
+	public String getName() {
+		if (cachedName == null) {
+			cachedName = super.getName();
+		}
+		return cachedName;
+	}
 }

--- a/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
@@ -95,7 +95,7 @@ public class ThreadGroup extends AbstractThreadGroup {
     /**
      * We cache thread group name for performance otherwise it's a contention point
      */
-	private transient String cachedName;
+    private transient String cachedName;
 
     /**
      * No-arg constructor.
@@ -638,11 +638,11 @@ public class ThreadGroup extends AbstractThreadGroup {
         }
     }
 
-	@Override
-	public String getName() {
-		if (cachedName == null) {
-			cachedName = super.getName();
-		}
-		return cachedName;
-	}
+    @Override
+    public String getName() {
+        if (cachedName == null) {
+            cachedName = super.getName();
+        }
+        return cachedName;
+    }
 }


### PR DESCRIPTION
Hello Team,

As reported in PR 601, we have noticed a major contention in JMeter that becomes a major problem at high scale.
The issue is related to the PrintWriter in ResultCollector.
In tests with high throughput (> 100 req/s), the lock taken by PrintWriter#println() will lead many threads to block waiting for the lock to be released (even with the underlying buffering).

Following review done by JMeter team (Thanks Felix and Vladimir), we noticed important performance enhancement and more stable results using ArrayBlockingQueue on different computers (compared to using LMAX-Disruptor). 
The tests done with JCTools were not conclusive on our side. 

The problem with RB and JCTools is always in our tests when the storage becomes full.
Results with ArrayBlockingQueue show more stability.

We notice an increase by 69% of the throughput of this:

`
jmeter -n -t test_bug_64558.jmx -Jjmeter.save.queue.size=524288 -Jthreads=2000 -Jduration=120 -Jrampup=10 -Jsummariser.name= -l results_buffer_256k_q524288.csv
`

vs this one JMeter 5.3:

`
jmeter -n -t test_bug_64558.jmx -Jthreads=2000 -Jduration=120 -Jrampup=10 -Jsummariser.name= -l results.csv
`

Please note it is critical to disable the Summariser during the test as it degrades throughput (we'll provide a future patch for this), using:

    -Jsummariser.name=
[test_bug_64558.jmx.txt](https://github.com/apache/jmeter/files/4840938/test_bug_64558.jmx.txt)


Implementation does the following:

- Introduce a configurable buffer for output CSV/XML file  (property:jmeter.save.saveservice.buffer) => This alone improves slightly performance
- Cache properties that are highly requested : Thread Group name, isSuccess, IsError , filename
- Introduce an ArrayBlockingQueue and make Sampler use it when saving SampleEvent and a thread that will read the queue and write
- Remove costly synchronization on some metrics in favor of multiple AtomicInteger, this looks an acceptable trade-off to me, but if needed we can revert it 

Contributed by UbikLoadPack Team:

    Florent
    Benoit
    Philippe

Website: https://ubikloadpack.com
Twitter: @ubikloadpack

Files:
