### PR TITLE
Bug 64581 - Allow SampleResult#setIgnore to influence behaviour on Sampler Error

### DIFF
--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -112,6 +112,7 @@ Summary
 <ul>
   <li><bug>64446</bug>Better parse curl commands with backslash at line endings and support <code>PUT</code> method with data arguments</li>
   <li><pr>599</pr>Ensure all buttons added to the toolbar behave/look consistently. Contributed by Jannis Weis</li>
+  <li><bug>64581</bug>Allow SampleResult#setIgnore to influence behaviour on Sampler Error</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -1119,6 +1119,13 @@ The JSR223 Sampler allows JSR223 script code to be used to perform a sample or s
 <note>
 If you don't want to generate a <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink> when this sampler is run, call the following method:
 <source>SampleResult.setIgnore();</source>
+This call will have the following impact:
+<ul>
+    <li>SampleResult will not be delivered to SampleListeners like View Results Tree, Summariser ...</li>
+    <li>SampleResult will not be evaluated in Assertions nor PostProcessors</li>
+    <li>SampleResult will be evaluated to computing last sample status (${JMeterThread.last_sample_ok}),
+    and ThreadGroup "Action to be taken after a Sampler error" (since JMeter 5.4)</li>
+</ul>
 </note>
 </p>
 <p>


### PR DESCRIPTION

## Description
See:
https://bz.apache.org/bugzilla/show_bug.cgi?id=64581

When SampleResult#isIgnore() is true, use is for impacting algorithmic
execution, it will be taken into account to:

- Decide what to do on Error ("Action to be taken after a Sampler error"
in Thread Group)
- set JMeterThread.last_sample_ok

Fix also misnamed lastSampleInError to lastSampleOk

## Motivation and Context

In version 4.0 of JMeter this method was introduced:

    https://jmeter.apache.org/api/org/apache/jmeter/samplers/SampleResult.html#setIgnore--


The aim was to provide the ability to custom tester code (JSR Sampler, PostProcessor) to not emit the SampleResult to listeners.

The current implementation is not be fully ok.

Currently , due to this:
https://github.com/apache/jmeter/blob/master/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java#L561

The SampleResult is not considered to decide on what to do:
https://github.com/apache/jmeter/blob/master/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java#L586

Besides, currently this condition is useless so it will be fixed:

    https://github.com/apache/jmeter/blob/master/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java#L574


This should be changed as user usually wants to influence whether we switch to next iteration, stop thread, test.

As a consequence, the enhancement will restrict this method to what its javadoc states:
- Don't sent 

To avoid breaking existing code relying on it and because it looks correct, if ignore is set, we will not run:
- Post Processor on it as it is not supposed to concern real request on which user would like to extract data from response
- Assertion on it as it is not supposed to concern real request on which user would like to check some content

Considering its use is for impacting algorithmic execution, it will be taken into account to:

- Decide what to do on Error ("Action to be taken after a Sampler error" in Thread Group)
- set JMeterThread.last_sample_ok

## How Has This Been Tested?

Run set of test:

./gradlew test


## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
