### PR TITLE
Add a switch to disable splash screen on startup

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/DefaultSplashScreen.java
+++ b/src/core/src/main/java/org/apache/jmeter/DefaultSplashScreen.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter;
+
+import java.awt.BorderLayout;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JProgressBar;
+import javax.swing.JWindow;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.weisj.darklaf.icons.ThemedSVGIcon;
+
+/**
+ * Splash Screen
+ * @since 3.2
+ */
+public class DefaultSplashScreen extends JWindow implements SplashScreen {
+    private static final Logger log = LoggerFactory.getLogger(DefaultSplashScreen.class);
+
+    private static final long serialVersionUID = 1L;
+    private final JProgressBar progressBar = new JProgressBar(0, 100);
+
+    /**
+     * Constructor
+     */
+    public DefaultSplashScreen() {
+        setLayout(new BorderLayout());
+        add(loadLogo(), BorderLayout.CENTER);
+        add(progressBar, BorderLayout.SOUTH);
+        pack();
+        setLocationRelativeTo(null);
+    }
+
+    public static JComponent loadLogo() {
+        JLabel logo = new JLabel();
+        logo.setBorder(new EmptyBorder(10, 10, 10, 10));
+        URI svgUri = null;
+        String svgResourcePath = "/org/apache/jmeter/images/logo.svg";
+        try {
+            URL svgUrl = JMeterUtils.class.getResource(svgResourcePath);
+            if (svgUrl != null) {
+                svgUri = svgUrl.toURI();
+            }
+        } catch (URISyntaxException e) {
+            log.warn("Unable to find logo " + svgResourcePath, e);
+        }
+
+        if (svgUri != null) {
+            Icon icon = new ThemedSVGIcon(svgUri, 521, 177);
+            logo.setIcon(icon);
+        } else {
+            // Fallback logo
+            logo.setText("<html>" +
+                    "<span style=\"font-size:36px;font-family:'Lucida Grande',Corbel,Arial;color:#D11123\">&nbsp;&nbsp;APACHE<br></span>" +
+                    "<span style=\"font-size:100px;font-family:'Lucida Grande',Corbel,Arial;font-weight:bold\">" +
+                    "<span style=\"color:#D11123\">J</span>Meter" +
+                    "<span style=\"color:#4d4d4d\">™</span></span></html>");
+        }
+        return logo;
+    }
+
+    /**
+     * Show screen
+     */
+    @Override
+    public void showScreen() {
+        SwingUtilities.invokeLater(() -> {
+            setVisible(true);
+            setAlwaysOnTop(true);
+        });
+    }
+
+    /**
+     * Close splash
+     */
+    @Override
+    public void close() {
+        SwingUtilities.invokeLater(() -> {
+            setVisible(false);
+            dispose();
+        });
+    }
+
+    /**
+     * @param progress Loading progress
+     */
+    @Override
+    public void setProgress(final int progress) {
+        SwingUtilities.invokeLater(() -> progressBar.setValue(progress));
+    }
+}

--- a/src/core/src/main/java/org/apache/jmeter/NullSplashScreen.java
+++ b/src/core/src/main/java/org/apache/jmeter/NullSplashScreen.java
@@ -17,21 +17,21 @@
 
 package org.apache.jmeter;
 
-public interface SplashScreen {
+public class NullSplashScreen implements SplashScreen {
 
-    /**
-     * Show screen
-     */
-    void showScreen();
+    @Override
+    public void showScreen() {
+        // Do nothing
+    }
 
-    /**
-     * Close splash
-     */
-    void close();
+    @Override
+    public void close() {
+        // Do nothing
+    }
 
-    /**
-     * @param progress Loading progress
-     */
-    void setProgress(int progress);
+    @Override
+    public void setProgress(int progress) {
+        // Do nothing
+    }
 
 }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AboutCommand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AboutCommand.java
@@ -37,7 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 
-import org.apache.jmeter.SplashScreen;
+import org.apache.jmeter.DefaultSplashScreen;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.util.EscapeDialog;
 import org.apache.jmeter.util.JMeterUtils;
@@ -134,7 +134,7 @@ public class AboutCommand extends AbstractAction {
         infos.add(releaseNotes);
         Container panel = about.getContentPane();
         panel.setLayout(new BorderLayout());
-        panel.add(SplashScreen.loadLogo(), BorderLayout.NORTH);
+        panel.add(DefaultSplashScreen.loadLogo(), BorderLayout.NORTH);
         panel.add(infos, BorderLayout.SOUTH);
         about.pack();
         return about;


### PR DESCRIPTION
## Description

Make showing of splash screen optional

## Motivation and Context

Some users don't like the splash screen always on top of everything.
This seems to be especially annoying, when JMeter takes a long time
to initialize.

[Bugzilla Id: 64658](https://bz.apache.org/bugzilla/show_bug.cgi?id=64658)

## How Has This Been Tested?

Tested by hand (starting from CLI)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
