### PR TITLE
Ensure fallback enabled fonts are used.

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/visualizers/AxisGraph.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/AxisGraph.java
@@ -30,6 +30,7 @@ import javax.swing.JPanel;
 import javax.swing.UIManager;
 
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.jCharts.axisChart.AxisChart;
 import org.jCharts.axisChart.customRenderers.axisValue.renderers.ValueLabelPosition;
 import org.jCharts.axisChart.customRenderers.axisValue.renderers.ValueLabelRenderer;
@@ -82,7 +83,7 @@ public class AxisGraph extends JPanel {
 
     private static final Font FONT_DEFAULT = UIManager.getDefaults().getFont("TextField.font");
 
-    protected Font valueFont = new Font("SansSerif", Font.PLAIN, (int) Math.round(FONT_DEFAULT.getSize() * 0.6));
+    protected Font valueFont = JMeterUIDefaults.createFont("SansSerif", Font.PLAIN, (int) Math.round(FONT_DEFAULT.getSize() * 0.6));
 
     protected Color[] color = { Color.YELLOW };
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
@@ -49,6 +49,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -283,7 +284,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
                 MailerModel.MailAuthType.NONE.toString(),
                 MailerModel.MailAuthType.SSL.toString(),
                 MailerModel.MailAuthType.TLS.toString()});
-        authTypeCombo.setFont(new Font("SansSerif", Font.PLAIN, 10)); // $NON-NLS-1$
+        authTypeCombo.setFont(JMeterUIDefaults.createFont("SansSerif", Font.PLAIN, 10)); // $NON-NLS-1$
         authTypePane.add(authTypeCombo, BorderLayout.CENTER);
 
         JPanel credPane = new JPanel(new BorderLayout());

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -21,7 +21,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.SimpleDateFormat;
@@ -66,6 +65,7 @@ import org.apache.jmeter.visualizers.utils.Colors;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.math.StatCalculatorLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -373,10 +373,12 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         graphPanel.setPointShape(StatGraphProperties.getPointShapeMap().get(pointShapeLine.getSelectedItem()));
         graphPanel.setStrokeWidth(Float.parseFloat((String) strokeWidthList.getSelectedItem()));
 
-        graphPanel.setTitleFont(new Font(StatGraphProperties.getFontNameMap().get(titleFontNameList.getSelectedItem()),
+        graphPanel.setTitleFont(JMeterUIDefaults.createFont(
+                StatGraphProperties.getFontNameMap().get(titleFontNameList.getSelectedItem()),
                 StatGraphProperties.getFontStyleMap().get(titleFontStyleList.getSelectedItem()),
                 Integer.parseInt((String) titleFontSizeList.getSelectedItem())));
-        graphPanel.setLegendFont(new Font(StatGraphProperties.getFontNameMap().get(fontNameList.getSelectedItem()),
+        graphPanel.setLegendFont(JMeterUIDefaults.createFont(
+                StatGraphProperties.getFontNameMap().get(fontNameList.getSelectedItem()),
                 StatGraphProperties.getFontStyleMap().get(fontStyleList.getSelectedItem()),
                 Integer.parseInt((String) fontSizeList.getSelectedItem())));
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -81,6 +81,7 @@ import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.gui.NumberRenderer;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.gui.ObjectTableSorter;
@@ -622,13 +623,16 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         graphPanel.setLegendPlacement(StatGraphProperties.getPlacementNameMap()
                 .get(legendPlacementList.getSelectedItem()));
 
-        graphPanel.setTitleFont(new Font(StatGraphProperties.getFontNameMap().get(titleFontNameList.getSelectedItem()),
+        graphPanel.setTitleFont(JMeterUIDefaults.createFont(
+                StatGraphProperties.getFontNameMap().get(titleFontNameList.getSelectedItem()),
                 StatGraphProperties.getFontStyleMap().get(titleFontStyleList.getSelectedItem()),
                 Integer.parseInt((String) titleFontSizeList.getSelectedItem())));
-        graphPanel.setLegendFont(new Font(StatGraphProperties.getFontNameMap().get(fontNameList.getSelectedItem()),
+        graphPanel.setLegendFont(JMeterUIDefaults.createFont(
+                StatGraphProperties.getFontNameMap().get(fontNameList.getSelectedItem()),
                 StatGraphProperties.getFontStyleMap().get(fontStyleList.getSelectedItem()),
                 Integer.parseInt((String) fontSizeList.getSelectedItem())));
-        graphPanel.setValueFont(new Font(StatGraphProperties.getFontNameMap().get(valueFontNameList.getSelectedItem()),
+        graphPanel.setValueFont(JMeterUIDefaults.createFont(
+                StatGraphProperties.getFontNameMap().get(valueFontNameList.getSelectedItem()),
                 StatGraphProperties.getFontStyleMap().get(valueFontStyleList.getSelectedItem()),
                 Integer.parseInt((String) valueFontSizeList.getSelectedItem())));
 
@@ -926,7 +930,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
 
     private JPanel createGraphTitlePane() {
         JPanel titleNamePane = new JPanel(new BorderLayout());
-        syncWithName.setFont(new Font("SansSerif", Font.PLAIN, 10));
+        syncWithName.setFont(JMeterUIDefaults.createFont("SansSerif", Font.PLAIN, 10));
         titleNamePane.add(graphTitle, BorderLayout.CENTER);
         titleNamePane.add(syncWithName, BorderLayout.EAST);
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -233,7 +233,7 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
         this.disableUndo = disableUndo;
         if (USER_FONT_FAMILY != null) {
             int fontSize = USER_FONT_SIZE > 0 ? USER_FONT_SIZE : getFont().getSize();
-            setFont(new Font(USER_FONT_FAMILY, Font.PLAIN, fontSize));
+            setFont(JMeterUIDefaults.createFont(USER_FONT_FAMILY, Font.PLAIN, fontSize));
             if (log.isDebugEnabled()) {
                 log.debug("Font is set to: {}", getFont());
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
@@ -20,14 +20,12 @@ package org.apache.jmeter.protocol.http.config.gui;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
-import java.awt.Font;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
-import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -68,10 +66,6 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
     private int tabRawBodyIndex = 1;
 
     private int tabFileUploadIndex = 2;
-
-    private static final Font FONT_DEFAULT = UIManager.getDefaults().getFont("TextField.font");
-
-    private static final Font FONT_SMALL = new Font("SansSerif", Font.PLAIN, (int) Math.round(FONT_DEFAULT.getSize() * 0.8));
 
     private HTTPArgumentsPanel argsPanel;
 


### PR DESCRIPTION
## Description
Makes sure the used fonts are fallback enabled.

## Motivation and Context
As reported in https://github.com/apache/jmeter/pull/499#issuecomment-689346454 Darklaf has issues with displaying certain character sets. This has been fixed in in darklaf version `2.4.7`. 

The issue stems from the fact that darklaf uses the native system font instead of the default `Dialog` font. Unlike the logical fonts physical fonts don't fallback to another font if certain characters are unsupported.
Because constructs like `new Font(...)` and `Font#derive(getAttributes())` either don't produce a fallback enabled font or don't preserve the underlying `Font2D` instance (which is responsible for fallback handling if of type `CompositeFont`) those had to be replaced to ensure all characters are displayed correctly.
-  `Font#derive(getAttributes())` was used to produce a non `UIResource` font and has been replaced by subclassing `Font` through `NonUIResourceFont` which exposes a constructor that takes a `Font` instance and preserves the `Font2D` handle.
- `new Font(...)` was replaced by `StyleContext#getFont(String,int,int)` which creates a `CompositeFont` if necessary. (The result is wrapped using `NonUIResourceFont` because the result may be of type `FontUIResource`).

I'm not quite sure whether `JMeterUIDefaults` is the correct/best class to place the `Font` factory method though.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
