### PR TITLE
Prevent NPE in ToolTipManager

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -674,7 +674,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
                         }
                     }
                 }
-                return null;
+                return "";
             }
         };
         treevar.setToolTipText("");


### PR DESCRIPTION
## Description
Return an empty string instead of `null` in `#getToolTipText(MouseEvent)` for main frame tree.

## Motivation and Context
Even though the documentation for `JTree#getToolTipText(MouseEvent)` says to return `null` if the event is `null` this violates an assumed invariant of the JDK 8 implementation of `ToolTipManager`.

Generally the `ToolTipManager` assumes that `JComponent#getToolTipText(MouseEvent)` always returns a non-null value. For components that simply return the value provided by `JComponent#setToolTipText(String)` this is always the case. Setting the tooltip to a null/non-null value unregisters or registers the component with the `ToolTipManager` respectively. For components such as trees where the tooltip text may depend on the current mouse location inside the component this invariant doesn't hold up (because the tree is registered through calling `tree.setToolTipText("")`).

In some scenarios this can cause a `NullPointerException` to be thrown in `ToolTipManager#initiateToolTip` specifically at the following location

````java
 if (!sameComponent || !toolTipText.equals(newToolTipText) || !sameLoc) // Line 478
````

This bug ([JDK-6219960](https://bugs.openjdk.java.net/browse/JDK-6219960)) has been fixed in newer version of the JDK by switching to
````java
Objects.equals(toolTipText, newToolTipText)
````
but this was never backported to JDK 8.

## How Has This Been Tested?
Returning `""` has the same semantics as returning `null` and will result in no tooltip being shown.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
