### PR TITLE
Guard against empty or wrong threadGroup names

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
@@ -583,7 +583,9 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
      */
     public String getSampleLabel(boolean includeGroup) {
         if (includeGroup) {
-            return threadName.substring(0, threadName.lastIndexOf(' ')) + ":" + label;
+            // while JMeters own samplers always set the threadName, that might not be the case for plugins
+            int lastSpacePos = Math.max(0, threadName.lastIndexOf(' '));
+            return threadName.substring(0, lastSpacePos) + ":" + label;
         }
         return label;
     }


### PR DESCRIPTION

## Description
JMeter should always set the names correctly, but that may
not be the case for third-party plugins.

## Motivation and Context
A [NPE was reported on the users mailing list](https://lists.apache.org/thread.html/r496aae284f5ac2cfe7b3ccd04338f90e90045fa1fa91ec64374f9fc3%40%3Cuser.jmeter.apache.org%3E) that only showed with a third party plugin.
 
## How Has This Been Tested?
Ran a few tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.


[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
