### PR TITLE
Use string formatting for log messages

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -473,7 +473,7 @@ public class JMeter implements JMeterPlugin {
             Thread.setDefaultUncaughtExceptionHandler(
                     (Thread t, Throwable e) -> {
                     if (!(e instanceof ThreadDeath)) {
-                        log.error("Uncaught exception in thread " + t, e);
+                        log.error("Uncaught exception in thread {}", t, e);
                         System.err.println("Uncaught Exception " + e + " in thread " + t + ". See log file for details.");//NOSONAR
                     }
             });

--- a/src/core/src/main/java/org/apache/jmeter/SplashScreen.java
+++ b/src/core/src/main/java/org/apache/jmeter/SplashScreen.java
@@ -71,7 +71,7 @@ public class SplashScreen extends JDialog {
                 svgUri = svgUrl.toURI();
             }
         } catch (URISyntaxException e) {
-            log.warn("Unable to find logo " + svgResourcePath, e);
+            log.warn("Unable to find logo {}", svgResourcePath, e);
         }
 
         if (svgUri != null) {

--- a/src/core/src/main/java/org/apache/jmeter/control/IfController.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/IfController.java
@@ -100,7 +100,7 @@ public class IfController extends GenericController implements Serializable, Thr
                 , "<cmd>", 1, null);
                 result = computeResultFromString(condition, Context.toString(cxResultObject));
             } catch (Exception e) {
-                log.error("{}: error while processing "+ "[{}]", testElementName, condition, e);
+                log.error("{}: error while processing [{}]", testElementName, condition, e);
             } finally {
                 Context.exit();
             }

--- a/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
@@ -236,7 +236,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
             }
             return getGui(node, guiClass, testClass);
         } catch (ClassNotFoundException e) {
-            log.error("Could not get GUI for " + node, e);
+            log.error("Could not get GUI for {}", node, e);
             return null;
         }
     }
@@ -374,7 +374,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
             nodesToGui.put(node, comp);
             return node;
         } catch (NoClassDefFoundError e) {
-            log.error("Problem retrieving gui for " + objClass, e);
+            log.error("Problem retrieving gui for {}", objClass, e);
             String msg="Cannot find class: "+e.getMessage();
             JOptionPane.showMessageDialog(null,
                     msg,
@@ -382,7 +382,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
                     JOptionPane.ERROR_MESSAGE);
             throw new RuntimeException(e.toString(), e); // Probably a missing jar
         } catch ( ReflectiveOperationException e) {
-            log.error("Problem retrieving gui for " + objClass, e);
+            log.error("Problem retrieving gui for {}", objClass, e);
             throw new RuntimeException(e.toString(), e); // Programming error: bail out.
         }
     }
@@ -919,8 +919,8 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
                     ret ^= stringValue.hashCode();
                 } else {
                     if (log.isDebugEnabled()) {
-                        log.debug("obj.getStringValue() returned null for test element:"
-                                + el.getName() + " at property:" + obj.getName());
+                        log.debug("obj.getStringValue() returned null for test element:{} at property:{}",
+                                el.getName(), obj.getName());
                     }
                 }
             }
@@ -950,7 +950,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
                 this.namingPolicy = (TreeNodeNamingPolicy) implementationClass.getDeclaredConstructor().newInstance();
 
             } catch (Exception ex) {
-                log.error("Failed to create configured naming policy:" + namingPolicyImplementation + ", will use default one", ex);
+                log.error("Failed to create configured naming policy:{}, will use default one", namingPolicyImplementation, ex);
                 this.namingPolicy = new DefaultTreeNodeNamingPolicy();
             }
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -297,7 +297,7 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
         try {
             return Theme.load(klass.getResourceAsStream(name));
         } catch (IOException e) {
-            log.error("Error reading " + name + " for JSyntaxTextArea", e);
+            log.error("Error reading {} for JSyntaxTextArea", name, e);
             return null;
         }
     }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
@@ -757,7 +757,7 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
         try {
             responseData = response.getBytes(getDataEncodingWithDefault());
         } catch (UnsupportedEncodingException e) {
-            log.warn("Could not convert string, using default encoding. "+e.getLocalizedMessage());
+            log.warn("Could not convert string, using default encoding. {}", e.getLocalizedMessage());
             responseData = response.getBytes(Charset.defaultCharset()); // N.B. default charset is used deliberately here
         }
     }
@@ -776,8 +776,8 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
             responseData = response.getBytes(encodeUsing);
             setDataEncoding(encodeUsing);
         } catch (UnsupportedEncodingException e) {
-            log.warn("Could not convert string using '"+encodeUsing+
-                    "', using default encoding: "+DEFAULT_CHARSET,e);
+            log.warn("Could not convert string using '{}', using default encoding: {}", encodeUsing, DEFAULT_CHARSET,
+                    e);
             responseData = response.getBytes(Charset.defaultCharset()); // N.B. default charset is used deliberately here
             setDataEncoding(DEFAULT_CHARSET);
         }
@@ -809,7 +809,7 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
             }
             return responseDataAsString;
         } catch (UnsupportedEncodingException e) {
-            log.warn("Using platform default as "+getDataEncodingWithDefault()+" caused "+e);
+            log.warn("Using platform default as {} caused {}", getDataEncodingWithDefault(), e.getLocalizedMessage());
             return new String(responseData,Charset.defaultCharset()); // N.B. default charset is used deliberately here
         }
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
@@ -170,7 +170,7 @@ public class DNSCacheManager extends ConfigTestElement implements TestIterationL
     }
 
     private void logCache(String hitOrMiss, String host, InetAddress[] addresses) {
-        log.debug("Cache " + hitOrMiss + " thread#{}: {} => {}",
+        log.debug("Cache {} thread#{}: {} => {}", hitOrMiss,
                 JMeterContextService.getContext().getThreadNum(),
                 host,
                 Arrays.toString(addresses));

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/KerberosManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/KerberosManager.java
@@ -69,12 +69,12 @@ public class KerberosManager implements Serializable {
                 loginCtx.login();
                 return loginCtx.getSubject();
             } catch (LoginException e) {
-                log.warn("Could not log in user " + username, e);
+                log.warn("Could not log in user {}", username, e);
             }
             return null;
         });
         if(log.isDebugEnabled()) {
-            log.debug("Subject cached:"+subjects.keySet() +" before:"+username);
+            log.debug("Subject cached:{} before:{}", subjects.keySet(), username);
         }
         Future<Subject> subjectFuture = subjects.putIfAbsent(username, task);
         if (subjectFuture == null) {
@@ -84,10 +84,10 @@ public class KerberosManager implements Serializable {
         try {
             return subjectFuture.get();
         } catch (InterruptedException e1) {
-            log.warn("Interrupted while getting subject for " + username, e1);
+            log.warn("Interrupted while getting subject for {}", username, e1);
             Thread.currentThread().interrupt();
         } catch (ExecutionException e1) {
-            log.warn("Execution of getting subject for " + username + " failed", e1);
+            log.warn("Execution of getting subject for {} failed", username, e1);
         }
         return null;
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/RegExUserParameters.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/RegExUserParameters.java
@@ -57,7 +57,7 @@ public class RegExUserParameters extends AbstractTestElement implements Serializ
     @Override
     public void process() {
         if (log.isDebugEnabled()) {
-            log.debug(Thread.currentThread().getName() + " Running up named: " + getName());//$NON-NLS-1$
+            log.debug("{} Running up named: {}", Thread.currentThread().getName(), getName());//$NON-NLS-1$
         }
         Sampler entry = getThreadContext().getCurrentSampler();
         if (!(entry instanceof HTTPSamplerBase)) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
@@ -208,7 +208,7 @@ public final class HtmlParsingUtils {
         tidy.setShowWarnings(false);
 
         if (log.isDebugEnabled()) {
-            log.debug("getParser1 : tidy parser created - " + tidy);
+            log.debug("getParser1 : tidy parser created - {}", tidy);
         }
 
         log.debug("End : getParser1");
@@ -232,7 +232,7 @@ public final class HtmlParsingUtils {
                                 text.getBytes(StandardCharsets.UTF_8)), null);
 
         if (log.isDebugEnabled()) {
-            log.debug("node : " + node);
+            log.debug("node : {}", node);
         }
 
         log.debug("End : getDOM1");
@@ -263,7 +263,7 @@ public final class HtmlParsingUtils {
      */
     public static HTTPSamplerBase createUrlFromAnchor(String parsedUrlString, URL context) throws MalformedURLException {
         if (log.isDebugEnabled()) {
-            log.debug("Creating URL from Anchor: " + parsedUrlString + ", base: " + context);
+            log.debug("Creating URL from Anchor: {}, base: {}", parsedUrlString, context);
         }
         URL url = ConversionUtils.makeRelativeURL(context, parsedUrlString);
         HTTPSamplerBase sampler =HTTPSamplerFactory.newInstance();
@@ -329,7 +329,7 @@ public final class HtmlParsingUtils {
                 }
             }
         } catch (Exception ex) {
-            log.warn("Some bad HTML " + printNode(tempNode), ex);
+            log.warn("Some bad HTML {}", printNode(tempNode), ex);
         }
         NodeList childNodes = tempNode.getChildNodes();
         for (int x = 0; x < childNodes.getLength(); x++) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
@@ -214,7 +214,7 @@ class JTidyHTMLParser extends HTMLParser {
         tidy.setQuiet(true);
         tidy.setShowWarnings(false);
         if (log.isDebugEnabled()) {
-            log.debug("getParser : tidy parser created - " + tidy);
+            log.debug("getParser : tidy parser created - {}", tidy);
         }
         log.debug("End   : getParser");
         return tidy;
@@ -234,7 +234,7 @@ class JTidyHTMLParser extends HTMLParser {
         log.debug("Start : getDOM");
         Node node = getTidyParser(encoding).parseDOM(new ByteArrayInputStream(text), null);
         if (log.isDebugEnabled()) {
-            log.debug("node : " + node);
+            log.debug("node : {}", node);
         }
         log.debug("End   : getDOM");
         return node;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
@@ -225,7 +225,8 @@ public class LagartoBasedHtmlParser extends HTMLParser {
         } catch (LagartoException e) {
             // TODO is it the best way ? https://bz.apache.org/bugzilla/show_bug.cgi?id=55634
             if(log.isDebugEnabled()) {
-                log.debug("Error extracting embedded resource URLs from:'"+baseUrl+"', probably not text content, message:"+e.getMessage());
+                log.debug("Error extracting embedded resource URLs from:'{}', probably not text content, message:{}",
+                        baseUrl, e.getMessage());
             }
             return Collections.<URL>emptyList().iterator();
         } catch (Exception e) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
@@ -216,7 +216,7 @@ public class HttpRequestHdr {
                 log.debug("Successfully built URI from url:{} => {}", url, testCleanUri.toString());
             }
         } catch (URISyntaxException e) {
-            log.warn("Url '" + url + "' contains unsafe characters, will escape it, message:"+e.getMessage());
+            log.warn("Url '{}' contains unsafe characters, will escape it, message:{}", url, e.getMessage());
             try {
                 String escapedUrl = ConversionUtils.escapeIllegalURLCharacters(url);
                 if(log.isDebugEnabled()) {
@@ -224,7 +224,7 @@ public class HttpRequestHdr {
                 }
                 url = escapedUrl;
             } catch (Exception e1) {
-                log.error("Error escaping URL:'"+url+"', message:"+e1.getMessage());
+                log.error("Error escaping URL:'{}', message:{}", url, e1.getMessage());
             }
         }
         log.debug("First Line url: {}", url);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
@@ -415,7 +415,7 @@ public class LogFilter implements Filter, Serializable {
             return JMeterUtils.getPatternCache().getPattern(pattern,
                     Perl5Compiler.READ_ONLY_MASK | Perl5Compiler.SINGLELINE_MASK);
         } catch (MalformedCachePatternException exception) {
-            log.error("Problem with pattern: "+pattern,exception);
+            log.error("Problem with pattern: {}", pattern, exception);
             return null;
         }
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/TCLogParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/TCLogParser.java
@@ -277,7 +277,7 @@ public class TCLogParser implements LogParser {
         // we clean the line to get
         // rid of extra stuff
         String cleanedLine = this.cleanURL(line);
-        log.debug("parsing line: " + line);
+        log.debug("parsing line: {}", line);
         // now we set request method
         el.setProperty(HTTPSamplerBase.METHOD, RMETHOD);
         if (FILTER != null) {

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
@@ -201,7 +201,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
             } catch (AbstractMethodError e) {
                 log.warn("JavaSamplerClient doesn't implement "
                         + "getDefaultParameters.  Default parameters won't "
-                        + "be shown.  Please update your client class: " + className);
+                        + "be shown.  Please update your client class: {}", className);
             }
 
             if (testParams != null) {
@@ -227,7 +227,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
             argsPanel.configure(newArgs);
             warningLabel.setVisible(false);
         } catch (Exception e) {
-            log.error("Error getting argument list for " + className, e);
+            log.error("Error getting argument list for {}", className, e);
             warningLabel.setVisible(true);
         }
     }
@@ -272,9 +272,9 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
             // Just to use client
             return client != null;
         } catch (Exception ex) {
-            log.error("Error creating class:'"+className+"' in JavaSampler "+getName()
-                +", check for a missing jar in your jmeter 'search_paths' and 'plugin_dependency_paths' properties",
-                ex);
+            log.error("Error creating class:'{}' in JavaSampler {}"
+                    + ", check for a missing jar in your jmeter 'search_paths' and 'plugin_dependency_paths' properties",
+                    className, getName(), ex);
             return false;
         }
     }

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
@@ -133,7 +133,7 @@ public class DataSourceElementBeanInfo extends BeanInfoSupport {
                 try {
                     return Integer.parseInt(tag);
                 } catch (NumberFormatException e) {
-                    log.warn("Illegal transaction isolation configuration '" + tag + "'");
+                    log.warn("Illegal transaction isolation configuration '{}'", tag);
                 }
             } else {
                 return isolationMode;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/Utils.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/Utils.java
@@ -226,7 +226,7 @@ public final class Utils {
             String name = me.getKey();
             Object value = me.getValue();
             if (log.isDebugEnabled()) {
-                log.debug("Adding property [" + name + "=" + value + "]");
+                log.debug("Adding property [{}={}]", name, value);
             }
 
             // Some JMS implemenations do not allow certain header fields to be set using properties

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/MailReaderSampler.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/MailReaderSampler.java
@@ -173,16 +173,16 @@ public class MailReaderSampler extends AbstractSampler implements Interruptible 
                 }
             } else if (isUseLocalTrustStore()){
                 File truststore = new File(getTrustStoreToUse());
-                log.info("load local truststore - try to load truststore from: "+truststore.getAbsolutePath());
+                log.info("load local truststore - try to load truststore from: {}", truststore.getAbsolutePath());
                 if(!truststore.exists()){
-                    log.info("load local truststore -Failed to load truststore from: "+truststore.getAbsolutePath());
+                    log.info("load local truststore -Failed to load truststore from: {}", truststore.getAbsolutePath());
                     truststore = new File(FileServer.getFileServer().getBaseDir(), getTrustStoreToUse());
-                    log.info("load local truststore -Attempting to read truststore from:  "+truststore.getAbsolutePath());
+                    log.info("load local truststore -Attempting to read truststore from: {}", truststore.getAbsolutePath());
                     if (!truststore.exists()){
                         log.info(
-                                "load local truststore -Failed to load truststore from: "
-                                        + truststore.getAbsolutePath()
-                                        + ". Local truststore not available, aborting execution.");
+                                "load local truststore -Failed to load truststore from: {}"
+                                        + ". Local truststore not available, aborting execution.",
+                                truststore.getAbsolutePath());
                         throw new IOException(
                                 "Local truststore file not found. Also not available under : "
                                         + truststore.getAbsolutePath());


### PR DESCRIPTION
## Description
Use string format instead of concatenating of strings in log messages

## Motivation and Context
It looks a bit nicer and might be faster, when the concatenated strings are not logged.

## How Has This Been Tested?
Let the commit/PR CI test this.

## Screenshots (if appropriate):

## Types of changes
- code styling

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
