### PR TITLE
Move guard clause for log message generation

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
@@ -148,32 +148,26 @@ public class DNSCacheManager extends ConfigTestElement implements TestIterationL
         // explicitly maps the key to null
         // https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html
         if (result != null || cache.containsKey(host)) {
-            if (log.isDebugEnabled()) {
-                logCache("hit", host, result);
-            }
+            logCache("hit", host, result);
             return result;
         } else if (isStaticHost(host)) {
             InetAddress[] staticAddresses = fromStaticHost(host);
-            if (log.isDebugEnabled()) {
-                logCache("miss", host, staticAddresses);
-            }
+            logCache("miss", host, staticAddresses);
             cache.put(host, staticAddresses);
             return staticAddresses;
         } else {
             InetAddress[] addresses = requestLookup(host);
-            if (log.isDebugEnabled()) {
-                logCache("miss", host, addresses);
-            }
+            logCache("miss", host, addresses);
             cache.put(host, addresses);
             return addresses;
         }
     }
 
     private void logCache(String hitOrMiss, String host, InetAddress[] addresses) {
-        log.debug("Cache {} thread#{}: {} => {}", hitOrMiss,
-                JMeterContextService.getContext().getThreadNum(),
-                host,
-                Arrays.toString(addresses));
+        if (log.isDebugEnabled()) {
+            log.debug("Cache {} thread#{}: {} => {}", hitOrMiss, JMeterContextService.getContext().getThreadNum(), host,
+                    Arrays.toString(addresses));
+        }
     }
 
     private boolean isStaticHost(String host) {
@@ -259,9 +253,7 @@ public class DNSCacheManager extends ConfigTestElement implements TestIterationL
             }
         } else {
             addresses = systemDefaultDnsResolver.resolve(host);
-            if (log.isDebugEnabled()) {
-                logCache("miss (resolved with system resolver)", host, addresses);
-            }
+            logCache("miss (resolved with system resolver)", host, addresses);
         }
 
         return addresses;


### PR DESCRIPTION

## Description
Move guard close for log message generation a bit closer to the line, where the logging is done.

## Motivation and Context
The guard clause is not visible for sonaqube and we
can silence a warning by this move. Another reason
for the move is, that we save a few lines of code.

## How Has This Been Tested?
Let the ci test it.

## Screenshots (if appropriate):

## Types of changes
- Code style

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
