### PR TITLE
Add a boolean property to choose if we want to propagate the state of…

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -165,6 +165,9 @@
 # Interval period in ms to process the queue of events of the listeners
 #jmeter.gui.refresh_period=500
 
+# Propagate the state of the current element to the children of the tree
+#jmeter.gui.propagates_parent_state_to_children=true
+
 # HiDPI mode (default: false)
 # Activate a 'pseudo'-HiDPI mode. Allows to increase size of some UI elements
 # which are not correctly managed by JVM with high resolution screens in Linux or Windows

--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -165,8 +165,8 @@
 # Interval period in ms to process the queue of events of the listeners
 #jmeter.gui.refresh_period=500
 
-# Propagate the state of the current element to the children of the tree
-#jmeter.gui.propagates_parent_state_to_children=true
+# Propagate the state of the current element to the children of the tree, boolean true (default) or false
+#jmeter.gui.propagate_parent_state_to_children=true
 
 # HiDPI mode (default: false)
 # Activate a 'pseudo'-HiDPI mode. Allows to increase size of some UI elements

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
@@ -40,8 +40,8 @@ public class EnableComponent extends AbstractAction {
     private static final Set<String> commands = new HashSet<>();
 
     // propagate the state of the current element to the children of the tree
-    private static final boolean PROPAGATES_PARENT_STATE_TO_CHILDREN_RENDER_TREE =
-            JMeterUtils.getPropDefault("jmeter.gui.propagates_parent_state_to_children", true);
+    private static final boolean PROPAGATE_PARENT_STATE_TO_CHILDREN_RENDER_TREE =
+            JMeterUtils.getPropDefault("jmeter.gui.propagate_parent_state_to_children", true);
 
     static {
         commands.add(ActionNames.ENABLE);
@@ -67,7 +67,7 @@ public class EnableComponent extends AbstractAction {
             toggleComponents(nodes);
          }
 
-        if (PROPAGATES_PARENT_STATE_TO_CHILDREN_RENDER_TREE) {
+        if (PROPAGATE_PARENT_STATE_TO_CHILDREN_RENDER_TREE) {
             log.debug("propagate the state of the current element to the children of the tree");
             triggerChildrenRender(nodes);
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
@@ -27,6 +27,7 @@ import javax.swing.tree.TreeNode;
 
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
+import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,10 @@ public class EnableComponent extends AbstractAction {
     private static final Logger log = LoggerFactory.getLogger(EnableComponent.class);
 
     private static final Set<String> commands = new HashSet<>();
+
+    // propagate the state of the current element to the children of the tree
+    private static final boolean PROPAGATES_PARENT_STATE_TO_CHILDREN_RENDER_TREE =
+            JMeterUtils.getPropDefault("jmeter.gui.propagates_parent_state_to_children", true);
 
     static {
         commands.add(ActionNames.ENABLE);
@@ -54,15 +59,20 @@ public class EnableComponent extends AbstractAction {
         if (e.getActionCommand().equals(ActionNames.ENABLE)) {
             log.debug("enabling currently selected gui objects");
             enableComponents(nodes, true);
-            triggerChildrenRender(nodes);
-        } else if (e.getActionCommand().equals(ActionNames.DISABLE)) {
+         } else if (e.getActionCommand().equals(ActionNames.DISABLE)) {
             log.debug("disabling currently selected gui objects");
             enableComponents(nodes, false);
-            triggerChildrenRender(nodes);
         } else if (e.getActionCommand().equals(ActionNames.TOGGLE)) {
             log.debug("toggling currently selected gui objects");
             toggleComponents(nodes);
+         }
+
+        if (PROPAGATES_PARENT_STATE_TO_CHILDREN_RENDER_TREE) {
+            log.debug("propagate the state of the current element to the children of the tree");
             triggerChildrenRender(nodes);
+        }
+        else {
+            log.debug("Do NOT propagate the state of the current element to the children of the tree");
         }
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
@@ -29,6 +29,7 @@ import javax.swing.tree.TreeNode;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.control.TestFragmentController;
+import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
 
 /**
@@ -43,6 +44,11 @@ public class JMeterCellRenderer extends DefaultTreeCellRenderer {
 
     private static final Border RED_BORDER = BorderFactory.createLineBorder(Color.red);
     private static final Border BLUE_BORDER = BorderFactory.createLineBorder(Color.blue);
+
+    // propagate the state of the current element to the children of the tree
+    private static final boolean PROPAGATE_PARENT_STATE_TO_CHILDREN_RENDER_TREE =
+            JMeterUtils.getPropDefault("jmeter.gui.propagate_parent_state_to_children", true);
+
     public JMeterCellRenderer() {
     }
 
@@ -55,8 +61,9 @@ public class JMeterCellRenderer extends DefaultTreeCellRenderer {
                         sel, expanded, leaf, row, p_hasFocus);
         boolean enabled = node.isEnabled();
         // Even in case the node itself is not disabled, we render it as disabled if
-        // one of its parents is in fact disabled.
-        for (TreeNode parent = node.getParent(); parent != null && enabled; parent = parent.getParent()) {
+        // one of its parents is in fact disabled and
+        // PROPAGATE_PARENT_STATE_TO_CHILDREN_RENDER_TREE == true
+        for (TreeNode parent = node.getParent(); parent != null && enabled && PROPAGATE_PARENT_STATE_TO_CHILDREN_RENDER_TREE; parent = parent.getParent()) {
             if (parent instanceof JMeterTreeNode) {
                 JMeterTreeNode jMeterTreeNode = (JMeterTreeNode) parent;
                 if (jMeterTreeNode.getTestElement() instanceof TestFragmentController) {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -120,6 +120,7 @@ applications when JMeter is starting up.</p>
   <li><pr>599</pr>Ensure all buttons added to the toolbar behave/look consistently. Contributed by Jannis Weis</li>
   <li><bug>64581</bug>Allow SampleResult#setIgnore to influence behaviour on Sampler Error</li>
   <li><bug>64680</bug>Fall back to <code>JMETER_HOME</code> on startup to detect JMeter's installation directory</li>
+  <li><pr>628</pr>Add jmeter property <code>jmeter.gui.propagate_parent_state_to_children</code> to choose if you want to propagate the state (enable or disable) of the current element to the children of the tree OR NOT (gray for disable for all chidren in the tree).Contributed by Vincent Daburon</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -195,6 +195,10 @@ Defaults to: <code>true</code>
     Interval period in <code>ms</code> to process the events of the listeners.<br/>
     Defaults to: <code>500</code></property>
 </properties>
+<property name="jmeter.gui.propagate_parent_state_to_children">
+    Propagate the state (enabled or disable) of the current element to the children of the tree<br/>
+    Defaults to: <code>true</code></property>
+</properties>
 </section>
 <section name="&sect-num;.4.1 Darklaf configuration" anchor="darklaf_config">
 <properties>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -194,10 +194,9 @@ Defaults to: <code>true</code>
 <property name="jmeter.gui.refresh_period">
     Interval period in <code>ms</code> to process the events of the listeners.<br/>
     Defaults to: <code>500</code></property>
-</properties>
 <property name="jmeter.gui.propagate_parent_state_to_children">
-    Propagate the state (enabled or disable) of the current element to the children of the tree<br/>
-    Defaults to: <code>true</code></property>
+     Propagate the state (enabled or disable) of the current element to the children of the tree<br/>
+     Defaults to: <code>true</code></property>
 </properties>
 </section>
 <section name="&sect-num;.4.1 Darklaf configuration" anchor="darklaf_config">


### PR DESCRIPTION
… the current element to the children of the tree

## Description
Add a new jmeter property to choose if you want to propagate the state of the current element to the children of the tree OR NOT (gray for disable for all chidren in the tree).


## Motivation and Context
The pull request https://github.com/apache/jmeter/pull/558  (Use gray icons for disabled elements in the tree) could be usefull in many cases.

But a script is not a simple tree from Thread Group but a graph when you use a Module Controler.

![arbo_chidren_enabled](https://user-images.githubusercontent.com/1881617/94363172-b7a9a000-00c0-11eb-8b74-567bbbd2e55b.png)

In the Thread Group 1, somes samplers are enabled (001 and 015) and somes are disabled (006, 008 and 014), you could see with the gray color or not.
The Thread Group 2 with module controler use a module controler that go to the Thread Group 1 > Recording Controller.

When i disable the "Thread Group 1" all the children samplers look disabled (gray), i can't see witch samplers are "really" enabled or disabled.

The Module Controler from Thead Group2 with module controler will call samplers children of Recording Controller but **now i can't see witch samplers will be really call** because all samplers look disabled.

![arbo_chidren_desabled](https://user-images.githubusercontent.com/1881617/94363191-ddcf4000-00c0-11eb-83d1-f60db79510cc.png)

I add a jmeter.property to choose if you want to propagate the state of the current element to the children of the tree or you do NOT want to propagate the state to children.

## How Has This Been Tested?
Add log to see if new jmeter property jmeter.gui.propagates_parent_state_to_children=true if this property is correcly read from jmeter.properties file

Test with defaut value jmeter property jmeter.gui.propagates_parent_state_to_children=true

Test with jmeter.gui.propagates_parent_state_to_children=false

Create a new script with a tree and enabled ou disabled a element in the tree and see if children are also change color gray or not

## Screenshots:
jmeter.gui.propagates_parent_state_to_children=false

![arbo_children_no_propagate](https://user-images.githubusercontent.com/1881617/94363545-34d61480-00c3-11eb-897c-3fc7cfc9ca52.png)


jmeter.gui.propagates_parent_state_to_children=true (defaut value)

![arbo_children_with_propagate](https://user-images.githubusercontent.com/1881617/94363644-d65d6600-00c3-11eb-8efa-6475b2510f77.png)


## Types of changes
- New feature (non-breaking change which adds functionality)


## Checklist:
- [x ] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation : changes.xml and properties_reference.xml

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
