### PR TITLE
Fix to Bug64776 - Add the possibility to add SecurityProviders

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -98,6 +98,7 @@ import org.apache.jmeter.threads.RemoteThreadsListenerTestElement;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.BeanShellServer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jmeter.util.SecurityProviderLoader;
 import org.apache.jmeter.util.ShutdownClient;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.collections.SearchByClass;
@@ -469,6 +470,8 @@ public class JMeter implements JMeterPlugin {
         }
         try {
             initializeProperties(parser); // Also initialises JMeter logging
+
+            SecurityProviderLoader.addSecurityProvider(JMeterUtils.getJMeterProperties());
 
             Thread.setDefaultUncaughtExceptionHandler(
                     (Thread t, Throwable e) -> {

--- a/src/core/src/main/java/org/apache/jmeter/util/SecurityProviderLoader.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/SecurityProviderLoader.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.util;
+
+import java.lang.reflect.Constructor;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Comparator;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecurityProviderLoader {
+    private static final Logger log = LoggerFactory.getLogger(SecurityProviderLoader.class);
+
+    public static void addSecurityProvider(Properties properties) {
+        properties.keySet().stream()
+                .filter(key -> key.toString().matches("security\\.provider(\\.\\d+)?"))
+                .sorted(Comparator.comparing(String::valueOf)).forEach(key -> addSecurityProvider(properties.get(key).toString()));
+    }
+
+    public static void addSecurityProvider(String securityProviderConfig) {
+        Pattern regex = Pattern.compile("^(?<classname>[^:]+)(:(?<position>\\d+)(:(?<config>.+))?)?$");
+        Matcher matcher = regex.matcher(securityProviderConfig);
+
+        if (matcher.matches()) {
+            final String classname = matcher.group("classname");
+            final Integer position = Integer.parseInt(StringUtils.defaultString(matcher.group("position"), "0"));
+            final String config = matcher.group("config");
+
+            try {
+                Class providerClass = Class.forName(classname);
+
+                Provider provider = null;
+
+                if (config != null) {
+                    try {
+                        Constructor constructor = providerClass.getConstructor(String.class);
+                        provider = (Provider) constructor.newInstance(config);
+                    } catch (NoSuchMethodException e) {
+                        log.warn("Security Provider {} has no constructor with a single String argument - try to use default constructor.", providerClass);
+                    }
+                }
+
+                if (provider == null) {
+                    provider = (Provider) providerClass.newInstance();
+                }
+                int installedPosition = Security.insertProviderAt(provider, position);
+
+                log.info("Security Provider {} ({}) is installed at position {}", provider.getClass().getSimpleName(), provider.getName(), installedPosition);
+            } catch (Exception exception) {
+                String message = String.format("Security Provider '%s' could not be installed.", classname);
+                log.error(message, exception);
+                System.err.print(message);
+                System.err.println(" - see the log for more information.");
+            }
+        }
+    }
+}

--- a/src/core/src/test/java/org/apache/jmeter/util/SecurityProviderLoaderTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/SecurityProviderLoaderTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.util;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class SecurityProviderLoaderTest {
+
+    @AfterEach
+    public void removeAllDummProviders() {
+        Security.removeProvider(DummyProvider.PROVIDER_NAME);
+        Security.removeProvider(DummyProviderWithConfig.PROVIDER_NAME);
+        Assert.assertNull(Security.getProvider(DummyProvider.PROVIDER_NAME));
+        Assert.assertNull(Security.getProvider(DummyProviderWithConfig.PROVIDER_NAME));
+    }
+
+    @Test
+    public void addSecurityProviderTest() {
+        removeAllDummProviders();
+        Provider[] providers = Security.getProviders();
+        int providersCountBefore = providers.length;
+
+
+        SecurityProviderLoader.addSecurityProvider(DummyProvider.class.getName());
+
+        Provider[] providers_after = Security.getProviders();
+        Provider provider = Security.getProvider(DummyProvider.PROVIDER_NAME);
+        try {
+            Assert.assertEquals(providersCountBefore + 1, providers_after.length);
+            Assert.assertNotNull("Provider not installed.", provider);
+            Assert.assertEquals(DummyProvider.class, provider.getClass());
+            Assert.assertEquals(provider, providers_after[providers_after.length - 1]);
+        } catch (AssertionError e){
+            Arrays.stream(providers).forEach(pro -> System.err.println(pro.getName()));
+            throw e;
+        }
+    }
+
+    @Test
+    public void addSecurityProviderTestWithConfigForUnconfigurableProvider() {
+        removeAllDummProviders();
+        int providersCountBefore = Security.getProviders().length;
+
+        SecurityProviderLoader.addSecurityProvider(DummyProvider.class.getName()+":0:Configure");
+
+        Provider[] providers_after = Security.getProviders();
+        Provider provider = Security.getProvider(DummyProvider.PROVIDER_NAME);
+
+        Assert.assertEquals(providersCountBefore + 1, providers_after.length);
+        Assert.assertNotNull("Provider not installed.", provider);
+        Assert.assertEquals(DummyProvider.class, provider.getClass());
+        Assert.assertEquals(provider, providers_after[providers_after.length - 1]);
+    }
+
+    @Test
+    public void addUnknownSecurityProviderTest() {
+        removeAllDummProviders();
+        int providersCountBefore = Security.getProviders().length;
+
+        SecurityProviderLoader.addSecurityProvider("org.apache.jmeter.util.SecurityProviderLoaderTest.UnknownProvider");
+
+        Provider[] providers_after = Security.getProviders();
+
+        Assert.assertEquals(providersCountBefore, providers_after.length);
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3})
+    public void addSecurityProviderWithPositionTest(int position) {
+        removeAllDummProviders();
+        int providersCountBefore = Security.getProviders().length;
+
+        SecurityProviderLoader.addSecurityProvider(DummyProvider.class.getName() + ":" + position);
+
+        Provider[] providers_after = Security.getProviders();
+        Provider provider = Security.getProvider(DummyProvider.PROVIDER_NAME);
+
+        Assert.assertEquals(providersCountBefore + 1, providers_after.length);
+        Assert.assertNotNull(provider);
+        Assert.assertEquals(DummyProvider.class, provider.getClass());
+        Assert.assertEquals(provider, providers_after[position == 0 ? providers_after.length - 1 : position - 1]);
+    }
+
+    @ParameterizedTest
+    @CsvSource({":0:TestConfig,0", ":2:TEST,2", ":3:TEST,3"})
+    public void addSecurityProviderWithPositionAndConfigTest(String config, int position) {
+        removeAllDummProviders();
+        int providersCountBefore = Security.getProviders().length;
+
+        SecurityProviderLoader.addSecurityProvider(DummyProviderWithConfig.class.getName() + config);
+
+        Provider[] providers_after = Security.getProviders();
+        Provider provider = Security.getProvider(DummyProviderWithConfig.PROVIDER_NAME);
+
+        Assert.assertNotNull("Provider not installed.", provider);
+        Assert.assertEquals(providersCountBefore + 1, providers_after.length);
+        Assert.assertEquals(DummyProviderWithConfig.class, provider.getClass());
+        Assert.assertEquals(provider, providers_after[position == 0 ? providers_after.length - 1 : position - 1]);
+        Assert.assertEquals(config.substring(config.lastIndexOf(":") + 1), ((DummyProviderWithConfig) provider).getConfig());
+
+
+    }
+
+    @Test
+    public void addSecurityProvidersViaProperties() {
+        removeAllDummProviders();
+        int providersCountBefore = Security.getProviders().length;
+
+        Properties properties = new Properties();
+        properties.put("security.provider.1", DummyProviderWithConfig.class.getName() + ":2:CONFIG");
+        properties.put("security.provider", DummyProvider.class.getName() + ":1");
+
+        SecurityProviderLoader.addSecurityProvider(properties);
+
+        Provider[] providers_after = Security.getProviders();
+        Assert.assertEquals(providersCountBefore + 2, providers_after.length);
+
+        Provider provider = Security.getProvider(DummyProvider.PROVIDER_NAME);
+        Provider providerWithConfig = Security.getProvider(DummyProviderWithConfig.PROVIDER_NAME);
+
+        Assert.assertNotNull("Provider not installed.", provider);
+        Assert.assertEquals(DummyProvider.class, provider.getClass());
+        Assert.assertEquals(provider, providers_after[0]);
+
+        Assert.assertNotNull("Provider not installed.", providerWithConfig);
+        Assert.assertEquals(DummyProviderWithConfig.class, providerWithConfig.getClass());
+        Assert.assertEquals(providerWithConfig, providers_after[1]);
+        Assert.assertEquals("CONFIG", ((DummyProviderWithConfig) providerWithConfig).getConfig());
+    }
+
+    public static class DummyProvider extends Provider {
+        public static final String PROVIDER_NAME = "DUMMY";
+
+        public DummyProvider() {
+            super(PROVIDER_NAME, 1.0, PROVIDER_NAME);
+        }
+
+    }
+
+    public static class DummyProviderWithConfig extends Provider {
+        public static final String PROVIDER_NAME = "DUMMY_CONFIG";
+
+        private String config = null;
+
+        public DummyProviderWithConfig() {
+            super(PROVIDER_NAME, 1.0, PROVIDER_NAME);
+        }
+
+        public DummyProviderWithConfig(String config) {
+            this();
+            this.config = config;
+        }
+
+        public String getConfig() {
+            return config;
+        }
+    }
+}

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1942,6 +1942,28 @@ JMETER-SERVER</source>
     No default value</property>
 </properties>
 </section>
+<section name="&sect-num;.46 Security Provider" anchor="securityprovider">
+<description>Advanced properties for documentation generation</description>
+<properties>
+    <property name="security.provider">
+        The value must be in this format: &lt;ClassName&gt;[:&lt;Postion&gt;[:&lt;ConfigString&gt;]]</property>.
+        Examples:<br/>
+        <dl>
+            <dt>org.bouncycastle.jce.provider.BouncyCastleProvider</dt>
+            <dd>Adds the <code>BouncyCastleProvider</code> to the next position available.</dd>
+            <dt>org.bouncycastle.jce.provider.BouncyCastleProvider:1</dt>
+            <dd>Adds the <code>BouncyCastleProvider</code>, at the first position.</dd>
+            <dt>org.bouncycastle.jsse.provider.BouncyCastleJsseProvider:2:BC</dt>
+            <dd>Adds the <code>BouncyCastleJsseProvider</code>, at the second position. And configure it to use the
+                BC provider.</dd>
+        </dl>
+    <property name="security.provider.&lt;n&gt;">
+        Replace the <code>&lt;n&gt;</code> with any number. The SecurityProviders will be added in the alphabetical
+        order of the property names. (First: <code>security.provider</code> and then <code>security.provider.2</code>, <code>security.provider.3</code>,...)
+        See property <code>security.provider</code>
+        </property>
+</properties>
+</section>
 <!--
 <section name="&sect-num;.10 Reports" anchor="Reports">
 <description>


### PR DESCRIPTION
## Description
Add the possibility to load new Security-Provider at the start of JMeter, these Prover could be added and configured via JMeter-Properties.

## Motivation and Context
For testing of a service that need special elicpic curves that are available in the BouncyCastleProvider. But to solve the proble it was necessary not only to load this provier, it was requied to load BouncyCastleJsseProvider, too. But the BouncyCastleJsseProvider must be configured to use the BouncyCastleProvider. This was not possible by modify the JVM Setting (java.security). And the creation of a add on that adds the security-providers at test-start was unseccesful.

## How Has This Been Tested?
For the two method, for loading the Secrurity-Provider: I've created some JUnit-Test.


## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly. (Added a section in the properties_reference.xml)

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
