### PR TITLE
Make allowed version of freemarker explicit

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
@@ -442,7 +442,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
         addToContext(DATA_CTX_OVERALL_FILTER, configuration.getSampleFilter(), dataContext);
 
         // Walk template directory to copy files and process templated ones
-        Configuration templateCfg = new Configuration(Configuration.getVersion());
+        Configuration templateCfg = new Configuration(Configuration.VERSION_2_3_30);
         try {
             templateCfg.setDirectoryForTemplateLoading(templateDirectory);
             templateCfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);

--- a/src/core/src/main/java/org/apache/jmeter/util/TemplateUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/TemplateUtil.java
@@ -43,7 +43,7 @@ public final class TemplateUtil {
     }
 
     private static Configuration init() {
-        Configuration templateConfiguration = new Configuration(Configuration.getVersion());
+        Configuration templateConfiguration = new Configuration(Configuration.VERSION_2_3_30);
         templateConfiguration.setDefaultEncoding(StandardCharsets.UTF_8.name());
         templateConfiguration.setInterpolationSyntax(Configuration.SQUARE_BRACKET_INTERPOLATION_SYNTAX);
         templateConfiguration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);


### PR DESCRIPTION
## Description

Make the compatible version of freemarker template engine explicit.

## Motivation and Context

The [freemarker docs state](https://freemarker.apache.org/docs/pgui_config_incompatible_improvements.html), that it is not allowed to use `Config#getVersion()`
directly, to specify the version, that we think we are compatible with.

Therefore, let us specify the current version and update it, as we update
the dependency or the templates.

## How Has This Been Tested?
Ran `./gradlew build` and grepped for `getVersion` in `src/dist-check/jmeter.log` and the following message is gone
```
$ grep -r Configuration.getVersion src/dist-check/jmeter.log
2020-11-03 16:20:29,732 ERROR f.configuration: DefaultObjectWrapper.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application.
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
