### PR TITLE
Correct width height ratio for somes images in the documentation

### DIFF
--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -211,7 +211,7 @@ https.default.protocol=SSLv3
         <a href="build-adv-web-test-plan.html#session_url_rewriting">6.1 Handling User Sessions With URL Rewriting</a>
         for additional configuration steps.</p>
 </description>
-<figure width="951" height="284" image="http-request-advanced-tab.png">HTTP Request Advanced config fields</figure>
+<figure width="951" height="548" image="http-request-advanced-tab.png">HTTP Request Advanced config fields</figure>
 <figure width="950" height="618" image="graphql-http-request.png">Screenshot of Control-Panel of GraphQL HTTP Request</figure>
 <figure width="950" height="618" image="graphql-http-request-vars.png">Variables field for GraphQL HTTP Request</figure>
 
@@ -3531,7 +3531,7 @@ By default, a Graphite implementation is provided.
     <br></br>
 </description>
 
-<component name="CSV Data Set Config" index="&sect-num;.4.1"  width="433" height="281" screenshot="csvdatasetconfig.png">
+<component name="CSV Data Set Config" index="&sect-num;.4.1"  width="658" height="281" screenshot="csvdatasetconfig.png">
 <description>
     <p>
     CSV Data Set Config is used to read lines from a file, and split them into variables.
@@ -6476,7 +6476,7 @@ See <a href="get-started.html#classpath">JMeter's Classpath</a> and
 </description>
 </component>
 
-<component name="Thread Group" index="&sect-num;.9.2"  width="911" height="390" screenshot="threadgroup.png">
+<component name="Thread Group" index="&sect-num;.9.2"  width="911" height="662" screenshot="threadgroup.png">
 <description>
 <p>A Thread Group defines a pool of users that will execute a particular test case against your server.  In the Thread Group GUI, you can control the number of users simulated (number of threads), the ramp up time (how long it takes to start all the threads), the number of times to perform the test, and optionally, a start and stop time for the test.</p>
 <p>

--- a/xdocs/usermanual/curl.xml
+++ b/xdocs/usermanual/curl.xml
@@ -43,11 +43,11 @@ Create a Test Plan From a cURL Command
   </li>
     <li>There are two ways to enter the curl command line. Firstly, we can enter it manually. Secondly, we can import a file containing the curl command line.
     This tool supports input of multiple curl command lines at the same time.
-    <figure width="767" height="316" image="curl/enter_command.png">Figure 2.1 - Enter curl command in text panel</figure>
-    <figure width="767" height="316" image="curl/enter_command_from_file.png">Figure 2.2 - Enter curl command from file</figure>
+    <figure width="767" height="443" image="curl/enter_command.png">Figure 2.1 - Enter curl command in text panel</figure>
+    <figure width="767" height="449" image="curl/enter_command_from_file.png">Figure 2.2 - Enter curl command from file</figure>
   </li>
   <li>Then, click <code>Create Test Plan</code> button and a new HTTP Sample will be added to the Test Plan.
-    <figure width="767" height="316" image="curl/result.png">Figure 3 - result of Test Plan</figure>
+    <figure width="767" height="464" image="curl/result.png">Figure 3 - result of Test Plan</figure>
   </li>
 </ol>
 </subsection>
@@ -163,7 +163,7 @@ Create a Test Plan From a cURL Command
 <p>
 When the command you entered is ignored or contains warning content, we will display warning in the comment section of HTTP Request.
 </p>
-<figure width="768" height="339" image="curl/http_request_warning.png">Figure 1 -Warning</figure>
+<figure width="768" height="464" image="curl/http_request_warning.png">Figure 1 -Warning</figure>
 
 </subsection>
 <subsection name="&sect-num;.4 Examples" anchor="example">


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->

Change width or heigth to keep the same ratio than the original image

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some image are too small or are distored because the reduction ratio width/height is incorrect

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I compute the ratio from the original image and compute the correct width/height in a excel file, i change only one parameter width or height 