### PR TITLE
Fix bug 64969, make RemoteJMeterEngineImpl instance release completely when RemoteJMeterEngineImpl#rexit() invoked

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/engine/RemoteJMeterEngineImpl.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/RemoteJMeterEngineImpl.java
@@ -24,6 +24,7 @@ import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.rmi.server.ServerNotActiveException;
+import java.rmi.server.UnicastRemoteObject;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -206,6 +207,8 @@ public final class RemoteJMeterEngineImpl extends java.rmi.server.UnicastRemoteO
             log.warn("{} is not bound", JMETER_ENGINE_RMI_NAME, e);
         }
         log.info("Unbound from registry");
+        // unexported object
+        UnicastRemoteObject.unexportObject(this, false);
         // Help with garbage control
         JMeterUtils.helpGC();
         et.start();


### PR DESCRIPTION
## Description
Add "UnicastRemoteObject#unexportObject(this, false)" after line 210 before "JMeterUtils.helpGC()" to release RemoteJMeterEngineImpl instance
 completely.

## Motivation and Context
https://bz.apache.org/bugzilla/show_bug.cgi?id=64969

## How Has This Been Tested?
1, Start a JMeter in server mode using parameter '-s' to do this.
2, Start another thread to construct a ClientJMeterEngine with the host and port pointing to the JMeter server in the first step.
3, Invoke ClientJMeterEngine#rexit() and check whether the JMeter server in the first step has released its local port or not.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (64969)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
