### PR TITLE
update xstreams to 1.4.15 (from 1.4.14)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -130,5 +130,5 @@ xml-apis.version=1.4.01
 xmlgraphics-commons.version=2.3
 xmlpull.version=1.1.3.1
 xpp3_min.version=1.1.4c
-xstream.version=1.4.14
+xstream.version=1.4.15
 wiremock-jre8.version=2.24.1

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -95,4 +95,4 @@
 671727,xmlgraphics-commons-2.3.jar
 7188,xmlpull-1.1.3.1.jar
 24956,xpp3_min-1.1.4c.jar
-627490,xstream-1.4.14.jar
+627848,xstream-1.4.15.jar

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -127,6 +127,7 @@ Summary
     <li>Updated ph-commons to 9.5.1 (from 9.4.1)</li>
     <li>Updated ph-css to 6.2.3 (from 6.2.1)</li>
     <li>Updated groovy to 3.0.7 (from 3.0.5)</li>
+    <li>Updated xstream to 1.4.15 (from 1.4.14)</li>
 </ul>
 
  <!-- =================== Bug fixes =================== -->


### PR DESCRIPTION
## Description
within the current xstream version 1.4.14 two more vulnerabilities were found. These are fixed with the update to 1.4.15.
* CVE-2020-26258 (Server-Side Forgery Request)
* CVE-2020-26259 (arbitrary file deletion)

## Motivation and Context
Fix potential security problems

## How Has This Been Tested?
run `gradlew check`, first run failed with one library (xstream) having changed as expected, rerun with `-PupdateExpectedJars` switch.
The following executions of `gradlew check` and `gradlew test` succeeded now.


## Screenshots (if appropriate):
none

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
