### PR TITLE
Fix to bug 65128 that updates component reference documentation for th…

### DIFF
--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6532,6 +6532,12 @@ Behaviour can be modified with some properties by setting in <code>user.properti
                 the ramp-up time is effectively <strong>zero</strong>. For the same reason, the tenth thread in
                 the above example will actually be started after 90 seconds and not 100 seconds.</note>
         </property>
+        <property name="Same user on each iteration" required="Yes">
+            If selected, cookie and cache data from the first sampler response are used in subsequent requests (requires a global Cookie and Cache Manager respectively).
+            <br></br>
+            If not selected, cookie and cache data from the first sampler response are not used in subsequent requests.
+            <note>If not selected, a new connection will be opened between iterations which will result in increased response times and consume more resources (memory and cpu).</note>
+        </property>
         <property name="Loop Count" required="Yes, unless Infinite is selected">Number of times to perform the test case.  Alternatively, "<code>infinite</code>" can be selected causing the test to run until manually stopped or end of the thread lifetime is reached.</property>
         <property name="Delay Thread creation until needed" required="Yes">
         If selected, threads are created only when the appropriate proportion of the ramp-up time has elapsed.


### PR DESCRIPTION
…read group - same user on each iteration

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->
Documentation to component reference page for thread group attribute "Same user on each iteration"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Updates the component reference documentation under thread group by adding documentation for "Same user on each iteration"
https://bz.apache.org/bugzilla/show_bug.cgi?id=65128

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested using gradlew 'check' and 'test' tasks running in IntelliJ IDE on windows 10
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [code style][style-guide] of this project.
- [x ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
