### PR TITLE
Encode the personal part of email addresses in SMTP Sampler

### DIFF
--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/SmtpSampler.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/SmtpSampler.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.protocol.smtp.sampler;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -38,10 +39,12 @@ import javax.mail.Part;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.ContentType;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeUtility;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.protocol.smtp.sampler.gui.SecuritySettingsPanel;
 import org.apache.jmeter.protocol.smtp.sampler.protocol.SendMailCommand;
@@ -272,7 +275,7 @@ public class SmtpSampler extends AbstractSampler {
         sendMailCmd.setEnableDebug(getPropertyAsBoolean(ENABLE_DEBUG));
 
         if (getPropertyAsString(MAIL_FROM).matches(".*@.*")) {
-            sendMailCmd.setSender(getPropertyAsString(MAIL_FROM));
+            sendMailCmd.setSender(encodeAddress(getPropertyAsString(MAIL_FROM)));
         }
 
         // Process address lists
@@ -368,12 +371,28 @@ public class SmtpSampler extends AbstractSampler {
         if (!propValue.isEmpty()) { // we have at least one potential address
             List<InternetAddress> addresses = new ArrayList<>();
             for (String address : propValue.split(";")) {
-                addresses.add(new InternetAddress(address.trim()));
+                addresses.add(new InternetAddress(encodeAddress(address)));
             }
             return addresses;
         } else {
             return null;
         }
+    }
+
+    private String encodeAddress(String address) throws AddressException {
+        String trimmedAddress = address.trim();
+        if (!StringUtils.isAsciiPrintable(trimmedAddress)) {
+            try {
+                final int startOfRealAddress = trimmedAddress.indexOf('<');
+                if (startOfRealAddress >= 0) {
+                    String personalPart = trimmedAddress.substring(0, startOfRealAddress);
+                    return MimeUtility.encodeWord(personalPart) + trimmedAddress.substring(startOfRealAddress);
+                }
+            } catch (UnsupportedEncodingException e) {
+                log.warn("Can't encode [{}] as quoted printable", trimmedAddress, e);
+            }
+        }
+        return trimmedAddress;
     }
 
     /**


### PR DESCRIPTION


## Description
Often those personal parts contain umlauts. Try to find these
and let `MimeUtility` encode those as quoted encodings.

## Motivation and Context
Bugzilla Id: 65149
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Used a simple test plan and a dummy smtp server.

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
