### PR TITLE
Add escaping for new lines in AbstractInfluxdbMetricsSender

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/AbstractInfluxdbMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/AbstractInfluxdbMetricsSender.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.visualizers.backend.influxdb;
 
 /**
  * Base class for {@link InfluxdbMetricsSender}
+ *
  * @since 3.2
  */
 abstract class AbstractInfluxdbMetricsSender implements InfluxdbMetricsSender {
@@ -28,7 +29,11 @@ abstract class AbstractInfluxdbMetricsSender implements InfluxdbMetricsSender {
      * \ to escape List of special characters : commas , equal sign = spaces
      */
     static final String tagToStringValue(String s) {
-        return s.trim().replaceAll(" ", "\\\\ ").replaceAll(",", "\\\\,").replaceAll("=", "\\\\=");
+        return s.trim()
+                .replaceAll(" ", "\\\\ ")
+                .replaceAll(",", "\\\\,")
+                .replaceAll("=", "\\\\=")
+                .replaceAll("\n", "\\\\n");
     }
 
     /**

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/AbstractInfluxdbMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/AbstractInfluxdbMetricsSender.java
@@ -30,10 +30,10 @@ abstract class AbstractInfluxdbMetricsSender implements InfluxdbMetricsSender {
      */
     static final String tagToStringValue(String s) {
         return s.trim()
-                .replaceAll(" ", "\\\\ ")
-                .replaceAll(",", "\\\\,")
-                .replaceAll("=", "\\\\=")
-                .replaceAll("\n", "\\\\n");
+                .replace(" ", "\\ ")
+                .replace(",", "\\,")
+                .replace("=", "\\=")
+                .replace("\n", "\\n");
     }
 
     /**
@@ -41,7 +41,8 @@ abstract class AbstractInfluxdbMetricsSender implements InfluxdbMetricsSender {
      * \ to escape " character
      */
     static final String fieldToStringValue(String s) {
-        return s.trim().replaceAll("\"", "\\\\\"");
+        return s.trim()
+                .replace("\"", "\\\"");
     }
 
 }


### PR DESCRIPTION

## Description
Add escaping for new lines in AbstractInfluxdbMetricsSender.tagToStringValue()

## Motivation and Context
For load- and performance testing (distributed testing) we send metrics to the InfluxDB.
From time to time, no metrics occur in the dashboard while testing:
![Missing metrics](https://user-images.githubusercontent.com/54536760/109140654-1ac95c80-775d-11eb-891f-79daa8a620d2.png)

In the log file of the JMeter controller, I find this line pretty often:
```
ERROR o.a.j.v.b.i.HttpMetricsSender: Error writing metrics to influxDB Url: https://<URL>, responseCode: 400, responseBody: {"code":"invalid","message":"unable to parse 'jmeter,application=<application name>,transaction=<transaction name>,responseCode=500,responseMessage=javax.script.ScriptException:\\ org.openqa.selenium.ElementClickInterceptedException:\\ element\\ click\\ intercepted:\\ Element\\ \u003cbutton\\ type\\=\"submit\"\\ class\\=\"btn\\ btn-primary\\ btn-next\"\u003e...\u003c/button\u003e\\ is\\ not\\ clickable\\ at\\ point\\ (313\\,\\ 620).\\ Other\\ element\\ would\\ receive\\ the\\ click:\\ \u003cdiv\\ class\\=\"dhl\\ redesign\\ frankieren-loading-overlay\"\u003e...\u003c/div\u003e': missing fields\nunable to parse '\\ \\ (Session\\ info:\\ headless\\ chrome\\=88.0.4324.150)': missing fields\nunable to parse 'Build\\ info:\\ version:\\ '3.14.0'\\,\\ revision:\\ 'aacccce0'\\,\\ time:\\ '2018-08-02T20:19:58.91Z'': missing fields\nunable to parse 'System\\ info:\\ host:\\ 'ip-172-31-45-153.internal'\\,\\ ip:\\ '172.31.45.153'\\,\\ os.name:\\ 'Linux'\\,\\ os.arch:\\ 'amd64'\\,\\ os.version:\\ '4.14.214-160.339.amzn2.x86_64'\\,\\ java.version:\\ '11.0.7'': missing fields\nunable to parse 'Driver\\ info:\\ org.openqa.selenium.chrome.ChromeDriver': missing fields\nunable to parse 'Capabilities\\ {acceptInsecureCerts:\\ false\\,\\ browserName:\\ chrome\\,\\ browserVersion:\\ 88.0.4324.150\\,\\ chrome:\\ {chromedriverVersion:\\ 88.0.4324.96\\ (68dba2d8a0b14...\\,\\ userDataDir:\\ /tmp/.com.google.Chrome.L3v1yY}\\,\\ goog:chromeOptions:\\ {debuggerAddress:\\ localhost:46619}\\,\\ javascriptEnabled:\\ true\\,\\ networkConnectionEnabled:\\ false\\,\\ pageLoadStrategy:\\ normal\\,\\ platform:\\ LINUX\\,\\ platformName:\\ LINUX\\,\\ proxy:\\ Proxy(manual\\,\\ http\\=localhos...\\,\\ setWindowRect:\\ true\\,\\ strictFileInteractability:\\ false\\,\\ timeouts:\\ {implicit:\\ 0\\,\\ pageLoad:\\ 300000\\,\\ script:\\ 30000}\\,\\ unhandledPromptBehavior:\\ dismiss\\ and\\ notify\\,\\ webauthn:extension:largeBlob:\\ true\\,\\ webauthn:virtualAuthenticators:\\ true}': missing fields"}
```

It seems that the escaping of the line breaks is not working properly. By that, invalid requests are sent to the InfluxDB, resulting in 'missing fields'.


## How Has This Been Tested?
1. Configure InfluxDB connection
2. Add a new JSR223 with the body
```java
throw new Exception('''Line 0
Line 1
Line 2
End
''')
```

Current JMeter 5.4.1 Release:
3. Looking at the console output / jmeter log file --> The error occurs
4. influxDB : No metrics received

JMeter 5.4.1 Release + this fix:
3. Looking at the console output / jmeter log file --> No error occurs
4. influxDB : metrics are received


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
