### PR TITLE
HTTP Sampler timestamp fix when exception is caught

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1299,7 +1299,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             }
             return res;
         } catch (Exception e) {
-            return errorResult(e, new HTTPSampleResult());
+            return errorResult(e, new HTTPSampleResult(0));
         }
     }
 


### PR DESCRIPTION
## Description
Currently, when HTTP Sampler fails with exception, the result is timestamped with 1970-01-01.
The proper timestamp is needed.

## Motivation and Context
-

## How Has This Been Tested?
Tested manually by comparing timestamps in View Results Tree listener before and after the fix.
With the change, SampleResult contain proper timestamps and 0 duration.
[corruptedHTTPSamplerConfig.zip](https://github.com/apache/jmeter/files/6126189/corruptedHTTPSamplerConfig.zip)

## Screenshots (if appropriate):
![Screenshot from 2021-03-11 23-53-42](https://user-images.githubusercontent.com/10652927/110860408-c8944980-82cd-11eb-8161-7fa49632d948.png)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)