### PR TITLE
Don't assume we have correct JSON at edit time

### DIFF
--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/TestGraphQLRequestParamUtils.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/TestGraphQLRequestParamUtils.java
@@ -68,7 +68,7 @@ class TestGraphQLRequestParamUtils {
     private static final String EXPECTED_POST_BODY =
             "{"
             + "\"operationName\":null,"
-            + "\"variables\":" + EXPECTED_VARIABLES_GET_PARAM_VALUE + ","
+            + "\"variables\":" + VARIABLES.trim() + ","
             + "\"query\":\"" + StringUtils.replace(QUERY.trim(), "\n", "\\n") + "\""
             + "}";
 
@@ -98,6 +98,14 @@ class TestGraphQLRequestParamUtils {
     }
 
     @Test
+    void testToBodyStringWithJMeterVarBug65108() throws Exception {
+        GraphQLRequestParams paramsWithVar = new GraphQLRequestParams(OPERATION_NAME, QUERY,
+                VARIABLES.replace("\"2001\"", "${my_var}"));
+        assertEquals(EXPECTED_POST_BODY.replace("\"2001\"", "${my_var}"),
+                GraphQLRequestParamUtils.toPostBodyString(paramsWithVar));
+    }
+
+    @Test
     void testToPostBodyString() throws Exception {
         assertEquals(EXPECTED_POST_BODY, GraphQLRequestParamUtils.toPostBodyString(params));
     }
@@ -109,7 +117,7 @@ class TestGraphQLRequestParamUtils {
 
     @Test
     void testVariablesToGetParamValue() throws Exception {
-        assertEquals(EXPECTED_VARIABLES_GET_PARAM_VALUE,
+        assertEquals(VARIABLES,
                 GraphQLRequestParamUtils.variablesToGetParamValue(params.getVariables()));
     }
 


### PR DESCRIPTION
## Description

Allow the usage of JMeter variables in all user definable parameters for GraphQL Sampler.

## Motivation and Context

When JMeter variables are used inside variable or query blocks for the
GraphQL Sampler, we cannot assume, that we still have valid JSON as
long those variables are not rendered. The rendering of the variables
is done at a later time in the life cycle. Therefore, we have to do
our best to render JSON without actually checking the validity.

Bugzilla Id: 65108

## How Has This Been Tested?

Test case has been added

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
