### PR TITLE
Changed manual exception testing for JUnit API recommendation

### DIFF
--- a/src/core/src/test/java/org/apache/jorphan/TestXMLBuffer.java
+++ b/src/core/src/test/java/org/apache/jorphan/TestXMLBuffer.java
@@ -17,8 +17,8 @@
 
 package org.apache.jorphan;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jorphan.util.XMLBuffer;

--- a/src/core/src/test/java/org/apache/jorphan/TestXMLBuffer.java
+++ b/src/core/src/test/java/org/apache/jorphan/TestXMLBuffer.java
@@ -18,7 +18,7 @@
 package org.apache.jorphan;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jorphan.util.XMLBuffer;
@@ -50,10 +50,8 @@ public class TestXMLBuffer extends JMeterTestCase {
     public void test4() throws Exception{
         XMLBuffer xb = new XMLBuffer();
         xb.openTag("abc");
-        try {
+        assertThrows(IllegalArgumentException.class, () -> {
             xb.closeTag("abcd");
-            fail("Should have caused IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-        }
+        });
     }
 }


### PR DESCRIPTION
This is a test refactoring.

**Problem:**
The Exception Handling test smell occurs when the test outcome is manually determined through pass or fail method calls, which are dependent on the production method throwing an exception, generally inside a try/catch block.

**Solution:**
We propose using JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code or throwing an exception. In this particular case, JUnit 5 assertThrows() was used to properly handle the expected exception.

**Result:**
_Before:_
```
try {
    xb.closeTag("abcd");
    fail("Should have caused IllegalArgumentException");
} catch (IllegalArgumentException e) {
}
```

_After:_
```
assertThrows(IllegalArgumentException.class, () -> {
    xb.closeTag("abcd");
});
```