### PR TITLE
fix doc for 'get-started' file

### DIFF
--- a/xdocs/usermanual/get-started.xml
+++ b/xdocs/usermanual/get-started.xml
@@ -316,7 +316,7 @@ will override the HEAP settings in the script.
 # it will be sourced in by bin/jmeter
 
 # Use a bigger heap, but a smaller metaspace, than the default
-export HEAP="-Xms1G -Xmx1G -XMaxMetaspaceSize=192m"
+export HEAP="-Xms1G -Xmx1G -XX:MaxMetaspaceSize=192m"
 
 # Try to guess the locale from the OS. The space as value is on purpose!
 export JMETER_LANGUAGE=" "


### PR DESCRIPTION
problem for 'export HEAP="-Xms1G -Xmx1G -XMaxMetaspaceSize=192m"'

