### PR TITLE
update x-stream to 1.4.16 (from 1.4.15)

### DIFF
--- a/checksum.xml
+++ b/checksum.xml
@@ -71,6 +71,7 @@
     <trusted-key id='379ce192d401ab61' group='info.picocli' />
     <trusted-key id='b2ca0dfe9ed21c6e' group='io.burt' />
     <trusted-key id='5b30d3b10694f057' group='io.codearte.gradle.nexus' />
+    <trusted-key id='602ec18d20c4661c' group='io.github.x-stream' />
     <trusted-key id='6425559c47cc79c4' group='javax.activation' />
     <trusted-key id='6425559c47cc79c4' group='javax.mail' />
     <trusted-key id='6425559c47cc79c4' group='javax.servlet' />
@@ -271,11 +272,11 @@
     <dependency group='oro' module='oro' version='2.0.8'>
       <sha512>9A98E493C4D771322B1331EC05AB0E363A83D8AC2AF8018D96A44DF2BF5BFC97D33EBE6F6F93E46AB10BF1536F0C29E9D9569318ED49BC18B4E96B1A8B476D37</sha512>
     </dependency>
-    <dependency group='xerces' module='xercesImpl' version='2.9.1'>
-      <sha512>37A13B129F3536A53F2A553151A53997DA6DE7CE4D7231EFEEFD26A68C92BE309666F2EE1F527D3B8C38BC6ADDC9FCCBBDD0D134759FD88667976B0CFF842435</sha512>
-    </dependency>
     <dependency group='xerces' module='xercesImpl' version='2.12.1'>
       <sha512>811AFD85CDD19545785FDE7FB39511F1E171E1D021A96117D105E2B2F37715536E17259E6AD0CE897B4C7C8A5BD1E88C9FA0825B0A2EF9F3956CD82944A33957</sha512>
+    </dependency>
+    <dependency group='xerces' module='xercesImpl' version='2.9.1'>
+      <sha512>37A13B129F3536A53F2A553151A53997DA6DE7CE4D7231EFEEFD26A68C92BE309666F2EE1F527D3B8C38BC6ADDC9FCCBBDD0D134759FD88667976B0CFF842435</sha512>
     </dependency>
     <dependency group='xml-resolver' module='xml-resolver' version='1.2'>
       <sha512>ECA19B8A6B04C279B7982B16F1763CA1D49B0081A8D4CA2B7419F057D22A0EC60795EB4D901C5EB25DD4A733248876AA2F522C17A6144A26C8EDE9FB2F84531A</sha512>

--- a/gradle.properties
+++ b/gradle.properties
@@ -131,5 +131,5 @@ xml-apis.version=1.4.01
 xmlgraphics-commons.version=2.6
 xmlpull.version=1.1.3.1
 xpp3_min.version=1.1.4c
-xstream.version=1.4.15
+xstream.version=1.4.16
 wiremock-jre8.version=2.24.1

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -76,6 +76,7 @@
 106939,miglayout-core-5.2.jar
 22390,miglayout-swing-5.2.jar
 419054,mongo-java-driver-2.11.3.jar
+29631,mxparser-1.2.1.jar
 4580832,neo4j-java-driver-4.2.0.jar
 65261,oro-2.0.8.jar
 1302550,ph-commons-9.5.1.jar
@@ -94,5 +95,4 @@
 220536,xml-apis-1.4.01.jar
 674607,xmlgraphics-commons-2.6.jar
 7188,xmlpull-1.1.3.1.jar
-24956,xpp3_min-1.1.4c.jar
-627848,xstream-1.4.15.jar
+629686,xstream-1.4.16.jar

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -127,6 +127,7 @@ Summary
 <ul>
   <li><bug>65128</bug><pr>643</pr>Add missing documentation about <code>Same user on each iteration</code> for Thread Groups. Contributed by njkuzas.</li>
   <li><pr>648</pr>Updated xmlgraphics-commons to 2.6 (from 2.3). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
+  <li><pr>655</pr>Updated x-stream to 1.4.16 (from 1.4.15). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
 </ul>
 
  <!-- =================== Bug fixes =================== -->


### PR DESCRIPTION
## Description
security update for com.thoughtworks.xstream:xstream from 1.4.15 to 1.4.16

## Motivation and Context

This update fixes the following CVE:

- CVE-2021-21341 (High)
- CVE-2021-21342 (Medium)
- CVE-2021-21343 (Medium)
- CVE-2021-21344 (Medium)
- CVE-2021-21345 (Medium)
- CVE-2021-21346 (Medium)
- CVE-2021-21347 (Medium)
- CVE-2021-21348 (Medium)
- CVE-2021-21349 (Medium)
- CVE-2021-21350 (Medium)
- CVE-2021-21351 (Medium)

## How Has This Been Tested?

Tested with running `gradlew test` and within our own installation where this library was replaced.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
