### PR TITLE
update json-smart to 2.4.1 and accessors-smart to 1.3

### DIFF
--- a/checksum.xml
+++ b/checksum.xml
@@ -80,6 +80,7 @@
     <trusted-key id='efe8086f9e93774e' group='junit' />
     <trusted-key id='15c71c0a4e0b8edd' group='net.java.dev.jna' />
     <trusted-key id='75bf031b7c94e183' group='net.java.dev.jna' />
+    <trusted-key id='1d0690e353be126d' group='net.minidev' />
     <trusted-key id='f6bc09712c8df6ec' group='net.minidev' />
     <trusted-key id='0da8a5ec02d11ead' group='net.sf.jopt-simple' />
     <trusted-key id='d4012dda1f1f0f82' group='net.sf.jtidy' />

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ org.nosphere.apache.rat.version=0.7.0
 org.sonarqube.version=3.0
 
 # Dependencies
-accessors-smart.version=1.2
+accessors-smart.version=1.3
 activemq.version=5.16.0
 apache-rat.version=0.13
 apiguardian-api.version=1.1.0
@@ -102,7 +102,7 @@ jmespath-core.version=0.5.0
 jmespath-jackson.version=0.5.0
 jodd.version=5.0.13
 json-path.version=2.4.0
-json-smart.version=2.3
+json-smart.version=2.4.1
 jsoup.version=1.13.1
 jtidy.version=r938
 junit4.version=4.13.1

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -1,4 +1,4 @@
-30035,accessors-smart-1.2.jar
+29863,accessors-smart-1.3.jar
 2387,apiguardian-api-1.1.0.jar
 121783,asm-9.0.jar
 113369,bsf-2.4.0.jar
@@ -63,7 +63,7 @@
 19858,jodd-log-5.0.13.jar
 26047,jodd-props-5.0.13.jar
 223186,json-path-2.4.0.jar
-120316,json-smart-2.3.jar
+119759,json-smart-2.4.1.jar
 393851,jsoup-1.13.1.jar
 249924,jtidy-r938.jar
 382708,junit-4.13.1.jar

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -127,6 +127,7 @@ Summary
 <ul>
   <li><bug>65128</bug><pr>643</pr>Add missing documentation about <code>Same user on each iteration</code> for Thread Groups. Contributed by njkuzas.</li>
   <li><pr>648</pr>Updated xmlgraphics-commons to 2.6 (from 2.3). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
+  <li><pr>656</pr>Updated json-smart to 2.4.1 (from 2.3) and accessors-smart to 1.3 (from 1.2). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
 </ul>
 
  <!-- =================== Bug fixes =================== -->


### PR DESCRIPTION
## Description

This PR updates the used net.minidev:json-smart library to version 1.3 to fix a security warning. The accessors-smart lib is updated too as it belongs to json-smart and is released together

Issue discussing the update is here: https://github.com/netplex/json-smart-v2/issues/62

Due to the long time since last release the gpg key has changed from the maintainer and `checksum.xml` was updated too.

## Motivation and Context

fix security warning with CVE-2021-27568 affecting everything up to json-smart 2.4. At least NIST/MITRE assign it a HIGH criticallity by now.

## How Has This Been Tested?

run `gradlew check` and use it for some days on our own setup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
