### PR TITLE
Clean task fix (bug 63914)

### DIFF
--- a/src/dist/build.gradle.kts
+++ b/src/dist/build.gradle.kts
@@ -98,6 +98,7 @@ tasks.named(BasePlugin.CLEAN_TASK_NAME).configure {
         delete(fileTree("$rootDir/bin") { include("ApacheJMeter.jar") })
         delete(fileTree("$rootDir/lib") { include("*.jar") })
         delete(fileTree("$rootDir/lib/ext") { include("ApacheJMeter*.jar") })
+        delete(fileTree("$rootDir/lib/junit") { include("*.jar") })
     }
 }
 


### PR DESCRIPTION
## Description
Clean command did not remove the test.jar file.
This bug was mentioned in Bugzilla https://bz.apache.org/bugzilla/show_bug.cgi?id=63914

## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
