### PR TITLE
65108: Support JMeter variables in GraphQL HTTP Request

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/GraphQLRequestParams.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/GraphQLRequestParams.java
@@ -64,4 +64,13 @@ public class GraphQLRequestParams implements Serializable {
     public void setVariables(String variables) {
         this.variables = variables;
     }
+
+    @Override
+    public String toString() {
+        return "GraphQLRequestParams{" +
+                "operationName='" + operationName + '\'' +
+                ", query='" + query + '\'' +
+                ", variables='" + variables + '\'' +
+                '}';
+    }
 }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/TestGraphQLRequestParamUtils.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/TestGraphQLRequestParamUtils.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
@@ -36,7 +36,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 class TestGraphQLRequestParamUtils {
 
@@ -72,6 +73,8 @@ class TestGraphQLRequestParamUtils {
             + "\"query\":\"" + StringUtils.replace(QUERY.trim(), "\n", "\\n") + "\""
             + "}";
 
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     private GraphQLRequestParams params;
 
     @BeforeEach
@@ -81,7 +84,7 @@ class TestGraphQLRequestParamUtils {
 
     @ParameterizedTest
     @ValueSource(strings = { "application/json", "application/json;charset=utf-8", "application/json; charset=utf-8" })
-    void testIsGraphQLContentType(String contentType) throws Exception {
+    void testIsGraphQLContentType(String contentType) {
         assertTrue(GraphQLRequestParamUtils.isGraphQLContentType(contentType));
     }
 
@@ -97,20 +100,32 @@ class TestGraphQLRequestParamUtils {
         assertFalse(GraphQLRequestParamUtils.isGraphQLContentType(contentType));
     }
 
-    @Test
-    void testToPostBodyString() throws Exception {
-        assertEquals(EXPECTED_POST_BODY, GraphQLRequestParamUtils.toPostBodyString(params));
+    static Stream<org.junit.jupiter.params.provider.Arguments> postBodyFieldNameAndJsonNodes() throws Exception {
+        final JsonNode expectedPostBodyJson = objectMapper.readTree(EXPECTED_POST_BODY);
+        final JsonNode actualPostBodyJson = objectMapper.readTree(
+                GraphQLRequestParamUtils.toPostBodyString(new GraphQLRequestParams(OPERATION_NAME, QUERY, VARIABLES)));
+        return Stream.of(
+                arguments(GraphQLRequestParamUtils.OPERATION_NAME_FIELD, expectedPostBodyJson, actualPostBodyJson),
+                arguments(GraphQLRequestParamUtils.VARIABLES_FIELD, expectedPostBodyJson, actualPostBodyJson),
+                arguments(GraphQLRequestParamUtils.QUERY_FIELD, expectedPostBodyJson, actualPostBodyJson));
+    }
+
+    @ParameterizedTest
+    @MethodSource("postBodyFieldNameAndJsonNodes")
+    void testFieldInJsonFromToPostBodyString(String fieldName, JsonNode expectedNode, JsonNode actualNode) {
+        assertEquals(expectedNode.get(fieldName), actualNode.get(fieldName),
+                "The value of the '" + fieldName + "' field doesn't match in " + actualNode);
     }
 
     @Test
-    void testQueryToGetParamValue() throws Exception {
+    void testQueryToGetParamValue() {
         assertEquals(EXPECTED_QUERY_GET_PARAM_VALUE, GraphQLRequestParamUtils.queryToGetParamValue(params.getQuery()));
     }
 
     @Test
     void testVariablesToGetParamValue() throws Exception {
-        assertEquals(EXPECTED_VARIABLES_GET_PARAM_VALUE,
-                GraphQLRequestParamUtils.variablesToGetParamValue(params.getVariables()));
+        assertEquals(objectMapper.readTree(EXPECTED_VARIABLES_GET_PARAM_VALUE),
+                objectMapper.readTree(GraphQLRequestParamUtils.variablesToGetParamValue(params.getVariables())));
     }
 
     @Test
@@ -132,24 +147,20 @@ class TestGraphQLRequestParamUtils {
 
     @ParameterizedTest
     @ValueSource(strings = { "", "{}"})
-    void testInvalidJsonData(String postDataAsString) throws JsonProcessingException, UnsupportedEncodingException {
+    void testInvalidJsonData(String postDataAsString) {
         byte[] postData = postDataAsString.getBytes(StandardCharsets.UTF_8);
         assertThrows(IllegalArgumentException.class,
-                () -> {
-                    GraphQLRequestParamUtils.toGraphQLRequestParams(postData, null);
-                });
+                () -> GraphQLRequestParamUtils.toGraphQLRequestParams(postData, null));
     }
 
     @ParameterizedTest
     @ValueSource(strings = { "{\"query\":\"select * from emp\"}",
             "{\"operationName\":{\"id\":123},\"query\":\"query { droid { id }}\"}",
             "{\"variables\":\"r2d2\",\"query\":\"query { droid { id }}\"}" })
-    void testInvalidGraphQueryParam(String postDataAsString)
-            throws JsonProcessingException, UnsupportedEncodingException {
+    void testInvalidGraphQueryParam(String postDataAsString) {
         byte[] postData = postDataAsString.getBytes(StandardCharsets.UTF_8);
-        assertThrows(IllegalArgumentException.class, () -> {
-            GraphQLRequestParamUtils.toGraphQLRequestParams(postData, null);
-        });
+        assertThrows(IllegalArgumentException.class,
+                () -> GraphQLRequestParamUtils.toGraphQLRequestParams(postData, null));
     }
 
     @Test
@@ -186,14 +197,14 @@ class TestGraphQLRequestParamUtils {
     }
 
     @Test
-    void testMissingParams() throws UnsupportedEncodingException {
+    void testMissingParams() {
         Arguments args = new Arguments();
         assertThrows(IllegalArgumentException.class,
                 () -> GraphQLRequestParamUtils.toGraphQLRequestParams(args, null));
     }
 
     @Test
-    void testInvalidQueryParam() throws UnsupportedEncodingException {
+    void testInvalidQueryParam() {
         Arguments args = new Arguments();
         args.addArgument(new HTTPArgument("query", "select * from emp", "=", false));
         assertThrows(IllegalArgumentException.class,
@@ -201,7 +212,7 @@ class TestGraphQLRequestParamUtils {
     }
 
     @Test
-    void testInvalidQueryParamVariables() throws UnsupportedEncodingException {
+    void testInvalidQueryParamVariables() {
         Arguments args = new Arguments();
         args.addArgument(new HTTPArgument("query", "query { droid { id }}", "=", false));
         args.addArgument(new HTTPArgument("variables", "r2d2", "=", false));

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -206,6 +206,7 @@ however, the profile can't be updated while the test is running.
     header in HC4 sampler.</li>
   <li><bug>65363</bug><code>NullPointerException</code> in <code>HTTPHC4Impl$ManagedCredentialsProvider.getAuthorizationForAuthScope</code> when <code>401</code> response from remote and <code>httpclient4.auth.preemptive=false</code></li>
   <li><bug>65692</bug>HTTP(s) Test Script Recorder: Enable setting enabled cipher suite and enabled protocols on SSLContext/ Align ssl properties between Java and HC4 impl</li>
+  <li><bug>65108</bug>Support JMeter variables in <a href="./usermanual/component_reference.html#HTTP_Request">GraphQL HTTP Request</a></li>
 </ul>
 
 <h3>Other Samplers</h3>


### PR DESCRIPTION
## Description

In GraphQL query/mutation variables, JMeter variables can be referenced.
A JSON String value with a JMeter variable reference (e.g, `{ "var1":"${jm.var1}"}`) has no problem as they are replaced at runtime without breaking any JSON spec, but a non-String value with JMeter variable reference (e.g, `{ "nvar1":${jm.nvar1}}`) causes a problem because it's not a valid JSON. We need to somehow allow to use JMeter variable references in non-String JSON values.

This PR provides a conceptually simple solution:
- If there's any JMeter variable references in a non-String JSON value, then replace the JMeter variable reference with a JSON Reference-like expression temporarily and parse it into a JSON Object.
- Before serializing the GraphQL variables JSON object to a string, restore the temporary JSON Reference-like expression to the original JMeter variable references.

That is,
- Step 1: User input for GraphQL variables:
```
{
  "var1": "hello",
  "var2": ${user.count}
}
```
- Step 2: Temporarily replace it with JSON Reference-like expressions:
```
{
  "var1": "hello",
  "var2": {"$ref":"jmeter#/nonStringVariables/user.count"}
}
```
- Step 3: Parse the string into JSONObject
- Step 4: Before serializing the JSONObject or its parent JSONObject, restore the JMeter variable references from the serialized json string:
```
{
  "var1": "hello",
  "var2": ${user.count}
}
```

## Motivation and Context

See Bugzilla Id: 65108 .
Also see PR #651 .

## How Has This Been Tested?
- Related unit test is updated.
- You can also test the demo JMeter script at xdocs/demos/SimpleGraphQLTestPlan.jmx:
```
# Run ApolloGraphQL starwars-server, an open-source demo Apollo GraphQL server.
./gradlew runGui
# open the JMeter script
# Start the test and verify the test result.
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
