### PR TITLE
Setters in ConstantThroughputTimer need to set Properties to be picked up by test during runtime

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/timers/ConstantThroughputTimerBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/ConstantThroughputTimerBeanInfo.java
@@ -30,14 +30,14 @@ public class ConstantThroughputTimerBeanInfo extends BeanInfoSupport {
         super(ConstantThroughputTimer.class);
 
         createPropertyGroup("delay",  //$NON-NLS-1$
-                new String[] { "throughput", //$NON-NLS-1$
-                "calcMode" }); //$NON-NLS-1$
+                new String[] { ConstantThroughputTimer.THROUGHPUT, //$NON-NLS-1$
+                ConstantThroughputTimer.CALC_MODE }); //$NON-NLS-1$
 
-        PropertyDescriptor p = property("throughput"); //$NON-NLS-1$
+        PropertyDescriptor p = property(ConstantThroughputTimer.THROUGHPUT); //$NON-NLS-1$
         p.setValue(NOT_UNDEFINED, Boolean.TRUE);
         p.setValue(DEFAULT, 0.0);
 
-        p = property("calcMode", ConstantThroughputTimer.Mode.class); //$NON-NLS-1$
+        p = property(ConstantThroughputTimer.CALC_MODE, ConstantThroughputTimer.Mode.class); //$NON-NLS-1$
         p.setValue(DEFAULT, ConstantThroughputTimer.Mode.ThisThreadOnly.ordinal());
         p.setValue(NOT_UNDEFINED, Boolean.TRUE); // must be defined
     }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -232,6 +232,7 @@ however, the profile can't be updated while the test is running.
   <li><bug>65269</bug>JSON Extractor and JSON JMESPath Extractor ignore sub-samples</li>
   <li><bug>65352</bug>Warning logged when Boundary Extractor doesn't find any match</li>
   <li><bug>65681</bug>Use default values for null values when extracting with JSONPostProcessor</li>
+  <li>Allow setters in ConstantThroughputTimer to updating the values during the run time</li>
 </ul>
 
 <h3>Functions</h3>
@@ -286,6 +287,7 @@ however, the profile can't be updated while the test is running.
   <li>Rithvik Patibandla (rithvikp98 at gmail.com)</li>
   <li>Mariusz (mawasak at gmail.com)</li>
   <li>peter.wong@csexperts.com</li>
+  <li>Magnus Spångdal (magnus.spangdal as avanza.se)</li>
 </ul>
 <p>We also thank bug reporters who helped us improve JMeter.</p>
 <ul>


### PR DESCRIPTION


## Description
ConstantThroughputTimer setters doesnt register without setting Property like for other elements like for example ThreadGroup

So this makes the setters and getters of ConstantThroughputTimer use setProperty / getProperty so users no longer have to run e.g. `constantThroughputTimer.setProperty("throughput", "300.5")` but instead can use constantThroughputTimer.setThroughput(300.5) like intended(?)

## Motivation and Context
See description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Probably should test more.  So far just throwing it out here since I noticed the problem when trying to use the java api

<!--- Include details of your testing environment, tests ran to see how -->
verified the issue on macos and windows running jmeter programmatically in Java

<!--- your change affects other areas of the code, etc. -->
Not sure, would love some feedback of potential side effects.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
