### PR TITLE
Some Cmd scripts don't work with spaces in JMeter path

### DIFF
--- a/bin/heapdump.cmd
+++ b/bin/heapdump.cmd
@@ -20,5 +20,5 @@ rem   Ask the JMeter client to perform a HeapDump
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient HeapDump %*
+java -cp "%~dp0ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient HeapDump %*
 pause

--- a/bin/heapdump.cmd
+++ b/bin/heapdump.cmd
@@ -20,5 +20,5 @@ rem   Ask the JMeter client to perform a HeapDump
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp %~dp0ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient HeapDump %*
+java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient HeapDump %*
 pause

--- a/bin/shutdown.cmd
+++ b/bin/shutdown.cmd
@@ -20,5 +20,5 @@ rem   Run the Shutdown client to stop a non-GUI instance gracefully
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient Shutdown %*
+java -cp "%~dp0ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient Shutdown %*
 pause

--- a/bin/shutdown.cmd
+++ b/bin/shutdown.cmd
@@ -20,5 +20,5 @@ rem   Run the Shutdown client to stop a non-GUI instance gracefully
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp %~dp0ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient Shutdown %*
+java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient Shutdown %*
 pause

--- a/bin/stoptest.cmd
+++ b/bin/stoptest.cmd
@@ -20,5 +20,5 @@ rem   Run the Shutdown client to stop a non-GUI instance abruptly
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient StopTestNow %*
+java -cp "%~dp0ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient StopTestNow %*
 pause

--- a/bin/stoptest.cmd
+++ b/bin/stoptest.cmd
@@ -20,5 +20,5 @@ rem   Run the Shutdown client to stop a non-GUI instance abruptly
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp %~dp0ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient StopTestNow %*
+java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient StopTestNow %*
 pause

--- a/bin/threaddump.cmd
+++ b/bin/threaddump.cmd
@@ -20,5 +20,5 @@ rem   Ask the JMeter client to perform a ThreadDump
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp %~dp0ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient ThreadDump %*
+java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient ThreadDump %*
 pause

--- a/bin/threaddump.cmd
+++ b/bin/threaddump.cmd
@@ -20,5 +20,5 @@ rem   Ask the JMeter client to perform a ThreadDump
 
 rem   P1 = command port for JMeter instance (defaults to 4445)
 
-java -cp "%~dp0"ApacheJMeter.jar org.apache.jmeter.util.ShutdownClient ThreadDump %*
+java -cp "%~dp0ApacheJMeter.jar" org.apache.jmeter.util.ShutdownClient ThreadDump %*
 pause


### PR DESCRIPTION
## Description
Some of the Windows *.cmd scripts do not work if the JMETER_HOME location (i.e. folder where JMeter is installed) contains spaces (or other characters that need to be escaped).

## Motivation and Context
Scripts would fail to run with the below error.
`Error: Could not find or load main class [...]\bin\ApacheJMeter.jar`
Work-around is to install JMeter at path without spaces however this may not always be in the user's control.

## How Has This Been Tested?
Tested locally.
No unit test added due to the (trivial) nature of the issue and fix.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
