### PR TITLE
update x-stream to 1.4.17 (from 1.4.16)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -131,5 +131,5 @@ xml-apis.version=1.4.01
 xmlgraphics-commons.version=2.6
 xmlpull.version=1.1.3.1
 xpp3_min.version=1.1.4c
-xstream.version=1.4.16
+xstream.version=1.4.17
 wiremock-jre8.version=2.24.1

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -95,4 +95,4 @@
 220536,xml-apis-1.4.01.jar
 674607,xmlgraphics-commons-2.6.jar
 7188,xmlpull-1.1.3.1.jar
-629686,xstream-1.4.16.jar
+629806,xstream-1.4.17.jar

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -132,7 +132,7 @@ Summary
 <ul>
   <li><bug>65128</bug><pr>643</pr>Add missing documentation about <code>Same user on each iteration</code> for Thread Groups. Contributed by njkuzas.</li>
   <li><pr>648</pr>Updated xmlgraphics-commons to 2.6 (from 2.3). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
-  <li><pr>655</pr>Updated x-stream to 1.4.16 (from 1.4.15). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
+  <li><pr>655</pr>Updated x-stream to 1.4.17 (from 1.4.15). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
   <li><pr>656</pr>Updated json-smart to 2.4.1 (from 2.3) and accessors-smart to 1.3 (from 1.2). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
   <li><bug>64831</bug>Log truststore entries in debug level for logger <code>org.apache.jmeter.util.keystore.JmeterKeyStore</code></li>
   <li><bug>65232</bug>Hide splash screen when an error is displayed because the test plan could not be parsed.</li>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -132,7 +132,7 @@ Summary
 <ul>
   <li><bug>65128</bug><pr>643</pr>Add missing documentation about <code>Same user on each iteration</code> for Thread Groups. Contributed by njkuzas.</li>
   <li><pr>648</pr>Updated xmlgraphics-commons to 2.6 (from 2.3). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
-  <li><pr>655</pr>Updated x-stream to 1.4.17 (from 1.4.15). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
+  <li><pr>655</pr><pr>667</pr>Updated x-stream to 1.4.17 (from 1.4.15). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
   <li><pr>656</pr>Updated json-smart to 2.4.1 (from 2.3) and accessors-smart to 1.3 (from 1.2). Contributed by Stefan Seide (stefan @ trilobyte.se.de)</li>
   <li><bug>64831</bug>Log truststore entries in debug level for logger <code>org.apache.jmeter.util.keystore.JmeterKeyStore</code></li>
   <li><bug>65232</bug>Hide splash screen when an error is displayed because the test plan could not be parsed.</li>


### PR DESCRIPTION
## Description

security update for com.thoughtworks.xstream:xstream from 1.4.16 to 1.4.17

## Motivation and Context

This update fixes the following CVE:
* CVE-2021-29505

## How Has This Been Tested?
run `gradle check` and used it ourself for some days without problems

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
