### PR TITLE
65461: support multiple keys in the client keystore (select the matching one by keyType)

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/util/JsseSSLManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JsseSSLManager.java
@@ -366,7 +366,7 @@ public class JsseSSLManager extends SSLManager {
          *
          * TODO? - does not actually allow the user to choose an alias at present
          *
-         * @param keyType the key algorithm type name(s), ordered with the most-preferred key type first.
+         * @param keyTypes the key algorithm type name(s), ordered with the most-preferred key type first.
          * @param issuers the list of acceptable CA issuer subject names or null if it does not matter which issuers are used.
          * @param socket the socket to be used for this connection.
          *     This parameter can be null, which indicates that implementations are free to select an alias applicable to any socket.
@@ -374,11 +374,11 @@ public class JsseSSLManager extends SSLManager {
          * @see javax.net.ssl.X509KeyManager#chooseClientAlias(String[], Principal[], Socket)
          */
         @Override
-        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+        public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
             if(log.isDebugEnabled()) {
-                log.debug("keyType: {}", keyType[0]);
+                log.debug("keyType: {}", keyTypes[0]);
             }
-            String alias = this.store.getAlias();
+            String alias = this.store.getAlias(keyTypes);
             if(log.isDebugEnabled()) {
                 log.debug("Client alias: '{}'", alias);
             }


### PR DESCRIPTION
## WiP STATUS
- there don't seem to be any tests around the key manager at present, please see comment below
- I'm not sure if this needs any documentation change, I don't think so, as it's just a bug fix.

## Description
Fixes support for cases when the key type request to the key manager
does not match the key type of the available keys. Without this fix,
a key of incorrect type may be returned to the SSL engine, resulting
in key misuse and connection failure.

## Motivation and Context
https://bz.apache.org/bugzilla/show_bug.cgi?id=65461

## How Has This Been Tested?
The tests pass, and I tested this for my case specifically, but I don't see
any unit test that exercise this code. Any pointers or suggestions on how
to test this during build? The simplest would probably be to have a keystore
and simulate calls to the key manager.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [  ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
