### PR TITLE
Fix to 65446 - Move statistic_window property to user.properties file

### DIFF
--- a/bin/reportgenerator.properties
+++ b/bin/reportgenerator.properties
@@ -61,10 +61,6 @@
 # Sets the temporary directory used by the generation process if it needs file I/O operations.
 #jmeter.reportgenerator.temp_dir=temp
 
-# Sets the size of the sliding window used by percentile evaluation.
-# Caution : higher value provides a better accuracy but needs more memory.
-#jmeter.reportgenerator.statistic_window = 20000
-
 # Configure this property to change the report title
 #jmeter.reportgenerator.report_title=Apache JMeter Dashboard
 

--- a/bin/user.properties
+++ b/bin/user.properties
@@ -75,6 +75,10 @@
 # Set to 60000 ms by default
 #jmeter.reportgenerator.overall_granularity=60000
 
+# Sets the size of the sliding window used by percentile evaluation.
+# Caution : higher value provides a better accuracy but needs more memory.
+#jmeter.reportgenerator.statistic_window = 20000
+
 # Change this parameter if you want to change the granularity of Response time distribution
 # Set to 100 ms by default
 #jmeter.reportgenerator.graph.responseTimeDistribution.property.set_granularity=100


### PR DESCRIPTION
## Description
PercentileAggregator class reads the value for statistic_window using the following line:

```
private static final int SLIDING_WINDOW_SIZE = JMeterUtils.getPropDefault(
            ReportGeneratorConfiguration.REPORT_GENERATOR_KEY_PREFIX
                    + ReportGeneratorConfiguration.KEY_DELIMITER
                    + "statistic_window", 20000);
```
getPropDefault() calls appProperties.getProperty(). But in the appProperties we are only loading jmeter.properties, user.properties, system.properties etc and _not_ reportgenerator.properties where the value for statistic_window is supposed to be set. So the default value of 20,000 is being picked irrespective of what is set in the properties file.

_There are multiple ways to fix this issue but I chose this approach because it is the least intrusive._

## Motivation and Context
https://bz.apache.org/bugzilla/show_bug.cgi?id=65446

## How Has This Been Tested?
I built the code with the new changes and generated dashboards with some debug log statements in the code. The dashboards were getting generated correctly and the log statements are printing whatever property value I am setting. (Without this patch, they always print 20,000 as the size of the statistic window even when I am setting a different value in reportgenerator.properties file)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
