### PR TITLE
update x-stream to 1.4.18 (from 1.4.17)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -131,5 +131,5 @@ xml-apis.version=1.4.01
 xmlgraphics-commons.version=2.6
 xmlpull.version=1.1.3.1
 xpp3_min.version=1.1.4c
-xstream.version=1.4.17
+xstream.version=1.4.18
 wiremock-jre8.version=2.30.0

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -75,7 +75,7 @@
 106949,miglayout-core-5.3.jar
 22576,miglayout-swing-5.3.jar
 419054,mongo-java-driver-2.11.3.jar
-29631,mxparser-1.2.1.jar
+29680,mxparser-1.2.2.jar
 4687205,neo4j-java-driver-4.3.3.jar
 65261,oro-2.0.8.jar
 1307434,ph-commons-10.1.2.jar
@@ -96,4 +96,4 @@
 220536,xml-apis-1.4.01.jar
 674607,xmlgraphics-commons-2.6.jar
 7188,xmlpull-1.1.3.1.jar
-629806,xstream-1.4.17.jar
+629707,xstream-1.4.18.jar

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -137,7 +137,7 @@ Summary
 <ul>
   <li><bug>65128</bug><pr>643</pr>Add missing documentation about <code>Same user on each iteration</code> for Thread Groups. Contributed by njkuzas.</li>
   <li><pr>648</pr>Updated xmlgraphics-commons to 2.6 (from 2.3). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
-  <li><pr>655</pr><pr>667</pr>Updated x-stream to 1.4.18 (from 1.4.15). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
+  <li><pr>655</pr><pr>667</pr><pr>675</pr>Updated x-stream to 1.4.18 (from 1.4.15). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
   <li><pr>656</pr><pr>668</pr>Updated json-smart to 2.4.7 (from 2.3), accessors-smart to 2.4.7 (from 1.2) and asm 9.1 (from 9.0). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
   <li><bug>64831</bug>Log truststore entries in debug level for logger <code>org.apache.jmeter.util.keystore.JmeterKeyStore</code></li>
   <li><bug>65232</bug>Hide splash screen when an error is displayed because the test plan could not be parsed.</li>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -137,7 +137,7 @@ Summary
 <ul>
   <li><bug>65128</bug><pr>643</pr>Add missing documentation about <code>Same user on each iteration</code> for Thread Groups. Contributed by njkuzas.</li>
   <li><pr>648</pr>Updated xmlgraphics-commons to 2.6 (from 2.3). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
-  <li><pr>655</pr><pr>667</pr>Updated x-stream to 1.4.17 (from 1.4.15). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
+  <li><pr>655</pr><pr>667</pr>Updated x-stream to 1.4.18 (from 1.4.15). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
   <li><pr>656</pr><pr>668</pr>Updated json-smart to 2.4.7 (from 2.3), accessors-smart to 2.4.7 (from 1.2) and asm 9.1 (from 9.0). Contributed by Stefan Seide (stefan at trilobyte-se.de)</li>
   <li><bug>64831</bug>Log truststore entries in debug level for logger <code>org.apache.jmeter.util.keystore.JmeterKeyStore</code></li>
   <li><bug>65232</bug>Hide splash screen when an error is displayed because the test plan could not be parsed.</li>


### PR DESCRIPTION
## Description
The latest update to xstream 1.4.18 contains fixes for 14 CVE (http://x-stream.github.io/changes.html)

## Motivation and Context
Up to version 1.4.17 (before this update) xstream used an internal blacklist to block potential security threads on class (de)serialisation. With this new version they changed to an internal whitelist to allow safe operations only.

BUT - jmeter initalizes xstream with an empty security framework (no white/blacklist at all) in JMeterUtils.java
(https://github.com/apache/jmeter/blob/5f1995de244986c820ed47028ceedf9167004673/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java#L1274:L1280), therefore i think the internal change in xstream does not change anything for jmeter.

On the other hand i am not really shure about the security implications of running without a list at all and if theses fixes really help...
Someone with a deeper understanding of jmeters usage of xstream should check where the serialisation is used and where the objects to searialize/unserialize came from (external/network or only internal).

## How Has This Been Tested?
`gradlew check` runs without problem and used it for nearly 2 months ourself without any problem.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
