### PR TITLE
Reduce memory consumption by the logging panel (disable undo events for it)

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -33,6 +33,7 @@ import org.apache.jmeter.gui.action.LookAndFeelCommand;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JMeterUIDefaults;
+import org.apache.jorphan.gui.ui.TextComponentUI;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rsyntaxtextarea.Theme;
@@ -240,6 +241,7 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
             }
         }
         if(disableUndo) {
+            TextComponentUI.uninstallUndo(this);
             // We need to do this to force recreation of undoManager which
             // will use the disableUndo otherwise it would always be false
             // See BUG 57440
@@ -276,7 +278,7 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
     protected RUndoManager createUndoManager() {
         RUndoManager undoManager = super.createUndoManager();
         if(disableUndo) {
-            undoManager.setLimit(0);
+            undoManager.setLimit(1);
         } else {
             undoManager.setLimit(MAX_UNDOS);
         }

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/AddUndoableEditListenerPropertyChangeListener.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/AddUndoableEditListenerPropertyChangeListener.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui.ui;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.text.Document;
+import javax.swing.undo.UndoManager;
+
+class AddUndoableEditListenerPropertyChangeListener implements PropertyChangeListener {
+    private final UndoManager manager;
+
+    public AddUndoableEditListenerPropertyChangeListener(UndoManager manager) {
+        this.manager = manager;
+    }
+
+    public final UndoManager getUndoManager() {
+        return manager;
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        manager.discardAllEdits();
+        if (evt.getOldValue() != null) {
+            ((Document) evt.getOldValue()).removeUndoableEditListener(manager);
+        }
+        if (evt.getNewValue() != null) {
+            ((Document) evt.getNewValue()).addUndoableEditListener(manager);
+        }
+    }
+}

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/DefaultUndoManager.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/DefaultUndoManager.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui.ui;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.swing.event.UndoableEditEvent;
+import javax.swing.undo.UndoManager;
+
+class DefaultUndoManager extends UndoManager {
+    private final AtomicInteger undoEpoch;
+    private int ourUndoEpoch;
+
+    DefaultUndoManager(AtomicInteger undoEpoch) {
+        this.undoEpoch = undoEpoch;
+        this.ourUndoEpoch = undoEpoch.get();
+    }
+
+    @Override
+    public synchronized void discardAllEdits() {
+        super.discardAllEdits();
+        ourUndoEpoch = undoEpoch.get();
+    }
+
+    @Override
+    public void undoableEditHappened(UndoableEditEvent e) {
+        int epoch = undoEpoch.get();
+        if (ourUndoEpoch != epoch) {
+            discardAllEdits();
+        }
+        super.undoableEditHappened(e);
+    }
+
+    @Override
+    public synchronized boolean canUndo() {
+        return ourUndoEpoch == undoEpoch.get() && super.canUndo();
+    }
+
+    @Override
+    public synchronized boolean canRedo() {
+        return ourUndoEpoch == undoEpoch.get() && super.canRedo();
+    }
+}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -131,6 +131,7 @@ Summary
 <ul>
   <li><bug>61805</bug><pr>663</pr>Add simple HTTP request template. Contributed by Ori Marko (orimarko at gmail.com)</li>
   <li><bug>65611</bug><pr>673</pr>Add support for IPv6 addresses when specifying a remote worker node. Based on a patch by Peter Wong (peter.wong at csexperts.com)</li>
+  <li>Reduce memory consumption by the logging panel (disable undo events for it)</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
## Description

`org.apache.jorphan.gui.ui.TextAreaUIWithUndo#createUI` is called by Swing automatically by ALL text area components (since JMeter installs `TextAreaUIWithUndo` as a UI class for the look and feel).
That is convenient since it makes all text fields and text areas support undo transparently, however, it results in surprising memory consumption by the logging panel.

Here's a heap dump:
<img width="777" alt="dominator tree" src="https://user-images.githubusercontent.com/213894/140286033-baacc384-e7c2-467b-969a-671d12e3b6cf.png">

`TextComponentUI$1` is `UndoManager`. I moved the anonymous class to a top-level named class so it is easier to understand in the future.

## How Has This Been Tested?

Test plan with JSR223 sampler that calls log.info("...") a lot.
After the change, the undo manager and text area are no longer in the top consumers.
