### PR TITLE
Align ssl props / Enable setting cipher suite  (WIP)

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -730,7 +730,8 @@ public class JMeterUtils implements UnitTestManager {
                 return strVal.trim().split("\\s+");
             }
         } catch (Exception e) {
-            log.warn("Exception '{}' occurred when fetching boolean property:'{}', defaulting to: {}", e.getMessage(), propName, defaultVal);
+            log.warn("Exception '{}' occurred when fetching Array property:'{}', defaulting to: {}",
+                    e.getMessage(), propName, defaultVal != null ? Arrays.toString(defaultVal) : null);
         }
         return defaultVal;
     }

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -52,6 +52,7 @@ import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jorphan.gui.JFactory;
@@ -706,6 +707,27 @@ public class JMeterUtils implements UnitTestManager {
                 return false;
             } else {
                 return Integer.parseInt(strVal) == 1;
+            }
+        } catch (Exception e) {
+            log.warn("Exception '{}' occurred when fetching boolean property:'{}', defaulting to: {}", e.getMessage(), propName, defaultVal);
+        }
+        return defaultVal;
+    }
+
+    /**
+     * Get an array of String if present and not empty, defaultValue if not present.
+     *
+     * @param propName
+     *            the name of the property.
+     * @param defaultVal
+     *            the default value.
+     * @return The PropDefault value
+     */
+    public static String[] getArrayPropDefault(String propName, String[] defaultVal) {
+        try {
+            String strVal = appProperties.getProperty(propName);
+            if (StringUtils.isNotBlank(strVal)) {
+                return strVal.trim().split("\\s+");
             }
         } catch (Exception e) {
             log.warn("Exception '{}' occurred when fetching boolean property:'{}', defaulting to: {}", e.getMessage(), propName, defaultVal);

--- a/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
@@ -19,7 +19,11 @@ package org.apache.jmeter.util;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class TestJMeterUtils {
 
@@ -37,5 +41,19 @@ public class TestJMeterUtils {
     @Test
     public void testGesResStringDefaultWithNonExistantKey() throws Exception {
         assertEquals("[res_key=noValidKey]", JMeterUtils.getResString("noValidKey"));
+    }
+
+    @Test
+    public void testGetArrayPropDefault() throws Exception {
+        Path props = Files.createTempFile("testGetArrayPropDefault", ".properties");
+        JMeterUtils.loadJMeterProperties(props.toString());
+        JMeterUtils.getJMeterProperties().setProperty("testGetArrayPropDefaultEmpty", "    ");
+        JMeterUtils.getJMeterProperties().setProperty("testGetArrayPropDefault", " Tolstoi  Dostoievski    Pouchkine       Gorki ");
+        Assertions.assertArrayEquals(new String[]{"Tolstoi", "Dostoievski", "Pouchkine", "Gorki"},
+                JMeterUtils.getArrayPropDefault("testGetArrayPropDefault", null));
+        Assertions.assertArrayEquals(new String[]{"Gilels", "Richter"},
+                JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultMissing", new String[]{"Gilels", "Richter"}));
+        Assertions.assertArrayEquals(null,
+                JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultEmpty", null));
     }
 }

--- a/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
@@ -19,11 +19,11 @@ package org.apache.jmeter.util;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TestJMeterUtils {
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
@@ -466,8 +466,12 @@ public class Proxy extends Thread {
                 secureSocket = (SSLSocket) sslFactory.createSocket(sock,
                         sock.getInetAddress().getHostName(), sock.getPort(), true);
                 secureSocket.setUseClientMode(false);
-                secureSocket.setEnabledCipherSuites(SUPPORTED_CIPHER_LIST);
-                secureSocket.setEnabledProtocols(SUPPORTED_PROTOCOL_LIST);
+                if (SUPPORTED_CIPHER_LIST != null) {
+                    secureSocket.setEnabledCipherSuites(SUPPORTED_CIPHER_LIST);
+                }
+                if (SUPPORTED_PROTOCOL_LIST != null) {
+                    secureSocket.setEnabledProtocols(SUPPORTED_PROTOCOL_LIST);
+                }
                 if (log.isDebugEnabled()){
                     log.debug("{} SSL transaction ok with cipher: {}", port, secureSocket.getSession().getCipherSuite());
                 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
@@ -89,6 +89,19 @@ public class Proxy extends Thread {
     private static final String SSLCONTEXT_PROTOCOL =
         JMeterUtils.getPropDefault("proxy.ssl.protocol", "TLS"); // $NON-NLS-1$ $NON-NLS-2$
 
+    private static final String PROTOCOL_LIST =
+            JMeterUtils.getPropDefault("https.socket.protocols", ""); // $NON-NLS-1$ $NON-NLS-2$
+
+    private static final String CIPHER_SUITE_LIST =
+            JMeterUtils.getPropDefault("https.cipherSuites", ""); // $NON-NLS-1$ $NON-NLS-2$
+
+    private static final String[] SUPPORTED_PROTOCOL_LIST =
+            PROTOCOL_LIST.isEmpty() ?
+                    null: PROTOCOL_LIST.split(" "); // $NON-NLS-1$
+    private static final String[] SUPPORTED_CIPHER_LIST =
+            CIPHER_SUITE_LIST.isEmpty() ?
+                    null : CIPHER_SUITE_LIST.split(" "); // $NON-NLS-1$
+
     // HashMap to save ssl connection between Jmeter proxy and browser
     private static final HashMap<String, SSLSocketFactory> HOST2SSL_SOCK_FAC = new HashMap<>();
 
@@ -453,6 +466,8 @@ public class Proxy extends Thread {
                 secureSocket = (SSLSocket) sslFactory.createSocket(sock,
                         sock.getInetAddress().getHostName(), sock.getPort(), true);
                 secureSocket.setUseClientMode(false);
+                secureSocket.setEnabledCipherSuites(SUPPORTED_CIPHER_LIST);
+                secureSocket.setEnabledProtocols(SUPPORTED_PROTOCOL_LIST);
                 if (log.isDebugEnabled()){
                     log.debug("{} SSL transaction ok with cipher: {}", port, secureSocket.getSession().getCipherSuite());
                 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
@@ -89,18 +89,11 @@ public class Proxy extends Thread {
     private static final String SSLCONTEXT_PROTOCOL =
         JMeterUtils.getPropDefault("proxy.ssl.protocol", "TLS"); // $NON-NLS-1$ $NON-NLS-2$
 
-    private static final String PROTOCOL_LIST =
-            JMeterUtils.getPropDefault("https.socket.protocols", ""); // $NON-NLS-1$ $NON-NLS-2$
+    private static final String[] SOCKET_PROTOCOL_ARRAY =
+            JMeterUtils.getArrayPropDefault("https.socket.protocols", null); // $NON-NLS-1$
 
-    private static final String CIPHER_SUITE_LIST =
-            JMeterUtils.getPropDefault("https.cipherSuites", ""); // $NON-NLS-1$ $NON-NLS-2$
-
-    private static final String[] SUPPORTED_PROTOCOL_LIST =
-            PROTOCOL_LIST.isEmpty() ?
-                    null: PROTOCOL_LIST.split(" "); // $NON-NLS-1$
-    private static final String[] SUPPORTED_CIPHER_LIST =
-            CIPHER_SUITE_LIST.isEmpty() ?
-                    null : CIPHER_SUITE_LIST.split(" "); // $NON-NLS-1$
+    private static final String[] SUPPORTED_CIPHER_ARRAY =
+            JMeterUtils.getArrayPropDefault("https.cipherSuites", null); // $NON-NLS-1$
 
     // HashMap to save ssl connection between Jmeter proxy and browser
     private static final HashMap<String, SSLSocketFactory> HOST2SSL_SOCK_FAC = new HashMap<>();
@@ -466,11 +459,11 @@ public class Proxy extends Thread {
                 secureSocket = (SSLSocket) sslFactory.createSocket(sock,
                         sock.getInetAddress().getHostName(), sock.getPort(), true);
                 secureSocket.setUseClientMode(false);
-                if (SUPPORTED_CIPHER_LIST != null) {
-                    secureSocket.setEnabledCipherSuites(SUPPORTED_CIPHER_LIST);
+                if (SUPPORTED_CIPHER_ARRAY != null) {
+                    secureSocket.setEnabledCipherSuites(SUPPORTED_CIPHER_ARRAY);
                 }
-                if (SUPPORTED_PROTOCOL_LIST != null) {
-                    secureSocket.setEnabledProtocols(SUPPORTED_PROTOCOL_LIST);
+                if (SOCKET_PROTOCOL_ARRAY != null) {
+                    secureSocket.setEnabledProtocols(SOCKET_PROTOCOL_ARRAY);
                 }
                 if (log.isDebugEnabled()){
                     log.debug("{} SSL transaction ok with cipher: {}", port, secureSocket.getSession().getCipherSuite());

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LazyLayeredConnectionSocketFactory.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LazyLayeredConnectionSocketFactory.java
@@ -45,12 +45,15 @@ public final class LazyLayeredConnectionSocketFactory implements LayeredConnecti
     private static final String CIPHER_LIST =
             JMeterUtils.getPropDefault("https.socket.ciphers", ""); // $NON-NLS-1$ $NON-NLS-2$
 
+    private static final String CIPHER_SUITE_LIST =
+            JMeterUtils.getPropDefault("https.cipherSuites", CIPHER_LIST); // $NON-NLS-1$ $NON-NLS-2$
+
     private static final String[] SUPPORTED_PROTOCOL_LIST =
             PROTOCOL_LIST.isEmpty() ?
                     null: PROTOCOL_LIST.split(" "); // $NON-NLS-1$
     private static final String[] SUPPORTED_CIPHER_LIST =
-            CIPHER_LIST.isEmpty() ?
-                    null : CIPHER_LIST.split(" "); // $NON-NLS-1$
+            CIPHER_SUITE_LIST.isEmpty() ?
+                    null : CIPHER_SUITE_LIST.split(" "); // $NON-NLS-1$
 
     private static class AdapteeHolder { // IODH idiom
         private static final LayeredConnectionSocketFactory ADAPTEE = checkAndInit();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LazyLayeredConnectionSocketFactory.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LazyLayeredConnectionSocketFactory.java
@@ -39,21 +39,14 @@ import org.slf4j.LoggerFactory;
  */
 public final class LazyLayeredConnectionSocketFactory implements LayeredConnectionSocketFactory{
     private static final Logger LOG = LoggerFactory.getLogger(LazyLayeredConnectionSocketFactory.class);
-    private static final String PROTOCOL_LIST =
-            JMeterUtils.getPropDefault("https.socket.protocols", ""); // $NON-NLS-1$ $NON-NLS-2$
+    private static final String[] SOCKET_PROTOCOL_ARRAY =
+            JMeterUtils.getArrayPropDefault("https.socket.protocols", null); // $NON-NLS-1$
 
-    private static final String CIPHER_LIST =
-            JMeterUtils.getPropDefault("https.socket.ciphers", ""); // $NON-NLS-1$ $NON-NLS-2$
+    private static final String[] SOCKET_CIPHER_ARRAY =
+            JMeterUtils.getArrayPropDefault("https.socket.ciphers", null); // $NON-NLS-1$
 
-    private static final String CIPHER_SUITE_LIST =
-            JMeterUtils.getPropDefault("https.cipherSuites", CIPHER_LIST); // $NON-NLS-1$ $NON-NLS-2$
-
-    private static final String[] SUPPORTED_PROTOCOL_LIST =
-            PROTOCOL_LIST.isEmpty() ?
-                    null: PROTOCOL_LIST.split(" "); // $NON-NLS-1$
-    private static final String[] SUPPORTED_CIPHER_LIST =
-            CIPHER_SUITE_LIST.isEmpty() ?
-                    null : CIPHER_SUITE_LIST.split(" "); // $NON-NLS-1$
+    private static final String[] CIPHER_SUITE_ARRAY =
+            JMeterUtils.getArrayPropDefault("https.cipherSuites", SOCKET_CIPHER_ARRAY); // $NON-NLS-1$
 
     private static class AdapteeHolder { // IODH idiom
         private static final LayeredConnectionSocketFactory ADAPTEE = checkAndInit();
@@ -65,8 +58,8 @@ public final class LazyLayeredConnectionSocketFactory implements LayeredConnecti
             LOG.info("Setting up HTTPS TrustAll Socket Factory");
             return new SSLConnectionSocketFactory(
                     new HttpSSLProtocolSocketFactory(JsseSSLManager.CPS),
-                    SUPPORTED_PROTOCOL_LIST,
-                    SUPPORTED_CIPHER_LIST,
+                    SOCKET_PROTOCOL_ARRAY,
+                    CIPHER_SUITE_ARRAY,
                     NoopHostnameVerifier.INSTANCE);
         }
 

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -189,6 +189,7 @@ Summary
   <li><bug>65310</bug>Don't let users override <code>multipart/form-data</code> <code>content-type</code>
     header in HC4 sampler.</li>
   <li><bug>65363</bug><code>NullPointerException</code> in <code>HTTPHC4Impl$ManagedCredentialsProvider.getAuthorizationForAuthScope</code> when <code>401</code> response from remote and <code>httpclient4.auth.preemptive=false</code></li>
+  <li><bug>65692</bug>HTTP(s) Test Script Recorder: Enable setting enabled cipher suite and enabled protocols on SSLContext/ Align ssl properties between Java and HC4 impl</li>
 </ul>
 
 <h3>Other Samplers</h3>


### PR DESCRIPTION
## Description

- Use https.cipherSuites property for HC4
- Use https.cipherSuites and https.socket.protocols in Proxy

## Motivation and Context

Clarification of use.
Allow fine grain control during recording.

## How Has This Been Tested?

Manual testing and debugging.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
