### PR TITLE
Deleted the redundant log variable in parse curl command action class

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -123,7 +123,6 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
     public static final String IMPORT_CURL = "import_curl";
     private static final String CREATE_REQUEST = "CREATE_REQUEST";
     private static final String CERT = "cert";
-    private Logger log = LoggerFactory.getLogger(getClass());
     /** A panel allowing results to be saved. */
     private FilePanel filePanel = null;
     static {
@@ -550,11 +549,11 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
                         if (contentFile.canRead()) {
                             contentType = tika.detect(contentFile);
                         } else {
-                            log.info("Can not read file {}, so guessing contentType by extension.", formValue);
+                            LOGGER.info("Can not read file {}, so guessing contentType by extension.", formValue);
                             contentType = tika.detect(formValue);
                         }
                     } catch (IOException e) {
-                        log.info(
+                        LOGGER.info(
                                 "Could not detect contentType for file {} by content, so falling back to detection by filename",
                                 formValue);
                         contentType = tika.detect(formValue);


### PR DESCRIPTION
## Description
Deleted the redundant `log` variable and used `LOGGER` which is used in the other places in the same class

## Motivation and Context

- Deleted the redundant `log` variable and used `LOGGER` which is used in the other places in the same class
- Code cleanup

## How Has This Been Tested?
n/a (Unit test covers the scenario)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
