### PR TITLE
Logger and string usage warning fix

### DIFF
--- a/src/functions/src/main/java/org/apache/jmeter/functions/StringFromFile.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/StringFromFile.java
@@ -122,7 +122,7 @@ public class StringFromFile extends AbstractFunction implements TestStateListene
 
     public StringFromFile() {
         if (log.isDebugEnabled()) {
-            log.debug("++++++++ Construct {}" + this);
+            log.debug("++++++++ Construct {}", this);
         }
     }
 
@@ -147,9 +147,8 @@ public class StringFromFile extends AbstractFunction implements TestStateListene
         String tn = Thread.currentThread().getName();
         fileName = ((CompoundVariable) values[0]).execute();
 
-        String start = "";
         if (values.length >= PARAM_START) {
-            start = ((CompoundVariable) values[PARAM_START - 1]).execute();
+            String start = ((CompoundVariable) values[PARAM_START - 1]).execute();
             try {
                 // Low chances to be non numeric, we parse
                 myStart = Integer.parseInt(start);


### PR DESCRIPTION
## Description
- Removed the string concatenation from logger statement which has the placeholder
-  `start` doesn't need to be initialised outside. IDE was showing warning for this. So, removed the variable declaration and used it inline

## Motivation and Context
- Fixing a minor issue in logging (i.e. using `{}` and concatenation together) 
- Fixed the warning on variable declaration 

## How Has This Been Tested?
n/a

Note:-
I can add unit test for `log` statement using external dependency [LogCaptor](https://github.com/Hakky54/log-captor). Please leave the preference in comment. I will add the below test in the separate PR. Thanks!

```
@Test
    public void testStringFromFileConstructorLogger() {
        LogCaptor logCaptor = LogCaptor.forClass(StringFromFile.class);
        new StringFromFile();
        assertThat(logCaptor.getDebugLogs().get(0),
                containsString("++++++++ Construct org.apache.jmeter.functions.StringFromFile@"));
    }
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
