### PR TITLE
keep JSyntaxTextArea text value for use in headless mode

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
@@ -92,7 +92,7 @@ public class Save extends AbstractAction {
     private static final int BACKUP_MAX_COUNT = JMeterUtils.getPropDefault(JMX_BACKUP_MAX_COUNT, 10);
 
     // NumberFormat to format version number in backup file names
-    private static final DecimalFormat BACKUP_VERSION_FORMATER = new DecimalFormat("000000"); //$NON-NLS-1$
+    private static final DecimalFormat BACKUP_VERSION_FORMAT = new DecimalFormat("000000"); //$NON-NLS-1$
 
     private static final int MS_PER_HOUR = 60 * 60 * 1000;
 
@@ -373,7 +373,7 @@ public class Save extends AbstractAction {
         // {baseName}{versionSeparator}{version}{jmxExtension}  // NOSONAR
         String backupName = baseName
                 + versionSeparator
-                + BACKUP_VERSION_FORMATER.format(lastVersionNumber + 1L)
+                + BACKUP_VERSION_FORMAT.format(lastVersionNumber + 1L)
                 + JMX_FILE_EXTENSION;
         File backupFile = new File(backupDir, backupName);
         // create file backup

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
@@ -92,7 +92,7 @@ public class Save extends AbstractAction {
     private static final int BACKUP_MAX_COUNT = JMeterUtils.getPropDefault(JMX_BACKUP_MAX_COUNT, 10);
 
     // NumberFormat to format version number in backup file names
-    private static final DecimalFormat BACKUP_VERSION_FORMAT = new DecimalFormat("000000"); //$NON-NLS-1$
+    private static final DecimalFormat BACKUP_VERSION_FORMATER = new DecimalFormat("000000"); //$NON-NLS-1$
 
     private static final int MS_PER_HOUR = 60 * 60 * 1000;
 
@@ -373,7 +373,7 @@ public class Save extends AbstractAction {
         // {baseName}{versionSeparator}{version}{jmxExtension}  // NOSONAR
         String backupName = baseName
                 + versionSeparator
-                + BACKUP_VERSION_FORMAT.format(lastVersionNumber + 1L)
+                + BACKUP_VERSION_FORMATER.format(lastVersionNumber + 1L)
                 + JMX_FILE_EXTENSION;
         File backupFile = new File(backupDir, backupName);
         // create file backup

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -101,6 +101,7 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
             // Allow override for unit testing only
             if ("true".equals(System.getProperty("java.awt.headless"))) { // $NON-NLS-1$ $NON-NLS-2$
                 return new JSyntaxTextArea(disableUndo) {
+                    private String savedText = "";
                     private static final long serialVersionUID = 1L;
                     @Override
                     protected void init() {
@@ -118,7 +119,15 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
                     @Override
                     public void discardAllEdits() { }
                     @Override
-                    public void setText(String t) { }
+                    public void setText(String t) {
+                        savedText = t;
+                    }
+
+                    @Override
+                    public String getText() {
+                        return savedText;
+                    }
+
                     @Override
                     public boolean isCodeFoldingEnabled(){ return true; }
                 };

--- a/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
@@ -63,8 +63,6 @@ public class JSyntaxTextAreaTest extends JMeterTestCase {
 
             String myText = "my text";
             textArea.setText(myText);
-            // next one fails with NPE when getInstance does not provide overridden method
-            textArea.setCodeFoldingEnabled(true);
             assertEquals(myText, textArea.getText());
 
         } catch (HeadlessException he) {

--- a/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
@@ -52,21 +52,19 @@ public class JSyntaxTextAreaTest extends JMeterTestCase {
     }
 
     @Test
-    public void testHeadless() {
+    public void testHeadlessGetText() {
         String key = "java.awt.headless";
         String initialValue = System.getProperty(key);
         try {
             System.setProperty(key, "true");
-            // getInstance returns anonymous class with some overridden methods
-            // to avoid errors due to 'java.awt.headless=true'
+            // getInstance() returns anonymous class with some overridden methods
+            // to avoid errors due to 'java.awt.headless=true'.
+            // E.g. it should not throw a HeadlessException.
             JSyntaxTextArea textArea = JSyntaxTextArea.getInstance(10,20);
 
             String myText = "my text";
             textArea.setText(myText);
             assertEquals(myText, textArea.getText());
-
-        } catch (HeadlessException he) {
-            fail("Unexpected HeadlessException, because of the explicit `java.awt.headless=true`.");
         } finally {
             if (initialValue != null) {
                 System.setProperty(key, initialValue);

--- a/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.jmeter.gui.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.awt.HeadlessException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -28,9 +31,6 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 // should not run in parallel due to using a System property that can impact
 // other tests

--- a/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/gui/util/JSyntaxTextAreaTest.java
@@ -68,7 +68,7 @@ public class JSyntaxTextAreaTest extends JMeterTestCase {
             assertEquals(myText, textArea.getText());
 
         } catch (HeadlessException he) {
-            fail("WARNING: Does not work in headless mode");
+            fail("Unexpected HeadlessException, because of the explicit `java.awt.headless=true`.");
         } finally {
             if (initialValue != null) {
                 System.setProperty(key, initialValue);


### PR DESCRIPTION
## Description
Keep the text that is set on overridden JSyntaxTextArea anonymous class in headless mode.

## Motivation and Context
Working on a project that uses jMeter components in a headless way (`java.awt.headless=true`), we found that the `setText(...)` is not kept on the `JSyntaxTextArea` from `getInstance(...)`. Following `getText()` call returns null. With `java.awt.headless=false`, to try and run with the original `JSyntaxTextArea` on headless linux it fails as there is no X11 display. 

This might benefit headless unit test as well.

## How Has This Been Tested?
Unit tests added. Snapshot build works in project.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly (javadocs and code comments)
