### PR TITLE
Used JUnit 5 assertion API to keep it consistent with JUnit 5 tests

### DIFF
--- a/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableModelTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableModelTest.java
@@ -19,7 +19,7 @@ package org.apache.jorphan.gui;
 
 import static java.lang.String.format;
 import static java.util.stream.IntStream.range;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.stream.IntStream;
@@ -238,10 +238,10 @@ public class ObjectTableModelTest {
     }
 
     private void assertModel(String... as) {
-        assertEquals("model row count", as.length, model.getRowCount());
+        assertEquals(as.length, model.getRowCount(), "model row count");
 
         for (int row = 0; row < as.length; row++) {
-            assertEquals(format("model[%d,0]", row), as[row], model.getValueAt(row, 0));
+            assertEquals(as[row], model.getValueAt(row, 0), format("model[%d,0]", row));
         }
     }
 

--- a/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableSorterTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/gui/ObjectTableSorterTest.java
@@ -28,8 +28,8 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.AbstractMap;
@@ -125,7 +125,7 @@ public class ObjectTableSorterTest {
     @Test
     public void customKeyOrder() {
         HashMap<String, Integer> customKeyOrder = Stream.of("a", "c", "b", "d")
-                .reduce(new HashMap<String, Integer>(), (map, key) -> {
+                .reduce(new HashMap<>(), (map, key) -> {
                     map.put(key, map.size());
                     return map;
                 }, (a, b) -> a);

--- a/src/jorphan/src/test/java/org/apache/jorphan/math/TestStatCalculator.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/math/TestStatCalculator.java
@@ -17,8 +17,8 @@
 
 package org.apache.jorphan.math;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 

--- a/src/jorphan/src/test/java/org/apache/jorphan/reflect/TestClassTools.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/reflect/TestClassTools.java
@@ -17,9 +17,9 @@
 
 package org.apache.jorphan.reflect;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jorphan.util.JMeterException;
 import org.junit.jupiter.api.Test;

--- a/src/jorphan/src/test/java/org/apache/jorphan/util/TestConverter.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/util/TestConverter.java
@@ -17,8 +17,8 @@
 
 package org.apache.jorphan.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.text.DateFormat;
 import java.util.Calendar;

--- a/src/jorphan/src/test/java/org/apache/jorphan/util/TestJorphanUtils.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/util/TestJorphanUtils.java
@@ -18,15 +18,16 @@
 package org.apache.jorphan.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.nio.charset.StandardCharsets;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -253,7 +254,7 @@ public class TestJorphanUtils {
 
     @Test
     public void testGetByteArraySlice() throws Exception {
-        Assert.assertArrayEquals(new byte[]{1, 2},
+        assertArrayEquals(new byte[]{1, 2},
                 JOrphanUtils.getByteArraySlice(new byte[]{0, 1, 2, 3}, 1, 2));
     }
 
@@ -280,16 +281,16 @@ public class TestJorphanUtils {
     }
 
     private void assertEqualsArray(byte[] expected, byte[] actual) {
-        assertEquals("arrays must be same length", expected.length, actual.length);
+        assertEquals(expected.length, actual.length, "arrays must be same length");
         for (int i = 0; i < expected.length; i++) {
-            assertEquals("values must be the same for index: " + i, expected[i], actual[i]);
+            assertEquals(expected[i], actual[i], "values must be the same for index: " + i);
         }
     }
 
     @Test
     public void testNullifyIfEmptyTrimmed() {
-        Assert.assertNull(JOrphanUtils.nullifyIfEmptyTrimmed(null));
-        Assert.assertNull(JOrphanUtils.nullifyIfEmptyTrimmed("\u0001"));
+        assertNull(JOrphanUtils.nullifyIfEmptyTrimmed(null));
+        assertNull(JOrphanUtils.nullifyIfEmptyTrimmed("\u0001"));
         assertEquals("1234", JOrphanUtils.nullifyIfEmptyTrimmed("1234"));
     }
 
@@ -334,37 +335,37 @@ public class TestJorphanUtils {
     @Test
     public void testReplaceAllWithRegexWithSearchValueContainedInReplaceValue() {
         // Bug 61054
-        Assert.assertArrayEquals(new Object[]{"abcd", 1},
+        assertArrayEquals(new Object[]{"abcd", 1},
                 JOrphanUtils.replaceAllWithRegex("abc", "abc", "abcd", true));
     }
 
     @Test
     public void testReplaceAllWithRegex() {
-        Assert.assertArrayEquals(new Object[]{"toto", 0},
+        assertArrayEquals(new Object[]{"toto", 0},
                 JOrphanUtils.replaceAllWithRegex("toto", "ti", "ta", true));
-        Assert.assertArrayEquals(new Object[]{"toto", 0},
+        assertArrayEquals(new Object[]{"toto", 0},
                 JOrphanUtils.replaceAllWithRegex("toto", "TO", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TITI", 2},
+        assertArrayEquals(new Object[]{"TITI", 2},
                 JOrphanUtils.replaceAllWithRegex("toto", "TO", "TI", false));
-        Assert.assertArrayEquals(new Object[]{"TITI", 2},
+        assertArrayEquals(new Object[]{"TITI", 2},
                 JOrphanUtils.replaceAllWithRegex("toto", "to", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TITIti", 2},
+        assertArrayEquals(new Object[]{"TITIti", 2},
                 JOrphanUtils.replaceAllWithRegex("tototi", "to", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TOTIti", 1},
+        assertArrayEquals(new Object[]{"TOTIti", 1},
                 JOrphanUtils.replaceAllWithRegex("TOtoti", "to", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TOTI", 1},
+        assertArrayEquals(new Object[]{"TOTI", 1},
                 JOrphanUtils.replaceAllWithRegex("TOtoti", "to.*", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TOTI", 1},
+        assertArrayEquals(new Object[]{"TOTI", 1},
                 JOrphanUtils.replaceAllWithRegex("TOtoti", "to.*ti", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TOTITITITIaTITITIti", 7},
+        assertArrayEquals(new Object[]{"TOTITITITIaTITITIti", 7},
                 JOrphanUtils.replaceAllWithRegex("TO1232a123ti", "[0-9]", "TI", true));
-        Assert.assertArrayEquals(new Object[]{"TOTIaTIti", 2},
+        assertArrayEquals(new Object[]{"TOTIaTIti", 2},
                 JOrphanUtils.replaceAllWithRegex("TO1232a123ti", "[0-9]+", "TI", true));
 
-        Assert.assertArrayEquals(new Object[]{"TO${var}2a${var}ti", 2},
+        assertArrayEquals(new Object[]{"TO${var}2a${var}ti", 2},
                 JOrphanUtils.replaceAllWithRegex("TO1232a123ti", "123", "${var}", true));
 
-        Assert.assertArrayEquals(new Object[]{"TO${var}2a${var}ti${var2}", 2},
+        assertArrayEquals(new Object[]{"TO${var}2a${var}ti${var2}", 2},
                 JOrphanUtils.replaceAllWithRegex("TO1232a123ti${var2}", "123", "${var}", true));
     }
 

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -197,6 +197,7 @@ however, the profile can't be updated while the test is running.
   <li><pr>689</pr>Code clean up in StringFromFile. Contributed by Sampath Kumar Krishnasamy (sampathkumar.krishnasamykuppusamy at aexp.com)</li>
   <li><pr>690</pr>Refactor a few unit tests. Contributed by Sampath Kumar Krishnasamy (sampathkumar.krishnasamykuppusamy at aexp.com)</li>
   <li><pr>692></pr>Fix a few deprecation warnings for Gradle. Contributed by Sampath Kumar Krishnasamy (sampathkumar.krishnasamykuppusamy at aexp.com)</li>
+  <li><pr>697></pr>Junit 5 tests to use asserts from Junit 5 API. Contributed by Sampath Kumar Krishnasamy (sampathkumar.krishnasamykuppusamy at aexp.com)</li>
 </ul>
 
  <!-- =================== Bug fixes =================== -->


### PR DESCRIPTION
## Description
Used JUnit 5 assertion API in the test to keep it consistent with JUnit 5 `@Test` annotation

## Motivation and Context
Keeping test annotation and assertion API usage consistent in the unit test

## How Has This Been Tested?
n/a - Build file change

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines