### PR TITLE
Replace oro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
       script:
         # This job verifies headless mode to ensure Apache JMeter is workable in headless as well
         # Spotless and Checkstyle are skipped here to save some time. They are verified anyway in Java 8 and Java 13 builds, so skipping them for Java 11 does not harm
-        - ./gradlew build -Djava.awt.headless=true -Djmeter.properties.jmeter.use_java_regex=true -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
+        - ./gradlew build -Djava.awt.headless=true -Djmeter.properties.jmeter.regex.engine=java -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
     - name: Tests with OpenJDK 11 on s390x
       os: linux
       arch: s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,20 @@ matrix:
         # This job verifies headless mode to ensure Apache JMeter is workable in headless as well
         # Spotless and Checkstyle are skipped here to save some time. They are verified anyway in Java 8 and Java 13 builds, so skipping them for Java 11 does not harm
         - ./gradlew build -Djava.awt.headless=true -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
+    - name: Tests with OpenJDK 11 and Java Regex
+      jdk: openjdk11
+      addons:
+        apt:
+          packages:
+            - language-pack-fr
+      env:
+        - TZ=Pacific/Chatham # flips between +12:45 and +13:45
+        - LANG=fr_FR.UTF-8
+        - LC_ALL=fr_FR.UTF-8
+      script:
+        # This job verifies headless mode to ensure Apache JMeter is workable in headless as well
+        # Spotless and Checkstyle are skipped here to save some time. They are verified anyway in Java 8 and Java 13 builds, so skipping them for Java 11 does not harm
+        - ./gradlew build -Djava.awt.headless=true -Djmeter.use_java_regex=true -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
     - name: Tests with OpenJDK 11 on s390x
       os: linux
       arch: s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
       script:
         # This job verifies headless mode to ensure Apache JMeter is workable in headless as well
         # Spotless and Checkstyle are skipped here to save some time. They are verified anyway in Java 8 and Java 13 builds, so skipping them for Java 11 does not harm
-        - ./gradlew build -Djava.awt.headless=true -Djmeter.use_java_regex=true -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
+        - ./gradlew build -Djava.awt.headless=true -Djmeter.properties.jmeter.use_java_regex=true -Duser.language=fr -Duser.country=FR -PskipCheckstyle -PskipSpotless $SKIP_TAR
     - name: Tests with OpenJDK 11 on s390x
       os: linux
       arch: s390x

--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1127,6 +1127,14 @@ cookies=cookies
 # If you want to use Rhino on JDK8, set this property to true
 #javascript.use_rhino=false
 
+# Ability to switch out the old Oro Regex implementation with the JDK built-in implementation
+# Any value different to 'oro' will disable the Oro implementation and enable the JDK based.
+#jmeter.regex.engine=oro
+
+# We assist the JDK based Regex implementation by caching Pattern objects. The size of the
+# cache can be set with this setting. It can be disabled by setting it to '0'.
+#jmeter.regex.patterncache.size=1000
+
 # Number of milliseconds to wait for a thread to stop
 #jmeterengine.threadstop.wait=5000
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -600,6 +600,7 @@ allprojects {
                     val value = System.getProperty(name) ?: default
                     value?.let { systemProperty(name, it) }
                 }
+                passProperty("jmeter.use_java_regex")
                 passProperty("java.awt.headless")
                 passProperty("skip.test_TestDNSCacheManager.testWithCustomResolverAnd1Server")
                 passProperty("junit.jupiter.execution.parallel.enabled", "true")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -600,7 +600,11 @@ allprojects {
                     val value = System.getProperty(name) ?: default
                     value?.let { systemProperty(name, it) }
                 }
-                passProperty("jmeter.use_java_regex")
+                System.getProperties().filter {
+                    it.key.toString().startsWith("jmeter.properties.")
+                }.forEach {
+                    systemProperty(it.key.toString().substring("jmeter.properties.".length), it.value)
+                }
                 passProperty("java.awt.headless")
                 passProperty("skip.test_TestDNSCacheManager.testWithCustomResolverAnd1Server")
                 passProperty("junit.jupiter.execution.parallel.enabled", "true")

--- a/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
@@ -48,7 +48,8 @@ public class CompareAssertion extends AbstractTestElement implements Assertion, 
 
     private Collection<SubstitutionElement> stringsToSkip;
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     public CompareAssertion() {
         super();
@@ -157,7 +158,7 @@ public class CompareAssertion extends AbstractTestElement implements Assertion, 
             return content;
         }
 
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             String result = content;
             for (SubstitutionElement element: stringsToSkip) {
                 result = result.replaceAll(element.getRegex(), element.getSubstitute());

--- a/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
@@ -48,6 +48,8 @@ public class CompareAssertion extends AbstractTestElement implements Assertion, 
 
     private Collection<SubstitutionElement> stringsToSkip;
 
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+
     public CompareAssertion() {
         super();
     }
@@ -155,17 +157,25 @@ public class CompareAssertion extends AbstractTestElement implements Assertion, 
             return content;
         }
 
-        String result = content;
-        for (SubstitutionElement regex : stringsToSkip) {
-            emptySub.setSubstitution(regex.getSubstitute());
-            result = Util.substitute(
-                    JMeterUtils.getMatcher(),
-                    JMeterUtils.getPatternCache().getPattern(regex.getRegex()),
-                    emptySub,
-                    result,
-                    Util.SUBSTITUTE_ALL);
+        if (useJavaRegex) {
+            String result = content;
+            for (SubstitutionElement element: stringsToSkip) {
+                result = result.replaceAll(element.getRegex(), element.getSubstitute());
+            }
+            return result;
+        } else {
+            String result = content;
+            for (SubstitutionElement regex : stringsToSkip) {
+                emptySub.setSubstitution(regex.getSubstitute());
+                result = Util.substitute(
+                        JMeterUtils.getMatcher(),
+                        JMeterUtils.getPatternCache().getPattern(regex.getRegex()),
+                        emptySub,
+                        result,
+                        Util.SUBSTITUTE_ALL);
+            }
+            return result;
         }
-        return result;
     }
 
     @Override

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -167,7 +167,7 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
         if (isUseRegex()) {
             String str = objectToString(subj);
             if (useJavaRegex) {
-                return java.util.regex.Pattern.matches(getExpectedValue(), str);
+                return JMeterUtils.compilePattern(getExpectedValue()).matcher(str).matches();
             } else {
                 Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());
                 return JMeterUtils.getMatcher().matches(str, pattern);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -51,7 +51,8 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
     public static final String INVERT = "INVERT";
     public static final String ISREGEX = "ISREGEX";
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     private static ThreadLocal<DecimalFormat> decimalFormatter =
             ThreadLocal.withInitial(JSONPathAssertion::createDecimalFormat);
@@ -166,7 +167,7 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
     private boolean isEquals(Object subj) {
         if (isUseRegex()) {
             String str = objectToString(subj);
-            if (useJavaRegex) {
+            if (USE_JAVA_REGEX) {
                 return JMeterUtils.compilePattern(getExpectedValue()).matcher(str).matches();
             } else {
                 Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -51,6 +51,8 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
     public static final String INVERT = "INVERT";
     public static final String ISREGEX = "ISREGEX";
 
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+
     private static ThreadLocal<DecimalFormat> decimalFormatter =
             ThreadLocal.withInitial(JSONPathAssertion::createDecimalFormat);
 
@@ -164,8 +166,12 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
     private boolean isEquals(Object subj) {
         if (isUseRegex()) {
             String str = objectToString(subj);
-            Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());
-            return JMeterUtils.getMatcher().matches(str, pattern);
+            if (useJavaRegex) {
+                return java.util.regex.Pattern.matches(getExpectedValue(), str);
+            } else {
+                Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());
+                return JMeterUtils.getMatcher().matches(str, pattern);
+            }
         } else {
             Object expected = JSONValue.parse(getExpectedValue());
             return Objects.equals(expected, subj);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -394,11 +394,11 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
     }
 
     private static boolean matchesWithJavaRegex(String toCheck, String stringPattern) {
-        return java.util.regex.Pattern.compile(stringPattern).matcher(toCheck).matches();
+        return JMeterUtils.compilePattern(stringPattern).matcher(toCheck).matches();
     }
 
     private static boolean containsWithJavaRegex(String toCheck, String stringPattern) {
-        return java.util.regex.Pattern.compile(stringPattern).matcher(toCheck).find();
+        return JMeterUtils.compilePattern(stringPattern).matcher(toCheck).find();
     }
 
     private String getStringToCheck(SampleResult response) {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -308,7 +308,6 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
         boolean contains = isContainsType(); // do it once outside loop
         boolean equals = isEqualsType();
         boolean substring = isSubstringType();
-        boolean matches = isMatchType();
 
         log.debug("Test Type Info: contains={}, notTest={}, orTest={}", contains, notTest, orTest);
 
@@ -342,7 +341,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
                     found = toCheck.equals(stringPattern);
                 } else if (substring) {
                     found = toCheck.contains(stringPattern);
-                } else {
+                } else { // this is the old `matches` part which means `isMatchType()` is true
                     if (useJavaRegex) {
                         found = matchesWithJavaRegex(toCheck, stringPattern);
                     } else {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -95,7 +95,8 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
     private static final String DIFF_DELTA_END
             = JMeterUtils.getPropDefault("assertion.equals_diff_delta_end", "]]]");
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     public ResponseAssertion() {
         setProperty(new CollectionProperty(TEST_STRINGS, new ArrayList<String>()));
@@ -330,7 +331,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
                 String stringPattern = jMeterProperty.getStringValue();
                 boolean found;
                 if (contains) {
-                    if (useJavaRegex) {
+                    if (USE_JAVA_REGEX) {
                         found = containsWithJavaRegex(toCheck, stringPattern);
                     } else {
                         Pattern pattern = JMeterUtils.getPatternCache()
@@ -342,7 +343,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
                 } else if (substring) {
                     found = toCheck.contains(stringPattern);
                 } else { // this is the old `matches` part which means `isMatchType()` is true
-                    if (useJavaRegex) {
+                    if (USE_JAVA_REGEX) {
                         found = matchesWithJavaRegex(toCheck, stringPattern);
                     } else {
                         Pattern pattern = JMeterUtils.getPatternCache()

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -93,6 +94,8 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
             = JMeterUtils.getPropDefault("assertion.equals_diff_delta_start", "[[[");
     private static final String DIFF_DELTA_END
             = JMeterUtils.getPropDefault("assertion.equals_diff_delta_end", "]]]");
+
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
 
     public ResponseAssertion() {
         setProperty(new CollectionProperty(TEST_STRINGS, new ArrayList<String>()));
@@ -326,19 +329,27 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
             List<String> allCheckMessage = new ArrayList<>();
             for (JMeterProperty jMeterProperty : getTestStrings()) {
                 String stringPattern = jMeterProperty.getStringValue();
-                Pattern pattern = null;
-                if (contains || matches) {
-                    pattern = JMeterUtils.getPatternCache().getPattern(stringPattern, Perl5Compiler.READ_ONLY_MASK);
-                }
                 boolean found;
                 if (contains) {
-                    found = localMatcher.contains(toCheck, pattern);
+                    if (useJavaRegex) {
+                        found = containsWithJavaRegex(toCheck, stringPattern);
+                    } else {
+                        Pattern pattern = JMeterUtils.getPatternCache()
+                                .getPattern(stringPattern, Perl5Compiler.READ_ONLY_MASK);
+                        found = localMatcher.contains(toCheck, pattern);
+                    }
                 } else if (equals) {
                     found = toCheck.equals(stringPattern);
                 } else if (substring) {
                     found = toCheck.contains(stringPattern);
                 } else {
-                    found = localMatcher.matches(toCheck, pattern);
+                    if (useJavaRegex) {
+                        found = matchesWithJavaRegex(toCheck, stringPattern);
+                    } else {
+                        Pattern pattern = JMeterUtils.getPatternCache()
+                                .getPattern(stringPattern, Perl5Compiler.READ_ONLY_MASK);
+                        found = localMatcher.matches(toCheck, pattern);
+                    }
                 }
                 boolean pass = notTest ? !found : found;
                 if (orTest) {
@@ -375,12 +386,20 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
                     result.setFailureMessage(customMsg);
                 }
             }
-        } catch (MalformedCachePatternException e) {
+        } catch (MalformedCachePatternException | PatternSyntaxException e) {
             result.setError(true);
             result.setFailure(false);
             result.setFailureMessage("Bad test configuration " + e);
         }
         return result;
+    }
+
+    private static boolean matchesWithJavaRegex(String toCheck, String stringPattern) {
+        return java.util.regex.Pattern.compile(stringPattern).matcher(toCheck).matches();
+    }
+
+    private static boolean containsWithJavaRegex(String toCheck, String stringPattern) {
+        return java.util.regex.Pattern.compile(stringPattern).matcher(toCheck).find();
     }
 
     private String getStringToCheck(SampleResult response) {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -533,7 +533,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
         String compDeltaSeq;
         String endingEqSeq = trunc(true, received.substring(lastRecDiff + 1, recLength));
         String                  recDeltaSeq;
-        if (endingEqSeq.length() == 0) {
+        if (endingEqSeq.isEmpty()) {
             recDeltaSeq = trunc(true, received.substring(firstDiff, recLength));
             compDeltaSeq = trunc(true, comparison.substring(firstDiff, compLength));
         } else {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
@@ -58,7 +58,8 @@ public class JMESPathAssertion extends AbstractTestElement implements Serializab
     private static final String ISREGEX = "ISREGEX";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /**
      * Used to do a JMESPath query and compute result if the expectedValue matches
@@ -179,7 +180,7 @@ public class JMESPathAssertion extends AbstractTestElement implements Serializab
     private boolean isEquals(ObjectMapper mapper, JsonNode jsonNode) throws JsonProcessingException {
         String str = objectToString(mapper, jsonNode);
         if (isUseRegex()) {
-            if (useJavaRegex) {
+            if (USE_JAVA_REGEX) {
                 return JMeterUtils.compilePattern(getExpectedValue()).matcher(str).matches();
             } else {
                 Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
@@ -180,7 +180,7 @@ public class JMESPathAssertion extends AbstractTestElement implements Serializab
         String str = objectToString(mapper, jsonNode);
         if (isUseRegex()) {
             if (useJavaRegex) {
-                return java.util.regex.Pattern.matches(getExpectedValue(), str);
+                return JMeterUtils.compilePattern(getExpectedValue()).matcher(str).matches();
             } else {
                 Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());
                 return JMeterUtils.getMatcher().matches(str, pattern);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
@@ -58,6 +58,8 @@ public class JMESPathAssertion extends AbstractTestElement implements Serializab
     private static final String ISREGEX = "ISREGEX";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+
     /**
      * Used to do a JMESPath query and compute result if the expectedValue matches
      * with the JMESPath query result
@@ -177,8 +179,12 @@ public class JMESPathAssertion extends AbstractTestElement implements Serializab
     private boolean isEquals(ObjectMapper mapper, JsonNode jsonNode) throws JsonProcessingException {
         String str = objectToString(mapper, jsonNode);
         if (isUseRegex()) {
-            Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());
-            return JMeterUtils.getMatcher().matches(str, pattern);
+            if (useJavaRegex) {
+                return java.util.regex.Pattern.matches(getExpectedValue(), str);
+            } else {
+                Pattern pattern = JMeterUtils.getPatternCache().getPattern(getExpectedValue());
+                return JMeterUtils.getMatcher().matches(str, pattern);
+            }
         } else {
             String expectedValueString = getExpectedValue();
             // first try to match as a string value, as

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -83,7 +83,8 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
 
     private static final boolean DEFAULT_VALUE_FOR_DEFAULT_EMPTY_VALUE = false;
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     private transient List<Object> template;
 
@@ -113,7 +114,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
             vars.put(refName, defaultValue);
         }
 
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             extractWithJavaRegex(previousResult, vars, refName, matchNumber);
         } else {
             extractWithOroRegex(previousResult, vars, refName, matchNumber);

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -391,8 +391,8 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
                 log.warn("Could not parse number: '{}'.", prevString);
             }
         }
-        //Note: match.groups() includes group 0
-        final int groups = match.groupCount();
+        //Note: match.groups() includes group 0, groupCount() not
+        final int groups = match.groupCount() + 1;
         for (int x = 0; x < groups; x++) {
             buf.append(x);
             vars.put(buf.toString(), match.group(x));

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -49,6 +49,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
 
     // What to match against. N.B. do not change the string value or test plans will break!
     private static final String MATCH_AGAINST = "RegexExtractor.useHeaders"; // $NON-NLS-1$
+
     /*
      * Permissible values:
      *  true - match against headers
@@ -104,7 +105,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         int matchNumber = getMatchNumber();
 
         final String defaultValue = getDefaultValue();
-        if (defaultValue.length() > 0 || isEmptyDefaultValue()) {// Only replace default if it is provided or empty default value is explicitly requested
+        if (!defaultValue.isEmpty() || isEmptyDefaultValue()) {// Only replace default if it is provided or empty default value is explicitly requested
             vars.put(refName, defaultValue);
         }
 
@@ -479,7 +480,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
     // Allow for property not yet being set (probably only applies to Test cases)
     public boolean useBody() {
         String prop = getPropertyAsString(MATCH_AGAINST);
-        return prop.length()==0 || USE_BODY.equalsIgnoreCase(prop);// $NON-NLS-1$
+        return prop.isEmpty() || USE_BODY.equalsIgnoreCase(prop);// $NON-NLS-1$
     }
 
     public boolean useUnescapedBody() {

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jmeter.processor.PostProcessor;
@@ -81,6 +83,8 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
 
     private static final boolean DEFAULT_VALUE_FOR_DEFAULT_EMPTY_VALUE = false;
 
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+
     private transient List<Object> template;
 
     /**
@@ -109,6 +113,14 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
             vars.put(refName, defaultValue);
         }
 
+        if (useJavaRegex) {
+            extractWithJavaRegex(previousResult, vars, refName, matchNumber);
+        } else {
+            extractWithOroRegex(previousResult, vars, refName, matchNumber);
+        }
+    }
+
+    private void extractWithOroRegex(SampleResult previousResult, JMeterVariables vars, String refName, int matchNumber) {
         Perl5Matcher matcher = JMeterUtils.getMatcher();
         String regex = getRegex();
         Pattern pattern = null;
@@ -167,6 +179,62 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         }
     }
 
+    private void extractWithJavaRegex(SampleResult previousResult, JMeterVariables vars, String refName, int matchNumber) {
+        String regex = getRegex();
+        java.util.regex.Pattern pattern = null;
+        try {
+            pattern = java.util.regex.Pattern.compile(regex);
+            List<java.util.regex.MatchResult> matches = processMatches(pattern, previousResult, matchNumber, vars);
+            int prevCount = 0;
+            String prevString = vars.get(refName + REF_MATCH_NR);
+            if (prevString != null) {
+                vars.remove(refName + REF_MATCH_NR);// ensure old value is not left defined
+                try {
+                    prevCount = Integer.parseInt(prevString);
+                } catch (NumberFormatException nfe) {
+                    log.warn("Could not parse number: '{}'", prevString);
+                }
+            }
+            int matchCount=0;// Number of refName_n variable sets to keep
+            try {
+                java.util.regex.MatchResult match;
+                if (matchNumber >= 0) {// Original match behaviour
+                    match = getCorrectMatchJavaRegex(matches, matchNumber);
+                    if (match != null) {
+                        vars.put(refName, generateResult(match));
+                        saveGroups(vars, refName, match);
+                    } else {
+                        // refname has already been set to the default (if present)
+                        removeGroups(vars, refName);
+                    }
+                } else // < 0 means we save all the matches
+                {
+                    removeGroups(vars, refName); // remove any single matches
+                    matchCount = matches.size();
+                    vars.put(refName + REF_MATCH_NR, Integer.toString(matchCount));// Save the count
+                    for (int i = 1; i <= matchCount; i++) {
+                        match = getCorrectMatchJavaRegex(matches, i);
+                        if (match != null) {
+                            final String refName_n = refName + UNDERSCORE + i;
+                            vars.put(refName_n, generateResult(match));
+                            saveGroups(vars, refName_n, match);
+                        }
+                    }
+                }
+                // Remove any left-over variables
+                for (int i = matchCount + 1; i <= prevCount; i++) {
+                    final String refName_n = refName + UNDERSCORE + i;
+                    vars.remove(refName_n);
+                    removeGroups(vars, refName_n);
+                }
+            } catch (RuntimeException e) {
+                log.warn("Error while generating result");
+            }
+        } catch (PatternSyntaxException e) {
+            log.error("Error in pattern: '{}'", regex);
+        }
+    }
+
     private String getInputString(SampleResult result) {
         String inputString = useUrl() ? result.getUrlAsString() // Bug 39707
                 : useHeaders() ? result.getResponseHeaders()
@@ -213,6 +281,36 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         return Collections.unmodifiableList(matches);
     }
 
+    private List<java.util.regex.MatchResult> processMatches(
+            java.util.regex.Pattern pattern, SampleResult result, int matchNumber, JMeterVariables vars) {
+        log.debug("Regex = '{}'", pattern.pattern());
+
+        List<java.util.regex.MatchResult> matches = new ArrayList<>();
+        int found = 0;
+
+        if (isScopeVariable()) {
+            String inputString=vars.get(getVariableName());
+            if(inputString == null) {
+                if (log.isWarnEnabled()) {
+                    log.warn("No variable '{}' found to process by RegexExtractor '{}', skipping processing",
+                            getVariableName(), getName());
+                }
+                return Collections.emptyList();
+            }
+            matchStrings(matchNumber, pattern, matches, found, inputString);
+        } else {
+            List<SampleResult> sampleList = getSampleList(result);
+            for (SampleResult sr : sampleList) {
+                String inputString = getInputString(sr);
+                found = matchStrings(matchNumber, pattern, matches, found, inputString);
+                if (matchNumber > 0 && found == matchNumber) {// no need to process further
+                    break;
+                }
+            }
+        }
+        return Collections.unmodifiableList(matches);
+    }
+
     private int matchStrings(int matchNumber, Perl5Matcher matcher,
             Pattern pattern, List<MatchResult> matches, int found,
             String inputString) {
@@ -221,6 +319,22 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
             if (matcher.contains(input, pattern)) {
                 log.debug("RegexExtractor: Match found!");
                 matches.add(matcher.getMatch());
+                found++;
+            } else {
+                break;
+            }
+        }
+        return found;
+    }
+
+    private int matchStrings(int matchNumber, java.util.regex.Pattern pattern,
+                             List<java.util.regex.MatchResult> matches, int found,
+                             String inputString) {
+        Matcher matcher = pattern.matcher(inputString);
+        while (matchNumber <=0 || found != matchNumber) {
+            if (matcher.find()) {
+                log.debug("RegexExtractor: Match found!");
+                matches.add(matcher.toMatchResult());
                 found++;
             } else {
                 break;
@@ -263,6 +377,35 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         }
     }
 
+    private void saveGroups(JMeterVariables vars, String basename, java.util.regex.MatchResult match) {
+        StringBuilder buf = new StringBuilder();
+        buf.append(basename);
+        buf.append("_g"); // $NON-NLS-1$
+        int pfxlen=buf.length();
+        String prevString=vars.get(buf.toString());
+        int previous=0;
+        if (prevString!=null){
+            try {
+                previous=Integer.parseInt(prevString);
+            } catch (NumberFormatException nfe) {
+                log.warn("Could not parse number: '{}'.", prevString);
+            }
+        }
+        //Note: match.groups() includes group 0
+        final int groups = match.groupCount();
+        for (int x = 0; x < groups; x++) {
+            buf.append(x);
+            vars.put(buf.toString(), match.group(x));
+            buf.setLength(pfxlen);
+        }
+        vars.put(buf.toString(), Integer.toString(groups-1));
+        for (int i = groups; i <= previous; i++){
+            buf.append(i);
+            vars.remove(buf.toString());// remove the remaining _gn vars
+            buf.setLength(pfxlen);
+        }
+    }
+
     /**
      * Removes the variables:<br/>
      * basename_gn, where n=0...# of groups<br/>
@@ -289,6 +432,22 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
     }
 
     private String generateResult(MatchResult match) {
+        StringBuilder result = new StringBuilder();
+        for (Object obj : template) {
+            if(log.isDebugEnabled()) {
+                log.debug("RegexExtractor: Template piece {} ({})", obj, obj.getClass());
+            }
+            if (obj instanceof Integer) {
+                result.append(match.group((Integer) obj));
+            } else {
+                result.append(obj);
+            }
+        }
+        log.debug("Regex Extractor result = '{}'", result);
+        return result.toString();
+    }
+
+    private String generateResult(java.util.regex.MatchResult match) {
         StringBuilder result = new StringBuilder();
         for (Object obj : template) {
             if(log.isDebugEnabled()) {
@@ -354,6 +513,21 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
      * @return MatchResult
      */
     private MatchResult getCorrectMatch(List<MatchResult> matches, int entry) {
+        int matchSize = matches.size();
+
+        if (matchSize <= 0 || entry > matchSize){
+            return null;
+        }
+
+        if (entry == 0) // Random match
+        {
+            return matches.get(JMeterUtils.getRandomInt(matchSize));
+        }
+
+        return matches.get(entry - 1);
+    }
+
+    private java.util.regex.MatchResult getCorrectMatchJavaRegex(List<java.util.regex.MatchResult> matches, int entry) {
         int matchSize = matches.size();
 
         if (matchSize <= 0 || entry > matchSize){

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -491,7 +491,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         }
 
         if (beginOffset < rawTemplate.length()) { // trailing string is not empty
-            combined.add(rawTemplate.substring(beginOffset, rawTemplate.length()));
+            combined.add(rawTemplate.substring(beginOffset));
         }
         if (log.isDebugEnabled()) {
             log.debug("Template item count: {}", combined.size());

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -183,7 +183,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         String regex = getRegex();
         java.util.regex.Pattern pattern = null;
         try {
-            pattern = java.util.regex.Pattern.compile(regex);
+            pattern = JMeterUtils.compilePattern(regex);
             List<java.util.regex.MatchResult> matches = processMatches(pattern, previousResult, matchNumber, vars);
             int prevCount = 0;
             String prevString = vars.get(refName + REF_MATCH_NR);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
@@ -121,7 +121,7 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
     private String processJavaRegex(String textToParse) {
         java.util.regex.Pattern pattern;
         try {
-            pattern = java.util.regex.Pattern.compile(regexpField.getText());
+            pattern = JMeterUtils.compilePattern(regexpField.getText());
         } catch (PatternSyntaxException e) {
             return e.toString();
         }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
@@ -138,7 +138,7 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
         for (int j = 0; j < size; j++) {
             java.util.regex.MatchResult mr = matches.get(j);
             final int groups = mr.groupCount();
-            for (int i = 0; i < groups; i++) {
+            for (int i = 0; i <= groups; i++) {
                 sb.append("Match[").append(j+1).append("][").append(i).append("]=").append(mr.group(i)).append("\n");
             }
         }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
@@ -67,7 +67,8 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
 
     private JTabbedPane rightSide;
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /** {@inheritDoc} */
     @Override
@@ -112,7 +113,7 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
     }
 
     private String process(String textToParse) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return processJavaRegex(textToParse);
         }
         return processOroRegex(textToParse);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
@@ -100,8 +100,8 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
      * @param textToParse
      */
     private void executeAndShowRegexpTester(String textToParse) {
-        if (textToParse != null && textToParse.length() > 0
-                && this.regexpField.getText().length() > 0) {
+        if (textToParse != null && !textToParse.isEmpty()
+                && !this.regexpField.getText().isEmpty()) {
             this.regexpResultField.setText(process(textToParse));
             this.regexpResultField.setCaretPosition(0); // go to first line
         }

--- a/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
@@ -258,7 +258,7 @@ public class ResponseAssertionTest {
         assertion.unsetNotType();
         assertion.setToContainsType();
         assertion.setTestFieldResponseData();
-        assertion.addTestString("value=\"\\${ID}\" Group\\$ctl00\\$drpEmails");
+        assertion.addTestString("value=\"\\$\\{ID\\}\" Group\\$ctl00\\$drpEmails");
 
         result = assertion.getResult(sample);
         assertPassed();

--- a/src/components/src/test/java/org/apache/jmeter/assertions/TestJSONPathAssertion.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/TestJSONPathAssertion.java
@@ -82,7 +82,7 @@ class TestJSONPathAssertion {
         "{\"myval\": 123}; $.myval; 123",
         "{\"myval\": [{\"test\":1},{\"test\":2},{\"test\":3}]}; $.myval[*].test; 2",
         "{\"myval\": []}; $.myval; []",
-        "{\"myval\": {\"key\": \"val\"}}; $.myval; {\"key\":\"val\"}"
+        "{\"myval\": {\"key\": \"val\"}}; $.myval; \\{\"key\":\"val\"\\}"
     }, delimiterString=";")
     void testGetResult_pathsWithOneResult(String data, String jsonPath, String expectedResult) {
         SampleResult samplerResult = new SampleResult();
@@ -311,14 +311,14 @@ class TestJSONPathAssertion {
         instance.setJsonPath("$.execution[0].scenario.requests[0].headers");
         instance.setJsonValidationBool(true);
         instance.setExpectNull(false);
-        instance.setExpectedValue("{headerkey=header value}");
+        instance.setExpectedValue("\\{headerkey=header value\\}");
         instance.setInvert(false);
         AssertionResult expResult = new AssertionResult("");
         AssertionResult result = instance.getResult(samplerResult);
         assertEquals(expResult.getName(), result.getName());
         assertTrue(result.isFailure());
         assertEquals(
-                "Value expected to match regexp '{headerkey=header value}', but it did not match: '{\"headerkey\":\"header value\"}'",
+                "Value expected to match regexp '\\{headerkey=header value\\}', but it did not match: '{\"headerkey\":\"header value\"}'",
                 result.getFailureMessage());
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -47,6 +47,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
      * Functions are wrapped in ${ and }
      */
     private static final String FUNCTION_REF_PREFIX = "${"; //$NON-NLS-1$
+    private static final String FUNCTION_REF_PREFIX_REGEX_SAFE = "\\${"; //$NON-NLS-1$
     /**
      * Functions are wrapped in ${ and }
      */
@@ -112,7 +113,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
             if (regexMatch) {
                 try {
                     java.util.regex.Pattern pattern = JMeterUtils.compilePattern(constructPattern(value));
-                    input = pattern.matcher(input).replaceAll(FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
+                    input = pattern.matcher(input).replaceAll(FUNCTION_REF_PREFIX_REGEX_SAFE + key + FUNCTION_REF_SUFFIX);
                 } catch (PatternSyntaxException e) {
                     log.warn("Malformed pattern: {}", value);
                 }

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -111,7 +111,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
             String value = entry.getValue();
             if (regexMatch) {
                 try {
-                    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(constructPattern(value));
+                    java.util.regex.Pattern pattern = JMeterUtils.compilePattern(constructPattern(value));
                     input = pattern.matcher(input).replaceAll(FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
                 } catch (PatternSyntaxException e) {
                     log.warn("Malformed pattern: {}", value);

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.engine.util;
 
 import java.util.Map;
+import java.util.regex.PatternSyntaxException;
 
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.testelement.property.JMeterProperty;
@@ -53,6 +54,8 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
 
     private final boolean regexMatch;// Should we match using regexes?
 
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+
     public ReplaceFunctionsWithStrings(CompoundVariable masterFunction, Map<String, String> variables) {
         this(masterFunction, variables, false);
     }
@@ -66,6 +69,13 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
 
     @Override
     public JMeterProperty transformValue(JMeterProperty prop) throws InvalidVariableException {
+        if (useJavaRegex) {
+            return transformValueWithJavaRegex(prop);
+        }
+        return transformValueWithOroRegex(prop);
+    }
+
+    private JMeterProperty transformValueWithOroRegex(JMeterProperty prop) throws InvalidVariableException {
         PatternMatcher pm = JMeterUtils.getMatcher();
         PatternCompiler compiler = new Perl5Compiler();
         String input = prop.getStringValue();
@@ -82,6 +92,28 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
                             new StringSubstitution(FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX),
                             input, Util.SUBSTITUTE_ALL);
                 } catch (MalformedPatternException e) {
+                    log.warn("Malformed pattern: {}", value);
+                }
+            } else {
+                input = StringUtilities.substitute(input, value, FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
+            }
+        }
+        return new StringProperty(prop.getName(), input);
+    }
+
+    private JMeterProperty transformValueWithJavaRegex(JMeterProperty prop) throws InvalidVariableException {
+        String input = prop.getStringValue();
+        if(input == null) {
+            return prop;
+        }
+        for(Map.Entry<String, String> entry : getVariables().entrySet()){
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (regexMatch) {
+                try {
+                    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(constructPattern(value));
+                    input = pattern.matcher(input).replaceAll(FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
+                } catch (PatternSyntaxException e) {
                     log.warn("Malformed pattern: {}", value);
                 }
             } else {

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -55,7 +55,8 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
 
     private final boolean regexMatch;// Should we match using regexes?
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     public ReplaceFunctionsWithStrings(CompoundVariable masterFunction, Map<String, String> variables) {
         this(masterFunction, variables, false);
@@ -70,7 +71,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
 
     @Override
     public JMeterProperty transformValue(JMeterProperty prop) throws InvalidVariableException {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return transformValueWithJavaRegex(prop);
         }
         return transformValueWithOroRegex(prop);

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -103,6 +103,8 @@ public class ReportGenerator {
     private final File testFile;
     private final ReportGeneratorConfiguration configuration;
 
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+
     /**
      * ResultCollector used
      */
@@ -439,9 +441,7 @@ public class ReportGenerator {
                 // by property jmeter.reportgenerator.apdex_per_transaction
                 // key in entry below can be a hardcoded name or a regex
                 for (Map.Entry<String, Long[]> entry : configuration.getApdexPerTransaction().entrySet()) {
-                    org.apache.oro.text.regex.Pattern regex = JMeterUtils.getPatternCache().getPattern(entry.getKey());
-                    PatternMatcher matcher = JMeterUtils.getMatcher();
-                    if (sampleName != null && matcher.matches(sampleName, regex)) {
+                    if (isMatching(sampleName, entry.getKey())) {
                         Long satisfied = entry.getValue()[0];
                         Long tolerated = entry.getValue()[1];
                         if(log.isDebugEnabled()) {
@@ -456,6 +456,19 @@ public class ReportGenerator {
                 return info;
         });
         return apdexSummaryConsumer;
+    }
+
+    private boolean isMatching(String sampleName, String keyName) {
+        if (sampleName == null) {
+            return false;
+        }
+        if (useJavaRegex) {
+            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(keyName);
+            return pattern.matcher(sampleName).matches();
+        }
+        org.apache.oro.text.regex.Pattern regex = JMeterUtils.getPatternCache().getPattern(keyName);
+        PatternMatcher matcher = JMeterUtils.getMatcher();
+        return matcher.matches(sampleName, regex);
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -103,7 +103,8 @@ public class ReportGenerator {
     private final File testFile;
     private final ReportGeneratorConfiguration configuration;
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /**
      * ResultCollector used
@@ -462,7 +463,7 @@ public class ReportGenerator {
         if (sampleName == null) {
             return false;
         }
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             java.util.regex.Pattern pattern = JMeterUtils.compilePattern(keyName);
             return pattern.matcher(sampleName).matches();
         }

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -463,7 +463,7 @@ public class ReportGenerator {
             return false;
         }
         if (useJavaRegex) {
-            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(keyName);
+            java.util.regex.Pattern pattern = JMeterUtils.compilePattern(keyName);
             return pattern.matcher(sampleName).matches();
         }
         org.apache.oro.text.regex.Pattern regex = JMeterUtils.getPatternCache().getPattern(keyName);

--- a/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
@@ -63,6 +63,14 @@ import org.slf4j.LoggerFactory;
  */
 // For unit tests, @see TestCSVSaveService
 public final class CSVSaveService {
+    private static final java.util.regex.Pattern DELIMITER_PATTERN = java.util.regex.Pattern
+            // This assumes the header names are all single words with no spaces
+            // word followed by 0 or more repeats of (non-word char + word)
+            // where the non-word char (\2) is the same
+            // e.g. abc|def|ghi but not abd|def~ghi
+            .compile("\\w+((\\W)\\w+)?(\\2\\w+)*(\\2\"\\w+\")*" // $NON-NLS-1$
+                    // last entries may be quoted strings
+            );
     private static final Logger log = LoggerFactory.getLogger(CSVSaveService.class);
 
     // ---------------------------------------------------------------------
@@ -557,15 +565,7 @@ public final class CSVSaveService {
     }
 
     private static String extractDelimWithJavaRegex(String headerLine) {
-        java.util.regex.Pattern pattern = java.util.regex.Pattern
-                // This assumes the header names are all single words with no spaces
-                // word followed by 0 or more repeats of (non-word char + word)
-                // where the non-word char (\2) is the same
-                // e.g. abc|def|ghi but not abd|def~ghi
-                .compile("\\w+((\\W)\\w+)?(\\2\\w+)*(\\2\"\\w+\")*" // $NON-NLS-1$
-                        // last entries may be quoted strings
-                        );
-        Matcher matcher = pattern.matcher(headerLine);
+        Matcher matcher = DELIMITER_PATTERN.matcher(headerLine);
         if (matcher.matches()) {
             return matcher.group(2);
         }

--- a/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
@@ -125,7 +125,8 @@ public final class CSVSaveService {
 
     private static final String LINE_SEP = System.getProperty("line.separator"); // $NON-NLS-1$
 
-    private static boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /**
      * Private constructor to prevent instantiation.
@@ -558,7 +559,7 @@ public final class CSVSaveService {
     }
 
     private static String extractDelimiter(String headerLine) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return extractDelimWithJavaRegex(headerLine);
         }
         return extractDelimWithOroRegex(headerLine);

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -101,7 +101,7 @@ public class JMeterUtils implements UnitTestManager {
     private static final class LazyJavaPatternCacheHolder {
         private LazyJavaPatternCacheHolder() {
             super();
-        };
+        }
         public static final LoadingCache<Pair<String, Integer>, java.util.regex.Pattern> INSTANCE =
                 Caffeine
                         .newBuilder()

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -105,7 +105,7 @@ public class JMeterUtils implements UnitTestManager {
         public static final LoadingCache<Pair<String, Integer>, java.util.regex.Pattern> INSTANCE =
                 Caffeine
                         .newBuilder()
-                        .maximumSize(getPropDefault("java_regex.patterncache.size", 1000))
+                        .maximumSize(getPropDefault("jmeter.regex.patterncache.size", 1000))
                         .build(key -> {
                             //noinspection MagicConstant
                             return java.util.regex.Pattern.compile(key.getLeft(), key.getRight().intValue());

--- a/src/core/src/test/java/org/apache/jmeter/engine/util/TestValueReplacer.java
+++ b/src/core/src/test/java/org/apache/jmeter/engine/util/TestValueReplacer.java
@@ -98,7 +98,7 @@ public class TestValueReplacer extends JMeterTestCase {
     public void testOverlappingMatches() throws Exception {
         TestPlan plan = new TestPlan();
         plan.addParameter("longMatch", "servername");
-        plan.addParameter("shortMatch", ".*");
+        plan.addParameter("shortMatch", ".+");
         ValueReplacer replacer = new ValueReplacer(plan);
         TestElement element = new TestPlan();
         element.setProperty(new StringProperty("domain", "servername.domain"));

--- a/src/core/src/test/java/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
@@ -37,7 +37,8 @@ public class ApdexPerTransactionTest extends JMeterTestCase {
     // it also includes hardcoded sample names mixed with regexes
     private static final String apdexString = "sample(\\d+):1000|2000;samples12:3000|4000;scenar01-12:5000|6000";
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     @Test
     public void testgetApdexPerTransactionProperty() throws Exception {
@@ -118,7 +119,7 @@ public class ApdexPerTransactionTest extends JMeterTestCase {
         for (String sampleName : sampleNames) {
             boolean hasMatched = false;
             for (Map.Entry<String, Long[]> entry : apdex.entrySet()) {
-                if (useJavaRegex) {
+                if (USE_JAVA_REGEX) {
                     Pattern pattern = JMeterUtils.compilePattern(entry.getKey());
                     Matcher matcher = pattern.matcher(sampleName);
                     if (matcher.matches()) {

--- a/src/core/src/test/java/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/report/dashboard/ApdexPerTransactionTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.jmeter.report.dashboard;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -31,6 +26,7 @@ import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jmeter.report.config.ReportGeneratorConfiguration;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.oro.text.regex.PatternMatcher;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import jodd.props.Props;
@@ -54,7 +50,7 @@ public class ApdexPerTransactionTest extends JMeterTestCase {
         props.load(this.getClass().getResourceAsStream("reportgenerator_test.properties"));
         final String apdexPerTransaction = getOptionalProperty(props,
                 REPORT_GENERATOR_KEY_APDEX_PER_TRANSACTION);
-        assertEquals(apdexString, apdexPerTransaction);
+        Assertions.assertEquals(apdexString, apdexPerTransaction);
     }
 
     @Test
@@ -63,48 +59,48 @@ public class ApdexPerTransactionTest extends JMeterTestCase {
         props.load(this.getClass().getResourceAsStream("reportgenerator_test.properties"));
         final String title = getOptionalProperty(props,
                 "jmeter.reportgenerator.graph.responseTimePercentiles.title");
-        assertNotNull("title should not be null", title);
+        Assertions.assertNotNull(title, "title should not be null");
     }
 
     @Test
     public void testGetApdexPerTransactionParts() {
         Map<String, Long[]> apdex = ReportGeneratorConfiguration.getApdexPerTransactionParts(apdexString);
-        assertNotNull("map should not be null", apdex);
-        assertEquals(3, apdex.size());
+        Assertions.assertNotNull(apdex, "map should not be null");
+        Assertions.assertEquals(3, apdex.size());
         Set<String> keys = apdex.keySet();
-        assertTrue(keys.contains("samples12"));
-        assertTrue(keys.contains("scenar01-12"));
-        assertTrue(keys.contains("sample(\\d+)"));
-        assertArrayEquals(new Long[] {1000L,  2000L}, apdex.get("sample(\\d+)"));
+        Assertions.assertTrue(keys.contains("samples12"));
+        Assertions.assertTrue(keys.contains("scenar01-12"));
+        Assertions.assertTrue(keys.contains("sample(\\d+)"));
+        Assertions.assertArrayEquals(new Long[] {1000L,  2000L}, apdex.get("sample(\\d+)"));
     }
 
    @Test
     public void testGetApdexPerTransactionPartsOneCustomization() {
         Map<String, Long[]> apdex = ReportGeneratorConfiguration.getApdexPerTransactionParts("sample(\\d+):1000|2000");
-        assertNotNull("map should not be null", apdex);
-        assertEquals(1, apdex.size());
+        Assertions.assertNotNull(apdex, "map should not be null");
+        Assertions.assertEquals(1, apdex.size());
         Set<String> keys = apdex.keySet();
-        assertTrue(keys.contains("sample(\\d+)"));
-        assertArrayEquals(new Long[] {1000L,  2000L}, apdex.get("sample(\\d+)"));
+        Assertions.assertTrue(keys.contains("sample(\\d+)"));
+        Assertions.assertArrayEquals(new Long[] {1000L,  2000L}, apdex.get("sample(\\d+)"));
     }
 
    @Test
    public void testGetApdexPerTransactionNoValue() {
        Map<String, Long[]> apdex = ReportGeneratorConfiguration.getApdexPerTransactionParts("");
-       assertNotNull("map should not be null", apdex);
-       assertEquals(0, apdex.size());
+       Assertions.assertNotNull(apdex, "map should not be null");
+       Assertions.assertEquals(0, apdex.size());
 
        apdex = ReportGeneratorConfiguration.getApdexPerTransactionParts(" ");
-       assertNotNull("map should not be null", apdex);
-       assertEquals(0, apdex.size());
+       Assertions.assertNotNull(apdex, "map should not be null");
+       Assertions.assertEquals(0, apdex.size());
    }
 
    @Test
    public void testGetApdexPerTransactionWrongFormat() {
        Map<String, Long[]> apdex =
                ReportGeneratorConfiguration.getApdexPerTransactionParts("sample1|123:434");
-       assertNotNull("map should not be null", apdex);
-       assertEquals(0, apdex.size());
+       Assertions.assertNotNull(apdex, "map should not be null");
+       Assertions.assertEquals(0, apdex.size());
    }
 
     @Test
@@ -136,7 +132,7 @@ public class ApdexPerTransactionTest extends JMeterTestCase {
                     }
                 }
             }
-            assertTrue(hasMatched);
+            Assertions.assertTrue(hasMatched);
         }
 
     }

--- a/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
@@ -18,9 +18,13 @@
 package org.apache.jmeter.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -55,5 +59,27 @@ public class TestJMeterUtils {
                 JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultMissing", new String[]{"Gilels", "Richter"}));
         Assertions.assertArrayEquals(null,
                 JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultEmpty", null));
+    }
+
+    @Test
+    void testCompilePatternOK() {
+        Pattern pattern = JMeterUtils.compilePattern("some.*");
+        assertTrue(pattern.matcher("something").matches());
+    }
+
+    @Test
+    void testCompilePatternMultilineCaseIgnoreOK() {
+        Pattern pattern = JMeterUtils.compilePattern("^some.*g$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+        assertTrue(pattern.matcher("abc\nsome good thing").find());
+    }
+
+    @Test
+    void testCompilePatternNull() {
+        assertThrows(NullPointerException.class, () -> JMeterUtils.compilePattern(null));
+    }
+
+    @Test
+    void testCompilePatternInvalid() {
+        assertThrows(PatternSyntaxException.class, () -> JMeterUtils.compilePattern("[missing closing bracket"));
     }
 }

--- a/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
@@ -32,7 +32,8 @@ public class TestJMeterUtils {
     @Test
     public void testGetResourceFileAsText() throws Exception{
         String sep = System.getProperty("line.separator");
-        Assertions.assertEquals("line one" + sep + "line two" + sep, JMeterUtils.getResourceFileAsText("resourcefile.txt"));
+        Assertions.assertEquals("line one" + sep + "line two" + sep,
+                JMeterUtils.getResourceFileAsText("resourcefile.txt"));
     }
 
     @Test
@@ -50,11 +51,13 @@ public class TestJMeterUtils {
         Path props = Files.createTempFile("testGetArrayPropDefault", ".properties");
         JMeterUtils.loadJMeterProperties(props.toString());
         JMeterUtils.getJMeterProperties().setProperty("testGetArrayPropDefaultEmpty", "    ");
-        JMeterUtils.getJMeterProperties().setProperty("testGetArrayPropDefault", " Tolstoi  Dostoievski    Pouchkine       Gorki ");
+        JMeterUtils.getJMeterProperties().setProperty("testGetArrayPropDefault",
+                " Tolstoi  Dostoievski    Pouchkine       Gorki ");
         Assertions.assertArrayEquals(new String[]{"Tolstoi", "Dostoievski", "Pouchkine", "Gorki"},
                 JMeterUtils.getArrayPropDefault("testGetArrayPropDefault", null));
         Assertions.assertArrayEquals(new String[]{"Gilels", "Richter"},
-                JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultMissing", new String[]{"Gilels", "Richter"}));
+                JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultMissing",
+                        new String[]{"Gilels", "Richter"}));
         Assertions.assertArrayEquals(null,
                 JMeterUtils.getArrayPropDefault("testGetArrayPropDefaultEmpty", null));
     }

--- a/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/TestJMeterUtils.java
@@ -17,9 +17,7 @@
 
 package org.apache.jmeter.util;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,17 +32,17 @@ public class TestJMeterUtils {
     @Test
     public void testGetResourceFileAsText() throws Exception{
         String sep = System.getProperty("line.separator");
-        assertEquals("line one" + sep + "line two" + sep, JMeterUtils.getResourceFileAsText("resourcefile.txt"));
+        Assertions.assertEquals("line one" + sep + "line two" + sep, JMeterUtils.getResourceFileAsText("resourcefile.txt"));
     }
 
     @Test
     public void testGetResourceFileAsTextWithMisingResource() throws Exception{
-        assertEquals("", JMeterUtils.getResourceFileAsText("not_existant_resourcefile.txt"));
+        Assertions.assertEquals("", JMeterUtils.getResourceFileAsText("not_existant_resourcefile.txt"));
     }
 
     @Test
     public void testGesResStringDefaultWithNonExistantKey() throws Exception {
-        assertEquals("[res_key=noValidKey]", JMeterUtils.getResString("noValidKey"));
+        Assertions.assertEquals("[res_key=noValidKey]", JMeterUtils.getResString("noValidKey"));
     }
 
     @Test
@@ -64,13 +62,13 @@ public class TestJMeterUtils {
     @Test
     void testCompilePatternOK() {
         Pattern pattern = JMeterUtils.compilePattern("some.*");
-        assertTrue(pattern.matcher("something").matches());
+        Assertions.assertTrue(pattern.matcher("something").matches());
     }
 
     @Test
     void testCompilePatternMultilineCaseIgnoreOK() {
         Pattern pattern = JMeterUtils.compilePattern("^some.*g$", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
-        assertTrue(pattern.matcher("abc\nsome good thing").find());
+        Assertions.assertTrue(pattern.matcher("abc\nsome good thing").find());
     }
 
     @Test

--- a/src/functions/src/main/java/org/apache/jmeter/functions/EscapeOroRegexpChars.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/EscapeOroRegexpChars.java
@@ -75,7 +75,7 @@ public class EscapeOroRegexpChars extends AbstractFunction {
 
         String escapedValue = Perl5Compiler.quotemeta(valueToEscape);
 
-        if (varName.length() > 0) {
+        if (!varName.isEmpty()) {
             JMeterVariables vars = getVariables();
             if (vars != null) {// Can be null if called from Config item testEnded() method
                 vars.put(varName, escapedValue);

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -99,7 +99,7 @@ public class RegexFunction extends AbstractFunction {
             if (values.length > 2) {
                 valueIndex = ((CompoundVariable) values[2]).execute();
             }
-            if (valueIndex.length() == 0) {
+            if (valueIndex.isEmpty()) {
                 valueIndex = "1"; //$NON-NLS-1$
             }
 
@@ -109,7 +109,7 @@ public class RegexFunction extends AbstractFunction {
 
             if (values.length > 4) {
                 String dv = ((CompoundVariable) values[4]).execute();
-                if (dv.length() != 0) {
+                if (!dv.isEmpty()) {
                     defaultValue = dv;
                 }
             }
@@ -133,19 +133,19 @@ public class RegexFunction extends AbstractFunction {
             return defaultValue;
         }
 
-        if (name.length() > 0) {
+        if (!name.isEmpty()) {
             vars.put(name, defaultValue);
         }
 
         String textToMatch=null;
 
-        if (inputVariable.length() > 0){
+        if (!inputVariable.isEmpty()){
             textToMatch=vars.get(inputVariable);
         } else if (previousResult != null){
             textToMatch = previousResult.getResponseDataAsString();
         }
 
-        if (textToMatch == null || textToMatch.length() == 0) {
+        if (textToMatch == null || textToMatch.isEmpty()) {
             return defaultValue;
         }
 
@@ -160,7 +160,7 @@ public class RegexFunction extends AbstractFunction {
                 }
             }
         } finally {
-            if (name.length() > 0){
+            if (!name.isEmpty()){
                 vars.put(name + "_matchNr", Integer.toString(collectAllMatches.size())); //$NON-NLS-1$
             }
         }
@@ -225,7 +225,7 @@ public class RegexFunction extends AbstractFunction {
                 result.append(match.group((Integer) t));
             }
         }
-        if (namep.length() > 0){
+        if (!namep.isEmpty()){
             vars.put(namep, result.toString());
         }
         return result.toString();

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -81,7 +81,8 @@ public class RegexFunction extends AbstractFunction {
         desc.add(JMeterUtils.getResString("regexfunc_param_7"));// input variable //$NON-NLS-1$
     }
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     public RegexFunction() {
         templatePattern = JMeterUtils.getPatternCache().getPattern(TEMPLATE_PATTERN,
@@ -149,7 +150,7 @@ public class RegexFunction extends AbstractFunction {
             return defaultValue;
         }
 
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getResultWithJavaRegex(valueIndex, defaultValue, between, name, tmplt, vars, textToMatch);
         }
         return getResultWithOroRegex(valueIndex, defaultValue, between, name, tmplt, vars, textToMatch);
@@ -354,7 +355,7 @@ public class RegexFunction extends AbstractFunction {
     }
 
     private Object[] generateTemplate(String rawTemplate) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return generateTemplateWithJavaRegex(rawTemplate);
         }
         return generateTemplateWithOroRegex(rawTemplate);
@@ -411,7 +412,7 @@ public class RegexFunction extends AbstractFunction {
     }
 
     private boolean isFirstElementGroup(String rawData) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return FIRST_ELEMENT_PATTERN.matcher(rawData).find();
         } else {
             Pattern pattern = JMeterUtils.getPatternCache().getPattern("^\\$\\d+\\$",  //$NON-NLS-1$

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -291,7 +291,7 @@ public class RegexFunction extends AbstractFunction {
     }
 
     private void saveGroups(java.util.regex.MatchResult result, String namep, JMeterVariables vars) {
-        for (int x = 0; x < result.groupCount(); x++) {
+        for (int x = 0; x <= result.groupCount(); x++) {
             vars.put(namep + "_g" + x, result.group(x)); //$NON-NLS-1$
         }
     }
@@ -363,32 +363,20 @@ public class RegexFunction extends AbstractFunction {
 
     private Object[] generateTemplateWithJavaRegex(String rawTemplate) {
         // String or Integer
-        List<Object> combined = new ArrayList<>();
-        List<String> pieces = Arrays.asList(templatePatternJava.split(rawTemplate));
+        List<Object> pieces = new ArrayList<>();
         Matcher matcher = templatePatternJava.matcher(rawTemplate);
-        boolean startsWith = isFirstElementGroup(rawTemplate);
-        if (startsWith) {
-            pieces.remove(0);// Remove initial empty entry
-        }
-        Iterator<String> iter = pieces.iterator();
-        while (iter.hasNext()) {
-            boolean matchExists = matcher.find();
-            if (startsWith) {
-                if (matchExists) {
-                    combined.add(Integer.valueOf(matcher.group(1)));
-                }
-                combined.add(iter.next());
-            } else {
-                combined.add(iter.next());
-                if (matchExists) {
-                    combined.add(Integer.valueOf(matcher.group(1)));
-                }
+        int pos = 0;
+        while (matcher.find()) {
+            if (pos < matcher.start()) {
+                pieces.add(rawTemplate.substring(pos, matcher.start()));
             }
+            pieces.add(Integer.valueOf(matcher.group(1)));
+            pos = matcher.end();
         }
-        if (matcher.find()) {
-            combined.add(Integer.valueOf(matcher.group(1)));
+        if (pos < rawTemplate.length()) {
+            pieces.add(rawTemplate.substring(pos));
         }
-        return combined.toArray();
+        return pieces.toArray();
     }
 
     private Object[] generateTemplateWithOroRegex(String rawTemplate) {

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -18,7 +18,6 @@
 package org.apache.jmeter.functions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -60,6 +60,8 @@ public class RegexFunction extends AbstractFunction {
 
     private static final List<String> desc = new ArrayList<>();
 
+    private static final java.util.regex.Pattern FIRST_ELEMENT_PATTERN = java.util.regex.Pattern.compile("^\\$\\d+\\$");
+
     private static final String TEMPLATE_PATTERN = "\\$(\\d+)\\$";  //$NON-NLS-1$
     /** initialised to the regex \$(\d+)\$ */
     private final Pattern templatePattern;
@@ -212,7 +214,7 @@ public class RegexFunction extends AbstractFunction {
 
     private java.util.regex.Pattern generateJavaPattern() throws InvalidVariableException {
         try {
-            return java.util.regex.Pattern.compile(((CompoundVariable) values[0]).execute());
+            return JMeterUtils.compilePattern(((CompoundVariable) values[0]).execute());
 
         } catch (PatternSyntaxException e) {
             log.error("Malformed regex pattern:{}", values[0], e);
@@ -423,7 +425,7 @@ public class RegexFunction extends AbstractFunction {
 
     private boolean isFirstElementGroup(String rawData) {
         if (useJavaRegex) {
-            return java.util.regex.Pattern.compile("^\\$\\d+\\$").matcher(rawData).find();
+            return FIRST_ELEMENT_PATTERN.matcher(rawData).find();
         } else {
             Pattern pattern = JMeterUtils.getPatternCache().getPattern("^\\$\\d+\\$",  //$NON-NLS-1$
                     Perl5Compiler.READ_ONLY_MASK);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
@@ -193,7 +193,7 @@ public class MultipartUrlConfig implements Serializable {
     }
 
     private static String getHeaderValueWithJavaRegex(String multiPart, String regularExpression) {
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regularExpression,
+        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(regularExpression,
                  java.util.regex.Pattern.CASE_INSENSITIVE
                         | java.util.regex.Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(multiPart);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
@@ -55,7 +55,8 @@ public class MultipartUrlConfig implements Serializable {
 
     private static final Logger log = LoggerFactory.getLogger(MultipartUrlConfig.class);
 
-    private static boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /**
      * HTTPFileArgs list to be uploaded with http request.
@@ -186,7 +187,7 @@ public class MultipartUrlConfig implements Serializable {
 
     private static String getHeaderValue(String headerName, String multiPart) {
         String regularExpression = headerName + "\\s*:\\s*(.*)$"; //$NON-NLS-1$
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getHeaderValueWithJavaRegex(multiPart, regularExpression);
         }
         return getHeaderValueWithOroRegex(multiPart, regularExpression);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
@@ -187,12 +187,12 @@ public class MultipartUrlConfig implements Serializable {
     private static String getHeaderValue(String headerName, String multiPart) {
         String regularExpression = headerName + "\\s*:\\s*(.*)$"; //$NON-NLS-1$
         if (useJavaRegex) {
-            return getHeaderValueWithJavaRegex(headerName, multiPart, regularExpression);
+            return getHeaderValueWithJavaRegex(multiPart, regularExpression);
         }
-        return getHeaderValueWithOroRegex(headerName, multiPart, regularExpression);
+        return getHeaderValueWithOroRegex(multiPart, regularExpression);
     }
 
-    private static String getHeaderValueWithJavaRegex(String headerName, String multiPart, String regularExpression) {
+    private static String getHeaderValueWithJavaRegex(String multiPart, String regularExpression) {
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regularExpression,
                  java.util.regex.Pattern.CASE_INSENSITIVE
                         | java.util.regex.Pattern.MULTILINE);
@@ -203,7 +203,7 @@ public class MultipartUrlConfig implements Serializable {
         return null;
     }
 
-    private static String getHeaderValueWithOroRegex(String headerName, String multiPart, String regularExpression) {
+    private static String getHeaderValueWithOroRegex(String multiPart, String regularExpression) {
         Perl5Matcher localMatcher = JMeterUtils.getMatcher();
         Pattern pattern = JMeterUtils.getPattern(regularExpression,
                 Perl5Compiler.READ_ONLY_MASK

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
@@ -317,7 +317,7 @@ public class HttpMirrorThread implements Runnable {
     private static String getRequestHeaderValueWithJavaRegex(String requestHeaders, String headerName) {
         // We use multi-line mask so can prefix the line with ^
         String expression = "^" + headerName + ":\\s+([^\\r\\n]+)"; // $NON-NLS-1$ $NON-NLS-2$
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(expression,
+        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(expression,
                 java.util.regex.Pattern.CASE_INSENSITIVE
                         | java.util.regex.Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(requestHeaders);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
@@ -109,7 +109,7 @@ public class HttpMirrorThread implements Runnable {
 
             baos.close();
             final String headerString = headers.toString();
-            if(headerString.length() == 0 || headerString.indexOf('\r') < 0) {
+            if(headerString.isEmpty() || headerString.indexOf('\r') < 0) {
                 log.error("Invalid request received:'{}'", headerString);
                 return;
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
@@ -28,6 +28,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.util.JMeterUtils;
@@ -67,6 +68,8 @@ public class HttpMirrorThread implements Runnable {
     private static final String STATUS = "status"; //$NON-NLS-1$
 
     private static final String VERBOSE = "v"; // $NON-NLS-1$
+
+    private static boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
 
     /** Socket to client. */
     private final Socket clientSocket;
@@ -290,6 +293,13 @@ public class HttpMirrorThread implements Runnable {
     }
 
     private static String getRequestHeaderValue(String requestHeaders, String headerName) {
+        if (useJavaRegex) {
+            return getRequestHeaderValueWithJavaRegex(requestHeaders, headerName);
+        }
+        return getRequestHeaderValueWithOroRegex(requestHeaders, headerName);
+    }
+
+    private static String getRequestHeaderValueWithOroRegex(String requestHeaders, String headerName) {
         Perl5Matcher localMatcher = JMeterUtils.getMatcher();
         // We use multi-line mask so can prefix the line with ^
         String expression = "^" + headerName + ":\\s+([^\\r\\n]+)"; // $NON-NLS-1$ $NON-NLS-2$
@@ -297,16 +307,49 @@ public class HttpMirrorThread implements Runnable {
                 Perl5Compiler.READ_ONLY_MASK
                         | Perl5Compiler.CASE_INSENSITIVE_MASK
                         | Perl5Compiler.MULTILINE_MASK);
-        if(localMatcher.contains(requestHeaders, pattern)) {
+        if (localMatcher.contains(requestHeaders, pattern)) {
             // The value is in the first group, group 0 is the whole match
             return localMatcher.getMatch().group(1);
         }
-        else {
-            return null;
+        return null;
+    }
+
+    private static String getRequestHeaderValueWithJavaRegex(String requestHeaders, String headerName) {
+        // We use multi-line mask so can prefix the line with ^
+        String expression = "^" + headerName + ":\\s+([^\\r\\n]+)"; // $NON-NLS-1$ $NON-NLS-2$
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(expression,
+                java.util.regex.Pattern.CASE_INSENSITIVE
+                        | java.util.regex.Pattern.MULTILINE);
+        Matcher matcher = pattern.matcher(requestHeaders);
+        if (matcher.find()) {
+            // The value is in the first group, group 0 is the whole match
+            return matcher.group(1);
         }
+        return null;
     }
 
     private static int getPositionOfBody(String stringToCheck) {
+        if (useJavaRegex) {
+            return getPositionOfBodyWithJavaRegex(stringToCheck);
+        }
+        return getPositionOfBodyWithOroRegex(stringToCheck);
+    }
+
+    private static int getPositionOfBodyWithJavaRegex(String stringToCheck) {
+        // The headers and body are divided by a blank line (the \r is to allow for the CR before LF)
+        String regularExpression = "^\\r$"; // $NON-NLS-1$
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regularExpression,
+                java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);
+
+        Matcher matcher = pattern.matcher(stringToCheck);
+        if (matcher.find()) {
+            return matcher.start(0);
+        }
+        // No divider was found
+        return -1;
+    }
+
+    private static int getPositionOfBodyWithOroRegex(String stringToCheck) {
         Perl5Matcher localMatcher = JMeterUtils.getMatcher();
         // The headers and body are divided by a blank line (the \r is to allow for the CR before LF)
         String regularExpression = "^\\r$"; // $NON-NLS-1$
@@ -316,7 +359,7 @@ public class HttpMirrorThread implements Runnable {
                         | Perl5Compiler.MULTILINE_MASK);
 
         PatternMatcherInput input = new PatternMatcherInput(stringToCheck);
-        if(localMatcher.contains(input, pattern)) {
+        if (localMatcher.contains(input, pattern)) {
             MatchResult match = localMatcher.getMatch();
             return match.beginOffset(0);
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
@@ -69,7 +69,8 @@ public class HttpMirrorThread implements Runnable {
 
     private static final String VERBOSE = "v"; // $NON-NLS-1$
 
-    private static boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /** Socket to client. */
     private final Socket clientSocket;
@@ -293,7 +294,7 @@ public class HttpMirrorThread implements Runnable {
     }
 
     private static String getRequestHeaderValue(String requestHeaders, String headerName) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getRequestHeaderValueWithJavaRegex(requestHeaders, headerName);
         }
         return getRequestHeaderValueWithOroRegex(requestHeaders, headerName);
@@ -329,7 +330,7 @@ public class HttpMirrorThread implements Runnable {
     }
 
     private static int getPositionOfBody(String stringToCheck) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getPositionOfBodyWithJavaRegex(stringToCheck);
         }
         return getPositionOfBodyWithOroRegex(stringToCheck);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorThread.java
@@ -337,7 +337,7 @@ public class HttpMirrorThread implements Runnable {
 
     private static int getPositionOfBodyWithJavaRegex(String stringToCheck) {
         // The headers and body are divided by a blank line (the \r is to allow for the CR before LF)
-        String regularExpression = "^\\r$"; // $NON-NLS-1$
+        String regularExpression = "^$"; // $NON-NLS-1$
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regularExpression,
                 java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -81,13 +81,13 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         String text = responseText.getResponseDataAsString();
         String value;
         if (isPathExtension() && isPathExtensionNoEquals() && isPathExtensionNoQuestionmark()) {
-            value = pathExtensionEqualsQuestionmarkExtractor.apply(text);
-        } else if (isPathExtension() && isPathExtensionNoEquals()) { // && !isPathExtensionNoQuestionmark()
-            value = pathExtensionEqualsNoQuestionmarkExtractor.apply(text);
-        } else if (isPathExtension() && isPathExtensionNoQuestionmark()) { // && !isPathExtensionNoEquals()
-            value = pathExtensionNoEqualsQuestionmarkExtractor.apply(text);
-        } else if (isPathExtension()) { // && !isPathExtensionNoEquals() && !isPathExtensionNoQuestionmark()
             value = pathExtensionNoEqualsNoQuestionmarkExtractor.apply(text);
+        } else if (isPathExtension() && isPathExtensionNoEquals()) { // && !isPathExtensionNoQuestionmark()
+            value = pathExtensionNoEqualsQuestionmarkExtractor.apply(text);
+        } else if (isPathExtension() && isPathExtensionNoQuestionmark()) { // && !isPathExtensionNoEquals()
+            value = pathExtensionEqualsNoQuestionmarkExtractor.apply(text);
+        } else if (isPathExtension()) { // && !isPathExtensionNoEquals() && !isPathExtensionNoQuestionmark()
+            value = pathExtensionEqualsQuestionmarkExtractor.apply(text);
         } else { // if ! isPathExtension()
             value = parameterExtractor.apply(text);
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -119,7 +119,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
 
         // Bug 15025 - save session value across samplers
         if (shouldCache()){
-            if (value == null || value.length() == 0) {
+            if (value == null || value.isEmpty()) {
                 value = savedValue;
             } else {
                 savedValue = value;
@@ -132,7 +132,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         if (isPathExtension()) {
             String oldPath = sampler.getPath();
             int indexOfSessionId = oldPath.indexOf(SEMI_COLON + getArgumentName());
-            if(oldPath.indexOf(SEMI_COLON + getArgumentName())>=0) {
+            if(oldPath.contains(SEMI_COLON + getArgumentName())) {
                 int indexOfQuestionMark = oldPath.indexOf('?');
                 if(indexOfQuestionMark < 0) {
                     oldPath = oldPath.substring(0, indexOfSessionId);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -18,6 +18,8 @@
 package org.apache.jmeter.protocol.http.modifier;
 
 import java.io.Serializable;
+import java.util.function.Function;
+import java.util.regex.Matcher;
 
 import org.apache.jmeter.processor.PreProcessor;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
@@ -41,15 +43,11 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
 
     private static final String SEMI_COLON = ";"; // $NON-NLS-1$
 
-    private transient Pattern pathExtensionEqualsQuestionmarkRegexp;
-
-    private transient Pattern pathExtensionEqualsNoQuestionmarkRegexp;
-
-    private transient Pattern parameterRegexp;
-
-    private transient Pattern pathExtensionNoEqualsQuestionmarkRegexp;
-
-    private transient Pattern pathExtensionNoEqualsNoQuestionmarkRegexp;
+    private transient Function<String, String> pathExtensionEqualsQuestionmarkExtractor;
+    private transient Function<String, String> pathExtensionEqualsNoQuestionmarkExtractor;
+    private transient Function<String, String> pathExtensionNoEqualsQuestionmarkExtractor;
+    private transient Function<String, String> pathExtensionNoEqualsNoQuestionmarkExtractor;
+    private transient Function<String, String> parameterExtractor;
 
     private static final String ARGUMENT_NAME = "argument_name"; // $NON-NLS-1$
 
@@ -62,6 +60,8 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
     private static final String SHOULD_CACHE = "cache_value"; // $NON-NLS-1$
 
     private static final String ENCODE = "encode"; // $NON-NLS-1$
+
+    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
 
     // PreProcessors are cloned per-thread, so this will be saved per-thread
     private transient String savedValue = ""; // $NON-NLS-1$
@@ -79,46 +79,21 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         }
         initRegex(getArgumentName());
         String text = responseText.getResponseDataAsString();
-        Perl5Matcher matcher = JMeterUtils.getMatcher();
-        String value = "";
+        String value;
         if (isPathExtension() && isPathExtensionNoEquals() && isPathExtensionNoQuestionmark()) {
-            if (matcher.contains(text, pathExtensionNoEqualsNoQuestionmarkRegexp)) {
-                MatchResult result = matcher.getMatch();
-                value = result.group(1);
-            }
-        } else if (isPathExtension() && isPathExtensionNoEquals()) // && !isPathExtensionNoQuestionmark()
-        {
-            if (matcher.contains(text, pathExtensionNoEqualsQuestionmarkRegexp)) {
-                MatchResult result = matcher.getMatch();
-                value = result.group(1);
-            }
-        } else if (isPathExtension() && isPathExtensionNoQuestionmark()) // && !isPathExtensionNoEquals()
-        {
-            if (matcher.contains(text, pathExtensionEqualsNoQuestionmarkRegexp)) {
-                MatchResult result = matcher.getMatch();
-                value = result.group(1);
-            }
-        } else if (isPathExtension()) // && !isPathExtensionNoEquals() && !isPathExtensionNoQuestionmark()
-        {
-            if (matcher.contains(text, pathExtensionEqualsQuestionmarkRegexp)) {
-                MatchResult result = matcher.getMatch();
-                value = result.group(1);
-            }
-        } else // if ! isPathExtension()
-        {
-            if (matcher.contains(text, parameterRegexp)) {
-                MatchResult result = matcher.getMatch();
-                for (int i = 1; i < result.groups(); i++) {
-                    value = result.group(i);
-                    if (value != null) {
-                        break;
-                    }
-                }
-            }
+            value = pathExtensionEqualsQuestionmarkExtractor.apply(text);
+        } else if (isPathExtension() && isPathExtensionNoEquals()) { // && !isPathExtensionNoQuestionmark()
+            value = pathExtensionEqualsNoQuestionmarkExtractor.apply(text);
+        } else if (isPathExtension() && isPathExtensionNoQuestionmark()) { // && !isPathExtensionNoEquals()
+            value = pathExtensionNoEqualsQuestionmarkExtractor.apply(text);
+        } else if (isPathExtension()) { // && !isPathExtensionNoEquals() && !isPathExtensionNoQuestionmark()
+            value = pathExtensionNoEqualsNoQuestionmarkExtractor.apply(text);
+        } else { // if ! isPathExtension()
+            value = parameterExtractor.apply(text);
         }
 
         // Bug 15025 - save session value across samplers
-        if (shouldCache()){
+        if (shouldCache()) {
             if (value == null || value.isEmpty()) {
                 value = savedValue;
             } else {
@@ -158,42 +133,113 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
 
     private void initRegex(String argName) {
         String quotedArg = Perl5Compiler.quotemeta(argName);// Don't get tripped up by RE chars in the arg name
-        pathExtensionEqualsQuestionmarkRegexp = JMeterUtils.getPatternCache().getPattern(
-                SEMI_COLON + quotedArg + "=([^\"'<>&\\s;]*)", // $NON-NLS-1$
-                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
+        pathExtensionEqualsQuestionmarkExtractor = generateExtractor(
+                SEMI_COLON + quotedArg + "=([^\"'<>&\\s;]*)" // $NON-NLS-1$
+        );
+        pathExtensionEqualsNoQuestionmarkExtractor = generateExtractor(
+                SEMI_COLON + quotedArg + "=([^\"'<>&\\s;?]*)" // $NON-NLS-1$
+        );
+        pathExtensionNoEqualsQuestionmarkExtractor = generateExtractor(
+                SEMI_COLON + quotedArg + "([^\"'<>&\\s;]*)"// $NON-NLS-1$
+        );
+        pathExtensionNoEqualsNoQuestionmarkExtractor = generateExtractor(
+                SEMI_COLON + quotedArg + "([^\"'<>&\\s;?]*)" // $NON-NLS-1$
+        );
 
-        pathExtensionEqualsNoQuestionmarkRegexp = JMeterUtils.getPatternCache().getPattern(
-                SEMI_COLON + quotedArg + "=([^\"'<>&\\s;?]*)", // $NON-NLS-1$
-                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
-
-        pathExtensionNoEqualsQuestionmarkRegexp = JMeterUtils.getPatternCache().getPattern(
-                SEMI_COLON + quotedArg + "([^\"'<>&\\s;]*)", // $NON-NLS-1$
-                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
-
-        pathExtensionNoEqualsNoQuestionmarkRegexp = JMeterUtils.getPatternCache().getPattern(
-                SEMI_COLON + quotedArg + "([^\"'<>&\\s;?]*)", // $NON-NLS-1$
-                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
-
-        parameterRegexp = JMeterUtils.getPatternCache().getPattern(
+        parameterExtractor = generateFirstMatchExtractor(
                 // ;sessionid=value
-                "[;\\?&]" + quotedArg + "=([^\"'<>&\\s;\\\\]*)" +  // $NON-NLS-1$
+                "[;\\?&]" + quotedArg + "=([^\"'<>&\\s;\\\\]*)"  // $NON-NLS-1$
 
-                // name="sessionid" value="value"
-                "|\\s[Nn][Aa][Mm][Ee]\\s*=\\s*[\"']" + quotedArg
-                + "[\"']" + "[^>]*"  // $NON-NLS-1$
-                + "\\s[vV][Aa][Ll][Uu][Ee]\\s*=\\s*[\"']" // $NON-NLS-1$
-                + "([^\"']*)" + "[\"']" // $NON-NLS-1$
+                        // name="sessionid" value="value"
+                        +  "|\\s[Nn][Aa][Mm][Ee]\\s*=\\s*[\"']" + quotedArg
+                        + "[\"']" + "[^>]*"  // $NON-NLS-1$
+                        + "\\s[vV][Aa][Ll][Uu][Ee]\\s*=\\s*[\"']" // $NON-NLS-1$
+                        + "([^\"']*)" + "[\"']" // $NON-NLS-1$
 
-                //  value="value" name="sessionid"
-                + "|\\s[vV][Aa][Ll][Uu][Ee]\\s*=\\s*[\"']" // $NON-NLS-1$
-                + "([^\"']*)" + "[\"']" + "[^>]*" // $NON-NLS-1$ // $NON-NLS-2$ // $NON-NLS-3$
-                + "\\s[Nn][Aa][Mm][Ee]\\s*=\\s*[\"']"  // $NON-NLS-1$
-                + quotedArg + "[\"']", // $NON-NLS-1$
-                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
+                        //  value="value" name="sessionid"
+                        + "|\\s[vV][Aa][Ll][Uu][Ee]\\s*=\\s*[\"']" // $NON-NLS-1$
+                        + "([^\"']*)" + "[\"']" + "[^>]*" // $NON-NLS-1$ // $NON-NLS-2$ // $NON-NLS-3$
+                        + "\\s[Nn][Aa][Mm][Ee]\\s*=\\s*[\"']"  // $NON-NLS-1$
+                        + quotedArg + "[\"']" // $NON-NLS-1$
+        );
         // NOTE: the handling of simple- vs. double-quotes could be formally
         // more accurate, but I can't imagine a session id containing
         // either, so we should be OK. The whole set of expressions is a
         // quick hack anyway, so who cares.
+    }
+
+    private Function<String, String> generateExtractor(String regex) {
+        if (useJavaRegex) {
+            return generateExtractorWithJavaRegex(regex);
+        }
+        return generateExtractorWithOroRegex(regex);
+    }
+
+    private Function<String, String> generateExtractorWithJavaRegex(String regex) {
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+                regex,
+                java.util.regex.Pattern.MULTILINE);
+        return text -> {
+            Matcher matcher = pattern.matcher(text);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+            return "";
+        };
+    }
+
+    private Function<String, String> generateExtractorWithOroRegex(String regex) {
+        Pattern pattern = JMeterUtils.getPatternCache().getPattern(
+                regex,
+                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
+        Perl5Matcher matcher = JMeterUtils.getMatcher();
+        return text -> {
+            if (matcher.contains(text, pattern)) {
+                MatchResult result = matcher.getMatch();
+                return result.group(1);
+            }
+            return "";
+        };
+    }
+
+    private Function<String, String> generateFirstMatchExtractor(String regex) {
+        if (useJavaRegex) {
+            return generateFirstMatchExtractorWithJavaRegex(regex);
+        }
+        return generateFirstMatchExtractorWithOroRegex(regex);
+    }
+
+    private Function<String, String> generateFirstMatchExtractorWithJavaRegex(String regex) {
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+                regex,
+                java.util.regex.Pattern.MULTILINE);
+        return text -> {
+            Matcher matcher = pattern.matcher(text);
+            for (int i = 1; i < matcher.groupCount(); i++) {
+                String value = matcher.group(i);
+                if (value != null) {
+                    return value;
+                }
+            }
+            return "";
+        };
+    }
+
+    private Function<String, String> generateFirstMatchExtractorWithOroRegex(String regex) {
+        Pattern pattern = JMeterUtils.getPatternCache().getPattern(
+                regex,
+                Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
+        Perl5Matcher matcher = JMeterUtils.getMatcher();
+        return text -> {
+            MatchResult result = matcher.getMatch();
+            for (int i = 1; i < result.groups(); i++) {
+                String value = result.group(i);
+                if (value != null) {
+                    return value;
+                }
+            }
+            return "";
+        };
     }
 
     public String getArgumentName() {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -176,7 +176,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
     }
 
     private Function<String, String> generateExtractorWithJavaRegex(String regex) {
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
                 regex,
                 java.util.regex.Pattern.MULTILINE);
         return text -> {
@@ -210,7 +210,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
     }
 
     private Function<String, String> generateFirstMatchExtractorWithJavaRegex(String regex) {
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
                 regex,
                 java.util.regex.Pattern.MULTILINE);
         return text -> {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -215,10 +215,12 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
                 java.util.regex.Pattern.MULTILINE);
         return text -> {
             Matcher matcher = pattern.matcher(text);
-            for (int i = 1; i < matcher.groupCount(); i++) {
-                String value = matcher.group(i);
-                if (value != null) {
-                    return value;
+            if (matcher.find()) {
+                for (int i = 1; i < matcher.groupCount(); i++) {
+                    String value = matcher.group(i);
+                    if (value != null) {
+                        return value;
+                    }
                 }
             }
             return "";
@@ -231,11 +233,13 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
                 Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
         Perl5Matcher matcher = JMeterUtils.getMatcher();
         return text -> {
-            MatchResult result = matcher.getMatch();
-            for (int i = 1; i < result.groups(); i++) {
-                String value = result.group(i);
-                if (value != null) {
-                    return value;
+            if (matcher.contains(text, pattern)) {
+                MatchResult result = matcher.getMatch();
+                for (int i = 1; i < result.groups(); i++) {
+                    String value = result.group(i);
+                    if (value != null) {
+                        return value;
+                    }
                 }
             }
             return "";

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -216,7 +216,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         return text -> {
             Matcher matcher = pattern.matcher(text);
             if (matcher.find()) {
-                for (int i = 1; i < matcher.groupCount(); i++) {
+                for (int i = 1; i <= matcher.groupCount(); i++) {
                     String value = matcher.group(i);
                     if (value != null) {
                         return value;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -61,7 +61,8 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
 
     private static final String ENCODE = "encode"; // $NON-NLS-1$
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     // PreProcessors are cloned per-thread, so this will be saved per-thread
     private transient String savedValue = ""; // $NON-NLS-1$
@@ -169,7 +170,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
     }
 
     private Function<String, String> generateExtractor(String regex) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return generateExtractorWithJavaRegex(regex);
         }
         return generateExtractorWithOroRegex(regex);
@@ -203,7 +204,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
     }
 
     private Function<String, String> generateFirstMatchExtractor(String regex) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return generateFirstMatchExtractorWithJavaRegex(regex);
         }
         return generateFirstMatchExtractorWithOroRegex(regex);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
@@ -49,6 +49,9 @@ import org.w3c.dom.NodeList;
 import org.w3c.tidy.Tidy;
 
 public final class HtmlParsingUtils {
+    private static final java.util.regex.Pattern EXTRACT_STYLE_PATTERN = java.util.regex.Pattern.compile(
+            "URL\\(\\s*('|\")(.*)('|\")\\s*\\)", // $NON-NLS-1$
+            java.util.regex.Pattern.CASE_INSENSITIVE);
     private static final Logger log = LoggerFactory.getLogger(HtmlParsingUtils.class);
 
     private static boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
@@ -451,10 +454,7 @@ public final class HtmlParsingUtils {
 
     private static void extractStyleURLsWithJavaRegex(URL baseUrl, URLCollection urls, String styleTagStr) {
 
-        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
-                "URL\\(\\s*('|\")(.*)('|\")\\s*\\)", // $NON-NLS-1$
-                java.util.regex.Pattern.CASE_INSENSITIVE);
-        Matcher matcher = pattern.matcher(styleTagStr);
+        Matcher matcher = EXTRACT_STYLE_PATTERN.matcher(styleTagStr);
         while (matcher.find()) {
             // The value is in the second group
             String styleUrl = matcher.group(2);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
@@ -89,7 +89,7 @@ public final class HtmlParsingUtils {
         }
 
         final String domain = config.getDomain();
-        if (domain != null && domain.length() > 0) {
+        if (domain != null && !domain.isEmpty()) {
             if (!isEqualOrMatches(newLink.getDomain(), domain, matcher, patternCache)){
                 return false;
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
@@ -54,7 +54,8 @@ public final class HtmlParsingUtils {
             java.util.regex.Pattern.CASE_INSENSITIVE);
     private static final Logger log = LoggerFactory.getLogger(HtmlParsingUtils.class);
 
-    private static boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /**
      * Private constructor to prevent instantiation.
@@ -87,7 +88,7 @@ public final class HtmlParsingUtils {
 
         final Arguments arguments = config.getArguments();
 
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return isAnchorMatchedWithJavaRegex(newLink, config, query, arguments);
         }
         return isAnchorMatchedWithOroRegex(newLink, config, query, arguments);
@@ -171,7 +172,7 @@ public final class HtmlParsingUtils {
      * @return true if both name and value match
      */
     public static boolean isArgumentMatched(Argument arg, Argument patternArg) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return isEqualOrMatchesWithJavaRegex(arg.getName(), patternArg.getName())
                     && isEqualOrMatchesWithJavaRegex(arg.getValue(), patternArg.getValue());
         }
@@ -240,7 +241,7 @@ public final class HtmlParsingUtils {
      * @return true if input matches the pattern
      */
     public static boolean isEqualOrMatches(String arg, String pat) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return isEqualOrMatchesWithJavaRegex(arg, pat);
         }
         return isEqualOrMatches(arg, pat, JMeterUtils.getMatcher(), JMeterUtils.getPatternCache());
@@ -256,7 +257,7 @@ public final class HtmlParsingUtils {
      * @return true if input matches the pattern
      */
     public static boolean isEqualOrMatchesCaseBlind(String arg, String pat) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return isEqualOrMatchesCaseBlindWithJavaRegex(arg, pat);
         }
         return isEqualOrMatchesCaseBlind(arg, pat, JMeterUtils.getMatcher(), JMeterUtils.getPatternCache());
@@ -445,7 +446,7 @@ public final class HtmlParsingUtils {
     }
 
     public static void extractStyleURLs(final URL baseUrl, final URLCollection urls, String styleTagStr) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             extractStyleURLsWithJavaRegex(baseUrl, urls, styleTagStr);
         } else {
             extractStyleURLsWithOroRegex(baseUrl, urls, styleTagStr);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
@@ -148,7 +148,7 @@ class RegexpHTMLParser extends HTMLParser {
             String input = new String(html, encoding);
             java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
                     REGEXP,
-                    java.util.regex.Pattern.CASE_INSENSITIVE
+                    java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
             );
 
             Matcher matcher = pattern.matcher(input);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
@@ -121,7 +121,8 @@ class RegexpHTMLParser extends HTMLParser {
     private static final ThreadLocal<PatternMatcherInput> localInput =
             ThreadLocal.withInitial(() -> new PatternMatcherInput(new char[0]));
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     /**
      * Make sure to compile the regular expression upon instantiation:
@@ -136,7 +137,7 @@ class RegexpHTMLParser extends HTMLParser {
     @Override
     public Iterator<URL> getEmbeddedResourceURLs(String userAgent, byte[] html, URL baseUrl,
                                                  URLCollection urls, String encoding) throws HTMLParseException {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getEmbeddedResourceURLsWithJavaRegex(html, baseUrl, urls, encoding);
         }
         return getEmbeddedResourceURLsWithOroRegex(html, baseUrl, urls, encoding);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * HtmlParser implementation using regular expressions.
  * <p>
  * This class will find URLs specified in the following ways (where <b>url</b>
- * represents the URL being found:
+ * represents the URL being found):
  * <ul>
  * <li>&lt;img src=<b>url</b> ... &gt;
  * <li>&lt;script src=<b>url</b> ... &gt;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
@@ -107,6 +107,10 @@ class RegexpHTMLParser extends HTMLParser {
             + "|LINK(?:" + SEP + "(?:HREF" + VALUE+"|REL\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet(?=[\\s>])))){2,}"
             + "|LINK(?:" + SEP + "(?:HREF" + VALUE+"|REL\\s*=\\s*(?:\"icon\"|'icon'|icon(?=[\\s>])))){2,}"
             + "|LINK(?:" + SEP + "(?:HREF" + VALUE+"|REL\\s*=\\s*(?:\"shortcut icon\"|'shortcut icon'|shortcut icon(?=[\\s>])))){2,})";
+    private static final java.util.regex.Pattern HTML_PATTERN = java.util.regex.Pattern.compile(
+            REGEXP,
+            java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
+    );
 
     // Number of capturing groups possibly containing Base HREFs:
     private static final int NUM_BASE_GROUPS = 3;
@@ -146,12 +150,8 @@ class RegexpHTMLParser extends HTMLParser {
             // probably a new PatternMatcherInput working on a byte[] would do
             // better.
             String input = new String(html, encoding);
-            java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
-                    REGEXP,
-                    java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
-            );
 
-            Matcher matcher = pattern.matcher(input);
+            Matcher matcher = HTML_PATTERN.matcher(input);
             while (matcher.find()) {
                 java.util.regex.MatchResult match = matcher.toMatchResult();
                 String s;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
@@ -130,15 +130,16 @@ class RegexpHTMLParser extends HTMLParser {
      * {@inheritDoc}
      */
     @Override
-    public Iterator<URL> getEmbeddedResourceURLs(String userAgent, byte[] html, URL baseUrl, URLCollection urls, String encoding) throws HTMLParseException {
+    public Iterator<URL> getEmbeddedResourceURLs(String userAgent, byte[] html, URL baseUrl,
+                                                 URLCollection urls, String encoding) throws HTMLParseException {
         if (useJavaRegex) {
-            return getEmbeddedResourceURLsWithJavaRegex(userAgent,html, baseUrl, urls, encoding);
+            return getEmbeddedResourceURLsWithJavaRegex(html, baseUrl, urls, encoding);
         }
-        return getEmbeddedResourceURLsWithOroRegex(userAgent,html, baseUrl, urls, encoding);
+        return getEmbeddedResourceURLsWithOroRegex(html, baseUrl, urls, encoding);
     }
 
-    private Iterator<URL> getEmbeddedResourceURLsWithJavaRegex(String userAgent, byte[] html, URL baseUrl,
-                                                               URLCollection urls, String encoding) throws HTMLParseException {
+    private Iterator<URL> getEmbeddedResourceURLsWithJavaRegex(byte[] html, URL baseUrl, URLCollection urls,
+                                                               String encoding) throws HTMLParseException {
         try {
 
             // TODO: find a way to avoid the cost of creating a String here --
@@ -188,7 +189,8 @@ class RegexpHTMLParser extends HTMLParser {
         }
     }
 
-    private Iterator<URL> getEmbeddedResourceURLsWithOroRegex(String userAgent, byte[] html, URL baseUrl, URLCollection urls, String encoding) throws HTMLParseException {
+    private Iterator<URL> getEmbeddedResourceURLsWithOroRegex(byte[] html, URL baseUrl, URLCollection urls,
+                                                              String encoding) throws HTMLParseException {
         Pattern pattern= null;
         Perl5Matcher matcher = null;
         try {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -246,7 +246,8 @@ public class ProxyControl extends GenericController implements NonTestElement {
     // Although this field is mutable, it is only accessed within the synchronized method deliverSampler()
     private static String LAST_REDIRECT = null;
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     private transient Daemon server;
 
@@ -882,7 +883,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
 
         try {
             boolean contains;
-            if (useJavaRegex) {
+            if (USE_JAVA_REGEX) {
                 contains = isContainedWithJavaRegex(expression, sampleContentType);
             } else {
                 contains = isContainedWithOroRegex(expression, sampleContentType);
@@ -1367,7 +1368,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     }
 
     private boolean matchesPatterns(String url, CollectionProperty patterns) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return matchesPatternsWithJavaRegex(url, patterns);
         }
         return matchesPatternsWithOroRegex(url, patterns);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -794,18 +794,18 @@ public class ProxyControl extends GenericController implements NonTestElement {
     // Package protected to allow test case access
     boolean filterUrl(HTTPSamplerBase sampler) {
         String domain = sampler.getDomain();
-        if (domain == null || domain.length() == 0) {
+        if (domain == null || domain.isEmpty()) {
             return false;
         }
 
         String url = generateMatchUrl(sampler);
         CollectionProperty includePatterns = getIncludePatterns();
-        if (includePatterns.size() > 0 && !matchesPatterns(url, includePatterns)) {
+        if (!includePatterns.isEmpty() && !matchesPatterns(url, includePatterns)) {
             return false;
         }
 
         CollectionProperty excludePatterns = getExcludePatterns();
-        if (excludePatterns.size() > 0 && matchesPatterns(url, excludePatterns)) {
+        if (!excludePatterns.isEmpty() && matchesPatterns(url, excludePatterns)) {
             return false;
         }
 
@@ -826,16 +826,14 @@ public class ProxyControl extends GenericController implements NonTestElement {
         String excludeExp = getContentTypeExclude();
 
         // If no expressions are specified, we let the sample pass
-        if((includeExp == null || includeExp.length() == 0) &&
-                (excludeExp == null || excludeExp.length() == 0)
-                )
-        {
+        if ((includeExp == null || includeExp.isEmpty()) &&
+                (excludeExp == null || excludeExp.isEmpty())) {
             return true;
         }
 
         // Check that we have a content type
         String sampleContentType = result.getContentType();
-        if (sampleContentType == null || sampleContentType.length() == 0) {
+        if (sampleContentType == null || sampleContentType.isEmpty()) {
             if (log.isDebugEnabled()) {
                 log.debug("No Content-type found for : {}", result.getUrlAsString());
             }
@@ -870,7 +868,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @return boolean true if Matching expression
      */
     private boolean testPattern(String expression, String sampleContentType, boolean expectedToMatch) {
-        if(expression != null && expression.length() > 0) {
+        if(expression != null && !expression.isEmpty()) {
             if(log.isDebugEnabled()) {
                 log.debug(
                         "Testing Expression : {} on sampleContentType: {}, expected to match: {}",
@@ -1324,7 +1322,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
             for (ConfigTestElement config : configurations) {
                 String configValue = config.getPropertyAsString(name);
 
-                if (configValue != null && configValue.length() > 0) {
+                if (configValue != null && !configValue.isEmpty()) {
                     if (configValue.equals(value)) {
                         sampler.setProperty(name, ""); // $NON-NLS-1$
                     }
@@ -1342,7 +1340,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         buf.append(':'); // $NON-NLS-1$
         buf.append(sampler.getPort());
         buf.append(sampler.getPath());
-        if (sampler.getQueryString().length() > 0) {
+        if (!sampler.getQueryString().isEmpty()) {
             buf.append('?'); // $NON-NLS-1$
             buf.append(sampler.getQueryString());
         }
@@ -1577,7 +1575,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
             keyStore = getKeyStore(storePassword.toCharArray()); // This should now work
         }
         final String sslDomains = getSslDomains().trim();
-        if (sslDomains.length() > 0) {
+        if (!sslDomains.isEmpty()) {
             final String[] domains = sslDomains.split(",");
             // The subject may be either a host or a domain
             for (String subject : domains) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -897,7 +897,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     }
 
     private boolean isContainedWithJavaRegex(String expression, String sampleContentType) {
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(expression);
+        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(expression);
         return pattern.matcher(sampleContentType).find();
     }
 
@@ -1377,7 +1377,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         for (JMeterProperty jMeterProperty : patterns) {
             String item = jMeterProperty.getStringValue();
             try {
-                java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(item);
+                java.util.regex.Pattern pattern = JMeterUtils.compilePattern(item);
                 if (pattern.matcher(url).matches()) {
                     return true;
                 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -381,9 +381,9 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         // If there is one file with no parameter name, the file will
         // be sent as post body.
         HTTPFileArg[] files = getHTTPFiles();
-        return (files.length == 1)
-                && (files[0].getPath().length() > 0)
-                && (files[0].getParamName().length() == 0);
+        return files.length == 1
+                && !files[0].getPath().isEmpty()
+                && files[0].getParamName().isEmpty();
     }
 
     /**
@@ -402,7 +402,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             for (JMeterProperty jMeterProperty : getArguments()) {
                 hasArguments = true;
                 HTTPArgument arg = (HTTPArgument) jMeterProperty.getObjectValue();
-                if (arg.getName() != null && arg.getName().length() > 0) {
+                if (arg.getName() != null && !arg.getName().isEmpty()) {
                     return false;
                 }
             }
@@ -458,7 +458,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      */
     public String getProtocol() {
         String protocol = getPropertyAsString(PROTOCOL);
-        if (protocol == null || protocol.length() == 0) {
+        if (protocol == null || protocol.isEmpty()) {
             return DEFAULT_PROTOCOL;
         }
         return protocol;
@@ -1104,7 +1104,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             // If no encoding is specified by user, we will get it
             // encoded in UTF-8, which is what the HTTP spec says
             String queryString = getQueryString(getContentEncoding());
-            if (queryString.length() > 0) {
+            if (!queryString.isEmpty()) {
                 if (path.contains(QRY_PFX)) {// Already contains a prefix
                     pathAndQuery.append(QRY_SEP);
                 } else {
@@ -1236,7 +1236,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 name = arg;
                 value = "";
             }
-            if (name.length() > 0) {
+            if (!name.isEmpty()) {
                 log.debug("Name: {} Value: {} Metadata: {}", name, value, metaData);
                 // If we know the encoding, we can decode the argument value,
                 // to make it easier to read for the user
@@ -1367,7 +1367,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             String allowRegex = getEmbeddedUrlRE();
             Perl5Matcher localMatcher = null;
             Pattern allowPattern = null;
-            if (allowRegex.length() > 0) {
+            if (!allowRegex.isEmpty()) {
                 try {
                     allowPattern = JMeterUtils.getPattern(allowRegex);
                     localMatcher = JMeterUtils.getMatcher();// don't fetch unless pattern compiles
@@ -1377,7 +1377,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             }
             Pattern excludePattern = null;
             String excludeRegex = getEmbededUrlExcludeRE();
-            if (excludeRegex.length() > 0) {
+            if (!excludeRegex.isEmpty()) {
                 try {
                     excludePattern = JMeterUtils.getPattern(excludeRegex);
                     if (localMatcher == null) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1481,7 +1481,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         }
         if (useJavaRegex) {
             try {
-                java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(regex);
+                java.util.regex.Pattern pattern = JMeterUtils.compilePattern(regex);
                 return s -> pattern.matcher(s.toString()).matches();
             } catch (PatternSyntaxException e) {
                 log.warn("Ignoring embedded URL {} string: {}", explanation, e.getMessage());

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -322,7 +322,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     private static final boolean SEPARATE_CONTAINER =
             JMeterUtils.getPropDefault("httpsampler.separate.container", true); // $NON-NLS-1$
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     static {
         String[] parsers = JOrphanUtils.split(RESPONSE_PARSERS, " " , true);// returns empty array for null
@@ -1479,7 +1480,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         if (StringUtils.isEmpty(regex)) {
             return s -> defaultAnswer;
         }
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             try {
                 java.util.regex.Pattern pattern = JMeterUtils.compilePattern(regex);
                 return s -> pattern.matcher(s.toString()).matches();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
@@ -381,7 +381,7 @@ public class LogFilter implements Filter, Serializable {
     protected boolean excPatternWithJavaRegex(String text) {
         this.USEFILE = true;
         for (String excludePattern : this.excludePatternStrings) {
-            if (JMeterUtils.compilePattern(text).matcher(text).find()) {
+            if (JMeterUtils.compilePattern(excludePattern).matcher(text).find()) {
                 this.USEFILE = false;
                 return true;
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
@@ -75,7 +75,8 @@ public class LogFilter implements Filter, Serializable {
 
     private static final Logger log = LoggerFactory.getLogger(LogFilter.class);
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     // protected members used by class to filter
 
@@ -336,7 +337,7 @@ public class LogFilter implements Filter, Serializable {
      * @return <code>true</code> if text is included
      */
     protected boolean incPattern(String text) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return incPatternWithJavaRegex(text);
         }
         return incPatternWithOroRegex(text);
@@ -372,7 +373,7 @@ public class LogFilter implements Filter, Serializable {
      * @return <code>true</code> if text is excluded
      */
     protected boolean excPattern(String text) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return excPatternWithJavaRegex(text);
         }
         return excPatternWithOroRegex(text);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
@@ -378,7 +378,7 @@ public class LogFilter implements Filter, Serializable {
         return excPatternWithOroRegex(text);
     }
 
-    protected boolean excPatternWithJavaRegex(String text) {
+    private boolean excPatternWithJavaRegex(String text) {
         this.USEFILE = true;
         for (String excludePattern : this.excludePatternStrings) {
             if (JMeterUtils.compilePattern(excludePattern).matcher(text).find()) {
@@ -389,7 +389,7 @@ public class LogFilter implements Filter, Serializable {
         return false;
     }
 
-    protected boolean excPatternWithOroRegex(String text) {
+    private boolean excPatternWithOroRegex(String text) {
         this.USEFILE = true;
         boolean exc = false;
         for (Pattern excludePattern : this.EXCPATTERNS) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
@@ -45,7 +45,8 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
     private static final long serialVersionUID = 233L;
     private static final Logger log = LoggerFactory.getLogger(SessionFilter.class);
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
 
     /**
@@ -91,7 +92,7 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
     }
 
     protected String getIpAddress(String logLine) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getIpAddressWithJavaRegex(logLine);
         }
         return getIpAddressWithOroRegex(logLine);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * Provides Session Filtering for the AccessLog Sampler.
  */
 public class SessionFilter implements Filter, Serializable, TestCloneable,ThreadListener {
+    private static final java.util.regex.Pattern IP_PATTERN = java.util.regex.Pattern.compile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
     private static final long serialVersionUID = 233L;
     private static final Logger log = LoggerFactory.getLogger(SessionFilter.class);
 
@@ -97,8 +98,7 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
     }
 
     private String getIpAddressWithJavaRegex(String logLine) {
-        java.util.regex.Pattern incIp = JMeterUtils.compilePattern("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
-        Matcher matcher = incIp.matcher(logLine);
+        Matcher matcher = IP_PATTERN.matcher(logLine);
         if (matcher.find()) {
             return matcher.group(0);
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
@@ -96,7 +96,7 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
         return getIpAddressWithOroRegex(logLine);
     }
 
-    protected String getIpAddressWithJavaRegex(String logLine) {
+    private String getIpAddressWithJavaRegex(String logLine) {
         java.util.regex.Pattern incIp = JMeterUtils.compilePattern("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
         Matcher matcher = incIp.matcher(logLine);
         if (matcher.find()) {
@@ -105,7 +105,7 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
         return "";
     }
 
-    protected String getIpAddressWithOroRegex(String logLine) {
+    private String getIpAddressWithOroRegex(String logLine) {
         Pattern incIp = JMeterUtils.getPatternCache().getPattern("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
                 Perl5Compiler.READ_ONLY_MASK | Perl5Compiler.SINGLELINE_MASK);
         Perl5Matcher matcher = JMeterUtils.getMatcher();

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -79,7 +79,8 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
 
     private final int item;
 
-    private boolean useJavaRegex = JMeterUtils.getPropDefault("jmeter.use_java_regex", false);
+    private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
+            "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
     public TestHTTPSamplersAgainstHttpMirrorServer(String arg0) {
         super(arg0);
@@ -1183,7 +1184,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     }
 
     private String getSentRequestHeaderValue(String requestHeaders, String headerName) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getSentRequestHeaderValueWithJavaRegex(requestHeaders, headerName);
         }
         return getSentRequestHeaderValueWithOroRegex(requestHeaders, headerName);
@@ -1216,7 +1217,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     }
 
     private boolean checkRegularExpression(String stringToCheck, String regularExpression) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return checkRegularExpressionWithJavaRegex(stringToCheck, regularExpression);
         }
         return checkRegularExpressionWithOroRegex(stringToCheck, regularExpression);
@@ -1238,7 +1239,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     }
 
     private int getPositionOfBody(String stringToCheck) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getPositionOfBodyWithJavaRegex(stringToCheck);
         }
         return getPositionOfBodyWithOroRegex(stringToCheck);
@@ -1275,7 +1276,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     }
 
     private String getBoundaryStringFromContentType(String requestHeaders) {
-        if (useJavaRegex) {
+        if (USE_JAVA_REGEX) {
             return getBoundaryStringFromContentTypeWithJavaRegex(requestHeaders);
         }
         return getBoundaryStringFromContentTypeWithOroRegex(requestHeaders);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -1190,7 +1190,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     private String getSentRequestHeaderValueWithJavaRegex(String requestHeaders, String headerName) {
         String expression = ".*" + headerName + ": (\\d*).*";
         java.util.regex.Pattern pattern = JMeterUtils.compilePattern(expression,
-                        java.util.regex.Pattern.CASE_INSENSITIVE);
+                        java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
         Matcher matcher = pattern.matcher(requestHeaders);
         if (matcher.matches()) {
             // The value is in the first group, group 0 is the whole match
@@ -1244,7 +1244,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
 
     private int getPositionOfBodyWithJavaRegex(String stringToCheck) {
         // The headers and body are divided by a blank line
-        String regularExpression = "^.$";
+        String regularExpression = "^$";
         java.util.regex.Pattern pattern = JMeterUtils.compilePattern(regularExpression,
                 java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);
 

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -835,7 +835,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
             String descriptionField,
             String descriptionValue,
             boolean valuesAlreadyUrlEncoded) throws IOException {
-        if (contentEncoding == null || contentEncoding.length() == 0) {
+        if (contentEncoding == null || contentEncoding.isEmpty()) {
             contentEncoding = samplerDefaultEncoding;
         }
         // Check URL
@@ -867,7 +867,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
             String titleValue,
             String descriptionField,
             String descriptionValue) throws IOException {
-        if (contentEncoding == null || contentEncoding.length() == 0) {
+        if (contentEncoding == null || contentEncoding.isEmpty()) {
             contentEncoding = samplerDefaultEncoding;
         }
         // Check URL
@@ -916,7 +916,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
             File fileValue,
             String fileMimeType,
             byte[] fileContent) throws IOException {
-        if (contentEncoding == null || contentEncoding.length() == 0) {
+        if (contentEncoding == null || contentEncoding.isEmpty()) {
             contentEncoding = samplerDefaultEncoding;
         }
         // Check URL
@@ -956,7 +956,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
             String contentEncoding,
             String expectedPostBody,
             String expectedContentType) throws IOException {
-        if (contentEncoding == null || contentEncoding.length() == 0) {
+        if (contentEncoding == null || contentEncoding.isEmpty()) {
             contentEncoding = samplerDefaultEncoding;
         }
         // Check URL
@@ -1037,7 +1037,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
             String descriptionField,
             String descriptionValue,
             boolean valuesAlreadyUrlEncoded) throws IOException {
-        if (contentEncoding == null || contentEncoding.length() == 0) {
+        if (contentEncoding == null || contentEncoding.isEmpty()) {
             contentEncoding = EncoderCache.URL_ARGUMENT_ENCODING;
         }
         // Check URL
@@ -1093,7 +1093,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         assertEquals(expectedMethod, methodSent);
         String uriSent = headersSent.substring(indexFirstSpace + 1, indexSecondSpace);
         int indexQueryStart = uriSent.indexOf('?');
-        if (expectedQueryString != null && expectedQueryString.length() > 0) {
+        if (expectedQueryString != null && !expectedQueryString.isEmpty()) {
             // We should have a query string part
             if (indexQueryStart <= 0 || indexQueryStart == uriSent.length() - 1) {
                 fail("Could not find query string in URI");
@@ -1110,7 +1110,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         String pathSent = uriSent.substring(0, indexQueryStart);
         assertEquals(expectedPath, pathSent);
         // Check query
-        if (expectedQueryString != null && expectedQueryString.length() > 0) {
+        if (expectedQueryString != null && !expectedQueryString.isEmpty()) {
             String queryStringSent = uriSent.substring(indexQueryStart + 1);
             // Is it only the parameter values which are encoded in the specified
             // content encoding, the rest of the query is encoded in UTF-8

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -60,6 +60,8 @@ import junit.framework.TestSuite;
  * started when the unit tests are executed.
  */
 public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit implements Describable {
+    private static final java.util.regex.Pattern EMPTY_LINE_PATTERN = java.util.regex.Pattern.compile("^$",
+            java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);
     private static final int HTTP_SAMPLER = 0;
     private static final int HTTP_SAMPLER3 = 2;
 
@@ -1244,11 +1246,8 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
 
     private int getPositionOfBodyWithJavaRegex(String stringToCheck) {
         // The headers and body are divided by a blank line
-        String regularExpression = "^$";
-        java.util.regex.Pattern pattern = JMeterUtils.compilePattern(regularExpression,
-                java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);
 
-        Matcher localMatcher = pattern.matcher(stringToCheck);
+        Matcher localMatcher = EMPTY_LINE_PATTERN.matcher(stringToCheck);
         if (localMatcher.find()) {
             java.util.regex.MatchResult match = localMatcher.toMatchResult();
             return match.start(0);

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1426,6 +1426,17 @@ JMETER-SERVER</source>
     If you want to use Rhino, set this value to <code>true</code></note>
     Defaults to: <code>false</code>
 </property>
+<property name="jmeter.regex.engine">
+    Ability to switch out the old Oro Regex implementation with the JDK built-in implementation.
+    Any value different to <code>oro</code> will disable the Oro implementation and enable the JDK based.
+    <note>We intend to switch the default to the JDK based one in a later version of JMeter.</note>
+    Defaults to: <code>oro</code>
+</property>
+<property name="jmeter.regex.patterncache.size">
+    We assist the JDK based Regex implementation by caching Pattern objects. The size of the
+    cache can be set with this setting. It can be disabled by setting it to <code>0</code>.
+    Defaults to: <code>1000</code>
+</property>
 <property name="jmeterengine.threadstop.wait">
     Number of milliseconds to wait for a thread to stop.<br/>
     Defaults to: <code>5000</code>

--- a/xdocs/usermanual/regular_expressions.xml
+++ b/xdocs/usermanual/regular_expressions.xml
@@ -41,6 +41,8 @@ a summary of the pattern matching characters</a>
 There is also documentation on an older incarnation of the product at
 <a href="http://www.savarese.org/oro/docs/OROMatcher/index.html">OROMatcher User's guide</a>, which might prove useful.
 </p>
+<note>With JMeter version 5.5 the Regex implementation can be switched from Oro to the JDK based one by setting
+the JMeter property <code>jmeter.regex.engine</code> to some value different than <code>oro</code>.</note>
 <p>
 The pattern matching is very similar to the pattern matching in Perl.
 A full installation of Perl will include plenty of documentation on regular expressions - look for <code>perlrequick</code>,


### PR DESCRIPTION
## Description
Try to replace usage of Oro Regex implementation by Java Regex implementation. This is done by adding a property to let the user switch between the two. Default is to use the old Oro based one.

This is not finished. There are not all occurrences enhanced with the switch. A lot of it feels like a hack, as much code has been duplicated.

I thought about adding some interfaces to hide the Oro and Java Regex implementations behind, but currently I believe it would be overengineered. But maybe someone has a good idea to make this code less hacky. 

## Motivation and Context
The Oro library has been unmaintained for years and is feature-wise behind the built-in Java Regex implementation. To make a smooth transition from Oro to the Java built-in implementation the plan is to 
* make switching possible while defaulting to the old one
* deprecate the usage of the old one and switching the default to the new one
* removing the old implementation

Every step should be made with at least one release in between.
 
Discussed in [Bug 57672](https://bz.apache.org/bugzilla/show_bug.cgi?id=57672) and [Bug 65883](https://bz.apache.org/bugzilla/show_bug.cgi?id=65883)
## How Has This Been Tested?
Tests were run with the default setting (Oro Regex) and some manual tests with the setting `jmeter.use_java_regex` to `true`.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
