### PR TITLE
ci: use https://www.apache.org instead of http://www.eu.apache.org for downloading Maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
       arch: s390x
       jdk: openjdk11
       script:
-        - wget http://www.eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+        - wget https://www.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
         - tar -xvzf apache-maven-3.6.3-bin.tar.gz
         - export PATH=`pwd`/apache-maven-3.6.3/bin/:$PATH
         - ./gradlew -PskipJavadoc publishToMavenLocal -Pjmeter.version=42.0 -PchecksumIgnore


### PR DESCRIPTION
## Use "main" site instead of "eu" site in Travis CI pipeline

## Motivation and Context
Seeing some error during CI build, and found such unresolvable in `wget`ting Maven for s390x build. Then trying to fix it.

## How Has This Been Tested?
After creating the PR, it will be tested instantly.

## Screenshots (if appropriate):

## Types of changes
- Bug fix
- 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
