### PR TITLE
Hack to make rendering of large text results faster

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1187,6 +1187,11 @@ cookies=cookies
 #view.results.tree.max_line_size=110000
 #view.results.tree.soft_wrap_line_size=100000
 
+# Even with the above setting the UI can be unresponsive on large contents in the text view,
+# so we allow to switch to a simpler view mode, that is faster, but does not break lines.
+# Can be switched off by setting it to -1
+#view.results.tree.simple_view_limit=10000
+
 # Order of Renderers in View Results Tree
 # Note full class names should be used for non JMeter core renderers
 # For JMeter core renderers, class names start with '.' and are automatically

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
@@ -106,6 +106,9 @@ public abstract class SamplerResultTab implements ResultRenderer {
 
     private static final String STYLE_REDIRECT = "Redirect"; // $NON-NLS-1$
 
+    private static final int SIMPLE_VIEW_LIMIT =
+            JMeterUtils.getPropDefault("view.results.tree.simple_view_limit", 10_000); // $NON-NLS-1$
+
     private JTextPane stats;
 
     /** Response Data pane */
@@ -706,7 +709,7 @@ public abstract class SamplerResultTab implements ResultRenderer {
         } catch (BadLocationException ex) {
             LOGGER.error("Error inserting text", ex);
         }
-        if (document.getLength() > 10_000) {
+        if (SIMPLE_VIEW_LIMIT >= 0 && document.getLength() > SIMPLE_VIEW_LIMIT) {
             results.setEditorKit(new NonWrappingPlainTextEditorKit(results.getEditorKit()));
         }
         KerningOptimizer.INSTANCE.configureKerning(results, document.getLength());

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1530,6 +1530,12 @@ JMETER-SERVER</source>
     Defaults to:
     <source>.RenderAsText,.RenderAsRegexp,.RenderAsCssJQuery,.RenderAsXPath,.RenderAsHTML,.RenderAsHTMLWithEmbedded,.RenderAsDocument,.RenderAsJSON,.RenderAsXML</source>
 </property>
+<property name="view.results.tree.simple_view_limit">
+    Configures maximum document length for text view before switching to a simpler view, that does not do line breaks.<br/>
+    Works probably best, when combined with a low setting of <code>view.results.tree.max_line_size</code>.
+    Can be switched off by setting the value to <code>-1</code>.<br/>
+    Defaults to: <code>10000</code>
+</property>
 <property name="document.max_size">
     Maximum size (in bytes) of Document that can be parsed by Tika engine<br/>
     Set to zero to disable the size check.<br/>


### PR DESCRIPTION
## Description

Currently the used JEditorPane is slow when using large texts, as it
tries to find good places to break words.

This hack disables word wrapping by using non-wrapping views
for every element in the JEditorPane.


## How Has This Been Tested?
Sampled a biggish http site and looked at the result in the view results tree. Especially switching between a small and a large text result, would take a few seconds and make the UI unresponsive.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
