### PR TITLE
Add necessary fixes for passing CI build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -403,6 +403,7 @@ allprojects {
                     disable(
                         "ComplexBooleanConstant",
                         "EqualsGetClass",
+                        "InlineMeSuggester",
                         "OperatorPrecedence",
                         "MutableConstantField",
                         // "ReferenceEquality",

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -705,7 +705,7 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         return buttonPanel;
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public String[] getXAxisLabels() {
         SimpleDateFormat formatter = new SimpleDateFormat(xAxisTimeFormat.getText()); //$NON-NLS-1$
         String[] xAxisLabels = new String[(int) durationTest]; // Test can't have a duration more than 2^31 secs (cast from long to int)

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
@@ -241,7 +241,7 @@ public abstract class SamplerResultTab implements ResultRenderer {
     }
 
     @Override
-    @SuppressWarnings({"boxing", "JdkObsolete"})
+    @SuppressWarnings({"boxing", "JavaUtilDate"})
     public void setupTabPane() {
         // Clear all data before display a new
         this.clearData();

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -456,7 +456,7 @@ public class JMeter implements JMeterPlugin {
      * Called reflectively by {@link NewDriver#main(String[])}
      * @param args The arguments for JMeter
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void start(String[] args) {
         CLArgsParser parser = new CLArgsParser(args, options);
         String error = parser.getErrorString();
@@ -1016,7 +1016,7 @@ public class JMeter implements JMeterPlugin {
     }
 
     // run test in batch mode
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     void runNonGui(String testFile, String logFile, boolean remoteStart, String remoteHostsString, boolean generateReportDashboard)
             throws ConfigurationException {
         try {
@@ -1323,7 +1323,7 @@ public class JMeter implements JMeterPlugin {
             }
         }
 
-        @SuppressWarnings("JdkObsolete")
+        @SuppressWarnings("JavaUtilDate")
         private void endTest(boolean isDistributed) {
             long now = System.currentTimeMillis();
             if (isDistributed) {

--- a/src/core/src/main/java/org/apache/jmeter/engine/DistributedRunner.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/DistributedRunner.java
@@ -121,7 +121,7 @@ public class DistributedRunner {
      *
      * @param addresses list of the DNS names or IP addresses of the remote testing engines
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void start(List<String> addresses) {
         long now = System.currentTimeMillis();
         println("Starting distributed test with remote engines: " + addresses + " @ " + new Date(now) + " (" + now + ")");

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -171,7 +171,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void runTest() throws JMeterEngineException {
         if (host != null){
             long now=System.currentTimeMillis();
@@ -209,7 +209,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         }
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private void notifyTestListenersOfEnd(SearchByClass<TestStateListener> testListeners) {
         log.info("Notifying test listeners of end of test");
         for (TestStateListener tl : testListeners.getSearchResults()) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/HtmlReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/HtmlReportGenerator.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.gui.action;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -83,7 +84,7 @@ public class HtmlReportGenerator {
             LOGGER.debug("Running report generation");
             resultCode = sc.run(generationCommand);
             if (resultCode != 0) {
-                errorMessageList.add(commandExecutionOutput.toString());
+                errorMessageList.add(commandExecutionOutput.toString(Charset.defaultCharset().name()));
                 LOGGER.info("The HTML report generation failed and returned: {}", commandExecutionOutput);
                 return errorMessageList;
             }

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JDateField.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JDateField.java
@@ -93,7 +93,7 @@ public class JDateField extends JTextField {
     }
 
     // Dummy constructor to allow JUnit tests to work
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public JDateField() {
         this(new Date());
     }
@@ -113,7 +113,7 @@ public class JDateField extends JTextField {
      *
      * @return The currently set date
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public Date getDate() {
         try {
             return dateFormat.parse(getText());

--- a/src/core/src/main/java/org/apache/jmeter/report/core/TimeHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/TimeHelper.java
@@ -76,7 +76,7 @@ public class TimeHelper {
      *            the format
      * @return the string
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public static String formatTimeStamp(long timeStamp, String format) {
         SimpleDateFormat dateFormat = format != null ? new SimpleDateFormat(
                 format) : new SimpleDateFormat();

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -270,7 +270,7 @@ public class ReportGenerator {
     /**
      * @return {@link FilterConsumer} that filter data based on date range
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private FilterConsumer createFilterByDateRange() {
         FilterConsumer dateRangeFilter = new FilterConsumer();
         dateRangeFilter.setName(DATE_RANGE_FILTER_CONSUMER_NAME);

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/NormalizerSampleConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/NormalizerSampleConsumer.java
@@ -89,7 +89,7 @@ public class NormalizerSampleConsumer extends AbstractSampleConsumer {
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void consume(Sample s, int channel) {
         Date date = null;
         try {

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
@@ -123,7 +123,7 @@ public class ResultSaver extends AbstractTestElement implements NoThreadClone, S
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void testStarted(String host) {
         synchronized(LOCK){
             sequenceNumber = 0;

--- a/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
@@ -203,7 +203,7 @@ public final class CSVSaveService {
      *
      * @throws JMeterError
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private static SampleEvent makeResultFromDelimitedString(
             final String[] parts,
             final SampleSaveConfiguration saveConfig, // may be updated
@@ -843,7 +843,7 @@ public final class CSVSaveService {
      *            the separation string
      * @return the separated value representation of the result
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public static String resultToDelimitedString(SampleEvent event,
             SampleResult sample,
             SampleSaveConfiguration saveConfig,

--- a/src/core/src/main/java/org/apache/jmeter/visualizers/Sample.java
+++ b/src/core/src/main/java/org/apache/jmeter/visualizers/Sample.java
@@ -208,7 +208,7 @@ public class Sample implements Serializable, Comparable<Sample> {
      * @return the start time using the specified format
      * Intended for use from Functors
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public String getStartTimeFormatted(Format format) {
         return format.format(new Date(getStartTime()));
     }

--- a/src/core/src/main/java/org/apache/jmeter/visualizers/TableSample.java
+++ b/src/core/src/main/java/org/apache/jmeter/visualizers/TableSample.java
@@ -107,7 +107,7 @@ public class TableSample implements Serializable, Comparable<TableSample> {
      * @return the start time using the specified format
      * Intended for use from Functors
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public String getStartTimeFormatted(Format format) {
         return format.format(new Date(getStartTime()));
     }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/DateTimeConvertFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/DateTimeConvertFunction.java
@@ -62,7 +62,7 @@ public class DateTimeConvertFunction extends AbstractFunction {
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
         String dateString = values[0].execute();
         String sourceDateFormat = values[1].execute();

--- a/src/functions/src/main/java/org/apache/jmeter/functions/TimeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/TimeFunction.java
@@ -77,7 +77,7 @@ public class TimeFunction extends AbstractFunction {
 
     /** {@inheritDoc} */
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public String execute(SampleResult previousResult, Sampler currentSampler) throws InvalidVariableException {
         String datetime;
         if (format.length() == 0){// Default to milliseconds

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CacheManager.java
@@ -63,7 +63,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
 
     private static final Logger log = LoggerFactory.getLogger(CacheManager.class);
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private static final Date EXPIRED_DATE = new Date(0L);
     private static final int DEFAULT_MAX_SIZE = 5000;
     private static final long ONE_YEAR_MS = 365*24*60*60*1000L;
@@ -307,7 +307,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         return expiresDate;
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private Date extractExpiresDateFromCacheControl(String lastModified,
             String cacheControl, String expires, String etag, String url,
             String date, final String maxAge, Date defaultExpiresDate) {
@@ -327,7 +327,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         return defaultExpiresDate;
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private Date calcExpiresDate(String lastModified, String cacheControl,
             String expires, String etag, String url, String date) {
         if(!StringUtils.isEmpty(lastModified) && !StringUtils.isEmpty(date)) {
@@ -516,7 +516,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
 
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private boolean entryStillValid(URL url, CacheEntry entry) {
         log.debug("Check if entry {} is still valid for url {}", entry, url);
         if (entry != null && entry.getVaryHeader() == null) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
@@ -104,7 +104,7 @@ public class HC4CookieHandler implements CookieHandler {
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void addCookieFromHeader(CookieManager cookieManager,
             boolean checkCookies, String cookieHeader, URL url) {
             boolean debugEnabled = log.isDebugEnabled();
@@ -240,7 +240,7 @@ public class HC4CookieHandler implements CookieHandler {
     /**
      * Create an HttpClient cookie from a JMeter cookie
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private org.apache.http.cookie.Cookie makeCookie(Cookie jmc) {
         long exp = jmc.getExpiresMillis();
         BasicClientCookie ret = new BasicClientCookie(jmc.getName(),

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -164,7 +165,7 @@ public class HttpRequestHdr {
                     inHeaders = false;
                     firstLine = false; // cannot be first line either
                 }
-                final String reqLine = line.toString();
+                final String reqLine = line.toString(StandardCharsets.ISO_8859_1.name());
                 if (firstLine) {
                     parseFirstLine(reqLine);
                     firstLine = false;
@@ -189,7 +190,7 @@ public class HttpRequestHdr {
         if (log.isDebugEnabled()){
             log.debug("rawPostData in default JRE encoding: {}, Request: '{}'",
                     new String(rawPostData, Charset.defaultCharset()),
-                    clientRequest.toString().replaceAll("\r\n", CRLF));
+                    clientRequest.toString(StandardCharsets.ISO_8859_1.name()).replaceAll("\r\n", CRLF));
         }
         return clientRequest.toByteArray();
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -773,7 +773,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         }
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public String[] getCertificateDetails() {
         if (isDynamicMode()) {
             try {
@@ -1540,7 +1540,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     /**
      * Initialise the user-provided keystore
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private void initUserKeyStore() {
         try {
             keyStore = getKeyStore(storePassword.toCharArray());
@@ -1562,7 +1562,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     /**
      * Initialise the dynamic domain keystore
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private void initDynamicKeyStore() throws IOException, GeneralSecurityException {
         if (storePassword  != null) { // Assume we have already created the store
             try {
@@ -1658,7 +1658,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     /**
      * Initialise the single key JMeter keystore (original behaviour)
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private void initJMeterKeyStore() throws IOException, GeneralSecurityException {
         if (storePassword != null) { // Assume we have already created the store
             try {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/BaseJMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/BaseJMSSampler.java
@@ -337,7 +337,7 @@ public abstract class BaseJMSSampler extends AbstractSampler {
      * @param message JMS Message
      * @return String with message header values.
      */
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public static String getMessageHeaders(Message message) {
         final StringBuilder response = new StringBuilder(256);
         try {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -747,7 +747,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
         }
     }
 
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     private void logThreadStart() {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Thread started {}", new Date());
@@ -794,7 +794,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
      * {@inheritDoc}
      */
     @Override
-    @SuppressWarnings("JdkObsolete")
+    @SuppressWarnings("JavaUtilDate")
     public void threadFinished() {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Thread ended {}", new Date());

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
 import org.apache.commons.lang3.StringUtils;
@@ -115,11 +116,15 @@ public class TCPClientImpl extends AbstractTCPClient {
 
             // do we need to close byte array (or flush it?)
             if(log.isDebugEnabled()) {
-                log.debug("Read: {}\n{}", w.size(), w.toString());
+                log.debug("Read: {}\n{}", w.size(), w.toString(CHARSET));
             }
             return w.toString(CHARSET);
         } catch (IOException e) {
-            throw new ReadException("Error reading from server, bytes read: " + w.size(), e, w.toString());
+            try {
+                throw new ReadException("Error reading from server, bytes read: " + w.size(), e, w.toString(CHARSET));
+            } catch (UnsupportedEncodingException ue) {
+                throw new RuntimeException("Unsupported CHARSET: " + CHARSET, ue);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Add necessary fixes such that CI build can pass.

Note that the solution I introduced, particularly for fixing the errorprone violations, are the ones requiring least amount of change, but not necessarily the most ideal:
- [`InlineMeSuggester`](http://errorprone.info/docs/inlineme) are reported in almost all places where `@Deprecated` annotation is used, thus suppressed.
- `JavaUtilDate` is suppressed, otherwise all instances of `Date` have to be replaced with `LocalDate` or `Instant`. Incidentally, all places where the violations exist are annotated with `@SuppressWarnings("JdkObsolete")`.
- For the charset-related fixes, I tried to look at what charsets are appropriate based on the file content, otherwise I fall back to `UTF8`.

## Motivation and Context

I notice that the CI build of this project has not been passing for a while now, in particular due to the commit 7d2afdc5eca3b9d6847712f79730fcac4c8a99db. A non-passing CI build allowed in development branch can and will hide subtle (and not subtle) system bugs.

## How Has This Been Tested?

Green tick in CI build. (sample: https://github.com/wkurniawan07/jmeter/actions/runs/2152075248)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
