### PR TITLE
Added Shortcut key event for Reset search - 66053

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/KeyStrokes.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/KeyStrokes.java
@@ -77,6 +77,7 @@ public final class KeyStrokes {
     public static final KeyStroke SAVE              = KeyStroke.getKeyStroke(KeyEvent.VK_S, CONTROL_MASK);
     public static final KeyStroke SAVE_ALL_AS       = KeyStroke.getKeyStroke(KeyEvent.VK_S, CONTROL_MASK | InputEvent.SHIFT_DOWN_MASK);
     public static final KeyStroke SEARCH_TREE       = KeyStroke.getKeyStroke(KeyEvent.VK_F, CONTROL_MASK);
+    public static final KeyStroke RESET_SEARCH_TREE = KeyStroke.getKeyStroke(KeyEvent.VK_F, CONTROL_MASK | InputEvent.ALT_DOWN_MASK);
     public static final KeyStroke TOGGLE            = KeyStroke.getKeyStroke(KeyEvent.VK_T, CONTROL_MASK);
     public static final KeyStroke PASTE             = KeyStroke.getKeyStroke(KeyEvent.VK_V, CONTROL_MASK);
     public static final KeyStroke WHAT_CLASS        = KeyStroke.getKeyStroke(KeyEvent.VK_W, CONTROL_MASK);

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeDialog.java
@@ -90,6 +90,8 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
 
     private JButton replaceAndFindButton;
 
+    private JButton resetSearchButton;
+
     private JButton cancelButton;
 
     private JTextField searchTF;
@@ -187,6 +189,10 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
         searchPanel.add(replaceTF);
         searchPanel.add(statusLabel, "span 2");
         searchPanel.add(searchCriterionPanel, "span 2");
+        resetSearchButton = createButton("menu_search_reset");
+        resetSearchButton.addActionListener(this);
+        searchPanel.add(resetSearchButton);
+
 
         JPanel buttonsPanel = new JPanel(new GridLayout(9, 1));
         searchButton = createButton("search_search_all"); //$NON-NLS-1$
@@ -256,7 +262,17 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
                 doReplace();
             }
             doNavigateToSearchResult(true);
+        } else if(source == resetSearchButton) {
+            doResetSearch(e);
         }
+    }
+
+
+    /**
+    * Provides Reset Search Action
+    */
+    private static void doResetSearch(ActionEvent event) {
+        ActionRouter.getInstance().doActionNow(new ActionEvent(event.getSource(), event.getID(), ActionNames.SEARCH_RESET));
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -548,7 +548,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
         searchMenu.add(search);
         search.setEnabled(true);
 
-        JMenuItem searchReset = makeMenuItemRes("menu_search_reset", 'R', ActionNames.SEARCH_RESET); //$NON-NLS-1$
+        JMenuItem searchReset = makeMenuItemRes("menu_search_reset", 'R', ActionNames.SEARCH_RESET, KeyStrokes.RESET_SEARCH_TREE); //$NON-NLS-1$
         searchMenu.add(searchReset);
         searchReset.setEnabled(true);
 

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -115,6 +115,7 @@ Summary
   <li><pr>5920</pr>Improve computation when many threads actively produce samplers by using <code>LongAdder</code> and similar concurrency classes to avoid synchronization in <code>Calculator</code></li>
   <li><pr>5920</pr>Reduce synchronization contention on <code>AbstractTestElement</code> that are shared between threads (the ones that implement <code>NoThreadClone</code>)</li>
   <li><pr>5934</pr>Added caching for date formatters for <code>__time</code> function</li>
+  <li><pr>710</pr><issue>5666</issue>Added Shortcut key event for Reset search: <code>ctrl + alt + F</code>, <code>cmd + alt + F</code></li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>
@@ -212,6 +213,7 @@ Summary
   <li>Stefan Seide (stefan at trilobyte-se.de)</li>
   <li>andreaslind01 Lind (andreaslind01 at gmail.com)</li>
   <li>Victor Peralta (vperaltac at github)</li>
+  <li>Mohamed Ibrahim (rollno748 at github)</li>
 </ul>
 <p>We also thank bug reporters who helped us improve JMeter.</p>
 <ul>


### PR DESCRIPTION
## Description
Shortcut key to Reset Search

## Motivation and Context
This shortcut will help to Reset Search while enhancing or debugging the script 

## How Has This Been Tested?
Executed Unit test on core 
Validated the shortcut in local - works perfectly!

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/18440913/167227536-d55de37f-6ca6-4cd9-9eb7-ad6fbf3e3640.png)


## Types of changes
* Adding Keyevent to enable shortcut for reset search functionality (non-breaking change which uses existing functionality)

## Checklist:
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

