### PR TITLE
Fix to Bug 66061 - Refine the log message in DefaultSamplerCreator  from the state of in progress to complete 

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -417,7 +417,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
             sampler.setPath(request.getPath(), null);
         }
         if (log.isDebugEnabled()) {
-            log.debug("Proxy: setting path: {}", sampler.getPath());
+            log.debug("Proxy: finished setting path: {}", sampler.getPath());
         }
     }
 


### PR DESCRIPTION
## Description and Motivation

Hello,

While viewing the https://issues.apache.org/jira/browse/MAPREDUCE-4262, I found that the logging statements might give inaccurate messages. 

I also find that in the line 420 of the file [DefaultSamplerCreator.java,](https://github.com/apache/jmeter/blob/659c1ff5eaea941eb7ad0638b58e904dcc06d961/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java#L420) the log messages says "setting path...". However, the path should have already been set in previous lines of code.

Would it be better if we change the verb "setting" to "finished setting" to indicate the action is completed? Or can we move the logging statement to the begining of the method? Since when there was an exception in previous lines, the logging message would not be printed, which may be not good for debugging.

Bug URL: https://bz.apache.org/bugzilla/show_bug.cgi?id=66061

## How Has This Been Tested?
logging message changed, no need to test


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
