### PR TITLE
Enable darklaf on rsyntaxtextarea again

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/LookAndFeelCommand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/LookAndFeelCommand.java
@@ -200,7 +200,7 @@ public class LookAndFeelCommand extends AbstractAction {
     }
 
     public static boolean isDarklafTheme() {
-        return "Darklaf".equals(UIManager.getLookAndFeel().getID()); // $NON-NLS-1$
+        return "Darklaf".equalsIgnoreCase(UIManager.getLookAndFeel().getID()); // $NON-NLS-1$
     }
 
     public static boolean isDark() {


### PR DESCRIPTION
## Description
SyntaxTextAreas look bad on dark mode with Darklaf, as
the id of the theme has been changed to all lowercase and we didn't recognize it anymore.

[Bugzilla Id: 66157](https://bz.apache.org/bugzilla/show_bug.cgi?id=66157)

## How Has This Been Tested?
Opened a test plan in dark mode with a JSR223 Sampler

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
