### PR TITLE
WIP: reduce use of xalan

### DIFF
--- a/extras/build.xml
+++ b/extras/build.xml
@@ -105,20 +105,13 @@
 
     <property name="lib.dir" value="${jmeter.home}/lib"/>
 
-    <!-- Use xalan copy from JMeter lib directory to ensure consistent processing with Java 1.4+ -->
-    <path id="xslt.classpath">
-        <fileset dir="${lib.dir}" includes="xalan*.jar"/>
-        <fileset dir="${lib.dir}" includes="serializer*.jar"/>
-    </path>
-
     <target name="report" depends="xslt-report,copy-images">
         <echo>Report generated at ${report.datestamp}</echo>
     </target>
 
-    <target name="xslt-report" depends="_message_xalan">
+    <target name="xslt-report">
         <tstamp><format property="report.datestamp" pattern="yyyy/MM/dd HH:mm"/></tstamp>
         <xslt
-            classpathref="xslt.classpath"
             force="true"
             in="${testpath}/${test}.jtl"
             out="${testpath}/${test}.html"
@@ -140,21 +133,5 @@
                 <equals arg1="${testpath}" arg2="${basedir}" />
         </condition>
     </target>
-
-    <!-- Check that the xalan libraries are present -->
-    <condition property="xalan.present">
-          <and>
-              <!-- No need to check all jars; just check a few -->
-            <available classpathref="xslt.classpath" classname="org.apache.xalan.processor.TransformerFactoryImpl"/>
-            <available classpathref="xslt.classpath" classname="org.apache.xml.serializer.ExtendedContentHandler"/>
-          </and>
-    </condition>
-
-    <target name="_message_xalan" unless="xalan.present">
-          <echo>Cannot find all xalan and/or serialiser jars</echo>
-        <echo>The XSLT formatting may not work correctly.</echo>
-        <echo>Check you have xalan and serializer jars in ${lib.dir}</echo>
-    </target>
-
 
 </project>

--- a/gradle.properties
+++ b/gradle.properties
@@ -134,7 +134,6 @@ spock-core.version=2.1-groovy-3.0
 springframework.version=4.3.17.RELEASE
 svgSalamander.version=1.1.2.4
 tika.version=1.28.3
-xalan.version=2.7.2
 xercesImpl.version=2.12.2
 xml-apis.version=1.4.01
 xmlgraphics-commons.version=2.7

--- a/lib/aareadme.txt
+++ b/lib/aareadme.txt
@@ -237,11 +237,6 @@ rsyntaxtextarea-3.0.4
 http://fifesoft.com/rsyntaxtextarea/
 - syntax coloration
 
-serialiser-2.7.1
-----------------
-http://www.apache.org/dyn/closer.cgi/xml/xalan-j
-- xalan
-
 slf4j-api-1.7.28
 ----------------
 http://www.slf4j.org/
@@ -258,7 +253,7 @@ commons-dbcp2-2.5.0 (org.apache.commons.dbcp2)
 --------------------------
 - DataSourceElement (JDBC)
 
-Saxon-HE-9.9.1-5 (net.sf.saxon)
+Saxon-HE-11.3 (net.sf.saxon)
 --------------------------
 - XPath2Extractor (XML)
 
@@ -266,11 +261,6 @@ velocity-1.7
 --------------
 http://velocity.apache.org/download.cgi
 - Anakia (create documentation) Not used by JMeter runtime
-
-xalan_2.7.1
------------
-http://www.apache.org/dyn/closer.cgi/xml/xalan-j
-+org.apache.xalan|xml|xpath
 
 xercesImpl-2.12.0
 ----------------

--- a/src/bom/build.gradle.kts
+++ b/src/bom/build.gradle.kts
@@ -162,8 +162,6 @@ dependencies {
         apiv("org.slf4j:slf4j-api", "slf4j")
         apiv("org.spockframework:spock-core")
         apiv("oro:oro")
-        apiv("xalan:serializer", "xalan")
-        apiv("xalan:xalan", "xalan")
         apiv("xerces:xercesImpl")
         apiv("xml-apis:xml-apis")
         apiv("xmlpull:xmlpull")

--- a/src/components/src/main/java/org/apache/jmeter/extractor/XPath2Extractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/XPath2Extractor.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.transform.TransformerException;
 
 import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.processor.PostProcessor;
@@ -223,7 +224,7 @@ public class XPath2Extractor
      * @throws FactoryConfigurationError
      */
     private void getValuesForXPath(String query, List<String> matchStrings, int matchNumber, String responseData)
-            throws SaxonApiException, FactoryConfigurationError {
+            throws SaxonApiException, TransformerException, FactoryConfigurationError {
         XPathUtil.putValuesForXPathInListUsingSaxon(responseData, query, matchStrings, getFragment(), matchNumber, getNamespaces());
     }
 

--- a/src/components/src/test/java/org/apache/jmeter/assertions/XPathAssertionTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/XPathAssertionTest.java
@@ -240,7 +240,8 @@ public class XPathAssertionTest extends JMeterTestCase {
         testLog.debug("isError() {} isFailure() {}", res.isError(), res.isFailure());
         testLog.debug("failure message: {}", res.getFailureMessage());
         assertFalse("Should not be an error", res.isError());
-        assertTrue("Should be a failure",res.isFailure());
+        //this used to result in isFailure()=true but is now fixed (after switching from Xalan to Saxon for XPath support)
+        assertFalse("Should not be a failure", res.isFailure());
     }
 
     @Test

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestXPathExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestXPathExtractor.java
@@ -32,6 +32,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jmeter.util.XPathUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -195,7 +196,7 @@ public class TestXPathExtractor {
         // No text, but using fragment mode
         extractor.setXPathQuery("//a");
         extractor.process();
-        assertEquals("<a><b/></a>", vars.get(VAL_NAME));
+        assertEquals(XPathUtil.formatXml("<a><b/></a>"), XPathUtil.formatXml(vars.get(VAL_NAME)));
     }
 
     @Test
@@ -283,7 +284,7 @@ public class TestXPathExtractor {
         if (Locale.getDefault().getLanguage().startsWith(Locale.ENGLISH.getLanguage())) {
             assertThat(
                     firstResult.getFailureMessage(),
-                    containsString("A location path was expected, but the following token was encountered")
+                    containsString("Unexpected token \"<\" at start of expression")
             );
         }
         assertEquals("Default", vars.get(VAL_NAME));

--- a/src/core/build.gradle.kts
+++ b/src/core/build.gradle.kts
@@ -50,11 +50,6 @@ dependencies {
     api("oro:oro") {
         because("Perl5Matcher org.apache.jmeter.util.JMeterUtils.getMatcher()")
     }
-    api("xalan:xalan") {
-        because("PropertiesBasedPrefixResolver extends PrefixResolverDefault")
-    }
-    // Note: Saxon should go AFTER xalan so xalan XSLT is used
-    // org.apache.jmeter.util.XPathUtilTest.testFormatXmlSimple assumes xalan transformer
     api("net.sf.saxon:Saxon-HE") {
         because("XPathUtil: throws SaxonApiException")
     }

--- a/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
@@ -128,7 +128,7 @@ public class PrefixResolverDefault
     /**
      * Return the base identifier.
      *
-     * @return null
+     * @return null by default
      */
     public String getBaseIdentifier()
     {
@@ -136,7 +136,7 @@ public class PrefixResolverDefault
     }
 
     /**
-     * @see PrefixResolver#handlesNullPrefixes()
+     * @return false by default
      */
     public boolean handlesNullPrefixes() {
         return false;

--- a/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
@@ -92,7 +92,9 @@ public class PrefixResolverDefault
                 if (type == Node.ELEMENT_NODE)
                 {
                     if (parent.getNodeName().indexOf(prefix+":") == 0)
+                    {
                         return parent.getNamespaceURI();
+                    }
                     NamedNodeMap nnm = parent.getAttributes();
 
                     for (int i = 0; i < nnm.getLength(); i++)

--- a/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
@@ -25,7 +25,6 @@ import org.w3c.dom.Node;
  * This class implements a generic PrefixResolver that
  * can be used to perform prefix-to-namespace lookup
  * for the XPath object.
- * @xsl.usage general
  */
 public class PrefixResolverDefault
 {

--- a/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
@@ -17,9 +17,10 @@
 
 package org.apache.jmeter.util;
 
-import org.apache.xml.utils.Constants;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+
+import javax.xml.XMLConstants;
 
 /**
  * This class implements a generic PrefixResolver that
@@ -79,7 +80,7 @@ public class PrefixResolverDefault
 
         if (prefix.equals("xml"))
         {
-            namespace = Constants.S_XMLNAMESPACEURI;
+            namespace = XMLConstants.XML_NS_URI;
         }
         else
         {

--- a/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.util;
+
+import org.apache.xml.utils.Constants;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+/**
+ * This class implements a generic PrefixResolver that
+ * can be used to perform prefix-to-namespace lookup
+ * for the XPath object.
+ * @xsl.usage general
+ */
+public class PrefixResolverDefault
+{
+
+    /**
+     * The context to resolve the prefix from, if the context
+     * is not given.
+     */
+    Node m_context;
+
+    /**
+     * Construct a PrefixResolverDefault object.
+     * @param xpathExpressionContext The context from
+     * which XPath expression prefixes will be resolved.
+     * Warning: This will not work correctly if xpathExpressionContext
+     * is an attribute node.
+     */
+    public PrefixResolverDefault(Node xpathExpressionContext)
+    {
+        m_context = xpathExpressionContext;
+    }
+
+    /**
+     * Given a namespace, get the corrisponding prefix.  This assumes that
+     * the PrevixResolver hold's it's own namespace context, or is a namespace
+     * context itself.
+     * @param prefix Prefix to resolve.
+     * @return Namespace that prefix resolves to, or null if prefix
+     * is not bound.
+     */
+    public String getNamespaceForPrefix(String prefix)
+    {
+        return getNamespaceForPrefix(prefix, m_context);
+    }
+
+    /**
+     * Given a namespace, get the corrisponding prefix.
+     * Warning: This will not work correctly if namespaceContext
+     * is an attribute node.
+     * @param prefix Prefix to resolve.
+     * @param namespaceContext Node from which to start searching for a
+     * xmlns attribute that binds a prefix to a namespace.
+     * @return Namespace that prefix resolves to, or null if prefix
+     * is not bound.
+     */
+    public String getNamespaceForPrefix(String prefix,
+                                        org.w3c.dom.Node namespaceContext)
+    {
+
+        Node parent = namespaceContext;
+        String namespace = null;
+
+        if (prefix.equals("xml"))
+        {
+            namespace = Constants.S_XMLNAMESPACEURI;
+        }
+        else
+        {
+            int type;
+
+            while ((null != parent) && (null == namespace)
+                    && (((type = parent.getNodeType()) == Node.ELEMENT_NODE)
+                    || (type == Node.ENTITY_REFERENCE_NODE)))
+            {
+                if (type == Node.ELEMENT_NODE)
+                {
+                    if (parent.getNodeName().indexOf(prefix+":") == 0)
+                        return parent.getNamespaceURI();
+                    NamedNodeMap nnm = parent.getAttributes();
+
+                    for (int i = 0; i < nnm.getLength(); i++)
+                    {
+                        Node attr = nnm.item(i);
+                        String aname = attr.getNodeName();
+                        boolean isPrefix = aname.startsWith("xmlns:");
+
+                        if (isPrefix || aname.equals("xmlns"))
+                        {
+                            int index = aname.indexOf(':');
+                            String p = isPrefix ? aname.substring(index + 1) : "";
+
+                            if (p.equals(prefix))
+                            {
+                                namespace = attr.getNodeValue();
+
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                parent = parent.getParentNode();
+            }
+        }
+
+        return namespace;
+    }
+
+    /**
+     * Return the base identifier.
+     *
+     * @return null
+     */
+    public String getBaseIdentifier()
+    {
+        return null;
+    }
+
+    /**
+     * @see PrefixResolver#handlesNullPrefixes()
+     */
+    public boolean handlesNullPrefixes() {
+        return false;
+    }
+
+}

--- a/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PrefixResolverDefault.java
@@ -17,10 +17,10 @@
 
 package org.apache.jmeter.util;
 
+import javax.xml.XMLConstants;
+
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
-
-import javax.xml.XMLConstants;
 
 /**
  * This class implements a generic PrefixResolver that

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
@@ -29,8 +29,6 @@ import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JOrphanUtils;
-import org.apache.xml.utils.PrefixResolver;
-import org.apache.xml.utils.PrefixResolverDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
@@ -38,7 +36,7 @@ import org.w3c.dom.Node;
 import javax.xml.namespace.NamespaceContext;
 
 /**
- * {@link PrefixResolver} implementation that loads prefix configuration from jmeter property xpath.namespace.config
+ * PrefixResolver implementation that loads prefix configuration from jmeter property xpath.namespace.config
  */
 public class PropertiesBasedPrefixResolver extends PrefixResolverDefault implements NamespaceContext {
     private static final Logger log = LoggerFactory.getLogger(PropertiesBasedPrefixResolver.class);

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
@@ -34,10 +35,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
 
+import javax.xml.namespace.NamespaceContext;
+
 /**
  * {@link PrefixResolver} implementation that loads prefix configuration from jmeter property xpath.namespace.config
  */
-public class PropertiesBasedPrefixResolver extends PrefixResolverDefault {
+public class PropertiesBasedPrefixResolver extends PrefixResolverDefault implements NamespaceContext {
     private static final Logger log = LoggerFactory.getLogger(PropertiesBasedPrefixResolver.class);
     private static final String XPATH_NAMESPACE_CONFIG = "xpath.namespace.config";
     private static final Map<String, String> NAMESPACE_MAP = new HashMap<>();
@@ -85,11 +88,44 @@ public class PropertiesBasedPrefixResolver extends PrefixResolverDefault {
      */
     @Override
     public String getNamespaceForPrefix(String prefix, Node namespaceContext) {
-        String namespace = NAMESPACE_MAP.get(prefix);
+        String namespace = getNamespaceURI(prefix);
         if(namespace==null) {
             return super.getNamespaceForPrefix(prefix, namespaceContext);
         } else {
             return namespace;
         }
+    }
+
+    @Override
+    public String getNamespaceURI(String prefix) {
+        return NAMESPACE_MAP.get(prefix);
+    }
+
+    @Override
+    public String getPrefix(String namespaceURI) {
+        if (namespaceURI != null) {
+            for (Map.Entry<String, String> entry : NAMESPACE_MAP.entrySet()) {
+                if (namespaceURI.equals(entry.getValue())) {
+                    return entry.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Iterator<String> getPrefixes(String namespaceURI) {
+        return NAMESPACE_MAP.keySet().iterator();
+    }
+
+    String getNamespacesAsLineDelimitedProperties() {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, String> entry : NAMESPACE_MAP.entrySet()) {
+            builder.append(entry.getKey())
+                    .append('=')
+                    .append(entry.getValue())
+                    .append('\n');
+        }
+        return builder.toString();
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
@@ -27,13 +27,13 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.xml.namespace.NamespaceContext;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
-
-import javax.xml.namespace.NamespaceContext;
 
 /**
  * PrefixResolver implementation that loads prefix configuration from jmeter property xpath.namespace.config

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
@@ -21,14 +21,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.xml.utils.PrefixResolver;
-import org.apache.xml.utils.PrefixResolverDefault;
 import org.w3c.dom.Node;
 
 import javax.xml.namespace.NamespaceContext;
 
 /**
- * {@link PrefixResolver} implementation that loads prefix configuration from
+ * PrefixResolver implementation that loads prefix configuration from
  * jmeter property xpath.namespace.config
  */
 public class PropertiesBasedPrefixResolverForXpath2 extends PrefixResolverDefault implements NamespaceContext {

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
@@ -21,9 +21,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.w3c.dom.Node;
-
 import javax.xml.namespace.NamespaceContext;
+
+import org.w3c.dom.Node;
 
 /**
  * PrefixResolver implementation that loads prefix configuration from

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
@@ -18,17 +18,20 @@
 package org.apache.jmeter.util;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.xml.utils.PrefixResolver;
 import org.apache.xml.utils.PrefixResolverDefault;
 import org.w3c.dom.Node;
 
+import javax.xml.namespace.NamespaceContext;
+
 /**
  * {@link PrefixResolver} implementation that loads prefix configuration from
  * jmeter property xpath.namespace.config
  */
-public class PropertiesBasedPrefixResolverForXpath2 extends PrefixResolverDefault {
+public class PropertiesBasedPrefixResolverForXpath2 extends PrefixResolverDefault implements NamespaceContext {
     private Map<String, String> namespaceMap = new HashMap<>();
 
     /**
@@ -55,11 +58,33 @@ public class PropertiesBasedPrefixResolverForXpath2 extends PrefixResolverDefaul
      */
     @Override
     public String getNamespaceForPrefix(String prefix, Node namespaceContext) {
-        String namespace = namespaceMap.get(prefix);
+        String namespace = getNamespaceURI(prefix);
         if (namespace == null) {
             return super.getNamespaceForPrefix(prefix, namespaceContext);
         } else {
             return namespace;
         }
+    }
+
+    @Override
+    public String getNamespaceURI(String prefix) {
+        return namespaceMap.get(prefix);
+    }
+
+    @Override
+    public String getPrefix(String namespaceURI) {
+        if (namespaceURI != null) {
+            for (Map.Entry<String, String> entry : namespaceMap.entrySet()) {
+                if (namespaceURI.equals(entry.getValue())) {
+                    return entry.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Iterator<String> getPrefixes(String namespaceURI) {
+        return namespaceMap.keySet().iterator();
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -50,12 +50,11 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactoryConfigurationException;
 
+import net.sf.saxon.s9api.ItemType;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.jmeter.assertions.AssertionResult;
-import org.apache.xml.utils.PrefixResolver;
-import org.apache.xpath.XPathAPI;
-import org.apache.xpath.objects.XObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -560,7 +559,7 @@ public class XPathUtil {
      *
      * @param document XML Document
      * @param namespaces String series of prefix/namespace values separator by line break
-     * @return {@link PrefixResolver}
+     * @return {@link PropertiesBasedPrefixResolverForXpath2}
      */
     private static PropertiesBasedPrefixResolverForXpath2 getPrefixResolverForXPath2(Document document, String namespaces) {
         return new PropertiesBasedPrefixResolverForXpath2(document.getDocumentElement(), namespaces);
@@ -651,7 +650,6 @@ public class XPathUtil {
             try {
                 Document doc;
                 doc = XPathUtil.makeDocumentBuilder(false, false, false, false).newDocument();
-                XObject xObject = XPathAPI.eval(doc, xPathQuery, getPrefixResolverForXPath2(doc, namespaces));
                 selector = xPathExecutable.load();
                 selector.setContextItem(xdmNode);
                 XdmValue nodes = selector.evaluate();
@@ -660,13 +658,13 @@ public class XPathUtil {
                 // In case we need to extract everything
                 if (length == 0) {
                     resultOfEval = false;
-                } else if (xObject.getType() == XObject.CLASS_BOOLEAN) {
+                } else if (nodes.itemAt(0).matches(ItemType.BOOLEAN)) {
                     resultOfEval = Boolean.parseBoolean(nodes.itemAt(0).getStringValue());
                 }
                 result.setFailure(isNegated ? resultOfEval : !resultOfEval);
                 result.setFailureMessage(
                         isNegated ? "Nodes Matched for " + xPathQuery : "No Nodes Matched for " + xPathQuery);
-            } catch (ParserConfigurationException | TransformerException e) { // NOSONAR Exception handled by return
+            } catch (ParserConfigurationException e) { // NOSONAR Exception handled by return
                 result.setError(true);
                 result.setFailureMessage("Exception: " + e.getMessage() + " for:" + xPathQuery);
             } finally {

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -646,8 +646,6 @@ public class XPathUtil {
         if (xPathExecutable != null) {
             XPathSelector selector = null;
             try {
-                Document doc;
-                doc = XPathUtil.makeDocumentBuilder(false, false, false, false).newDocument();
                 selector = xPathExecutable.load();
                 selector.setContextItem(xdmNode);
                 XdmValue nodes = selector.evaluate();
@@ -662,9 +660,6 @@ public class XPathUtil {
                 result.setFailure(isNegated ? resultOfEval : !resultOfEval);
                 result.setFailureMessage(
                         isNegated ? "Nodes Matched for " + xPathQuery : "No Nodes Matched for " + xPathQuery);
-            } catch (ParserConfigurationException e) { // NOSONAR Exception handled by return
-                result.setError(true);
-                result.setFailureMessage("Exception: " + e.getMessage() + " for:" + xPathQuery);
             } finally {
                 if (selector != null) {
                     try {

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -50,8 +51,6 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactoryConfigurationException;
 
-import net.sf.saxon.s9api.ItemType;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.jmeter.assertions.AssertionResult;
@@ -67,6 +66,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import net.sf.saxon.s9api.ItemType;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XPathExecutable;
@@ -78,8 +78,6 @@ import net.sf.saxon.xpath.XPathFactoryImpl;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
-
-import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
  * This class provides a few utility methods for dealing with XML/XPath.
@@ -127,7 +125,7 @@ public class XPathUtil {
                 || documentBuilderFactory.isIgnoringElementContentWhitespace() != whitespace) {
             // configure the document builder factory
             documentBuilderFactory = DocumentBuilderFactory.newInstance();
-            documentBuilderFactory.setFeature(FEATURE_SECURE_PROCESSING, true);
+            documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             documentBuilderFactory.setValidating(validate);
             documentBuilderFactory.setNamespaceAware(namespace);
             documentBuilderFactory.setIgnoringElementContentWhitespace(whitespace);
@@ -528,7 +526,7 @@ public class XPathUtil {
     /**
      *
      * @param document XML Document
-     * @return {@link PrefixResolver}
+     * @return {@link PropertiesBasedPrefixResolver}
      */
     private static PropertiesBasedPrefixResolver getPrefixResolver(Document document) {
         return new PropertiesBasedPrefixResolver(document.getDocumentElement());
@@ -688,7 +686,7 @@ public class XPathUtil {
     public static String formatXml(String xml){
         try {
             TransformerFactory factory = TransformerFactory.newInstance();
-            factory.setFeature(FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             Transformer serializer= factory.newTransformer();
             serializer.setOutputProperty(OutputKeys.INDENT, "yes");
             serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
@@ -708,7 +706,7 @@ public class XPathUtil {
 
     private static XPath newXPath(NamespaceContext namespaceContext) throws XPathFactoryConfigurationException {
         XPathFactoryImpl xPathFactory = new XPathFactoryImpl();
-        xPathFactory.setFeature(FEATURE_SECURE_PROCESSING, true);
+        xPathFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         XPath xPath = xPathFactory.newXPath();
         xPath.setNamespaceContext(namespaceContext);
         return xPath;

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -42,7 +42,6 @@ import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
@@ -66,6 +65,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import net.sf.saxon.jaxp.SaxonTransformerFactory;
 import net.sf.saxon.s9api.ItemType;
 import net.sf.saxon.s9api.Processor;
 import net.sf.saxon.s9api.SaxonApiException;
@@ -693,11 +693,12 @@ public class XPathUtil {
      */
     public static String formatXml(String xml){
         try {
-            TransformerFactory factory = TransformerFactory.newInstance();
+            SaxonTransformerFactory factory = new SaxonTransformerFactory();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            Transformer serializer= factory.newTransformer();
+            Transformer serializer = factory.newTransformer();
+            serializer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
             serializer.setOutputProperty(OutputKeys.INDENT, "yes");
-            serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            //serializer.setOutputProperty("{http://saxon.sf.net/}indent-spaces", "2");
             Source xmlSource = new SAXSource(new InputSource(new StringReader(xml)));
             StringWriter stringWriter = new StringWriter();
             StreamResult res = new StreamResult(stringWriter);

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -27,7 +27,6 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
@@ -309,26 +308,6 @@ public class XPathUtil {
             }
         }
     }
-
-    /**
-     * Return value for node including node element
-     * @param node Node
-     * @return String
-     */
-    private static String getNodeContent(Node node) {
-        StringWriter sw = new StringWriter();
-        try {
-            TransformerFactory factory = TransformerFactory.newInstance();
-            factory.setFeature(FEATURE_SECURE_PROCESSING, true);
-            Transformer t = factory.newTransformer();
-            t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-            t.transform(new DOMSource(node), new StreamResult(sw));
-        } catch (TransformerException e) {
-            sw.write(e.getMessageAndLocation());
-        }
-        return sw.toString();
-    }
-
 
     /**
      * @param node {@link Node}

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -72,7 +73,7 @@ public class XPathUtilTest {
     }
 
     @Test
-    public void testputValuesForXPathInListUsingSaxon() throws SaxonApiException, FactoryConfigurationError{
+    public void testputValuesForXPathInListUsingSaxon() throws Exception {
         String xPathQuery="//Employees/Employee/role";
         ArrayList<String> matchStrings = new ArrayList<String>();
         boolean fragment = false;
@@ -263,10 +264,13 @@ public class XPathUtilTest {
     }
 
     @Test
-    public void testPutValuesForXPathInList() throws ParserConfigurationException, SAXException, IOException, TidyException, TransformerException {
+    public void testPutValuesForXPathInList()
+            throws ParserConfigurationException, SAXException, IOException, TidyException, TransformerException {
         String responseData = "<book><page>one</page><page>two</page><empty></empty><a><b></b></a></book>";
         Document testDoc = XPathUtil.makeDocument(
-                new ByteArrayInputStream(responseData.getBytes(StandardCharsets.UTF_8)), false, false, false, false,
+                new ByteArrayInputStream(
+                        responseData.getBytes(StandardCharsets.UTF_8)),
+                false, false, false, false,
                 false, false, false, false, false);
         String xpathquery = "/book/page";
         List<String> matchs=new ArrayList<>();
@@ -275,8 +279,13 @@ public class XPathUtilTest {
         assertEquals("<page>two</page>", matchs.get(1));
         matchs=new ArrayList<>();
         XPathUtil.putValuesForXPathInList(testDoc, xpathquery, matchs, false);
+        assertEquals(2, matchs.size());
         assertEquals("one", matchs.get(0));
         assertEquals("two", matchs.get(1));
+        matchs=new ArrayList<>();
+        XPathUtil.putValuesForXPathInList(testDoc, "/book/a", matchs, false);
+        assertEquals(1, matchs.size());
+        assertNull(matchs.get(0));
     }
 
     @Test

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -147,7 +147,7 @@ public class XPathUtilTest {
     @Test
     public void testFormatXmlSimple() {
         assertThat(XPathUtil.formatXml("<one foo='bar'>Test</one>"),
-                CoreMatchers.is("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                CoreMatchers.is("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + lineSeparator
                         + "<one foo=\"bar\">Test</one>" + lineSeparator));
     }
 
@@ -156,11 +156,12 @@ public class XPathUtilTest {
         assertThat(
                 XPathUtil.formatXml(
                         "<one foo='bar'><two/><three><four p=\"1\"/></three>...</one>"),
-                CoreMatchers.is(String.join(lineSeparator, "<?xml version=\"1.0\" encoding=\"UTF-8\"?><one foo=\"bar\">",
-                        "  <two/>",
-                        "  <three>",
-                        "    <four p=\"1\"/>",
-                        "  </three>...</one>",
+                CoreMatchers.is(String.join(lineSeparator, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                        "<one foo=\"bar\">",
+                        "   <two/>",
+                        "   <three>",
+                        "      <four p=\"1\"/>",
+                        "   </three>...</one>",
                         "")));
     }
 

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -147,8 +147,8 @@ public class XPathUtilTest {
     @Test
     public void testFormatXmlSimple() {
         assertThat(XPathUtil.formatXml("<one foo='bar'>Test</one>"),
-                CoreMatchers.is("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + lineSeparator
-                        + "<one foo=\"bar\">Test</one>" + lineSeparator));
+                CoreMatchers.is("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n"
+                        + "<one foo=\"bar\">Test</one>" + "\n"));
     }
 
     @Test
@@ -156,7 +156,7 @@ public class XPathUtilTest {
         assertThat(
                 XPathUtil.formatXml(
                         "<one foo='bar'><two/><three><four p=\"1\"/></three>...</one>"),
-                CoreMatchers.is(String.join(lineSeparator, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                CoreMatchers.is(String.join("\n", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
                         "<one foo=\"bar\">",
                         "   <two/>",
                         "   <three>",

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import net.sf.saxon.s9api.Processor;
@@ -259,5 +261,20 @@ public class XPathUtilTest {
         XPathUtil.putValuesForXPathInList(testDoc, "/book/a", matchs, false);
         assertEquals(1, matchs.size());
         assertNull(matchs.get(0));
+    }
+
+    @Test
+    public void testSelectNodeList() throws ParserConfigurationException, SAXException, IOException, TidyException, TransformerException {
+        String responseData = "<book><page>one</page><page>two</page><empty></empty><a><b></b></a></book>";
+        Document testDoc = XPathUtil.makeDocument(
+                new ByteArrayInputStream(responseData.getBytes(StandardCharsets.UTF_8)), false, false, false, false,
+                false, false, false, false, false);
+        String xpathquery = "/book/page";
+        NodeList nodeList = XPathUtil.selectNodeList(testDoc, xpathquery);
+        assertEquals(2, nodeList.getLength());
+        Element e0 = (Element) nodeList.item(0);
+        Element e1 = (Element) nodeList.item(1);
+        assertEquals("one", e0.getTextContent());
+        assertEquals("two", e1.getTextContent());
     }
 }

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -40,6 +40,8 @@ import org.apache.jmeter.assertions.AssertionResult;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import net.sf.saxon.s9api.Processor;
@@ -275,5 +277,20 @@ public class XPathUtilTest {
         XPathUtil.putValuesForXPathInList(testDoc, xpathquery, matchs, false);
         assertEquals("one", matchs.get(0));
         assertEquals("two", matchs.get(1));
+    }
+
+    @Test
+    public void testSelectNodeList() throws ParserConfigurationException, SAXException, IOException, TidyException, TransformerException {
+        String responseData = "<book><page>one</page><page>two</page><empty></empty><a><b></b></a></book>";
+        Document testDoc = XPathUtil.makeDocument(
+                new ByteArrayInputStream(responseData.getBytes(StandardCharsets.UTF_8)), false, false, false, false,
+                false, false, false, false, false);
+        String xpathquery = "/book/page";
+        NodeList nodeList = XPathUtil.selectNodeList(testDoc, xpathquery);
+        assertEquals(2, nodeList.getLength());
+        Element e0 = (Element) nodeList.item(0);
+        Element e1 = (Element) nodeList.item(1);
+        assertEquals("one", e0.getTextContent());
+        assertEquals("two", e1.getTextContent());
     }
 }

--- a/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/XPathUtilTest.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -251,7 +252,12 @@ public class XPathUtilTest {
         assertEquals("<page>two</page>", matchs.get(1));
         matchs=new ArrayList<>();
         XPathUtil.putValuesForXPathInList(testDoc, xpathquery, matchs, false);
+        assertEquals(2, matchs.size());
         assertEquals("one", matchs.get(0));
         assertEquals("two", matchs.get(1));
+        matchs=new ArrayList<>();
+        XPathUtil.putValuesForXPathInList(testDoc, "/book/a", matchs, false);
+        assertEquals(1, matchs.size());
+        assertNull(matchs.get(0));
     }
 }

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -118,7 +118,6 @@
 1383644,rhino-1.7.14.jar
 1248250,rsyntaxtextarea-3.2.0.jar
 5111311,Saxon-HE-11.3.jar
-276420,serializer-2.7.2.jar
 41125,slf4j-api-1.7.36.jar
 301279,svgSalamander-1.1.2.4.jar
 10192,swing-extensions-laf-support-0.1.3.jar
@@ -126,7 +125,6 @@
 735701,tika-core-1.28.3.jar
 1587751,tika-parsers-1.28.3.jar
 174661,vis-svg-portable-jvm-2.2.1.jar
-3154938,xalan-2.7.2.jar
 1446149,xercesImpl-2.12.2.jar
 220536,xml-apis-1.4.01.jar
 85686,xml-apis-ext-1.3.04.jar

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -118,6 +118,7 @@
 1383644,rhino-1.7.14.jar
 1248250,rsyntaxtextarea-3.2.0.jar
 5111311,Saxon-HE-11.3.jar
+276420,serializer-2.7.2.jar
 41125,slf4j-api-1.7.36.jar
 301279,svgSalamander-1.1.2.4.jar
 10192,swing-extensions-laf-support-0.1.3.jar
@@ -125,6 +126,7 @@
 735701,tika-core-1.28.3.jar
 1587751,tika-parsers-1.28.3.jar
 174661,vis-svg-portable-jvm-2.2.1.jar
+3154938,xalan-2.7.2.jar
 1446149,xercesImpl-2.12.2.jar
 220536,xml-apis-1.4.01.jar
 85686,xml-apis-ext-1.3.04.jar

--- a/src/functions/src/main/java/org/apache/jmeter/functions/XPathFileContainer.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/XPathFileContainer.java
@@ -62,7 +62,7 @@ public class XPathFileContainer {
         nodeList=load(xpath);
     }
 
-    private NodeList load(String xpath) throws IOException, FileNotFoundException, ParserConfigurationException, SAXException,
+    private NodeList load(String xpath) throws IOException, ParserConfigurationException, SAXException,
             TransformerException {
         NodeList nl = null;
         try ( FileInputStream fis = new FileInputStream(fileName);


### PR DESCRIPTION
## Description

See:
* https://github.com/apache/jmeter/issues/5690
* https://bz.apache.org/bugzilla/show_bug.cgi?id=66171


This is a POC - if the changes look like a valid way forward, I can put more effort in.
Some tests are failing and will be investigated
Probably need some new tests too
The ant build.xml needs changes - is Ant still used?

## Motivation and Context

* Xalan releases are infrequent.
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-34169 is not fixed


## How Has This Been Tested?

unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

Probably not a huge deal. Main worry is that some XPath expressions may not behave exactly the same as before. Another issue is that PropertiesBasedPrefixResolver and PropertiesBasedPrefixResolverForXpath2 are public classes that extend a xalan interface (PrefixResolver) - this POC removes the use of that xalan interface.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
