### PR TITLE
[65318] JSON Assertion: Use correct number format

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -19,6 +19,8 @@ package org.apache.jmeter.assertions;
 
 import java.io.Serializable;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -58,7 +60,7 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
             ThreadLocal.withInitial(JSONPathAssertion::createDecimalFormat);
 
     private static DecimalFormat createDecimalFormat() {
-        DecimalFormat decimalFormatter = new DecimalFormat("#.#");
+        DecimalFormat decimalFormatter = new DecimalFormat("#.#", new DecimalFormatSymbols(Locale.US));
         decimalFormatter.setMaximumFractionDigits(340); // java.text.DecimalFormat.DOUBLE_FRACTION_DIGITS == 340
         decimalFormatter.setMinimumFractionDigits(1);
         return decimalFormatter;


### PR DESCRIPTION
## Description
See https://bz.apache.org/bugzilla/show_bug.cgi?id=65318

## Motivation and Context
This PR fixes the issues with JSON Assertions mentioned here: https://bz.apache.org/bugzilla/show_bug.cgi?id=65318

## How Has This Been Tested?
Tested with the example testplan provided in the issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
