### PR TITLE
Bug 66269: Add NoThreadClone to HeaderManager to reduce heap utilization

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -489,6 +489,15 @@ remote_hosts=127.0.0.1
 # RETURN_CUSTOM_STATUS.message=
 
 #---------------------------------------------------------------------------
+# HTTP Header Manager configuration
+#---------------------------------------------------------------------------
+# Save memory by sharing HTTP Header Manager across threads.
+# The drawback is that HTTP Header Manager's can't be modified in the runtime
+# as all the threads would notice the change.
+# If you need dynamic headers, consider using ${..} functions or variables
+#http.header_manager.is_shareable=true
+
+#---------------------------------------------------------------------------
 # Results file configuration
 #---------------------------------------------------------------------------
 

--- a/src/core/src/main/java/org/apache/jmeter/engine/TreeCloner.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/TreeCloner.java
@@ -71,7 +71,7 @@ public class TreeCloner implements HashTreeTraverser {
     protected Object addNodeToTree(Object node) {
         if ( (node instanceof TestElement) // Check can cast for clone
            // Don't clone NoThreadClone unless honourNoThreadClone == false
-          && !(honourNoThreadClone && node instanceof NoThreadClone)
+          && !(honourNoThreadClone && node instanceof NoThreadClone && ((NoThreadClone) node).isShareable())
         ) {
             Object newNode = ((TestElement) node).clone();
             newTree.add(objects, newNode);

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/NoThreadClone.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/NoThreadClone.java
@@ -24,4 +24,13 @@ package org.apache.jmeter.engine.util;
  *
  */
 public interface NoThreadClone {
+    /**
+     * Allows element to indicate whether it can be shared between threads.
+     * By default, elements that implement {@code NoThreadClone} are shareable.
+     *
+     * @return true if the element is shareable between threads, so it won't be cloned
+     */
+    default boolean isShareable() {
+        return true;
+    }
 }

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -503,7 +503,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
      */
     @Override
     public void recoverRunningVersion() {
-        if (this instanceof NoThreadClone) {
+        if (this instanceof NoThreadClone && ((NoThreadClone) this).isShareable()) {
             // The element is shared between threads, so there's nothing to recover
             // See https://github.com/apache/jmeter/issues/5875
             return;

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -108,6 +108,7 @@ Summary
     Previously it cached the values based on iteration number only which triggered wrong results on concurrent executions.
     The previous behavior can be temporary restored with <code>function.cache.per.iteration</code> property.
   </li>
+  <li><pr></pr> Add <code>NoThreadClone#isShareable</code> method so the elements can dynamically decide if they need cloning or not</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -75,6 +75,7 @@ Summary
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
   <li><pr>5911</pr> Use Caffeine for caching HTTP headers instead of commons-collections4 LRUMap</li>
+  <li><pr>727</pr> Save memory when test plan contains lots of HTTP Header Manager elements by sharing the managers across threads (add NoThreadClone to HeaderManager)</li>
 </ul>
 
 <h3>Other samplers</h3>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -602,6 +602,23 @@ JMETER-SERVER</source>
 </property>
 </properties>
 </section>
+
+  <section name="&sect-num;.14 HTTP Header Manager configuration" anchor="http_header_manager">
+    <properties>
+      <property name="http.header_manager.is_shareable">
+        By default, HTTP Header Manager elements are shared between threads. It enables to save memory by not
+        cloning the elements for each thread, however, the drawback is that HTTP Header Manager's can't be
+        modified in the runtime.<br/>
+        However, HTTP Header Managers still support <code>${...}</code> functions and variables, so it is still
+        possible to have dynamic headers.
+        <br/>
+        Defaults to:
+        <code>true</code>
+      </property>
+    </properties>
+  </section>
+
+
 <section name="&sect-num;.15 Results file configuration" anchor="results_file_config">
 <properties>
 <property name="jmeter.save.saveservice.output_format">


### PR DESCRIPTION
## Motivation and Context

HeaderManager consumes heap, and it looks it can be reused between threads.

Fixes https://github.com/apache/jmeter/issues/5708