### PR TITLE
doc: handle <issue> markup in documentation

### DIFF
--- a/xdocs/stylesheets/website-style.xsl
+++ b/xdocs/stylesheets/website-style.xsl
@@ -552,7 +552,7 @@
       Bug
       <xsl:value-of select="./text()" />
     </a>
-    -
+    <xsl:call-template name="issue_separator"/>
   </xsl:template>
 
   <xsl:template match="rfc">
@@ -566,23 +566,27 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="pr[following-sibling::pr or following-sibling::bug]">
-    <a href="https://github.com/apache/jmeter/pull/{./text()}">
-      Pull request #<xsl:value-of select="./text()" />
-    </a>,
-  </xsl:template>
-
-  <xsl:template match="pr[not(following-sibling::pr) and (not(preceding-sibling::*) or preceding-sibling::bug or preceding-sibling::pr)]">
-    <a href="https://github.com/apache/jmeter/pull/{./text()}">
-      Pull request #<xsl:value-of select="./text()" />
-    </a>
-    -
-  </xsl:template>
-
   <xsl:template match="pr">
     <a href="https://github.com/apache/jmeter/pull/{./text()}">
       Pull request #<xsl:value-of select="./text()" />
     </a>
+    <xsl:call-template name="issue_separator"/>
+  </xsl:template>
+
+  <xsl:template match="issue">
+    <a href="https://github.com/apache/jmeter/issues/{./text()}">
+      Issue #<xsl:value-of select="./text()" />
+    </a>
+    <xsl:call-template name="issue_separator"/>
+  </xsl:template>
+
+  <xsl:template name="issue_separator">
+    <xsl:choose>
+      <xsl:when test="following-sibling::issue or following-sibling::pr or following-sibling::bug">, </xsl:when>
+      <!-- If preceding element is text, then avoid adding "," or "-". It looks like inline reference to an issue, PR -->
+      <xsl:when test="preceding-sibling::text()[normalize-space() != '']"/>
+      <xsl:otherwise> &ndash; </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="links">


### PR DESCRIPTION
## Motivation and Context

input:

```xml
    <p><issue>5709</issue> fixed</p>
    <p><issue>5707</issue><issue>5708</issue><issue>5709</issue> fixed</p>
    <p><issue>5707</issue><pr>5710</pr><issue>5708</issue><issue>5709</issue> fixed</p>
    <p>test <issue>5707</issue> fixed</p>
```

Rendered doc:
![xsl rendering](https://user-images.githubusercontent.com/213894/192108284-9f11c8cf-ef89-4272-8c0e-539aeab193b7.png)
