### PR TITLE
Add jsonpath string to jsonpath assertion error message

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -119,7 +119,7 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
                 JSONArray arrayValue = (JSONArray) value;
                 if (arrayValue.isEmpty() && !JsonPath.isPathDefinite(getJsonPath())) {
                     throw new IllegalStateException(String.format("JSONPath '%s' is indefinite and the extracted Value is an empty Array." +
-                            " Please use an assertion value, to be sure to get a correct result. '%s'", getJsonPath(), getExpectedValue()));
+                            " Please use an assertion value, to be sure to get a correct result. Expected value was '%s'", getJsonPath(), getExpectedValue()));
                 }
             }
             return;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -118,8 +118,8 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
             if (value instanceof JSONArray) {
                 JSONArray arrayValue = (JSONArray) value;
                 if (arrayValue.isEmpty() && !JsonPath.isPathDefinite(getJsonPath())) {
-                    throw new IllegalStateException("JSONPath is indefinite and the extracted Value is an empty Array." +
-                            " Please use an assertion value, to be sure to get a correct result. " + getExpectedValue());
+                    throw new IllegalStateException(String.format("JSONPath '%s' is indefinite and the extracted Value is an empty Array." +
+                            " Please use an assertion value, to be sure to get a correct result. '%s'", getJsonPath(), getExpectedValue()));
                 }
             }
             return;
@@ -137,15 +137,15 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
         }
 
         if (isExpectNull()) {
-            throw new IllegalStateException(String.format("Value expected to be null, but found '%s'", value));
+            throw new IllegalStateException(String.format("Value in json path '%s' expected to be null, but found '%s'", getJsonPath(), value));
         } else {
             String msg;
             if (isUseRegex()) {
-                msg = "Value expected to match regexp '%s', but it did not match: '%s'";
+                msg = "Value in json path '%s' expected to match regexp '%s', but it did not match: '%s'";
             } else {
-                msg = "Value expected to be '%s', but found '%s'";
+                msg = "Value in json path '%s' expected to be '%s', but found '%s'";
             }
-            throw new IllegalStateException(String.format(msg, getExpectedValue(), objectToString(value)));
+            throw new IllegalStateException(String.format(msg, getJsonPath(), getExpectedValue(), objectToString(value)));
         }
     }
 

--- a/src/components/src/test/java/org/apache/jmeter/assertions/TestJSONPathAssertion.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/TestJSONPathAssertion.java
@@ -311,18 +311,20 @@ class TestJSONPathAssertion {
         samplerResult.setResponseData(str.getBytes(Charset.defaultCharset()));
 
         JSONPathAssertion instance = new JSONPathAssertion();
-        instance.setJsonPath("$.execution[0].scenario.requests[0].headers");
+        String jsonPath = "$.execution[0].scenario.requests[0].headers";
+        String expectedValue = "\\{headerkey=header value\\}";
+        instance.setJsonPath(jsonPath);
         instance.setJsonValidationBool(true);
         instance.setExpectNull(false);
-        instance.setExpectedValue("\\{headerkey=header value\\}");
+        instance.setExpectedValue(expectedValue);
         instance.setInvert(false);
         AssertionResult expResult = new AssertionResult("");
         AssertionResult result = instance.getResult(samplerResult);
         assertEquals(expResult.getName(), result.getName());
         assertTrue(result.isFailure());
-        assertEquals(
-                "Value expected to match regexp '\\{headerkey=header value\\}', but it did not match: '{\"headerkey\":\"header value\"}'",
-                result.getFailureMessage());
+        assertEquals(String.format(
+                "Value in json path '%s' expected to match regexp '%s', but it did not match: '{\"headerkey\":\"header value\"}'",
+                        jsonPath, expectedValue), result.getFailureMessage());
     }
 
     @Test


### PR DESCRIPTION
## Description
This PR adds the jsonpath string to the jsonpath assertion error message so it is easier to understand the actual error.

## Motivation and Context
Currently, the jsonpath error produced when a mismatch occurs is not easy to understand because it does not contain the underlying analyzed jsonpath. 

Example: 
```
Assertion error:false
Assertion failure:true
Assertion failure message:Value expected to be 'true', but found '[]'
```
There is no way to understand what is expected to be 'true' here.

Thus, the actual jsonpath which caused the error shall be added, example:
```
Assertion error:false
Assertion failure:true
Assertion failure message:Value in json path '$.response.valid' expected to be 'true', but found '[]'
```

## How Has This Been Tested?
tested locally

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [ x] My code follows the [code style][style-guide] of this project.
- [ x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
