### PR TITLE
ci: add randomized matrix for better test coverage  defect, TestElement.contentEquals edition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,40 +18,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  windows:
-    name: 'Windows (JDK 17)'
-    runs-on: windows-latest
+  matrix_prep:
+    name: Matrix Preparation
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      # Number of jobs to generate in matrix.js
+      MATRIX_JOBS: 4
     steps:
-    - uses: actions/checkout@v3
-    - name: 'Set up JDK 17'
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        run: |
+          node .github/workflows/matrix.js
+
+  test:
+    needs: matrix_prep
+    name: '${{ matrix.name }}'
+    runs-on: ${{ matrix.os }}
+    env:
+      TZ: ${{ matrix.tz }}
+    strategy:
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
+      fail-fast: false
+      # max-parallel: 4
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 50
+    - name: Set up Java ${{ matrix.java_version }}, ${{ matrix.java_distribution }}
       uses: actions/setup-java@v3
       with:
-        java-version: 17
-        distribution: 'zulu'
+        java-version: ${{ matrix.java_version }}
+        distribution: ${{ matrix.java_distribution }}
+        architecture: x64
+    - name: Steps to reproduce
+      uses: actions/github-script@v6
+      with:
+        script: |
+          console.log('The following command might help reproducing CI results, use Java ${{ matrix.java_version }}')
+          console.log('TZ="${{ matrix.tz }}" _JAVA_OPTIONS="${{ matrix.testExtraJvmArgs }}" ./gradlew build -x distTar -x distTarSource -x distTarSha512 -x distTarSourceSha512 ${{ matrix.extraGradleArgs }}')
     - uses: burrunan/gradle-cache-action@v1
       name: Test
       with:
-        job-id: jdk17
+        job-id: jdk${{ matrix.java_version }}
         multi-cache-enabled: false
         # An explicit skip for Sha512 tasks is required due to https://github.com/gradle/gradle/issues/16789
-        arguments: --scan --no-parallel build -x distTar -x distTarSource -x distTarSha512 -x distTarSourceSha512
-
-  mac:
-    name: 'macOS (JDK 17)'
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: 'Set up JDK 17'
-      uses: actions/setup-java@v3
-      with:
-        java-version: 17
-        distribution: 'zulu'
-    - uses: burrunan/gradle-cache-action@v1
-      name: Test
-      with:
-        job-id: jdk14
-        multi-cache-enabled: false
-        arguments: --scan --no-parallel build -x distTar -x distTarSource -x distTarSha512 -x distTarSourceSha512 -Dskip.test_TestDNSCacheManager.testWithCustomResolverAnd1Server=true
+        arguments: --scan --no-parallel build -x distTar -x distTarSource -x distTarSha512 -x distTarSourceSha512 ${{ matrix.extraGradleArgs }}
+      env:
+        _JAVA_OPTIONS: ${{ matrix.testExtraJvmArgs }}
 
   errorprone:
     name: 'Error Prone (JDK 11)'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
       # Number of jobs to generate in matrix.js
-      MATRIX_JOBS: 4
+      MATRIX_JOBS: 10
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -1,0 +1,151 @@
+// The script generates a random subset of valid jdk, os, timezone, and other axes.
+// You can preview the results by running "node matrix.js"
+// See https://github.com/vlsi/github-actions-random-matrix
+let fs = require('fs');
+let os = require('os');
+let {MatrixBuilder} = require('./matrix_builder');
+const matrix = new MatrixBuilder();
+matrix.addAxis({
+  name: 'java_distribution',
+  values: [
+    {value: 'corretto', weight: 1},
+    {value: 'liberica', weight: 1},
+    {value: 'microsoft', weight: 1},
+    {value: 'oracle', weight: 1},
+    {value: 'semeru', weight: 4},
+    {value: 'temurin', weight: 1},
+    {value: 'zulu', weight: 1},
+  ]
+});
+
+matrix.addAxis({
+  name: 'java_version',
+  // Strings allow versions like 18-ea
+  values: [
+    '8',
+    '11',
+    '17',
+  ]
+});
+
+matrix.addAxis({
+  name: 'tz',
+  values: [
+    'America/New_York',
+    'Pacific/Chatham',
+    'UTC'
+  ]
+});
+
+matrix.addAxis({
+  name: 'os',
+  title: x => x.replace('-latest', ''),
+  values: [
+    // TODO: X11 is not available. Un-comment when https://github.com/burrunan/gradle-cache-action/issues/48 is resolved
+    // 'ubuntu-latest',
+    'windows-latest',
+    'macos-latest'
+  ]
+});
+
+// Test cases when Object#hashCode produces the same results
+// It allows capturing cases when the code uses hashCode as a unique identifier
+matrix.addAxis({
+  name: 'hash',
+  values: [
+    {value: 'regular', title: '', weight: 42},
+    {value: 'same', title: 'same hashcode', weight: 1}
+  ]
+});
+matrix.addAxis({
+  name: 'locale',
+  title: x => x.language + '_' + x.country,
+  values: [
+    {language: 'de', country: 'DE'},
+    {language: 'fr', country: 'FR'},
+    // TODO: fix :src:dist-check:batchBUG_62847
+    // Fails with "ERROR o.a.j.u.JMeterUtils: Could not find resources for 'ru_EN'"
+    // {language: 'ru', country: 'RU'},
+    {language: 'tr', country: 'TR'},
+  ]
+});
+
+matrix.setNamePattern(['java_version', 'java_distribution', 'hash', 'os', 'tz', 'locale']);
+
+// Semeru uses OpenJ9 jit which has no option for making hash codes the same
+matrix.exclude({java_distribution: {value: 'semeru'}, hash: {value: 'same'}});
+// Microsoft Java has no distribution for 8
+matrix.exclude({java_distribution: {value: 'microsoft'}, java_version: '8'});
+// Oracle JDK is only supported for JDK 17 and later
+matrix.exclude({java_distribution: {value: 'oracle'}, java_version: ['8', '11']});
+// Ensure at least one job with "same" hashcode exists
+matrix.generateRow({hash: {value: 'same'}});
+// Ensure at least one Windows and at least one Linux job is present (macOS is almost the same as Linux)
+matrix.generateRow({os: 'windows-latest'});
+// TODO: un-comment when xvfb will be possible
+// matrix.generateRow({os: 'ubuntu-latest'});
+// Ensure there will be at least one job with Java 8
+matrix.generateRow({java_version: "8"});
+// Ensure there will be at least one job with Java 11
+matrix.generateRow({java_version: "11"});
+// Ensure there will be at least one job with Java 17
+matrix.generateRow({java_version: "17"});
+const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
+if (include.length === 0) {
+  throw new Error('Matrix list is empty');
+}
+include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
+include.forEach(v => {
+  // Pass locale via Gradle arguments in case it won't be inherited from _JAVA_OPTIONS
+  // In fact, _JAVA_OPTIONS is non-standard and might be ignored by some JVMs
+  let gradleArgs = [
+    `-Duser.country=${v.locale.country}`,
+    `-Duser.language=${v.locale.language}`,
+  ];
+  v.extraGradleArgs = gradleArgs.join(' ');
+});
+include.forEach(v => {
+  let jvmArgs = [];
+  if (v.hash.value === 'same') {
+    jvmArgs.push('-XX:+UnlockExperimentalVMOptions', '-XX:hashCode=2');
+  }
+  // Gradle does not work in tr_TR locale, so pass locale to test only: https://github.com/gradle/gradle/issues/17361
+  jvmArgs.push(`-Duser.country=${v.locale.country}`);
+  jvmArgs.push(`-Duser.language=${v.locale.language}`);
+  v.java_distribution = v.java_distribution.value;
+  if (v.java_distribution !== 'semeru' && Math.random() > 0.5) {
+    // The following options randomize instruction selection in JIT compiler
+    // so it might reveal missing synchronization in TestNG code
+    v.name += ', stress JIT';
+    jvmArgs.push('-XX:+UnlockDiagnosticVMOptions');
+    if (v.java_version >= 8) {
+      // Randomize instruction scheduling in GCM
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressGCM');
+      // Randomize instruction scheduling in LCM
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressLCM');
+    }
+    if (v.java_version >= 16) {
+      // Randomize worklist traversal in IGVN
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressIGVN');
+    }
+    if (v.java_version >= 17) {
+      // Randomize worklist traversal in CCP
+      // share/opto/c2_globals.hpp
+      jvmArgs.push('-XX:+StressCCP');
+    }
+  }
+  v.testExtraJvmArgs = jvmArgs.join(' ');
+  delete v.hash;
+});
+
+console.log(include);
+
+let filePath = process.env['GITHUB_OUTPUT'] || '';
+if (filePath) {
+    fs.appendFileSync(filePath, `matrix<<MATRIX_BODY${os.EOL}${JSON.stringify({include})}${os.EOL}MATRIX_BODY${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}

--- a/.github/workflows/matrix_builder.js
+++ b/.github/workflows/matrix_builder.js
@@ -1,0 +1,242 @@
+// License: Apache-2.0
+// Copyright Vladimir Sitnikov, 2021
+// See https://github.com/vlsi/github-actions-random-matrix
+
+class Axis {
+  constructor({name, title, values}) {
+    this.name = name;
+    this.title = title;
+    this.values = values;
+    // If all entries have same weight, the axis has uniform distribution
+    this.uniform = values.reduce((a, b) => a === (b.weight || 1) ? a : 0, values[0].weight || 1) !== 0
+    this.totalWeight = this.uniform ? values.length : values.reduce((a, b) => a + (b.weight || 1), 0);
+  }
+
+  static matches(row, filter) {
+    if (typeof filter === 'function') {
+      return filter(row);
+    }
+    if (Array.isArray(filter)) {
+      // e.g. row={os: 'windows'}; filter=[{os: 'linux'}, {os: 'linux'}]
+      return filter.find(v => Axis.matches(row, v));
+    }
+    if (typeof filter === 'object') {
+      // e.g. row={jdk: {name: 'openjdk', version: 8}}; filter={jdk: {version: 8}}
+      for (const [key, value] of Object.entries(filter)) {
+        if (!row.hasOwnProperty(key) || !Axis.matches(row[key], value)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    return row === filter;
+  }
+
+  pickValue(filter) {
+    let values = this.values;
+    if (filter) {
+      values = values.filter(v => Axis.matches(v, filter));
+    }
+    if (values.length === 0) {
+      const filterStr = typeof filter === 'string' ? filter.toString() : JSON.stringify(filter);
+      throw Error(`No values produces for axis '${this.name}' from ${JSON.stringify(this.values)}, filter=${filterStr}`);
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    if (this.uniform) {
+      return values[Math.floor(Math.random() * values.length)];
+    }
+    const totalWeight = !filter ? this.totalWeight : values.reduce((a, b) => a + (b.weight || 1), 0);
+    let weight = Math.random() * totalWeight;
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i];
+      weight -= value.weight || 1;
+      if (weight <= 0) {
+        return value;
+      }
+    }
+    return values[values.length - 1];
+  }
+}
+
+class MatrixBuilder {
+  constructor() {
+    this.axes = [];
+    this.axisByName = {};
+    this.rows = [];
+    this.duplicates = {};
+    this.excludes = [];
+    this.includes = [];
+    this.failOnUnsatisfiableFilters = false;
+  }
+
+  /**
+   * Specifies include filter (all the generated rows would comply with all the include filters)
+   * @param filter
+   */
+  include(filter) {
+    this.includes.push(filter);
+  }
+
+  /**
+   * Specifies exclude filter (e.g. exclude a forbidden combination)
+   * @param filter
+   */
+  exclude(filter) {
+    this.excludes.push(filter);
+  }
+
+  addAxis({name, title, values}) {
+    const axis = new Axis({name, title, values});
+    this.axes.push(axis);
+    this.axisByName[name] = axis;
+    return axis;
+  }
+
+  setNamePattern(names) {
+    this.namePattern = names;
+  }
+
+  /**
+   * Returns true if the row matches the include and exclude filters.
+   * @param row input row
+   * @returns {boolean}
+   */
+  matches(row) {
+    return (this.excludes.length === 0 || !this.excludes.find(f => Axis.matches(row, f))) &&
+           (this.includes.length === 0 || this.includes.find(f => Axis.matches(row, f)));
+  }
+
+  failOnUnsatisfiableFilters(value) {
+    this.failOnUnsatisfiableFilters = value;
+  }
+
+  /**
+   * Adds a row that matches the given filter to the resulting matrix.
+   * filter values could be
+   *  - literal values: filter={os: 'windows-latest'}
+   *  - arrays: filter={os: ['windows-latest', 'linux-latest']}
+   *  - functions: filter={os: x => x!='windows-latest'}
+   * @param filter object with keys matching axes names
+   * @returns {*}
+   */
+  generateRow(filter) {
+    let res;
+    if (filter) {
+      // If matching row already exists, no need to generate more
+      res = this.rows.find(v => Axis.matches(v, filter));
+      if (res) {
+        return res;
+      }
+    }
+    for (let i = 0; i < 142; i++) {
+      res = this.axes.reduce(
+        (prev, next) =>
+          Object.assign(prev, {
+            [next.name]: next.pickValue(filter ? filter[next.name] : undefined)
+          }),
+        {}
+      );
+      if (!this.matches(res)) {
+        continue;
+      }
+      const key = JSON.stringify(res);
+      if (!this.duplicates.hasOwnProperty(key)) {
+        this.duplicates[key] = true;
+        res.name =
+          this.namePattern.map(axisName => {
+            let value = res[axisName];
+            const title = value.title;
+            if (typeof title != 'undefined') {
+              return title;
+            }
+            const computeTitle = this.axisByName[axisName].title;
+            if (computeTitle) {
+                return computeTitle(value);
+            }
+            if (typeof value === 'object' && value.hasOwnProperty('value')) {
+                return value.value;
+            }
+            return value;
+          }).filter(Boolean).join(", ");
+        this.rows.push(res);
+        return res;
+      }
+    }
+    const filterStr = typeof filter === 'string' ? filter.toString() : JSON.stringify(filter);
+    const msg = `Unable to generate row for ${filterStr}. Please check include and exclude filters`;
+    if (this.failOnUnsatisfiableFilters) {
+      throw Error(msg);
+    } else {
+      console.warn(msg);
+    }
+  }
+
+  generateRows(maxRows, filter) {
+    for (let i = 0; this.rows.length < maxRows && i < maxRows; i++) {
+      this.generateRow(filter);
+    }
+    return this.rows;
+  }
+
+  /**
+   * Computes the number of all the possible combinations.
+   * @returns {{bad: number, good: number}}
+   */
+  summary() {
+   let position = -1;
+   let indices = [];
+   let values = {};
+   const axes = this.axes;
+   function resetValuesUpTo(nextPosition) {
+     for(let i=0; i<nextPosition; i++) {
+       const axis = axes[i];
+       values[axis.name] = axis.values[0];
+       indices[i] = 1; // next index
+     }
+     position = 0;
+   }
+
+   function nextAvailablePosition() {
+    let size = axes.length;
+    for (let i = position; i < size; i++) {
+      if (indices[i] < axes[i].values.length) {
+        return i;
+      }
+    }
+    return -1;
+   }
+   // The first initialization of the values
+   resetValuesUpTo(this.axes.length);
+   let good = 0;
+   let bad = 0;
+   while (true) {
+     if (indices[position] < this.axes[position].values.length) {
+       // Advance iterator at the current position if possible
+       const axis = this.axes[position];
+       values[axis.name] = axis.values[indices[position]];
+       indices[position]++;
+     } else {
+       // Advance the next iterator, and reset [0..nextPosition)
+       position++;
+       let nextPosition = nextAvailablePosition();
+       if (nextPosition === -1) {
+         break;
+       }
+       const axis = this.axes[nextPosition];
+       values[axis.name] = axis.values[indices[nextPosition]];
+       indices[nextPosition]++;
+       resetValuesUpTo(nextPosition);
+     }
+     if (this.matches(values)) {
+       good++;
+     } else {
+       bad++;
+     }
+   }
+   return {good: good, bad: bad};
+  }
+}
+
+module.exports = {Axis, MatrixBuilder};

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListener.java
@@ -137,6 +137,7 @@ public class BackendListener
      *
      * @return a String identifier for this sampler instance
      */
+    @SuppressWarnings("deprecation")
     private String whoAmI() {
         return Thread.currentThread().getName() + "@" + Integer.toHexString(hashCode()) + "-" + getName();
     }

--- a/src/core/build.gradle.kts
+++ b/src/core/build.gradle.kts
@@ -16,6 +16,7 @@
  */
 
 import com.github.autostyle.gradle.AutostyleTask
+import com.github.vlsi.gradle.ide.IdeExtension
 
 plugins {
     id("build-logic.jvm-published-library")
@@ -140,7 +141,10 @@ val versionClass by tasks.registering(Sync::class) {
     into(generatedVersionDir)
 }
 
-ide {
+// For some reason, using `ide { ... }` sometimes causes
+// Caused by: java.lang.IllegalStateException: couldn't find inline method
+// Lorg/gradle/kotlin/dsl/Accessorslkzxmv806rumtqvft7195qyhKt;.getIde(Lorg/gradle/api/Project;)Lcom/github/vlsi/gradle/ide/IdeExtension;
+configure<IdeExtension> {
     generatedJavaSources(versionClass.get(), generatedVersionDir)
 }
 

--- a/src/core/src/main/java/org/apache/jmeter/config/Arguments.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/Arguments.java
@@ -216,7 +216,7 @@ public class Arguments extends ConfigTestElement implements Serializable, Iterab
         PropertyIterator iter = getArguments().iterator();
         while (iter.hasNext()) {
             Argument item = (Argument) iter.next().getObjectValue();
-            if (arg.equals(item)) {
+            if (arg.contentEquals(item)) {
                 iter.remove();
             }
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/CheckDirty.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/CheckDirty.java
@@ -143,7 +143,7 @@ public class CheckDirty extends AbstractAction implements HashTreeTraverser, Act
             // Only check if we have not found any differences so far
             if(!dirty) {
                 if (previousGuiItems.containsKey(treeNode)) {
-                    if (!previousGuiItems.get(treeNode).equals(treeNode.getTestElement())) {
+                    if (!previousGuiItems.get(treeNode).contentEquals(treeNode.getTestElement())) {
                         dirty = true;
                     }
                 } else {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/LoadRecentProject.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/LoadRecentProject.java
@@ -126,7 +126,7 @@ public class LoadRecentProject extends Load {
                 .mapToObj(LoadRecentProject::getRecentFile)
                 .filter(Objects::nonNull)
                 .filter(s -> !s.equals(loadedFileName))
-                .collect(Collectors.toCollection(ArrayDeque::new));
+                .collect(Collectors.<String, ArrayDeque<String>>toCollection(ArrayDeque::new));
         newRecentFiles.addFirst(loadedFileName);
 
         // Store the recent files

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
@@ -341,22 +341,6 @@ public class ResultSaver extends AbstractTestElement implements NoThreadClone, S
         int num;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj);
-    }
-
     public void setAddTimestamp(boolean selected) {
         setProperty(ADD_TIMESTAMP, selected, false);
     }

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -42,8 +42,12 @@ import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
+import org.apiguardian.api.API;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.errorprone.annotations.InlineMe;
+import com.google.errorprone.annotations.InlineMeValidationDisabled;
 
 /**
  */
@@ -111,14 +115,35 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
 
     /**
      * {@inheritDoc}
+     * <p>If you override {@link #equals(Object)} for comparing test element contents,
+     * then consider overriding {@link #contentEquals(TestElement)} instead.</p>
+     * @deprecated since 5.5 {@link #equals(Object)} uses reference equality, so consider
+     * using {@link #contentEquals(TestElement)} if you want comparing element contents
+     * @see #contentEquals(TestElement)
      */
     @Override
-    public boolean equals(Object o) {
-        if (o instanceof AbstractTestElement) {
-            return ((AbstractTestElement) o).propMap.equals(propMap);
-        } else {
+    @Deprecated
+    @API(since = "5.5", status = API.Status.MAINTAINED)
+    @InlineMe(replacement = "this.contentEquals(o)")
+    @InlineMeValidationDisabled("most likely users need contentEquals")
+    public final boolean equals(Object o) {
+        return o == this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>The implementation returns {@code false} of the class of the input argument differs
+     * from the class of the current object</p>
+     */
+    @Override
+    public boolean contentEquals(TestElement other) {
+        if (other == this) {
+            return true;
+        }
+        if (other == null || other.getClass() != getClass()) {
             return false;
         }
+        return propMap.equals(((AbstractTestElement) other).propMap);
     }
 
     // TODO temporary hack to avoid unnecessary bug reports for subclasses
@@ -126,9 +151,28 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
     /**
      * {@inheritDoc}
      */
+    /**
+     * {@inheritDoc}
+     * <p>If you override {@link #hashCode()} for comparing test element hash code,
+     * then consider overriding {@link #contentHashCode()} instead.</p>
+     * @deprecated since 5.5 {@link #hashCode()} uses reference equality, so consider
+     *   using {@link #contentHashCode()} if you need the hashcode of the contents.
+     * @see #contentHashCode()
+     */
     @Override
-    public int hashCode(){
+    @Deprecated
+    @API(since = "5.5", status = API.Status.MAINTAINED)
+    @InlineMe(replacement = "this.contentHashCode()")
+    @InlineMeValidationDisabled("most likely users need contentHashCode")
+    public final int hashCode(){
         return System.identityHashCode(this);
+    }
+
+    @Override
+    public int contentHashCode() {
+        int hash = getClass().hashCode();
+        hash = hash * 31 + propMap.hashCode();
+        return hash;
     }
 
     /*

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestElement.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.threads.JMeterContext;
+import org.apiguardian.api.API;
 
 public interface TestElement extends Cloneable {
     String NAME = "TestElement.name"; //$NON-NLS-1$
@@ -35,6 +36,47 @@ public interface TestElement extends Cloneable {
     // Also TestElementConverter and TestElementPropertyConverter for handling empty comments
     String COMMENTS = "TestPlan.comments"; //$NON-NLS-1$
     // N.B. Comments originally only applied to Test Plans, hence the name - which can now not be easily changed
+
+    /**
+     * {@inheritDoc}
+     * @deprecated since 5.5 {@link #equals(Object)} uses reference equality, so consider
+     *   using {@link #contentEquals(TestElement)} if you want comparing element contents.
+     */
+    @Override
+    @Deprecated
+    @API(since = "5.5", status = API.Status.MAINTAINED)
+    boolean equals(Object o);
+
+    /**
+     * {@inheritDoc}
+     * @deprecated since 5.5 {@link #hashCode()} uses reference equality, so consider
+     *   using {@link #contentHashCode()} if you need the hashcode of the contents.
+     */
+    @Override
+    @Deprecated
+    @API(since = "5.5", status = API.Status.MAINTAINED)
+    int hashCode();
+
+    /**
+     * Returns the hash code of the contents of this element.
+     * Note: it should be consisten with {@link #contentEquals(TestElement)}
+     * @return hash code of the contents of this element.
+     */
+    default int contentHashCode() {
+        return System.identityHashCode(this);
+    }
+
+    /**
+     * Compares contents of two {@link TestElement} objects, and returns {@code true}
+     * if and only if they are the same.
+     * <p>{@code TestElement.equals(Object)} uses reference equality</p>
+     * @param other another TestElement
+     * @return true if other test element is the same as this one, or it has the same properties
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "5.5.1")
+    default boolean contentEquals(TestElement other) {
+        return this == other;
+    }
 
     void addTestElement(TestElement child);
 

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/TestElementProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/TestElementProperty.java
@@ -48,7 +48,8 @@ public class TestElementProperty extends MultiProperty {
                 return true;
             }
             if (value != null) {
-                return value.equals(((JMeterProperty) o).getObjectValue());
+                Object other = ((JMeterProperty) o).getObjectValue();
+                return other instanceof TestElement && value.contentEquals((TestElement) other);
             }
         }
         return false;
@@ -56,7 +57,7 @@ public class TestElementProperty extends MultiProperty {
 
     @Override
     public int hashCode() {
-        return value == null ? 0 : value.hashCode();
+        return value == null ? 0 : value.contentHashCode();
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
@@ -290,6 +290,7 @@ public class TestCompiler implements HashTreeTraverser {
 
         /** {@inheritDoc} */
         @Override
+        @SuppressWarnings("deprecation")
         public int hashCode() {
             return child.hashCode() + parent.hashCode();
         }

--- a/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
@@ -59,7 +59,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
      * Cache of compiled scripts
      */
     private static final Map<String, CompiledScript> compiledScriptsCache =
-            Collections.synchronizedMap(
+            Collections.<String, CompiledScript>synchronizedMap(
                     new LRUMap<>(JMeterUtils.getPropDefault("jsr223.compiled_scripts_cache_size", 100)));
 
     /** If not empty then script in ScriptText will be compiled and cached */

--- a/src/core/src/test/java/org/apache/jmeter/threads/TestJMeterThread.java
+++ b/src/core/src/test/java/org/apache/jmeter/threads/TestJMeterThread.java
@@ -24,6 +24,7 @@ import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
+import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.timers.Timer;
 import org.apache.jorphan.collections.HashTree;
@@ -47,22 +48,16 @@ class TestJMeterThread {
         }
 
         @Override
-        public int hashCode() {
+        public int contentHashCode() {
             final int prime = 31;
-            int result = super.hashCode();
+            int result = super.contentHashCode();
             result = prime * result + (called ? 1231 : 1237);
             return result;
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (!super.equals(obj)) {
-                return false;
-            }
-            if (!getClass().equals(obj.getClass())) {
+        public boolean contentEquals(TestElement obj) {
+            if (!super.contentEquals(obj)) {
                 return false;
             }
             DummySampler other = (DummySampler) obj;

--- a/src/functions/src/test/groovy/org/apache/jmeter/functions/ChangeCaseSpec.groovy
+++ b/src/functions/src/test/groovy/org/apache/jmeter/functions/ChangeCaseSpec.groovy
@@ -22,12 +22,15 @@ import org.apache.jmeter.samplers.SampleResult
 import org.apache.jmeter.threads.JMeterContextService
 import org.apache.jmeter.threads.JMeterVariables
 
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
 class ChangeCaseSpec extends Specification {
 
+    // See https://github.com/apache/jmeter/issues/5723
+    @IgnoreIf({ 'i'.toUpperCase() != 'I' || 'I'.toLowerCase() != 'i' })
     def "convert '#input' using mode #mode to '#output'"() {
         given:
             def changeCase = new ChangeCase()

--- a/src/functions/src/test/java/org/apache/jmeter/functions/RandomFunctionTest.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/RandomFunctionTest.java
@@ -90,7 +90,7 @@ public class RandomFunctionTest extends JMeterTestCase {
     private boolean stringOnlyContainsChars(String value, String allowedChars) {
         Set<Character> allowedCharsAsSet = allowedChars.chars()
                 .mapToObj(i -> (char) i)
-                .collect(Collectors.toCollection(HashSet::new));
+                .collect(Collectors.<Character, Set<Character>>toCollection(HashSet::new));
         return value.chars().allMatch(c -> allowedCharsAsSet.contains((char)c));
     }
 }

--- a/src/functions/src/test/java/org/apache/jmeter/functions/SumFunctionTest.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/SumFunctionTest.java
@@ -78,7 +78,7 @@ class SumFunctionTest extends JMeterTestCase {
     private void checkSum(AbstractFunction func, String value, String[] addends)  throws Exception {
         Collection<CompoundVariable> parms = Arrays.stream(addends)
                 .map(CompoundVariable::new)
-                .collect(Collectors.toCollection(ArrayList::new));
+                .collect(Collectors.<CompoundVariable, ArrayList<CompoundVariable>>toCollection(ArrayList::new));
         parms.add(new CompoundVariable("Result"));
         func.setParameters(parms);
         Assertions.assertEquals(value, func.execute(null,null));
@@ -89,7 +89,7 @@ class SumFunctionTest extends JMeterTestCase {
     private void checkSumNoVar(AbstractFunction func, String value, String[] addends)  throws Exception {
         Collection<CompoundVariable> parms = Arrays.stream(addends)
                 .map(CompoundVariable::new)
-                .collect(Collectors.toCollection(ArrayList::new));
+                .collect(Collectors.<CompoundVariable, ArrayList<CompoundVariable>>toCollection(ArrayList::new));
         func.setParameters(parms);
         Assertions.assertEquals(value, func.execute(null,null));
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArgs.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArgs.java
@@ -171,7 +171,7 @@ public class HTTPFileArgs extends ConfigTestElement implements Serializable {
         PropertyIterator iter = getHTTPFileArgsCollection().iterator();
         while (iter.hasNext()) {
             HTTPFileArg item = (HTTPFileArg) iter.next().getObjectValue();
-            if (file.equals(item)) {
+            if (file.contentEquals(item)) {
                 iter.remove();
             }
         }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JavaSampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JavaSampler.java
@@ -252,6 +252,7 @@ public class JavaSampler extends AbstractSampler implements TestStateListener, I
      *
      * @return a String identifier for this sampler instance
      */
+    @SuppressWarnings("deprecation")
     private String whoAmI() {
         return Thread.currentThread().getName() +
                 "@" +

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSProperties.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSProperties.java
@@ -188,7 +188,7 @@ public class JMSProperties extends AbstractTestElement implements Serializable {
         PropertyIterator iter = getProperties().iterator();
         while (iter.hasNext()) {
             JMSProperty item = (JMSProperty) iter.next().getObjectValue();
-            if (arg.equals(item)) {
+            if (arg.contentEquals(item)) {
                 iter.remove();
             }
         }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -759,6 +759,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
                 .format(instant);
     }
 
+    @SuppressWarnings("deprecation")
     private void logThreadStart() {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Thread started {}", formatLikeDate(Instant.now()));

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArguments.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArguments.java
@@ -198,7 +198,7 @@ public class LDAPArguments extends ConfigTestElement implements Serializable {
         PropertyIterator iter = getArguments().iterator();
         while (iter.hasNext()) {
             LDAPArgument item = (LDAPArgument) iter.next().getObjectValue();
-            if (arg.equals(item)) {
+            if (arg.contentEquals(item)) {
                 iter.remove();
             }
         }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -119,6 +119,7 @@ Summary
   <li><pr>5763</pr>Updated Gradle to 7.3 (from 7.2)</li>
   <li>Update lets-plot-jvm to 4.3.0 (from 3.1.1)</li>
   <li>Update lets-plot-batik to 3.1.0 (from 2.1.1)</li>
+  <li>Added randomized test GitHub Actions matrix for better coverage of locales and time zones</li>
 </ul>
 
  <!-- =================== Bug fixes =================== -->


### PR DESCRIPTION
This is an alternative implementation for https://github.com/apache/jmeter/pull/693
The key difference is that I create `TestElement.contentEquals` and mark `TestElement.equals` deprecated.
