### PR TITLE
UPPER is the default case for changeCase

### DIFF
--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -1701,7 +1701,7 @@ returns:
     <properties>
     <property name="String to change case" required="Yes">The String
             which case will be changed</property>
-        <property name="change case mode" required="Yes">
+        <property name="change case mode" required="No, default=UPPER">
             The mode to be used to change case, for example for <code>ab-CD eF</code>:
             <ul>
                 <li><code>UPPER</code> result as AB-CD EF</li>


### PR DESCRIPTION
## Description
Fix documentation for changeCase parameters that UPPER is the default case

## Motivation and Context
Wrong documentation for changeCase function

## How Has This Been Tested?
Checked in code ChangeCase.java and on application

## Types of changes
None

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
