### PR TITLE
Allow SampleResult#setEndTime be set in JSR223Sampler

### DIFF
--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.protocol.java.sampler;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -43,7 +44,7 @@ import org.slf4j.LoggerFactory;
 @TestElementMetadata(labelResource = "displayName")
 public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampler, TestBean, ConfigMergabilityIndicator {
     private static final Set<String> APPLIABLE_CONFIG_CLASSES = new HashSet<>(
-            Arrays.asList("org.apache.jmeter.config.gui.SimpleConfigGui"));
+            Collections.singletonList("org.apache.jmeter.config.gui.SimpleConfigGui"));
 
     private static final long serialVersionUID = 235L;
 
@@ -58,7 +59,7 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
         result.setResponseMessageOK();
 
         final String filename = getFilename();
-        if (filename.length() > 0){
+        if (!filename.isEmpty()){
             result.setSamplerData("File: "+filename);
         } else {
             result.setSamplerData(getScript());

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -18,7 +18,6 @@
 package org.apache.jmeter.protocol.java.sampler;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -79,7 +79,9 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
             result.setResponseCode("500"); // $NON-NLS-1$
             result.setResponseMessage(e.toString());
         }
-        result.sampleEnd();
+        if (result.getEndTime() == 0) {
+            result.sampleEnd();
+        }
         return result;
     }
 

--- a/src/protocol/java/src/test/java/org/apache/jmeter/protocol/java/sampler/JSR223SamplerTest.java
+++ b/src/protocol/java/src/test/java/org/apache/jmeter/protocol/java/sampler/JSR223SamplerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.java.sampler;
+
+import org.apache.jmeter.samplers.SampleResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JSR223SamplerTest {
+
+    @Test
+    void sampleWithEndTimeSet() {
+        JSR223Sampler sampler = new JSR223Sampler();
+        sampler.setName("jsr223Test");
+        sampler.setScript("SampleResult.setEndTime(42); 'OK'");
+        sampler.setScriptLanguage("groovy");
+        SampleResult sampleResult = sampler.sample(null);
+        assertEquals(42, sampleResult.getEndTime());
+    }
+
+    @Test
+    void sampleWithoutEndTimeSet() {
+        JSR223Sampler sampler = new JSR223Sampler();
+        sampler.setName("jsr223Test");
+        sampler.setScript("'OK'");
+        sampler.setScriptLanguage("groovy");
+        SampleResult sampleResult = sampler.sample(null);
+        assertEquals(System.currentTimeMillis(), sampleResult.getEndTime(), 1000);
+    }
+}

--- a/src/protocol/java/src/test/java/org/apache/jmeter/protocol/java/sampler/JSR223SamplerTest.java
+++ b/src/protocol/java/src/test/java/org/apache/jmeter/protocol/java/sampler/JSR223SamplerTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.jmeter.protocol.java.sampler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.jmeter.samplers.SampleResult;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class JSR223SamplerTest {
 


### PR DESCRIPTION
Issue #5733

## Description
JSR223Sampler throws an exception, when the sampler has set the endTime of the sampleResult. 

## Motivation and Context
JSR223Sampler is often used to create results in a freestyle mode. So setting the endTime of a SampleResult should be allowed.

## How Has This Been Tested?
Added a new Test class, that tests both paths setting and not setting the endTime on the SampleResult.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

It is a bit hard to decide on this. I think of it as a bug fix.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
