### PR TITLE
Add new properties for test plan external configuration serialize, functional tearDown

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -97,7 +97,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             String propFunctionalModeProperty = JMeterUtils.getProperty(PROP_FUNCTIONAL_MODE);
             if (propFunctionalModeProperty != null) {
                 functionalModeReturn = JMeterUtils.getPropDefault(PROP_FUNCTIONAL_MODE, functionalModeDefault);
-                log.info("Change with property " + PROP_FUNCTIONAL_MODE + ", value=" + functionalModeReturn);
+                log.info("Overriding the value of \"Functional Test Mode\" with property " + PROP_FUNCTIONAL_MODE + " value=" + functionalModeReturn);
             }
         }
         functionalMode = functionalModeReturn;
@@ -181,7 +181,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             String tearDownOnShutdownProperty = JMeterUtils.getProperty(PROP_TEARDOWN_ON_SHUTDOWN);
             if (tearDownOnShutdownProperty != null) {
                 tearDownOnShutdownReturn = JMeterUtils.getPropDefault(PROP_TEARDOWN_ON_SHUTDOWN, tearDownOnShutdown);
-                log.info("Change with property " + PROP_TEARDOWN_ON_SHUTDOWN + ", value=" + tearDownOnShutdownReturn);
+                log.info("Overriding the value of \"Run tearDown Thread Groups after shutdown of main threads\" with property " + PROP_TEARDOWN_ON_SHUTDOWN + " value=" + tearDownOnShutdownReturn);
             }
         }
         return tearDownOnShutdownReturn;
@@ -243,7 +243,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             String serializedThreadGroupProperty = JMeterUtils.getProperty(PROP_SERIALIZE_THREADGROUPS);
             if (serializedThreadGroupProperty != null) {
                 serializedThreadGroupReturn = JMeterUtils.getPropDefault(PROP_SERIALIZE_THREADGROUPS, serializedThreadGroupDefault);
-                log.info("Change with property " + PROP_SERIALIZE_THREADGROUPS + ", value=" + serializedThreadGroupReturn);
+                log.info("Overriding the value of \"Run Thread Groups consecutively (serialize thread groups)\" with property "  + PROP_SERIALIZE_THREADGROUPS + " value=" + serializedThreadGroupReturn);
             }
         }
         return serializedThreadGroupReturn;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -85,7 +85,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     }
 
     /**
-     * Fetches the functional mode property<br>
+     * Fetches the functional mode property.
      * Could be change for no-GUI test with jmeter property: {@code PROP_FUNCTIONAL_MODE}
      * @return functional mode
      */
@@ -170,7 +170,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
         setProperty(TEARDOWN_ON_SHUTDOWN, tearDown, false);
     }
 
-    /** Fetches the Tear Down On Shutdown property<br>
+    /** Fetches the Tear Down On Shutdown property.
      * Could be change for no-GUI test with jmeter property:  {@code PROP_TEARDOWN_ON_SHUTDOWN}
      * @return  TearDownOnShutdown setting
      */
@@ -233,7 +233,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     }
 
     /**
-     * Fetch the serialize threadgroups property<br>
+     * Fetch the serialize threadgroups property (Run Thread Groups consecutively).
      * Could be change for no-GUI test with jmeter property: {@code PROP_SERIALIZE_THREADGROUPS}
      * @return serialized setting
      */

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -97,7 +97,8 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             String propFunctionalModeProperty = JMeterUtils.getProperty(PROP_FUNCTIONAL_MODE);
             if (propFunctionalModeProperty != null) {
                 functionalModeReturn = JMeterUtils.getPropDefault(PROP_FUNCTIONAL_MODE, functionalModeDefault);
-                log.info("Overriding the value of \"Functional Test Mode\" with property " + PROP_FUNCTIONAL_MODE + " value=" + functionalModeReturn);
+                log.info("Overriding the value of \"Functional Test Mode\" with property " +
+                        PROP_FUNCTIONAL_MODE + " value=" + functionalModeReturn);
             }
         }
         functionalMode = functionalModeReturn;
@@ -181,7 +182,8 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             String tearDownOnShutdownProperty = JMeterUtils.getProperty(PROP_TEARDOWN_ON_SHUTDOWN);
             if (tearDownOnShutdownProperty != null) {
                 tearDownOnShutdownReturn = JMeterUtils.getPropDefault(PROP_TEARDOWN_ON_SHUTDOWN, tearDownOnShutdown);
-                log.info("Overriding the value of \"Run tearDown Thread Groups after shutdown of main threads\" with property " + PROP_TEARDOWN_ON_SHUTDOWN + " value=" + tearDownOnShutdownReturn);
+                log.info("Overriding the value of \"Run tearDown Thread Groups after shutdown of main threads\" with property " +
+                        PROP_TEARDOWN_ON_SHUTDOWN + " value=" + tearDownOnShutdownReturn);
             }
         }
         return tearDownOnShutdownReturn;
@@ -243,7 +245,8 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             String serializedThreadGroupProperty = JMeterUtils.getProperty(PROP_SERIALIZE_THREADGROUPS);
             if (serializedThreadGroupProperty != null) {
                 serializedThreadGroupReturn = JMeterUtils.getPropDefault(PROP_SERIALIZE_THREADGROUPS, serializedThreadGroupDefault);
-                log.info("Overriding the value of \"Run Thread Groups consecutively (serialize thread groups)\" with property "  + PROP_SERIALIZE_THREADGROUPS + " value=" + serializedThreadGroupReturn);
+                log.info("Overriding the value of \"Run Thread Groups consecutively (serialize thread groups)\" with property "  +
+                        PROP_SERIALIZE_THREADGROUPS + " value=" + serializedThreadGroupReturn);
             }
         }
         return serializedThreadGroupReturn;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -85,24 +85,23 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     }
 
     /**
-     * Fetches the functional mode property
-     * Could be change for no gui test with jmeter property : PROP_FUNCTIONAL_MODE
+     * Fetches the functional mode property<br>
+     * Could be change for no-GUI test with jmeter property: {@code PROP_FUNCTIONAL_MODE}
      * @return functional mode
      */
     public boolean isFunctionalMode() {
-        boolean bFunctionalModeDefault = getPropertyAsBoolean(FUNCTIONAL_MODE);
-        log.debug("bFunctionalModeDefault=" + bFunctionalModeDefault);
-        String sIsNonGui = System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI);
-        boolean bFunctionalModeReturn = bFunctionalModeDefault;
-        if ("true".equals(sIsNonGui)) {
-            String sPropFunctionalModeProperty = JMeterUtils.getProperty(PROP_FUNCTIONAL_MODE);
-            if (sPropFunctionalModeProperty != null) {
-                bFunctionalModeReturn = JMeterUtils.getPropDefault(PROP_FUNCTIONAL_MODE, bFunctionalModeDefault);
-                log.info("Change with property " + PROP_FUNCTIONAL_MODE + ", value=" + bFunctionalModeReturn);
+        boolean functionalModeDefault = getPropertyAsBoolean(FUNCTIONAL_MODE);
+        log.debug("functionalModeDefault=" + functionalModeDefault);
+        boolean functionalModeReturn = functionalModeDefault;
+        if (isNonGui()) {
+            String propFunctionalModeProperty = JMeterUtils.getProperty(PROP_FUNCTIONAL_MODE);
+            if (propFunctionalModeProperty != null) {
+                functionalModeReturn = JMeterUtils.getPropDefault(PROP_FUNCTIONAL_MODE, functionalModeDefault);
+                log.info("Change with property " + PROP_FUNCTIONAL_MODE + ", value=" + functionalModeReturn);
             }
         }
-        functionalMode = bFunctionalModeReturn;
-        return bFunctionalModeReturn;
+        functionalMode = functionalModeReturn;
+        return functionalModeReturn;
     }
 
     public void setUserDefinedVariables(Arguments vars) {
@@ -170,23 +169,30 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
         setProperty(TEARDOWN_ON_SHUTDOWN, tearDown, false);
     }
 
-    /** Fetches the Tear Down On Shutdown property
-     * Could be change for no gui test with jmeter property : PROP_TEARDOWN_ON_SHUTDOWN
+    /** Fetches the Tear Down On Shutdown property<br>
+     * Could be change for no-GUI test with jmeter property:  {@code PROP_TEARDOWN_ON_SHUTDOWN}
      * @return  TearDownOnShutdown setting
      */
     public boolean isTearDownOnShutdown() {
-        boolean bTearDownOnShutdown = getPropertyAsBoolean(TEARDOWN_ON_SHUTDOWN, false);
-        log.debug("bTearDownOnShutdown=" + bTearDownOnShutdown);
-        String sIsNonGui = System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI);
-        boolean bTearDownOnShutdownReturn = bTearDownOnShutdown;
-        if ("true".equals(sIsNonGui)) {
-            String sTearDownOnShutdownProperty = JMeterUtils.getProperty(PROP_TEARDOWN_ON_SHUTDOWN);
-            if (sTearDownOnShutdownProperty != null) {
-                bTearDownOnShutdownReturn = JMeterUtils.getPropDefault(PROP_TEARDOWN_ON_SHUTDOWN, bTearDownOnShutdown);
-                log.info("Change with property " + PROP_TEARDOWN_ON_SHUTDOWN + ", value=" + bTearDownOnShutdownReturn);
+        boolean tearDownOnShutdown = getPropertyAsBoolean(TEARDOWN_ON_SHUTDOWN, false);
+        log.debug("tearDownOnShutdown=" + tearDownOnShutdown);
+        boolean tearDownOnShutdownReturn = tearDownOnShutdown;
+        if (isNonGui()) {
+            String tearDownOnShutdownProperty = JMeterUtils.getProperty(PROP_TEARDOWN_ON_SHUTDOWN);
+            if (tearDownOnShutdownProperty != null) {
+                tearDownOnShutdownReturn = JMeterUtils.getPropDefault(PROP_TEARDOWN_ON_SHUTDOWN, tearDownOnShutdown);
+                log.info("Change with property " + PROP_TEARDOWN_ON_SHUTDOWN + ", value=" + tearDownOnShutdownReturn);
             }
         }
-        return bTearDownOnShutdownReturn;
+        return tearDownOnShutdownReturn;
+    }
+
+    /**
+     * Is JMeter launch in a non-GUI mode ?
+     * @return true if JMeter is launch in a non-GUI mode, false if JMeter is launch in a GUI mode.
+     */
+    private boolean isNonGui() {
+        return Boolean.parseBoolean(System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI));
     }
 
     /**
@@ -225,23 +231,22 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     }
 
     /**
-     * Fetch the serialize threadgroups property
-     * Could be change for no gui test with jmeter property : PROP_SERIALIZE_THREADGROUPS
+     * Fetch the serialize threadgroups property<br>
+     * Could be change for no-GUI test with jmeter property: {@code PROP_SERIALIZE_THREADGROUPS}
      * @return serialized setting
      */
     public boolean isSerialized() {
-        boolean bSerializedThreadGroupDefault = getPropertyAsBoolean(SERIALIZE_THREADGROUPS);
-        log.debug("bSerializedThreadGroupDefault=" + bSerializedThreadGroupDefault);
-        String sIsNonGui = System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI);
-        boolean bSerializedThreadGroupReturn = bSerializedThreadGroupDefault;
-        if ("true".equals(sIsNonGui)) {
-            String sSerializedThreadGroupProperty = JMeterUtils.getProperty(PROP_SERIALIZE_THREADGROUPS);
-            if (sSerializedThreadGroupProperty != null) {
-                bSerializedThreadGroupReturn = JMeterUtils.getPropDefault(PROP_SERIALIZE_THREADGROUPS, bSerializedThreadGroupDefault);
-                log.info("Change with property " + PROP_SERIALIZE_THREADGROUPS + ", value=" + bSerializedThreadGroupReturn);
+        boolean serializedThreadGroupDefault = getPropertyAsBoolean(SERIALIZE_THREADGROUPS);
+        log.debug("serializedThreadGroupDefault=" + serializedThreadGroupDefault);
+        boolean serializedThreadGroupReturn = serializedThreadGroupDefault;
+        if (isNonGui()) {
+            String serializedThreadGroupProperty = JMeterUtils.getProperty(PROP_SERIALIZE_THREADGROUPS);
+            if (serializedThreadGroupProperty != null) {
+                serializedThreadGroupReturn = JMeterUtils.getPropDefault(PROP_SERIALIZE_THREADGROUPS, serializedThreadGroupDefault);
+                log.info("Change with property " + PROP_SERIALIZE_THREADGROUPS + ", value=" + serializedThreadGroupReturn);
             }
         }
-        return bSerializedThreadGroupReturn;
+        return serializedThreadGroupReturn;
     }
 
     public void addParameter(String name, String value) {

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -98,7 +98,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             if (propFunctionalModeProperty != null) {
                 functionalModeReturn = JMeterUtils.getPropDefault(PROP_FUNCTIONAL_MODE, functionalModeDefault);
                 log.info("Overriding the value of \"Functional Test Mode\" with property " +
-                        PROP_FUNCTIONAL_MODE + " value=" + functionalModeReturn);
+                        PROP_FUNCTIONAL_MODE + "=" + functionalModeReturn);
             }
         }
         functionalMode = functionalModeReturn;
@@ -183,7 +183,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             if (tearDownOnShutdownProperty != null) {
                 tearDownOnShutdownReturn = JMeterUtils.getPropDefault(PROP_TEARDOWN_ON_SHUTDOWN, tearDownOnShutdown);
                 log.info("Overriding the value of \"Run tearDown Thread Groups after shutdown of main threads\" with property " +
-                        PROP_TEARDOWN_ON_SHUTDOWN + " value=" + tearDownOnShutdownReturn);
+                        PROP_TEARDOWN_ON_SHUTDOWN + "=" + tearDownOnShutdownReturn);
             }
         }
         return tearDownOnShutdownReturn;
@@ -246,7 +246,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
             if (serializedThreadGroupProperty != null) {
                 serializedThreadGroupReturn = JMeterUtils.getPropDefault(PROP_SERIALIZE_THREADGROUPS, serializedThreadGroupDefault);
                 log.info("Overriding the value of \"Run Thread Groups consecutively (serialize thread groups)\" with property "  +
-                        PROP_SERIALIZE_THREADGROUPS + " value=" + serializedThreadGroupReturn);
+                        PROP_SERIALIZE_THREADGROUPS + "=" + serializedThreadGroupReturn);
             }
         }
         return serializedThreadGroupReturn;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -31,6 +31,7 @@ import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.AbstractThreadGroup;
+import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,9 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     private static final String TEARDOWN_ON_SHUTDOWN = "TestPlan.tearDown_on_shutdown"; //$NON-NLS-1$
 
     //- JMX field names
-
+    private static final String PROP_FUNCTIONAL_MODE = "jmeter.test_plan.functional_mode"; //$NON-NLS-1$
+    private static final String PROP_SERIALIZE_THREADGROUPS = "jmeter.test_plan.serialize_threadgroups"; //$NON-NLS-1$
+    private static final String PROP_TEARDOWN_ON_SHUTDOWN = "jmeter.test_plan.tearDown_on_shutdown"; //$NON-NLS-1$
     private static final String CLASSPATH_SEPARATOR = ","; //$NON-NLS-1$
 
     private static final String BASEDIR = "basedir";
@@ -83,11 +86,23 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
 
     /**
      * Fetches the functional mode property
-     *
+     * Could be change for no gui test with jmeter property : PROP_FUNCTIONAL_MODE
      * @return functional mode
      */
     public boolean isFunctionalMode() {
-        return getPropertyAsBoolean(FUNCTIONAL_MODE);
+        boolean bFunctionalModeDefault = getPropertyAsBoolean(FUNCTIONAL_MODE);
+        log.debug("bFunctionalModeDefault=" + bFunctionalModeDefault);
+        String sIsNonGui = System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI);
+        boolean bFunctionalModeReturn = bFunctionalModeDefault;
+        if ("true".equals(sIsNonGui)) {
+            String sPropFunctionalModeProperty = JMeterUtils.getProperty(PROP_FUNCTIONAL_MODE);
+            if (sPropFunctionalModeProperty != null) {
+                bFunctionalModeReturn = JMeterUtils.getPropDefault(PROP_FUNCTIONAL_MODE, bFunctionalModeDefault);
+                log.info("Change with property " + PROP_FUNCTIONAL_MODE + ", value=" + bFunctionalModeReturn);
+            }
+        }
+        functionalMode = bFunctionalModeReturn;
+        return bFunctionalModeReturn;
     }
 
     public void setUserDefinedVariables(Arguments vars) {
@@ -155,8 +170,23 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
         setProperty(TEARDOWN_ON_SHUTDOWN, tearDown, false);
     }
 
+    /** Fetches the Tear Down On Shutdown property
+     * Could be change for no gui test with jmeter property : PROP_TEARDOWN_ON_SHUTDOWN
+     * @return  TearDownOnShutdown setting
+     */
     public boolean isTearDownOnShutdown() {
-        return getPropertyAsBoolean(TEARDOWN_ON_SHUTDOWN, false);
+        boolean bTearDownOnShutdown = getPropertyAsBoolean(TEARDOWN_ON_SHUTDOWN, false);
+        log.debug("bTearDownOnShutdown=" + bTearDownOnShutdown);
+        String sIsNonGui = System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI);
+        boolean bTearDownOnShutdownReturn = bTearDownOnShutdown;
+        if ("true".equals(sIsNonGui)) {
+            String sTearDownOnShutdownProperty = JMeterUtils.getProperty(PROP_TEARDOWN_ON_SHUTDOWN);
+            if (sTearDownOnShutdownProperty != null) {
+                bTearDownOnShutdownReturn = JMeterUtils.getPropDefault(PROP_TEARDOWN_ON_SHUTDOWN, bTearDownOnShutdown);
+                log.info("Change with property " + PROP_TEARDOWN_ON_SHUTDOWN + ", value=" + bTearDownOnShutdownReturn);
+            }
+        }
+        return bTearDownOnShutdownReturn;
     }
 
     /**
@@ -196,11 +226,22 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
 
     /**
      * Fetch the serialize threadgroups property
-     *
+     * Could be change for no gui test with jmeter property : PROP_SERIALIZE_THREADGROUPS
      * @return serialized setting
      */
     public boolean isSerialized() {
-        return getPropertyAsBoolean(SERIALIZE_THREADGROUPS);
+        boolean bSerializedThreadGroupDefault = getPropertyAsBoolean(SERIALIZE_THREADGROUPS);
+        log.debug("bSerializedThreadGroupDefault=" + bSerializedThreadGroupDefault);
+        String sIsNonGui = System.getProperty(org.apache.jmeter.JMeter.JMETER_NON_GUI);
+        boolean bSerializedThreadGroupReturn = bSerializedThreadGroupDefault;
+        if ("true".equals(sIsNonGui)) {
+            String sSerializedThreadGroupProperty = JMeterUtils.getProperty(PROP_SERIALIZE_THREADGROUPS);
+            if (sSerializedThreadGroupProperty != null) {
+                bSerializedThreadGroupReturn = JMeterUtils.getPropDefault(PROP_SERIALIZE_THREADGROUPS, bSerializedThreadGroupDefault);
+                log.info("Change with property " + PROP_SERIALIZE_THREADGROUPS + ", value=" + bSerializedThreadGroupReturn);
+            }
+        }
+        return bSerializedThreadGroupReturn;
     }
 
     public void addParameter(String name, String value) {

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6491,15 +6491,15 @@ Selecting Functional Testing instructs JMeter to save the  additional sample inf
 This increases the resources needed to run a test, and may adversely impact JMeter performance.
 If more data is required for a particular sampler only, then add a Listener to it, and configure the fields as required.
 <note>The option does not affect CSV result files, which cannot currently store such information.</note>
-<note>For non gui test, you can set the Functional Testing with the jmeter property : jmeter.test_plan.functional_mode (true or false, false default value). This property is not by default in the jmeter.properties</note>
+<note>For non-GUI test, you can set the Functional Testing with the jmeter property: <code>jmeter.test_plan.functional_mode</code> (<code>true</code> or <code>false</code>, default value is <code>false</code>). This property is not by default in the <code>jmeter.properties</code></note>
 </p>
 <p>Also, an option exists here to instruct JMeter to run the <complink name="Thread Group"/> serially rather than in parallel.
-<note>For non gui test, you can set the Serially with the jmeter property : jmeter.test_plan.serialize_threadgroups (true or false, false default value). This property is by default not in the jmeter.properties</note>
+<note>For non-GUI test, you can set the Serial mode with the jmeter property: <code>jmeter.test_plan.serialize_threadgroups</code> (<code>true</code> or <code>false</code>, default value is <code>false</code>). This property is by default not in the <code>jmeter.properties</code></note>
 </p>
 <p>Run tearDown Thread Groups after shutdown of main threads:
 if selected, the tearDown groups (if any) will be run after graceful shutdown of the main threads.
 The tearDown threads won't be run if the test is forcibly stopped.
-<note>For non gui test, you can set the Run tearDown Thread Groups after shutdown with the jmeter property : jmeter.test_plan.tearDown_on_shutdown (true or false, true default value). This property is not by default in the jmeter.properties</note>
+<note>For non-GUI test, you can set the Run tearDown Thread Groups after shutdown with the jmeter property: <code>jmeter.test_plan.tearDown_on_shutdown</code> (<code>true</code> or  <code>false</code>, default value is <code>true</code>). This property is not by default in the <code>jmeter.properties</code></note>
 </p>
 <p>
 Test plan now provides an easy way to add classpath setting to a specific test plan.

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6494,7 +6494,7 @@ If more data is required for a particular sampler only, then add a Listener to i
 <note>For non-GUI test, you can set the Functional Testing with the jmeter property: <code>jmeter.test_plan.functional_mode</code> (<code>true</code> or <code>false</code>, default value is <code>false</code>). This property is not by default in the <code>jmeter.properties</code></note>
 </p>
 <p>Also, an option exists here to instruct JMeter to run the <complink name="Thread Group"/> serially rather than in parallel.
-<note>For non-GUI test, you can set the Serial mode with the jmeter property: <code>jmeter.test_plan.serialize_threadgroups</code> (<code>true</code> or <code>false</code>, default value is <code>false</code>). This property is by default not in the <code>jmeter.properties</code></note>
+<note>For non-GUI test, you can set the Serial mode (Run Thread Groups consecutively) with the jmeter property: <code>jmeter.test_plan.serialize_threadgroups</code> (<code>true</code> or <code>false</code>, default value is <code>false</code>). This property is by default not in the <code>jmeter.properties</code></note>
 </p>
 <p>Run tearDown Thread Groups after shutdown of main threads:
 if selected, the tearDown groups (if any) will be run after graceful shutdown of the main threads.

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6491,11 +6491,15 @@ Selecting Functional Testing instructs JMeter to save the  additional sample inf
 This increases the resources needed to run a test, and may adversely impact JMeter performance.
 If more data is required for a particular sampler only, then add a Listener to it, and configure the fields as required.
 <note>The option does not affect CSV result files, which cannot currently store such information.</note>
+<note>For non gui test, you can set the Functional Testing with the jmeter property : jmeter.test_plan.functional_mode (true or false, false default value). This property is not by default in the jmeter.properties</note>
 </p>
-<p>Also, an option exists here to instruct JMeter to run the <complink name="Thread Group"/> serially rather than in parallel.</p>
+<p>Also, an option exists here to instruct JMeter to run the <complink name="Thread Group"/> serially rather than in parallel.
+<note>For non gui test, you can set the Serially with the jmeter property : jmeter.test_plan.serialize_threadgroups (true or false, false default value). This property is by default not in the jmeter.properties</note>
+</p>
 <p>Run tearDown Thread Groups after shutdown of main threads:
 if selected, the tearDown groups (if any) will be run after graceful shutdown of the main threads.
 The tearDown threads won't be run if the test is forcibly stopped.
+<note>For non gui test, you can set the Run tearDown Thread Groups after shutdown with the jmeter property : jmeter.test_plan.tearDown_on_shutdown (true or false, true default value). This property is not by default in the jmeter.properties</note>
 </p>
 <p>
 Test plan now provides an easy way to add classpath setting to a specific test plan.

--- a/xdocs/usermanual/get-started.xml
+++ b/xdocs/usermanual/get-started.xml
@@ -516,6 +516,7 @@ To do so, use the following options:</p>
 <dl>
 <dt><code>-D[prop_name]=[value]</code></dt><dd>defines a java system property value.</dd>
 <dt><code>-J[prop_name]=[value]</code></dt><dd>defines a local JMeter property.</dd>
+<dt><code>-q[propertyfile]</code></dt><dd>defines a file containing additional JMeter properties</dd>
 <dt><code>-G[prop_name]=[value]</code></dt><dd>defines a JMeter property to be sent to all remote servers.</dd>
 <dt><code>-G[propertyfile]</code></dt><dd>defines a file containing JMeter properties to be sent to all remote servers.</dd>
 <dt><code>-L[category]=[priority]</code></dt><dd>overrides a logging setting, setting a particular category to the given priority level.</dd>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1569,18 +1569,18 @@ JMETER-SERVER</source>
     Defaults to: <code>false</code>
 </property>
 <property name="jmeter.test_plan.serialize_threadgroups">
-    For non gui test, set the following value to <code>true</code> in order to set
-    Run Thread Groups consecutively at the Test Plan level. Not in the jmeter.properties file but in parameter like : jmeter -n -Jjmeter.test_plan.serialize_threadgroups=[true/false] -t script.jmx<br/>
+    For non-GUI test, set the following value to <code>true</code> in order to set
+    Run Thread Groups consecutively at the Test Plan level. Not in the <code>jmeter.properties</code> file but in parameter like: <code>jmeter -n -Jjmeter.test_plan.serialize_threadgroups=[true/false] -t script.jmx</code><br/>
     Defaults to: <code>false</code>
 </property>
 <property name="jmeter.test_plan.functional_mode">
-    For non gui test, set the following value to <code>true</code> in order to set
-    Functional Test Mode at the Test Plan level. Not in the jmeter.properties file but in parameter like : jmeter -n -Jjmeter.test_plan.functional_mode=[true/false] -t script.jmx<br/>
+    For non-GUI test, set the following value to <code>true</code> in order to set
+    Functional Test Mode at the Test Plan level. Not in the <code>jmeter.properties</code> file but in parameter like: <code>jmeter -n -Jjmeter.test_plan.functional_mode=[true/false] -t script.jmx</code><br/>
     Defaults to: <code>false</code>
 </property>
 <property name="jmeter.test_plan.tearDown_on_shutdown">
-    For non gui test, set the following value to <code>true</code> in order to set
-    Run tearDown Thread Groups after shutdown of main threads at the Test Plan level. Not in the jmeter.properties file but in parameter like : jmeter -n -Jjmeter.test_plan.tearDown_on_shutdown=[true/false] -t script.jmx <br/>
+    For non-GUI test, set the following value to <code>true</code> in order to set
+    Run tearDown Thread Groups after shutdown of main threads at the Test Plan level. Not in the <code>jmeter.properties</code> file but in parameter like: <code>jmeter -n -Jjmeter.test_plan.tearDown_on_shutdown=[true/false] -t script.jmx</code><br/>
     Defaults to: <code>true</code>
 </property>
 </properties>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1568,6 +1568,21 @@ JMETER-SERVER</source>
     confirmation dialogue.<br/>
     Defaults to: <code>false</code>
 </property>
+<property name="jmeter.test_plan.serialize_threadgroups">
+    For non gui test, set the following value to <code>true</code> in order to set
+    Run Thread Groups consecutively at the Test Plan level. Not in the jmeter.properties file but in parameter like : jmeter -n -Jjmeter.test_plan.serialize_threadgroups=[true/false] -t script.jmx<br/>
+    Defaults to: <code>false</code>
+</property>
+<property name="jmeter.test_plan.functional_mode">
+    For non gui test, set the following value to <code>true</code> in order to set
+    Functional Test Mode at the Test Plan level. Not in the jmeter.properties file but in parameter like : jmeter -n -Jjmeter.test_plan.functional_mode=[true/false] -t script.jmx<br/>
+    Defaults to: <code>false</code>
+</property>
+<property name="jmeter.test_plan.tearDown_on_shutdown">
+    For non gui test, set the following value to <code>true</code> in order to set
+    Run tearDown Thread Groups after shutdown of main threads at the Test Plan level. Not in the jmeter.properties file but in parameter like : jmeter -n -Jjmeter.test_plan.tearDown_on_shutdown=[true/false] -t script.jmx <br/>
+    Defaults to: <code>true</code>
+</property>
 </properties>
 </section>
 <section name="&sect-num;.36 Classpath configuration" anchor="classpath">


### PR DESCRIPTION
jmeter.test_plan.serialize_threadgroups (true or false, false default value)
 jmeter.test_plan.functional_mode (true or false, false default value)
 jmeter.test_plan.tearDown_on_shutdown (true or false, true default value)

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue : [Issue 5729](https://github.com/apache/jmeter/issues/5729)

Currently you can't change Test Plan check box for serialize_threadgroups, functional_mode, tearDown_on_shutdown with a external JMeter properties.
Be able to set options with external properties.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Launch this gui or no gui load test and look at jmeter log what is the values of Test plan configuration.

no GUI : 
jmeter.bat -n -Jjmeter.test_plan.functional_mode=false -Jjmeter.test_plan.serialize_threadgroups=false -Jjmeter.test_plan.tearDown_on_shutdown=false -t ..\test_plan_change_mode_std_v02.jmx

Informations in the log file : 
2023-01-10 18:33:17,525 INFO o.a.j.s.SaveService: Loading file: ..\test_plan_change_mode_std_v02.jmx
2023-01-10 18:33:17,592 INFO o.a.j.t.TestPlan: Change with property jmeter.test_plan.**functional_mode**, value=false
2023-01-10 18:33:17,592 INFO o.a.j.t.TestPlan: Change with property jmeter.test_plan.**serialize_threadgroups**, value=false
2023-01-10 18:33:17,596 INFO o.a.j.JMeter: Creating summariser <summary>
2023-01-10 18:33:26,727 INFO o.a.j.t.TestPlan: Change with property jmeter.test_plan.serialize_threadgroups, value=false
2023-01-10 18:33:26,727 INFO o.a.j.t.TestPlan: Change with property jmeter.test_plan.**tearDown_on_shutdown**, value=false
2023-01-10 18:33:26,734 INFO o.a.j.e.StandardJMeterEngine: Running the test!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
