### PR TITLE
Fix InfluxDBRawBackendListenerClient missing data

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
@@ -122,8 +122,10 @@ public class InfluxDBRawBackendListenerClient implements BackendListenerClient {
         // remove surrounding quotes and spaces from sample label
         String label = StringUtils.strip(sampleResult.getSampleLabel(), "\" ");
         String transaction = AbstractInfluxdbMetricsSender.tagToStringValue(label);
+        String threadName = StringUtils.deleteWhitespace(sampleResult.getThreadName());
         return "status=" + status
-                + ",transaction=" + transaction;
+                + ",transaction=" + transaction
+                + ",threadName=" + threadName;
     }
 
     private String createFields(SampleResult sampleResult) {

--- a/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClientSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClientSpec.groovy
@@ -33,6 +33,7 @@ class InfluxDBRawBackendListenerClientSpec extends Specification {
         okSample.setLatency(42)
         okSample.setConnectTime(7)
         okSample.setSampleLabel("myLabel")
+        okSample.setThreadName("myThread")
         okSample.setResponseOK()
         return okSample
     }
@@ -62,7 +63,7 @@ class InfluxDBRawBackendListenerClientSpec extends Specification {
             def tags = sut.createTags(okSample)
             def fields = sut.createFields(okSample)
         then:
-            tags == "status=ok,transaction=myLabel"
+            tags == "status=ok,transaction=myLabel,threadName=myThread"
             fields == "duration=100,ttfb=42,connectTime=7"
     }
 
@@ -70,8 +71,9 @@ class InfluxDBRawBackendListenerClientSpec extends Specification {
         given:
             def koSample = new SampleResult()
             koSample.setSampleLabel("myLabel")
+            koSample.setThreadName("myThread")
         expect:
-            sut.createTags(koSample) == "status=ko,transaction=myLabel"
+            sut.createTags(koSample) == "status=ko,transaction=myLabel,threadName=myThread"
     }
 
     def "Upon handling sample result data is added to influxDBMetricsManager and written"() {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->

This PR includes a new tag `threadName` for InfluxDBRawBackendListenerClient. This allows InfluxDB to insert multiple entries with the same `timestamp` but with different `threadName`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #5654 


There is currently an issue where Jmeter will send requests coming from multiple threads where the timestamp for those requests is the exact same, this causes InfluxDB to override that data and only keep 1 entry. 
Here is an example with a test that runs 12 requests:

```
time                connectTime duration status transaction  ttfb
----                ----------- -------- ------ -----------  ----
1678045696972000000 56          72       ok     user2        72
1678045698040000000 0           16       ok     userlist     16
1678045698044000000 0           25       ok     userlist     25
1678045699056000000 0           19       ok     listresource 19
1678045699070000000 0           15       ok     listresource 14
1678045700076000000 30          46       ok     user2        46
1678045700085000000 34          50       ok     user2        50
1678045701122000000 0           14       ok     userlist     14
1678045701136000000 0           15       ok     userlist     15
1678045702136000000 0           16       ok     listresource 16
1678045702150000000 0           16       ok     listresource 16
```

In this example there is 1 entry missing at the beginning, there should be 2 entries for the transaction `user2`. The reason why the second entry is not there is because both had the same `timestamp`, `status` and `transaction` values.

After adding the tag `threadName`, InfluxDB will save both entries since they differ in the value for that tag. Notice how the time for the 2 first entries is the same:

```
time                connectTime duration status threadName     transaction  ttfb
----                ----------- -------- ------ ----------     -----------  ----
1678046919362000000 39          55       ok     ThreadGroup1-1 user2        55
1678046919362000000 36          59       ok     ThreadGroup1-2 user2        59
1678046920418000000 0           19       ok     ThreadGroup1-1 userlist     19
1678046920421000000 0           18       ok     ThreadGroup1-2 userlist     18
1678046921438000000 0           18       ok     ThreadGroup1-1 listresource 18
1678046921439000000 0           21       ok     ThreadGroup1-2 listresource 21
1678046922457000000 38          53       ok     ThreadGroup1-1 user2        53
1678046922461000000 37          56       ok     ThreadGroup1-2 user2        56
1678046923511000000 0           17       ok     ThreadGroup1-1 userlist     17
1678046923517000000 0           18       ok     ThreadGroup1-2 userlist     18
1678046924528000000 0           26       ok     ThreadGroup1-1 listresource 26
1678046924536000000 0           16       ok     ThreadGroup1-2 listresource 16
```
This change removes any white spaces in the thread name, but given that this value can be set by the user, maybe this is not enough, I would appreciate some feedback here.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran multiple tests after making the changes with over 3000 requests, did not lose any data this time.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
