### PR TITLE
Update website copyright year to 2023

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache JMeter
-Copyright 1998-2022 The Apache Software Foundation
+Copyright 1998-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/xdocs/stylesheets/website-style.xsl
+++ b/xdocs/stylesheets/website-style.xsl
@@ -38,7 +38,7 @@
   <xsl:param name="cssdir" select="concat($relative-path, '/css')" />
   <xsl:param name="apidir" select="concat($relative-path, '/api')" />
   <xsl:param name="jakarta-site" select="'https://jakarta.apache.org'" />
-  <xsl:param name="year" select="'2022'" />
+  <xsl:param name="year" select="'2023'" />
   <xsl:param name="max-img-width" select="'600'" />
 
   <!-- Output method -->


### PR DESCRIPTION
## Description

Update the copyright year in the NOTICE, which also affects the website.

## Motivation and Context

Do we really need the year here?

## How Has This Been Tested?

`./gradlew buildPreviewSite`

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
