### PR TITLE
Add KeyStroke for start_no_timers (Start no pauses: CRTL+SHIFT+n)

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/KeyStrokes.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/KeyStrokes.java
@@ -72,6 +72,7 @@ public final class KeyStrokes {
     public static final KeyStroke OPEN              = KeyStroke.getKeyStroke(KeyEvent.VK_O, CONTROL_MASK);
     public static final KeyStroke EXIT              = KeyStroke.getKeyStroke(KeyEvent.VK_Q, CONTROL_MASK);
     public static final KeyStroke ACTION_START      = KeyStroke.getKeyStroke(KeyEvent.VK_R, CONTROL_MASK);
+    public static final KeyStroke ACTION_START_NO_PAUSE  = KeyStroke.getKeyStroke(KeyEvent.VK_N, CONTROL_MASK | InputEvent.SHIFT_DOWN_MASK);
     public static final KeyStroke REMOTE_START_ALL  = KeyStroke.getKeyStroke(KeyEvent.VK_R, CONTROL_MASK | InputEvent.SHIFT_DOWN_MASK);
     public static final KeyStroke SAVE              = KeyStroke.getKeyStroke(KeyEvent.VK_S, CONTROL_MASK);
     public static final KeyStroke SAVE_ALL_AS       = KeyStroke.getKeyStroke(KeyEvent.VK_S, CONTROL_MASK | InputEvent.SHIFT_DOWN_MASK);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -448,7 +448,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
 
         runStart = makeMenuItemRes("start", 'S', ActionNames.ACTION_START, KeyStrokes.ACTION_START); //$NON-NLS-1$
 
-        runStartNoTimers = makeMenuItemRes("start_no_timers", 'N', ActionNames.ACTION_START_NO_TIMERS); //$NON-NLS-1$
+        runStartNoTimers = makeMenuItemRes("start_no_timers", 'N', ActionNames.ACTION_START_NO_TIMERS, KeyStrokes.ACTION_START_NO_PAUSE); //$NON-NLS-1$
 
         runStop = makeMenuItemRes("stop", 'T', ActionNames.ACTION_STOP, KeyStrokes.ACTION_STOP); //$NON-NLS-1$
         runStop.setEnabled(false);


### PR DESCRIPTION
## Description
Add an additional KeyStroke to Start a local test, skipping the Timers.

## Motivation and Context
In our daily doing we setup load tests, using Timers.
For faster test preparation, we want to skip timers.

## How Has This Been Tested?
./gradlew createDist
./bin/jmeter -t Testplan-with-pauses.jmx

Execute Testplan with Crtl-R
Execute Testplan with Ctrl-Shift-N

> Testplan will be executed, skipping the timers

## Types of changes
- New feature (non-breaking change which adds functionality)
