### PR TITLE
Dynamic charset for TcpSampler

### DIFF
--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
@@ -59,6 +59,8 @@ public class TCPConfigGui extends AbstractConfigGui {
 
     private JTextField soLinger;
 
+    private JTextField charset;
+
     private JTextField eolByte;
 
     private JSyntaxTextArea requestData;
@@ -95,6 +97,7 @@ public class TCPConfigGui extends AbstractConfigGui {
         requestData.setCaretPosition(0);
         closeConnection.setTristateFromProperty(element, TCPSampler.CLOSE_CONNECTION);
         soLinger.setText(element.getPropertyAsString(TCPSampler.SO_LINGER));
+        charset.setText(element.getPropertyAsString(TCPSampler.CHARSET));
         eolByte.setText(element.getPropertyAsString(TCPSampler.EOL_BYTE));
     }
 
@@ -124,6 +127,7 @@ public class TCPConfigGui extends AbstractConfigGui {
         element.setProperty(TCPSampler.REQUEST, requestData.getText());
         closeConnection.setPropertyFromTristate(element, TCPSampler.CLOSE_CONNECTION); // Don't use default for saving tristates
         element.setProperty(TCPSampler.SO_LINGER, soLinger.getText(), "");
+        element.setProperty(TCPSampler.CHARSET, charset.getText(), "");
         element.setProperty(TCPSampler.EOL_BYTE, eolByte.getText(), "");
     }
 
@@ -141,6 +145,7 @@ public class TCPConfigGui extends AbstractConfigGui {
         setNoDelay.setSelected(false); // TODO should this be indeterminate?
         closeConnection.setSelected(TCPSampler.CLOSE_CONNECTION_DEFAULT); // TODO should this be indeterminate?
         soLinger.setText(""); //$NON-NLS-1$
+        charset.setText(""); //$NON-NLS-1$
         eolByte.setText(""); //$NON-NLS-1$
     }
 
@@ -201,6 +206,19 @@ public class TCPConfigGui extends AbstractConfigGui {
         return soLingerPanel;
     }
 
+    private JPanel createCharsetPanel() {
+        JLabel label = new JLabel(JMeterUtils.getResString("charset")); //$NON-NLS-1$
+
+        charset = new JTextField(6); // 6 columns size
+        charset.setMaximumSize(new Dimension(charset.getPreferredSize()));
+        label.setLabelFor(charset);
+
+        JPanel charsetPanel = new JPanel(new FlowLayout());
+        charsetPanel.add(label);
+        charsetPanel.add(charset);
+        return charsetPanel;
+    }
+
     private JPanel createEolBytePanel() {
         JLabel label = new JLabel(JMeterUtils.getResString("eolbyte")); //$NON-NLS-1$
 
@@ -249,6 +267,7 @@ public class TCPConfigGui extends AbstractConfigGui {
         optionsPanel.add(createCloseConnectionPanel());
         optionsPanel.add(createNoDelayPanel());
         optionsPanel.add(createSoLingerOption());
+        optionsPanel.add(createCharsetPanel());
         optionsPanel.add(createEolBytePanel());
         mainPanel.add(optionsPanel);
         mainPanel.add(createRequestPanel());

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
@@ -88,6 +88,8 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
 
     public static final String SO_LINGER = "TCPSampler.soLinger"; //$NON-NLS-1$
 
+    public static final String CHARSET = "TCPSampler.charset"; //$NON-NLS-1$
+
     public static final String EOL_BYTE = "TCPSampler.EolByte"; //$NON-NLS-1$
 
     private static final String TCPKEY = "TCP"; //$NON-NLS-1$ key for HashMap
@@ -236,6 +238,14 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
         return getPropertyAsInt(SO_LINGER);
     }
 
+    public void setCharset(String charset) {
+        this.setProperty(CHARSET, charset, "");
+    }
+
+    public String getCharset() {
+        return getPropertyAsString(CHARSET);
+    }
+
     public void setEolByte(String eol) {
         this.setProperty(EOL_BYTE, eol, "");
     }
@@ -337,6 +347,11 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
             if (getPropertyAsString(EOL_BYTE, "").length()>0){
                 tcpClient.setEolByte(getEolByte());
                 log.info("Using eolByte={}", getEolByte());
+            }
+
+            if(getPropertyAsString(CHARSET, "").length() > 0 && tcpClient instanceof AbstractTCPClient) {
+                ((AbstractTCPClient)tcpClient).setCharset(getCharset());
+                log.info("Using charset={}", getCharset());
             }
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION

## Description


When I use tcp sampler, when multiple samplers correspond to transactions that use different charsets, the request or response becomes garbled,

## Our Vision
By dynamically setting the sampler charset, can make the charset configurable during sampler initialization, or set the charset through the pre-processor on each iteration, 
such as
```groovy
// for init protocolHandler
if(sampler.firstSample) {
  sampler.initSampling()
  sampler.firstSample = false
}
sampler.protocolHandler.charset = xxx// Can be changed by sampler.name or other thing
```
## Current Situation
When use tcp sampler, their charset as one determined by the script start time
## Types of changes
Minor changes