### PR TITLE
Escape control characters in CSV log file

### DIFF
--- a/src/core/src/test/java/org/apache/jmeter/save/TestCSVSaveService.java
+++ b/src/core/src/test/java/org/apache/jmeter/save/TestCSVSaveService.java
@@ -25,14 +25,24 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestCSVSaveService extends JMeterTestCase {
+
+    private static final String[] EMPTY_STRING_ARRAY = {};
 
     private void checkSplitString(String input, char delim, String[] expected) throws Exception {
         String[] out = CSVSaveService.csvSplitString(input, delim);
@@ -49,7 +59,7 @@ public class TestCSVSaveService extends JMeterTestCase {
     // This is what JOrphanUtils.split() does
     @Test
     public void testSplitEmpty() throws Exception {
-        checkSplitString("",         ',', new String[]{});
+        checkSplitString("",         ',', EMPTY_STRING_ARRAY);
     }
 
     // These tests should agree with those for JOrphanUtils.split() as far as possible
@@ -86,6 +96,7 @@ public class TestCSVSaveService extends JMeterTestCase {
         checkSplitString("a,bc,d,",      ',', new String[]{"a","bc","d",""});
         checkSplitString("a,bc,d,\"\"",  ',', new String[]{"a","bc","d",""});
         checkSplitString("a,bc,d,\"\"\n",',', new String[]{"a","bc","d",""});
+        checkSplitString("a\\nx,bc,d,\"\"\n",',', new String[]{"a\nx","bc","d",""});
 
         // \u00e7 = LATIN SMALL LETTER C WITH CEDILLA
         // \u00e9 = LATIN SMALL LETTER E WITH ACUTE
@@ -94,7 +105,7 @@ public class TestCSVSaveService extends JMeterTestCase {
 
     @Test
     public void testSplitBadQuote() throws Exception {
-        assertThrows(IOException.class, () -> checkSplitString("a\"b", ',', new String[] {}));
+        assertThrows(IOException.class, () -> checkSplitString("a\"b", ',', EMPTY_STRING_ARRAY));
     }
 
     @Test
@@ -111,9 +122,9 @@ public class TestCSVSaveService extends JMeterTestCase {
         assertEquals("Expected to be at EOF",-1,br.read());
         // Empty strings at EOF
         out = CSVSaveService.csvReadFile(br, ',');
-        checkStrings(new String[]{}, out);
+        checkStrings(EMPTY_STRING_ARRAY, out);
         out = CSVSaveService.csvReadFile(br, ',');
-        checkStrings(new String[]{}, out);
+        checkStrings(EMPTY_STRING_ARRAY, out);
     }
 
     @Test
@@ -136,7 +147,7 @@ public class TestCSVSaveService extends JMeterTestCase {
     public void testEmptyFile() throws Exception  {
         BufferedReader br = new BufferedReader(new StringReader(""));
         String[] out = CSVSaveService.csvReadFile(br, ',');
-        checkStrings(new String[]{}, out);
+        checkStrings(EMPTY_STRING_ARRAY, out);
         assertEquals("Expected to be at EOF",-1,br.read());
     }
 
@@ -157,29 +168,61 @@ public class TestCSVSaveService extends JMeterTestCase {
         assertEquals("Header text has changed", HDR, CSVSaveService.printableFieldNamesToString());
     }
 
-    @Test
+    static Stream<Arguments> sampleData() throws MalformedURLException {
+        List<Arguments> args = new ArrayList<>();
+        for (String message: Arrays.asList(
+                "normal message with no new line",
+                "Something happened:\nmessage with new line",
+                "message with comma, really",
+                "message with comma,\nand a new line",
+                "",
+                "message with \r\nCR and NL"
+                )
+        ) {
+
+            SampleResult result = new SampleResult();
+            result.setSaveConfig(new SampleSaveConfiguration());
+            result.setStampAndTime(1, 2);
+            result.setSampleLabel("3");
+            result.setResponseCode("4");
+            result.setResponseMessage(message);
+            result.setThreadName("6");
+            result.setDataType("7");
+            result.setSuccessful(true);
+            result.setBytes(8L);
+            result.setURL(new URL("https://jmeter.apache.org"));
+            result.setSentBytes(9);
+            result.setGroupThreads(10);
+            result.setAllThreads(11);
+            result.setLatency(12);
+            result.setIdleTime(13);
+            result.setConnectTime(14);
+            String csvLine = String.format(
+                    "1,2,3,4,%s,6,7,true,,8,9,10,11,https://jmeter.apache.org,12,13,14",
+                    escapeString(message)
+            );
+            args.add(Arguments.of(new SampleEvent(result, ""), csvLine));
+        }
+        return args.stream();
+    }
+
+    private static String escapeString(String message) {
+        if (StringUtils.containsAny("\"\r\n,", message)) {
+            return String.format(
+                    "\"%s\"",
+                    message
+                            .replace("\"", "\"\"")
+                            .replace("\r", "\\r")
+                            .replace("\n", "\\n"));
+        }
+        return message;
+    }
+
+    @ParameterizedTest
+    @MethodSource("sampleData")
     // sample format should not change unexpectedly
     // if this test fails, check whether the default was intentionally changed or not
-    public void testSample() throws MalformedURLException {
-        final String RESULT = "1,2,3,4,5,6,7,true,,8,9,10,11,https://jmeter.apache.org,12,13,14";
-        SampleResult result = new SampleResult();
-        result.setSaveConfig(new SampleSaveConfiguration());
-        result.setStampAndTime(1, 2);
-        result.setSampleLabel("3");
-        result.setResponseCode("4");
-        result.setResponseMessage("5");
-        result.setThreadName("6");
-        result.setDataType("7");
-        result.setSuccessful(true);
-        result.setBytes(8L);
-        result.setURL(new URL("https://jmeter.apache.org"));
-        result.setSentBytes(9);
-        result.setGroupThreads(10);
-        result.setAllThreads(11);
-        result.setLatency(12);
-        result.setIdleTime(13);
-        result.setConnectTime(14);
-
-        assertEquals("Result text has changed", RESULT, CSVSaveService.resultToDelimitedString(new SampleEvent(result,"")));
+    public void testSample(SampleEvent event, String csvLine) throws MalformedURLException {
+        assertEquals("Result text has changed", csvLine, CSVSaveService.resultToDelimitedString(event));
     }
 }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -179,6 +179,7 @@ Summary
 <ul>
   <li><bug>66157</bug><pr>719</pr>Correct theme for darklaf on rsyntaxtextarea</li>
   <li><issue>5872</issue><pr>5874</pr>Trim name in Argument objects.</li>
+  <li><issue>5770</issue><pr>5805</pr>Escape control characters in CSV log file when using <code>CSVSaveService</code></li>
 </ul>
 
  <!--  =================== Thanks =================== -->


### PR DESCRIPTION
## Description

This patch escapes new line and carriage return characters when writing and unescapes them when reading those CSV log files.

## Motivation and Context

As reported in #5770 and on the users mailing list, we currently do not escape new line characters when writing the CSV log file.


## How Has This Been Tested?

Tested on a local test plan and add JUnit tests.


## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
  But could also be seen as a new feature or even breaking change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
