### PR TITLE
Bug GH 5807 - Fix an ArrayIndexOutOfBoundsException on HTTP parameter…

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -287,6 +287,9 @@ public class RequestViewHTTP implements RequestView {
         String[] params = query.split(PARAM_CONCATENATE);
         for (String param : params) {
             String[] paramSplit = param.split("=");
+            if (paramSplit.length == 0) {
+                return map;
+            }
             String name = decodeQuery(paramSplit[0]);
 
             // hack for SOAP request (generally)

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -287,6 +287,9 @@ public class RequestViewHTTP implements RequestView {
         String[] params = query.split(PARAM_CONCATENATE);
         for (String param : params) {
             String[] paramSplit = param.split("=");
+            if (paramSplit.length == 0) { // Bug Github 5807
+                return map;
+            }
             String name = decodeQuery(paramSplit[0]);
 
             // hack for SOAP request (generally)

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTPTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTPTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import junit.framework.TestCase;
@@ -192,5 +193,21 @@ public class RequestViewHTTPTest extends TestCase {
         Assert.assertEquals(1, param1.getValue().length);
         Assert.assertEquals(query, param1.getValue()[0]);
         Assert.assertTrue(StringUtils.isBlank(param1.getKey()));
+    }
+    
+    @Test
+    public void testGetQueryMapWithEmptyKeyAndValue() {
+        String query = "k1=v1&=&k2=v2";
+        Map<String, String[]> params = RequestViewHTTP.getQueryMap(query);
+        Assert.assertNotNull(params);
+        Assertions.assertEquals(2, params.size() + 1); // 2 params found
+    }
+    
+    @Test
+    public void testGetQueryMapWithOnlyEmptyKeyAndValue() {
+        String query = "=";
+        Map<String, String[]> params = RequestViewHTTP.getQueryMap(query);
+        Assert.assertNotNull(params);
+        Assertions.assertEquals(0, params.size()); // 0 param found
     }
 }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -137,6 +137,7 @@ Summary
 <h3>Listeners</h3>
 <ul>
   <li><issue>5740</issue><pr>5741</pr>Fix Aggregated Graph component to cope with empty names of samplers</li>
+  <li><issue>5807</issue>Fix an ArrayIndexOutOfBoundsException on HTTP parameters line on special case when key and value are empty, i.e.: "k1=v1&amp;&#61;&amp;k2=v2"</li>
 </ul>
 
 <h3>Timers, Assertions, Config, Pre- &amp; Post-Processors</h3>


### PR DESCRIPTION
…s line on special case when key and value are empty, i.e.: "k1=v1&=&k2=v2"

## Description
Fix parsing issue on special case when key and value are empty, i.e.: "k1=v1&=&k2=v2"

## Motivation and Context
Related to https://github.com/apache/jmeter/issues/5807

## How Has This Been Tested?
Run the provided test case from https://github.com/apache/jmeter/issues/5807 and followed the instructions given there.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
