### PR TITLE
Bug #5807 - Fix an ArrayIndexOutOfBoundsException on HTTP parameters …

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -287,6 +287,9 @@ public class RequestViewHTTP implements RequestView {
         String[] params = query.split(PARAM_CONCATENATE);
         for (String param : params) {
             String[] paramSplit = param.split("=");
+            if (paramSplit.length == 0) {
+                continue; // We found no key-/value-pair, so continue on the next param
+            }
             String name = decodeQuery(paramSplit[0]);
 
             // hack for SOAP request (generally)
@@ -318,7 +321,6 @@ public class RequestViewHTTP implements RequestView {
             }
             map.put(name, known);
         }
-
         return map;
     }
 

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -137,6 +137,7 @@ Summary
 <h3>Listeners</h3>
 <ul>
   <li><issue>5740</issue><pr>5741</pr>Fix Aggregated Graph component to cope with empty names of samplers</li>
+  <li><issue>5807</issue>Fix an ArrayIndexOutOfBoundsException on HTTP parameters line on special case when key and value are empty, i.e.: "k1=v1&amp;&#61;&amp;k2=v2"</li>
 </ul>
 
 <h3>Timers, Assertions, Config, Pre- &amp; Post-Processors</h3>


### PR DESCRIPTION
… line on special case when key and value are empty, i.e.: "k1=v1&=&k2=v2"

## Description
Fix parsing issue on special case when key and value are empty, i.e.: "k1=v1&=&k2=v2"

## Motivation and Context
Related to https://github.com/apache/jmeter/issues/5807

## How Has This Been Tested?
Run the provided test case from https://github.com/apache/jmeter/issues/5807 and followed the instructions given there.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the [code style][style-guide] of this project.
