### PR TITLE
chore: call verifyReleaseDependencies only when building release version

### DIFF
--- a/src/dist/build.gradle.kts
+++ b/src/dist/build.gradle.kts
@@ -237,6 +237,10 @@ val verifyReleaseDependencies by tasks.registering {
         if (updateExpectedJars) {
             println("Updating ${expectedLibs.relativeTo(rootDir)}")
             actualLibs.copyTo(expectedLibs, overwrite = true)
+        } else if (version.toString().endsWith("-SNAPSHOT")) {
+            // Renovate requires self-hosted runner for executing postUpgradeTasks,
+            // so we can't make Renovate to update expected_release_jars.csv at the moment
+            logger.lifecycle(sb.toString())
         } else {
             throw GradleException(sb.toString())
         }


### PR DESCRIPTION
For non-snapshot versions, don't fail the build if the actual dependencies differ from the expected ones.

It would enable accepting PRs from Renovate bot without resorting to manual resolution every time.

Renovate's `postUpgradeTasks` requires self-hosted runner, so we can't make it update `expected_release_jars.csv` automatically.
I think it would be fine to update it once every release.

## Motivation and Context

Renovate will create PRs to bump dependencies from time to time, however, I'm not sure if we can teach it to 
