### PR TITLE
Deadlock in testsuite

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
@@ -47,6 +47,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.HyperlinkEvent;
@@ -260,7 +261,9 @@ public class SelectTemplatesDialog extends JDialog implements ChangeListener, Ac
 
         this.pack();
         this.setMinimumSize(new Dimension(MINIMAL_BOX_WIDTH, MINIMAL_BOX_HEIGHT));
-        ComponentUtil.centerComponentInWindow(this, 50); // center position and 50% of screen size
+        SwingUtilities.invokeLater(() ->
+            ComponentUtil.centerComponentInWindow(this, 50) // center position and 50% of screen size
+        );
         populateTemplatePage();
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
@@ -47,7 +47,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.HyperlinkEvent;
@@ -261,9 +260,7 @@ public class SelectTemplatesDialog extends JDialog implements ChangeListener, Ac
 
         this.pack();
         this.setMinimumSize(new Dimension(MINIMAL_BOX_WIDTH, MINIMAL_BOX_HEIGHT));
-        SwingUtilities.invokeLater(() ->
-            ComponentUtil.centerComponentInWindow(this, 50) // center position and 50% of screen size
-        );
+        ComponentUtil.centerComponentInWindow(this, 50); // center position and 50% of screen size
         populateTemplatePage();
     }
 

--- a/src/dist-check/src/test/java/org/apache/jmeter/junit/JMeterTest.java
+++ b/src/dist-check/src/test/java/org/apache/jmeter/junit/JMeterTest.java
@@ -22,7 +22,6 @@ import java.awt.HeadlessException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -63,7 +62,6 @@ import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -122,7 +120,7 @@ public class JMeterTest extends JMeterTestCaseJUnit implements Describable {
         StringBuilder sb = new StringBuilder();
         sb.append(getName());
         if (guiItem instanceof TestBeanGUI) {
-            sb.append(" ").append(guiItem.toString());
+            sb.append(" ").append(guiItem);
         } else if (guiItem != null) {
             sb.append(" ").append(guiItem.getClass().getName());
         } else if (serObj != null) {
@@ -190,13 +188,12 @@ public class JMeterTest extends JMeterTestCaseJUnit implements Describable {
     }
 
     /**
-     * @return
-     * @throws ParserConfigurationException
-     * @throws IOException
-     * @throws SAXException
-     * @throws FileNotFoundException
+     * @return first element named {@code body}
+     * @throws ParserConfigurationException when stream contains invalid XML
+     * @throws IOException when stream can not be read
+     * @throws SAXException in case of XML parsing error
      */
-    private Element getBodyFromXMLDocument(InputStream stream)
+    private org.w3c.dom.Element getBodyFromXMLDocument(InputStream stream)
             throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setIgnoringElementContentWhitespace(true);
@@ -242,14 +239,14 @@ public class JMeterTest extends JMeterTestCaseJUnit implements Describable {
         }
 
         int unseen = 0;
-        for (String key : s) {
-            if (!m.get(key).equals(Boolean.TRUE)) {
+        for (Map.Entry<String, Boolean> entry : m.entrySet()) {
+            if (!entry.getValue().equals(Boolean.TRUE)) {
                 if (unseen == 0)// first time
                 {
                     System.out.println("\nNames remaining in " + t + " Map:");
                 }
                 unseen++;
-                System.out.println(key);
+                System.out.println(entry.getKey());
             }
         }
         return unseen;
@@ -318,7 +315,7 @@ public class JMeterTest extends JMeterTestCaseJUnit implements Describable {
      * Test GUI elements - run the test
      */
     public void runGUITitle() throws Exception {
-        if (guiTitles.size() > 0) {
+        if (!guiTitles.isEmpty()) {
             String title = guiItem.getDocAnchor();
             boolean ct = guiTitles.containsKey(title);
             if (ct) {
@@ -326,7 +323,7 @@ public class JMeterTest extends JMeterTestCaseJUnit implements Describable {
             }
             String name = guiItem.getClass().getName();
             if (// Is this a work in progress or an internal GUI component?
-                title != null && title.length() > 0 // Will be "" for internal components
+                title != null && !title.isEmpty() // Will be "" for internal components
                 && !title.toUpperCase(Locale.ENGLISH).contains("(ALPHA")
                 && !title.toUpperCase(Locale.ENGLISH).contains("(BETA")
                 && !title.toUpperCase(Locale.ENGLISH).contains("(DEPRECATED")
@@ -356,7 +353,7 @@ public class JMeterTest extends JMeterTestCaseJUnit implements Describable {
             try {
                 String label = guiItem.getLabelResource();
                 assertNotNull("Label should not be null for "+name, label);
-                assertTrue("Label should not be empty for "+name, label.length() > 0);
+                assertTrue("Label should not be empty for "+name, !label.isEmpty());
                 assertFalse("'" + label + "' should be in resource file for " + name, JMeterUtils.getResString(
                         label).startsWith(JMeterUtils.RES_KEY_PFX));
             } catch (UnsupportedOperationException uoe) {

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ComponentUtil.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ComponentUtil.java
@@ -23,7 +23,7 @@ import java.awt.Rectangle;
 
 /**
  * This class is a Util for awt Component and could be used to place them in
- * center of an other.
+ * center of another.
  *
  */
 public final class ComponentUtil {
@@ -36,19 +36,12 @@ public final class ComponentUtil {
      * @param component
      *            the component you want to center and set size on
      * @param percentOfScreen
-     *            the percent of the current screensize you want the component
+     *            the percent of the current screen size you want the component
      *            to be
      */
     public static void centerComponentInWindow(Component component, int percentOfScreen) {
-        if (percentOfScreen < 0) {
-            centerComponentInWindow(component, -percentOfScreen);
-            return;
-        }
-        if (percentOfScreen > 100) {
-            centerComponentInWindow(component, 100);
-            return;
-        }
-        double percent = percentOfScreen / 100.d;
+        int validPercentOfScreen = Math.min(Math.abs(percentOfScreen), 100);
+        double percent = validPercentOfScreen / 100.d;
         Rectangle bounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration().getBounds();
         component.setSize((int) (bounds.getWidth() * percent), (int) (bounds.getHeight() * percent));
         centerComponentInWindow(component);


### PR DESCRIPTION
## Description

Place code, that acts on live AWT components into the AWT thread.

Simplify code, that used recursion to set input parameters. Saw this one, while looking at the code, that was potentially in the wrong thread.

## Motivation and Context

Try to overcome a deadlock in test suite
    
When running locally, I observed the following deadlock:
    
    "AWT-EventQueue-1" #23 prio=6 os_prio=0 tid=0x00007f3de9bf6800 nid=0x722b2 waiting for monitor entry [0x00007f3dcb4ee000]
       java.lang.Thread.State: BLOCKED (on object monitor)
            at java.awt.Component$AccessibleAWTComponent.getLocationOnScreen(Component.java:9494)
            - waiting to lock <0x00000000e0653ef0> (a java.awt.Component$AWTTreeLock)
            at javax.swing.JComponent$AccessibleJComponent.getLocationOnScreen(JComponent.java:3663)
            at javax.swing.text.JTextComponent$AccessibleJTextComponent.<init>(JTextComponent.java:2516)
            at javax.swing.JEditorPane$AccessibleJEditorPane.<init>(JEditorPane.java:1644)
            at javax.swing.JEditorPane$JEditorPaneAccessibleHypertextSupport.<init>(JEditorPane.java:1971)
            at javax.swing.JEditorPane$AccessibleJEditorPaneHTML.getAccessibleText(JEditorPane.java:1703)
            at org.GNOME.Accessibility.AtkObject.lambda$getTFlagFromObj$0(AtkObject.java:70)
            at org.GNOME.Accessibility.AtkObject$$Lambda$317/331870887.call(Unknown Source)
            at org.GNOME.Accessibility.AtkUtil.invokeInSwing(AtkUtil.java:58)
            at org.GNOME.Accessibility.AtkObject.getTFlagFromObj(AtkObject.java:55)
            at org.GNOME.Accessibility.AtkWrapper.boundsChanged(Native Method)
            at org.GNOME.Accessibility.AtkWrapper$3.componentResized(AtkWrapper.java:235)
            at java.awt.AWTEventMulticaster.componentResized(AWTEventMulticaster.java:159)
            at java.awt.Component.processComponentEvent(Component.java:6365)
            at java.awt.Component.processEvent(Component.java:6319)
            at java.awt.Container.processEvent(Container.java:2239)
            at java.awt.Component.dispatchEventImpl(Component.java:4889)
            at java.awt.Container.dispatchEventImpl(Container.java:2297)
            at java.awt.Component.dispatchEvent(Component.java:4711)
            at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:760)
            at java.awt.EventQueue.access$500(EventQueue.java:97)
            at java.awt.EventQueue$3.run(EventQueue.java:709)
            at java.awt.EventQueue$3.run(EventQueue.java:703)
            at java.security.AccessController.doPrivileged(Native Method)
            at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
            at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:84)
            at java.awt.EventQueue$4.run(EventQueue.java:733)
            at java.awt.EventQueue$4.run(EventQueue.java:731)
            at java.security.AccessController.doPrivileged(Native Method)
            at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
            at java.awt.EventQueue.dispatchEvent(EventQueue.java:730)
            at org.GNOME.Accessibility.AtkWrapper$6.dispatchEvent(AtkWrapper.java:717)
            at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
            at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
            at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
            at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
            at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
            at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
    
    "Test worker" #1 prio=5 os_prio=0 tid=0x00007f3de8012000 nid=0x7228f waiting on condition [0x00007f3def695000]
       java.lang.Thread.State: WAITING (parking)
            at sun.misc.Unsafe.park(Native Method)
            - parking to wait for  <0x00000000f80386a8> (a java.util.concurrent.FutureTask)
            at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
            at java.util.concurrent.FutureTask.awaitDone(FutureTask.java:429)
            at java.util.concurrent.FutureTask.get(FutureTask.java:191)
            at org.GNOME.Accessibility.AtkUtil.invokeInSwing(AtkUtil.java:68)
            at org.GNOME.Accessibility.AtkObject.hashCode(AtkObject.java:234)
            at org.GNOME.Accessibility.AtkWrapper.emitSignal(Native Method)
            at org.GNOME.Accessibility.AtkWrapper$5.propertyChange(AtkWrapper.java:557)
            at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
            at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
            at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
            at javax.accessibility.AccessibleContext.firePropertyChange(AccessibleContext.java:768)
            at javax.swing.JScrollPane$AccessibleJScrollPane.stateChanged(JScrollPane.java:1506)
            at javax.swing.JViewport.fireStateChanged(JViewport.java:1369)
            at javax.swing.JViewport.reshape(JViewport.java:839)
            at java.awt.Component.setBounds(Component.java:2261)
            at java.awt.Component.setBounds(Component.java:2405)
            at javax.swing.ScrollPaneLayout.layoutContainer(ScrollPaneLayout.java:890)
            at java.awt.Container.layout(Container.java:1513)
            at java.awt.Container.doLayout(Container.java:1502)
            at java.awt.Container.validateTree(Container.java:1698)
            at java.awt.Container.validateTree(Container.java:1707)
            at java.awt.Container.validateTree(Container.java:1707)
            at java.awt.Container.validateTree(Container.java:1707)
            at java.awt.Container.validateTree(Container.java:1707)
            at java.awt.Container.validate(Container.java:1633)
            - locked <0x00000000e0653ef0> (a java.awt.Component$AWTTreeLock)
            at org.apache.jorphan.gui.ComponentUtil.centerComponentInWindow(ComponentUtil.java:67)
            at org.apache.jorphan.gui.ComponentUtil.centerComponentInWindow(ComponentUtil.java:54)
            at org.apache.jmeter.gui.action.SelectTemplatesDialog.init(SelectTemplatesDialog.java:263)
            at org.apache.jmeter.gui.action.SelectTemplatesDialog.<init>(SelectTemplatesDialog.java:105)
            at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
            at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
            at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
            at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
            at org.apache.jmeter.junit.JMeterTest.instantiateClass(JMeterTest.java:512)
            at org.apache.jmeter.junit.JMeterTest.getObjects(JMeterTest.java:474)
            at org.apache.jmeter.junit.JMeterTest.suiteSerializableElements(JMeterTest.java:407)
            at org.apache.jmeter.junit.JMeterTest.suite(JMeterTest.java:149)
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.junit.internal.runners.SuiteMethod.testFromSuiteMethod(SuiteMethod.java:35)
    
I hope to get rid of this by placing the code to center the newly created dialog
in the AWT thread.
    
I believe the deadlock happens only in our test code, when the dialog is created
and instantaneously destroyed.

## How Has This Been Tested?

Ran the tests a few time and looked at the GUI.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
