### PR TITLE
Add GUI Effect Checker to ensure UI actions are called on UI thread only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,3 +69,20 @@ jobs:
         job-id: errprone
         multi-cache-enabled: false
         arguments: --scan --no-parallel --no-daemon -PenableErrorprone classes
+
+  checkerframework:
+    name: 'Checkerframework (JDK 11)'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: 'Set up JDK 11'
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: 'zulu'
+    - uses: burrunan/gradle-cache-action@v1
+      name: Test
+      with:
+        job-id: checkerframework
+        multi-cache-enabled: false
+        arguments: --scan --no-parallel --no-daemon -PenableCheckerframework classes

--- a/build-logic/verification/src/main/kotlin/build-logic.checkerframework.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.checkerframework.gradle.kts
@@ -46,10 +46,10 @@ checkerFramework {
     skipVersionCheck = true
     excludeTests = true
     // See https://checkerframework.org/manual/#introduction
-    checkers.add("org.checkerframework.checker.nullness.NullnessChecker")
-    checkers.add("org.checkerframework.checker.optional.OptionalChecker")
+    checkers.add("org.checkerframework.checker.guieffect.GuiEffectChecker")
+    // checkers.add("org.checkerframework.checker.optional.OptionalChecker")
     // checkers.add("org.checkerframework.checker.index.IndexChecker")
-    checkers.add("org.checkerframework.checker.regex.RegexChecker")
+    // checkers.add("org.checkerframework.checker.regex.RegexChecker")
     extraJavacArgs.add(
         "-Astubs=" +
             fileTree("$rootDir/config/checkerframework") {

--- a/config/checkerframework/AbstractButton.astub
+++ b/config/checkerframework/AbstractButton.astub
@@ -1,0 +1,24 @@
+package javax.swing;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
+abstract class AbstractButton {
+  @SafeEffect
+  public void addChangeListener(@UI ChangeListener l);
+
+  @SafeEffect
+  public void removeChangeListener(@UI ChangeListener l);
+
+  @SafeEffect
+  public @UI ChangeListener[] getChangeListeners();
+
+  @SafeEffect
+  public void addActionListener(@UI ActionListener l);
+
+  @SafeEffect
+  public void removeActionListener(@UI ActionListener l);
+
+  @SafeEffect
+  public @UI ActionListener[] getActionListeners();
+}

--- a/config/checkerframework/Callable.astub
+++ b/config/checkerframework/Callable.astub
@@ -1,0 +1,10 @@
+package java.util.function;
+
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+
+@PolyUIType
+public interface Consumer<T> {
+    @PolyUIEffect
+    public void accept(T t);
+}

--- a/config/checkerframework/Closeable.astub
+++ b/config/checkerframework/Closeable.astub
@@ -1,11 +1,11 @@
 package java.io;
 
+import org.checkerframework.checker.guieffect.qual.PolyUI;
 import org.checkerframework.checker.guieffect.qual.PolyUIType;
 import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
 
 @PolyUIType
-interface Closeable extends AutoCloseable {
-
+public interface Closeable {
   @PolyUIEffect
   public void close() throws IOException;
 }

--- a/config/checkerframework/Closeable.astub
+++ b/config/checkerframework/Closeable.astub
@@ -1,0 +1,11 @@
+package java.io;
+
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+
+@PolyUIType
+interface Closeable extends AutoCloseable {
+
+  @PolyUIEffect
+  public void close() throws IOException;
+}

--- a/config/checkerframework/Component.astub
+++ b/config/checkerframework/Component.astub
@@ -1,0 +1,10 @@
+package java.awt;
+
+import java.beans.PropertyChangeListener;
+import org.checkerframework.checker.guieffect.qual.UI;
+
+class Component {
+  public void addPropertyChangeListener(
+    String propertyName,
+    @UI PropertyChangeListener listener);
+}

--- a/config/checkerframework/Component.astub
+++ b/config/checkerframework/Component.astub
@@ -2,9 +2,22 @@ package java.awt;
 
 import java.beans.PropertyChangeListener;
 import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 class Component {
   public void addPropertyChangeListener(
     String propertyName,
     @UI PropertyChangeListener listener);
+
+  @SafeEffect
+  public void addFocusListener(@UI FocusListener l);
+
+  @SafeEffect
+  public synchronized void removeFocusListener(@UI FocusListener l);
+
+  @SafeEffect
+  public synchronized @UI FocusListener[] getFocusListeners();
+
+  @SafeEffect
+  public void toString();
 }

--- a/config/checkerframework/Consumer.astub
+++ b/config/checkerframework/Consumer.astub
@@ -1,5 +1,6 @@
 package java.util.function;
 
+import org.checkerframework.checker.guieffect.qual.PolyUI;
 import org.checkerframework.checker.guieffect.qual.PolyUIType;
 import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
 

--- a/config/checkerframework/Container.astub
+++ b/config/checkerframework/Container.astub
@@ -1,0 +1,10 @@
+package java.awt;
+
+import java.beans.PropertyChangeListener;
+import org.checkerframework.checker.guieffect.qual.UI;
+
+class Container {
+  public void addPropertyChangeListener(
+    String propertyName,
+    @UI PropertyChangeListener listener);
+}

--- a/config/checkerframework/Customizer.astub
+++ b/config/checkerframework/Customizer.astub
@@ -1,0 +1,13 @@
+package java.beans;
+
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+
+@PolyUIType
+public @PolyUI interface Customizer {
+   @PolyUIEffect
+   public void setObject(Object bean);
+   public void addPropertyChangeListener(@PolyUI PropertyChangeListener listener);
+   public void removePropertyChangeListener(@PolyUI PropertyChangeListener listener);
+}

--- a/config/checkerframework/DefaultTableCellRenderer.astub
+++ b/config/checkerframework/DefaultTableCellRenderer.astub
@@ -1,0 +1,7 @@
+package javax.swing.table;
+
+import org.checkerframework.checker.guieffect.qual.UIType;
+
+@UIType
+class DefaultTableCellRenderer {
+}

--- a/config/checkerframework/Document.astub
+++ b/config/checkerframework/Document.astub
@@ -1,0 +1,10 @@
+package javax.swing.text;
+
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
+interface Document {
+    @SafeEffect
+    public void removeDocumentListener(DocumentListener listener);
+    @SafeEffect
+    public void addDocumentListener(DocumentListener listener);
+}

--- a/config/checkerframework/DocumentEvent.astub
+++ b/config/checkerframework/DocumentEvent.astub
@@ -1,0 +1,7 @@
+package javax.swing.event;
+
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
+public interface DocumentEvent {
+}

--- a/config/checkerframework/EventListenerList.astub
+++ b/config/checkerframework/EventListenerList.astub
@@ -1,0 +1,7 @@
+package javax.swing.event;
+
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
+public class EventListenerList {
+}

--- a/config/checkerframework/Function.astub
+++ b/config/checkerframework/Function.astub
@@ -1,0 +1,15 @@
+package java.util.function;
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+
+@PolyUIType
+public interface Function<T, R> {
+  @PolyUIEffect
+  R apply(T t);
+  @PolyUIEffect
+  <V> Function<V, R> compose(@PolyUI Function<? super V, ? extends T> before);
+  @PolyUIEffect
+  <V> Function<T, V> andThen(@PolyUI Function<? super R, ? extends V> after);
+  static <T> Function<T, T> identity();
+}

--- a/config/checkerframework/Function.astub
+++ b/config/checkerframework/Function.astub
@@ -1,4 +1,5 @@
 package java.util.function;
+
 import org.checkerframework.checker.guieffect.qual.PolyUI;
 import org.checkerframework.checker.guieffect.qual.PolyUIType;
 import org.checkerframework.checker.guieffect.qual.PolyUIEffect;

--- a/config/checkerframework/Function.astub
+++ b/config/checkerframework/Function.astub
@@ -2,14 +2,15 @@ package java.util.function;
 import org.checkerframework.checker.guieffect.qual.PolyUI;
 import org.checkerframework.checker.guieffect.qual.PolyUIType;
 import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @PolyUIType
 public interface Function<T, R> {
   @PolyUIEffect
   R apply(T t);
-  @PolyUIEffect
-  <V> Function<V, R> compose(@PolyUI Function<? super V, ? extends T> before);
-  @PolyUIEffect
-  <V> Function<T, V> andThen(@PolyUI Function<? super R, ? extends V> after);
+  @SafeEffect
+  <V> @PolyUI Function<V, R> compose(@PolyUI Function<? super V, ? extends T> before);
+  @SafeEffect
+  <V> @PolyUI Function<T, V> andThen(@PolyUI Function<? super R, ? extends V> after);
   static <T> Function<T, T> identity();
 }

--- a/config/checkerframework/Iterable.astub
+++ b/config/checkerframework/Iterable.astub
@@ -1,0 +1,11 @@
+package java.lang;
+
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+
+@PolyUIType
+interface Iterable<E> {
+  @PolyUIEffect
+  void forEach(@PolyUI Consumer<? super T> action);
+}

--- a/config/checkerframework/JComboBox.astub
+++ b/config/checkerframework/JComboBox.astub
@@ -1,0 +1,8 @@
+package javax.swing;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+
+class JComboBox<E> {
+   public void addItemListener(@UI ItemListener aListener);
+   public void removeItemListener(@UI ItemListener aListener);
+}

--- a/config/checkerframework/JTextField.astub
+++ b/config/checkerframework/JTextField.astub
@@ -1,0 +1,16 @@
+package javax.swing;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
+class JTextField {
+  @SafeEffect
+  public void addActionListener(@UI ActionListener l);
+
+  @SafeEffect
+  public void removeActionListener(@UI ActionListener l);
+
+  @SafeEffect
+  public @UI ActionListener[] getActionListeners();
+}

--- a/config/checkerframework/MouseEvent.astub
+++ b/config/checkerframework/MouseEvent.astub
@@ -1,0 +1,7 @@
+package java.awt.event;
+
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
+public class MouseEvent {
+}

--- a/config/checkerframework/PropertyDescriptor.astub
+++ b/config/checkerframework/PropertyDescriptor.astub
@@ -1,0 +1,7 @@
+package java.beans;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+
+public class PropertyDescriptor {
+  public void setPropertyEditorClass(Class<? extends @UI Object> propertyEditorClass);
+}

--- a/config/checkerframework/PropertyEditor.astub
+++ b/config/checkerframework/PropertyEditor.astub
@@ -1,0 +1,46 @@
+package java.beans;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
+@PolyUIType
+public interface PropertyEditor {
+    @PolyUIEffect
+    void setValue(Object value);
+
+    @PolyUIEffect
+    Object getValue();
+
+    @SafeEffect
+    boolean isPaintable();
+
+    @PolyUIEffect
+    void paintValue(java.awt.Graphics gfx, java.awt.Rectangle box);
+
+    @SafeEffect
+    String getJavaInitializationString();
+
+    @PolyUIEffect
+    String getAsText(@PolyUI PropertyEditor this);
+
+    @PolyUIEffect
+    void setAsText(@PolyUI PropertyEditor this, String text) throws java.lang.IllegalArgumentException;
+
+    @SafeEffect
+    String[] getTags();
+
+    @PolyUIEffect
+    java.awt.Component getCustomEditor(@PolyUI PropertyEditor this);
+
+    @SafeEffect
+    boolean supportsCustomEditor();
+
+    @SafeEffect
+    void addPropertyChangeListener(@PolyUI PropertyChangeListener listener);
+
+    @SafeEffect
+    void removePropertyChangeListener(@PolyUI PropertyChangeListener listener);
+}

--- a/config/checkerframework/PropertyEditorSupport.astub
+++ b/config/checkerframework/PropertyEditorSupport.astub
@@ -1,0 +1,49 @@
+package java.beans;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
+@PolyUIType
+public class PropertyEditorSupport implements PropertyEditor {
+    @PolyUIEffect
+    void setValue(Object value);
+
+    @PolyUIEffect
+    Object getValue();
+
+    @SafeEffect
+    boolean isPaintable();
+
+    @PolyUIEffect
+    void paintValue(java.awt.Graphics gfx, java.awt.Rectangle box);
+
+    @SafeEffect
+    String getJavaInitializationString();
+
+    @PolyUIEffect
+    String getAsText();
+
+    @PolyUIEffect
+    void setAsText(String text) throws java.lang.IllegalArgumentException;
+
+    @SafeEffect
+    String[] getTags();
+
+    @PolyUIEffect
+    java.awt.Component getCustomEditor();
+
+    @SafeEffect
+    boolean supportsCustomEditor();
+
+    @SafeEffect
+    void addPropertyChangeListener(@PolyUI PropertyChangeListener listener);
+
+    @SafeEffect
+    void removePropertyChangeListener(@PolyUI PropertyChangeListener listener);
+
+    @PolyUIEffect
+    public void firePropertyChange();
+}

--- a/config/checkerframework/RowSorter.astub
+++ b/config/checkerframework/RowSorter.astub
@@ -1,0 +1,10 @@
+package javax.swing;
+
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
+public abstract class RowSorter<M> {
+  @SafeType
+  public static class SortKey{
+  }
+}

--- a/config/checkerframework/SwingUtilities.astub
+++ b/config/checkerframework/SwingUtilities.astub
@@ -1,0 +1,8 @@
+package javax.swing;
+
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
+class SwingUtilities {
+  @SafeEffect
+  public boolean isEventDispatchThread();
+}

--- a/config/checkerframework/UIDefaults.astub
+++ b/config/checkerframework/UIDefaults.astub
@@ -1,0 +1,16 @@
+package javax.swing;
+
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+
+class UIDefaults extends Hashtable<Object, @UI Object> {
+  Object put(Object key, @UI Object value);
+
+  @PolyUIType
+  public interface LazyValue {
+    @PolyUIEffect
+    Object createValue(UIDefaults table);
+  }
+}

--- a/config/checkerframework/UndoManager.astub
+++ b/config/checkerframework/UndoManager.astub
@@ -1,0 +1,7 @@
+package javax.swing.undo;
+
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
+class UndoManager {
+}

--- a/config/checkerframework/UndoableEditListener.astub
+++ b/config/checkerframework/UndoableEditListener.astub
@@ -1,0 +1,7 @@
+package javax.swing.event;
+
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
+interface UndoableEditListener {
+}

--- a/src/bom-thirdparty/build.gradle.kts
+++ b/src/bom-thirdparty/build.gradle.kts
@@ -119,6 +119,7 @@ dependencies {
         api("org.bouncycastle:bcpkix-jdk15on:1.70")
         api("org.bouncycastle:bcprov-jdk15on:1.70")
         api("org.brotli:dec:0.1.2")
+        api("org.checkerframework:checker-qual:3.33.0")
         api("org.exparity:hamcrest-date:2.0.8")
         api("org.freemarker:freemarker:2.3.32")
         api("org.jdom:jdom:1.1.3")

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/AssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/AssertionGui.java
@@ -54,6 +54,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI interface for a {@link ResponseAssertion}.
@@ -140,6 +141,7 @@ public class AssertionGui extends AbstractAssertionGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "assertion_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/BeanShellAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/BeanShellAssertionGui.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @GUIMenuSortOrder(Integer.MAX_VALUE)
 @TestElementMetadata(labelResource = "bsh_assertion_title")
@@ -87,6 +88,7 @@ public class BeanShellAssertionGui extends AbstractAssertionGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "bsh_assertion_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/DurationAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/DurationAssertionGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI for {@link DurationAssertion}
@@ -45,6 +46,7 @@ public class DurationAssertionGui extends AbstractAssertionGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "duration_assertion_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/HTMLAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/HTMLAssertionGui.java
@@ -40,6 +40,7 @@ import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +87,7 @@ public class HTMLAssertionGui extends AbstractAssertionGui implements KeyListene
      * Returns the label to be shown within the JTree-Component.
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "html_assertion_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/JSONPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/JSONPathAssertionGui.java
@@ -35,6 +35,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * Java class representing GUI for the {@link JSONPathAssertion} component in JMeter
  * @since 4.0
@@ -123,6 +125,7 @@ public class JSONPathAssertionGui extends AbstractAssertionGui implements Change
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return JSON_ASSERTION_TITLE;
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI class supporting the MD5Hex assertion functionality.
@@ -76,6 +77,7 @@ public class MD5HexAssertionGUI extends AbstractAssertionGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "md5hex_assertion_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/SMIMEAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/SMIMEAssertionGui.java
@@ -33,6 +33,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "smime_assertion_title")
  public class SMIMEAssertionGui extends AbstractAssertionGui {
@@ -71,6 +72,7 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "smime_assertion_title";
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/SizeAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/SizeAssertionGui.java
@@ -34,6 +34,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI for {@link SizeAssertion}
@@ -78,6 +79,7 @@ public class SizeAssertionGui extends AbstractAssertionGui implements ActionList
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "size_assertion_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLAssertionGui.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.assertions.XMLAssertion;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "xml_assertion_title")
 public class XMLAssertionGui extends AbstractAssertionGui {
@@ -37,6 +38,7 @@ public class XMLAssertionGui extends AbstractAssertionGui {
      * Returns the label to be shown within the JTree-Component.
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "xml_assertion_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLSchemaAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XMLSchemaAssertionGUI.java
@@ -31,6 +31,7 @@ import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +59,7 @@ public class XMLSchemaAssertionGUI extends AbstractAssertionGui {
      * Returns the label to be shown within the JTree-Component.
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "xmlschema_assertion_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2AssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2AssertionGui.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @GUIMenuSortOrder(50)
 @TestElementMetadata(labelResource = "xpath2_assertion_title")
@@ -46,6 +47,7 @@ public class XPath2AssertionGui extends AbstractAssertionGui { // $NOSONAR
      * Returns the label to be shown within the JTree-Component.
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "xpath2_assertion_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPathAssertionGui.java
@@ -27,6 +27,7 @@ import org.apache.jmeter.assertions.XPathAssertion;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "xpath_assertion_title")
 public class XPathAssertionGui extends AbstractAssertionGui {
@@ -46,6 +47,7 @@ public class XPathAssertionGui extends AbstractAssertionGui {
      * Returns the label to be shown within the JTree-Component.
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "xpath_assertion_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/gui/JMESPathAssertionGui.java
@@ -31,6 +31,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * Java class representing GUI for the {@link JMESPathAssertion} component in
  * JMeter.
@@ -103,6 +105,7 @@ public class JMESPathAssertionGui extends JSONPathAssertionGui {
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return JMES_ASSERTION_TITLE;
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/CriticalSectionControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/CriticalSectionControllerGui.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.control.CriticalSectionController;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The user interface for a controller which specifies that its subcomponents
@@ -129,6 +130,7 @@ public class CriticalSectionControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "critical_section_controller_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ForeachControlPanel.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ForeachControlPanel.java
@@ -30,6 +30,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * The user interface for a foreach controller which specifies that its
  * sub-components should be executed some number of times in a loop. This
@@ -155,6 +157,7 @@ public class ForeachControlPanel extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "foreach_controller_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/IncludeControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/IncludeControllerGui.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "include_controller")
 public class IncludeControllerGui extends AbstractControllerGui
@@ -44,6 +45,7 @@ public class IncludeControllerGui extends AbstractControllerGui
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "include_controller";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/InterleaveControlGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/InterleaveControlGui.java
@@ -25,6 +25,7 @@ import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "interleave_control_title")
 public class InterleaveControlGui extends AbstractControllerGui {
@@ -86,6 +87,7 @@ public class InterleaveControlGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "interleave_control_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ModuleControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ModuleControllerGui.java
@@ -57,6 +57,7 @@ import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * ModuleControllerGui provides UI for configuring ModuleController element.
@@ -180,6 +181,7 @@ public class ModuleControllerGui extends AbstractControllerGui implements Action
 
     /** {@inheritDoc}} */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "module_controller_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/OnceOnlyControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/OnceOnlyControllerGui.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.control.OnceOnlyController;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "once_only_controller_title")
 public class OnceOnlyControllerGui extends AbstractControllerGui {
@@ -48,6 +49,7 @@ public class OnceOnlyControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "once_only_controller_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/RandomControlGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/RandomControlGui.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "random_control_title")
 public class RandomControlGui extends AbstractControllerGui {
@@ -79,6 +80,7 @@ public class RandomControlGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "random_control_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/RandomOrderControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/RandomOrderControllerGui.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.control.gui;
 import org.apache.jmeter.control.RandomOrderController;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI for RandomOrderController.
@@ -31,6 +32,7 @@ public class RandomOrderControllerGui extends LogicControllerGui {
     private static final long serialVersionUID = 240L;
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "random_order_control_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/SwitchControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/SwitchControllerGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.MenuInfo;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @GUIMenuSortOrder(MenuInfo.SORT_ORDER_DEFAULT+2)
 @TestElementMetadata(labelResource = "switch_controller_title")
@@ -77,6 +78,7 @@ public class SwitchControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "switch_controller_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ThroughputControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ThroughputControllerGui.java
@@ -35,6 +35,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 @GUIMenuSortOrder(MenuInfo.SORT_ORDER_DEFAULT+1)
 @TestElementMetadata(labelResource = "throughput_control_title")
 public class ThroughputControllerGui extends AbstractControllerGui {
@@ -119,6 +121,7 @@ public class ThroughputControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "throughput_control_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/BoundaryExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/BoundaryExtractorGui.java
@@ -39,6 +39,7 @@ import org.apache.jmeter.testelement.AbstractScopedTestElement;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Boundary Extractor Post-Processor GUI
@@ -85,6 +86,7 @@ public class BoundaryExtractorGui extends AbstractPostProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "boundaryextractor_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/HtmlExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/HtmlExtractorGui.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.testelement.AbstractScopedTestElement;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * CSS/JQuery Expression Extractor Post-Processor GUI
@@ -70,6 +71,7 @@ public class HtmlExtractorGui extends AbstractPostProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "html_extractor_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
@@ -38,6 +38,7 @@ import org.apache.jmeter.testelement.AbstractScopedTestElement;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Regular Expression Extractor Post-Processor GUI
@@ -69,6 +70,7 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "regex_extractor_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPath2ExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPath2ExtractorGui.java
@@ -34,6 +34,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * GUI for XPath2Extractor class.
  * @since 5.0
@@ -57,6 +59,7 @@ public class XPath2ExtractorGui extends AbstractPostProcessorGui{ // NOSONAR Ign
     private JSyntaxTextArea namespacesTA;
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "xpath2_extractor_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
@@ -35,6 +35,8 @@ import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * GUI for XPathExtractor class.
  */
@@ -62,6 +64,7 @@ public class XPathExtractorGui extends AbstractPostProcessorGui {
     private final XMLConfPanel xml = new XMLConfPanel();
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "xpath_extractor_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/gui/JMESPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/gui/JMESPathExtractorGui.java
@@ -33,6 +33,7 @@ import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI for {@link JMESPathExtractor}
@@ -55,6 +56,7 @@ public class JMESPathExtractorGui extends AbstractPostProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "jmes_extractor_title";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/gui/JSONPostProcessorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/gui/JSONPostProcessorGui.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI for {@link JSONPostProcessor}
@@ -59,6 +60,7 @@ public class JSONPostProcessorGui extends AbstractPostProcessorGui {
 
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "json_post_processor_title";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/CounterConfigGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/CounterConfigGui.java
@@ -33,6 +33,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 @TestElementMetadata(labelResource = "counter_config_title")
 public class CounterConfigGui extends AbstractConfigGui implements ActionListener {
     private static final long serialVersionUID = 240L;
@@ -51,6 +53,7 @@ public class CounterConfigGui extends AbstractConfigGui implements ActionListene
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "counter_config_title";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/SampleTimeoutGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/SampleTimeoutGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The GUI for SampleTimeout.
@@ -65,6 +66,7 @@ public class SampleTimeoutGui extends AbstractPreProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "sample_timeout_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
@@ -52,6 +52,7 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,6 +91,7 @@ public class UserParametersGui extends AbstractPreProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "user_parameters_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/sampler/gui/TestActionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/sampler/gui/TestActionGui.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @GUIMenuSortOrder(1)
 @TestElementMetadata(labelResource = "test_action_title")
@@ -97,6 +98,7 @@ public class TestActionGui extends AbstractSamplerGui { // NOSONAR Ignore hierar
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "test_action_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/AbstractRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/AbstractRandomTimerGui.java
@@ -31,6 +31,8 @@ import org.apache.jorphan.gui.layout.VerticalLayout;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * Abstract Random timer GUI.
  *
@@ -148,6 +150,7 @@ public abstract class AbstractRandomTimerGui extends AbstractTimerGui {
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public abstract String getLabelResource();
 
     /**

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/ConstantTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/ConstantTimerGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.timers.ConstantTimer;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The GUI for ConstantTimer.
@@ -58,6 +59,7 @@ public class ConstantTimerGui extends AbstractTimerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "constant_timer_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/GaussianRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/GaussianRandomTimerGui.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.timers.GaussianRandomTimer;
 import org.apache.jmeter.timers.RandomTimer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Implementation of a gaussian random timer.
@@ -46,6 +47,7 @@ public class GaussianRandomTimerGui extends AbstractRandomTimerGui {
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "gaussian_timer_title";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/PoissonRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/PoissonRandomTimerGui.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.timers.PoissonRandomTimer;
 import org.apache.jmeter.timers.RandomTimer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Implementation of a Poisson random timer.
@@ -39,6 +40,7 @@ public class PoissonRandomTimerGui extends AbstractRandomTimerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "poisson_timer_title";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/gui/UniformRandomTimerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/gui/UniformRandomTimerGui.java
@@ -22,6 +22,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.timers.RandomTimer;
 import org.apache.jmeter.timers.UniformRandomTimer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Implementation of a uniform random timer.
@@ -40,6 +41,7 @@ public class UniformRandomTimerGui extends AbstractRandomTimerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "uniform_timer_title";//$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/AssertionVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/AssertionVisualizer.java
@@ -34,6 +34,7 @@ import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "assertion_visualizer_title")
 public class AssertionVisualizer extends AbstractVisualizer implements Clearable {
@@ -48,6 +49,7 @@ public class AssertionVisualizer extends AbstractVisualizer implements Clearable
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "assertion_visualizer_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ComparisonVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ComparisonVisualizer.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "comparison_visualizer_title")
 public class ComparisonVisualizer extends AbstractVisualizer implements Clearable {
@@ -72,6 +73,7 @@ public class ComparisonVisualizer extends AbstractVisualizer implements Clearabl
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "comparison_visualizer_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/GraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/GraphVisualizer.java
@@ -48,6 +48,7 @@ import org.apache.jmeter.samplers.Clearable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This class implements a statistical analyser that calculates both the average
@@ -165,6 +166,7 @@ public class GraphVisualizer extends AbstractVisualizer implements ImageVisualiz
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "graph_results_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
@@ -50,6 +50,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.JMeterUIDefaults;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -298,6 +299,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "mailer_visualizer_title"; //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/PropertyControlGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/PropertyControlGui.java
@@ -49,6 +49,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "property_visualiser_title", actionGroups = MenuFactory.NON_TEST_ELEMENTS)
 public class PropertyControlGui extends AbstractConfigGui implements
@@ -82,11 +83,13 @@ public class PropertyControlGui extends AbstractConfigGui implements
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "property_visualiser_title"; // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.NON_TEST_ELEMENTS);
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -68,6 +68,7 @@ import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.math.StatCalculatorLong;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -439,6 +440,7 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "graph_resp_time_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SimpleDataWriter.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SimpleDataWriter.java
@@ -22,6 +22,7 @@ import java.awt.BorderLayout;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This listener can record results to a file but not to the UI. It is meant to
@@ -40,6 +41,7 @@ public class SimpleDataWriter extends AbstractVisualizer {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "simple_data_writer_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -88,6 +88,7 @@ import org.apache.jorphan.gui.ObjectTableSorter;
 import org.apache.jorphan.gui.RateRenderer;
 import org.apache.jorphan.gui.RendererUtils;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -465,6 +466,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "aggregate_graph_title";                        //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
@@ -54,6 +54,7 @@ import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.gui.ObjectTableSorter;
 import org.apache.jorphan.gui.RendererUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Aggregate Table-Based Reporting Visualizer for JMeter.
@@ -108,6 +109,7 @@ public class StatVisualizer extends AbstractVisualizer implements Clearable, Act
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "aggregate_report";  //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
@@ -62,6 +62,7 @@ import org.apache.jorphan.gui.ObjectTableSorter;
 import org.apache.jorphan.gui.RateRenderer;
 import org.apache.jorphan.gui.RendererUtils;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Simpler (lower memory) version of Aggregate Report (StatVisualizer).
@@ -215,6 +216,7 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "summary_report";  //$NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/TableVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/TableVisualizer.java
@@ -55,6 +55,7 @@ import org.apache.jorphan.gui.RightAlignRenderer;
 import org.apache.jorphan.gui.layout.VerticalLayout;
 import org.apache.jorphan.reflect.Functor;
 import org.apache.jorphan.util.AlphaNumericComparator;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This class implements a statistical analyser that calculates both the average
@@ -163,6 +164,7 @@ public class TableVisualizer extends AbstractVisualizer implements Clearable {
 
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "view_results_in_table"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -76,6 +76,7 @@ import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.util.StringWrap;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -334,6 +335,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "view_results_tree_title"; // $NON-NLS-1$
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -46,6 +46,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
 import org.apache.jorphan.reflect.ClassFinder;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +90,7 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "backend_listener"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/assertions/gui/AbstractAssertionGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/assertions/gui/AbstractAssertionGui.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 
 import org.apache.jmeter.gui.AbstractScopedJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This is the base class for JMeter GUI components which manage assertions.
@@ -45,6 +46,7 @@ public abstract class AbstractAssertionGui extends AbstractScopedJMeterGuiCompon
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.ASSERTIONS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/AbstractConfigGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/AbstractConfigGui.java
@@ -24,6 +24,7 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This is the base class for JMeter GUI components which provide configuration
@@ -59,6 +60,7 @@ public abstract class AbstractConfigGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.CONFIG_ELEMENTS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -53,6 +53,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * A GUI panel allowing the user to enter name-value argument pairs. These
@@ -269,6 +270,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         if (standalone) {
             return super.getMenuCategories();
@@ -277,6 +279,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "user_defined_variables"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/LoginConfigGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/LoginConfigGui.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * A GUI component allowing the user to enter a username and password for a
@@ -76,6 +77,7 @@ public class LoginConfigGui extends AbstractConfigGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "login_config_element"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ObsoleteGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ObsoleteGui.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Default config gui for Configuration Element.
@@ -51,6 +52,7 @@ public class ObsoleteGui extends AbstractJMeterGuiComponent {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "obsolete_test_element"; // $NON-NLS-1$
     }
@@ -70,6 +72,7 @@ public class ObsoleteGui extends AbstractJMeterGuiComponent {
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return null;
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/SimpleConfigGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/SimpleConfigGui.java
@@ -39,6 +39,7 @@ import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.Data;
 import org.apache.jorphan.gui.GuiUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Default config gui for Configuration Element.
@@ -103,6 +104,7 @@ public class SimpleConfigGui extends AbstractConfigGui implements ActionListener
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "simple_config_element"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@UIPackage
+package org.apache.jmeter.config.gui;
+
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/AbstractControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/AbstractControllerGui.java
@@ -24,6 +24,7 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This is the base class for JMeter GUI components which manage controllers.
@@ -58,6 +59,7 @@ public abstract class AbstractControllerGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.CONTROLLERS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/IfControllerPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/IfControllerPanel.java
@@ -43,6 +43,8 @@ import org.apache.jorphan.gui.JMeterUIDefaults;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * The user interface for a controller which specifies that its subcomponents
  * should be executed while a condition holds. This component can be used
@@ -161,6 +163,7 @@ public class IfControllerPanel extends AbstractControllerGui implements ChangeLi
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "if_controller_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/LogicControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/LogicControllerGui.java
@@ -22,6 +22,7 @@ import java.awt.BorderLayout;
 import org.apache.jmeter.control.GenericController;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * A generic controller component.
@@ -53,6 +54,7 @@ public class LogicControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "logic_controller_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/LoopControlPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/LoopControlPanel.java
@@ -34,6 +34,7 @@ import org.apache.jmeter.gui.util.FocusRequester;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The user interface for a controller which specifies that its subcomponents
@@ -181,6 +182,7 @@ public class LoopControlPanel extends AbstractControllerGui implements ActionLis
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "loop_controller_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/RunTimeGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/RunTimeGui.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.control.RunTime;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The user interface for a controller which specifies that its subcomponents
@@ -140,6 +141,7 @@ public class RunTimeGui extends AbstractControllerGui implements ActionListener 
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "runtime_controller_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TestFragmentControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TestFragmentControllerGui.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This defines a simple Test Fragment GUI that can be used instead of a Thread Group
@@ -65,6 +66,7 @@ public class TestFragmentControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "test_fragment_title"; // $NON-NLS-1$
     }
@@ -82,6 +84,7 @@ public class TestFragmentControllerGui extends AbstractControllerGui {
      * Over-ride this so that we add ourselves to the Test Fragment Category instead.
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.FRAGMENTS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TestPlanGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TestPlanGui.java
@@ -38,6 +38,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestPlan;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * JMeter GUI component representing the test plan which will be executed when
@@ -133,6 +134,7 @@ public class TestPlanGui extends AbstractJMeterGuiComponent {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "test_plan"; // $NON-NLS-1$
     }
@@ -146,6 +148,7 @@ public class TestPlanGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return null;
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TransactionControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TransactionControllerGui.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * A Transaction controller component.
@@ -74,6 +75,7 @@ public class TransactionControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "transaction_controller_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/WhileControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/WhileControllerGui.java
@@ -31,6 +31,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 @GUIMenuSortOrder(4)
 @TestElementMetadata(labelResource = "while_controller_title")
 public class WhileControllerGui extends AbstractControllerGui {
@@ -105,6 +107,7 @@ public class WhileControllerGui extends AbstractControllerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "while_controller_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/WorkBenchGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/WorkBenchGui.java
@@ -31,6 +31,7 @@ import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * JMeter GUI component representing a work bench where users can make
@@ -61,6 +62,7 @@ public class WorkBenchGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return null;
     }
@@ -140,6 +142,7 @@ public class WorkBenchGui extends AbstractJMeterGuiComponent {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "workbench_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/control/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@UIPackage
+package org.apache.jmeter.control.gui;
+
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -42,6 +42,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Printable;
 import org.apache.jorphan.gui.JFactory;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -343,6 +344,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     }
 
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         return JMeterUtils.getResString(getLabelResource());
     }
@@ -352,6 +354,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
      * @return String anchor
      */
     @Override
+    @SafeEffect
     public String getDocAnchor() {
         // Ensure we use default bundle
         String label =  JMeterUtils.getResString(getLabelResource(), new Locale("",""));

--- a/src/core/src/main/java/org/apache/jmeter/gui/ClearGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/ClearGui.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.gui;
 
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+
 public interface ClearGui {
 
     /**
@@ -25,6 +27,7 @@ public interface ClearGui {
      * multiple test element objects and thus they need to be cleared between
      * uses.
      */
+    @UIEffect
     void clearGui();
     // N.B. originally called clear()
     // @see also Clearable

--- a/src/core/src/main/java/org/apache/jmeter/gui/GlobalUndoableEdit.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GlobalUndoableEdit.java
@@ -17,12 +17,15 @@
 
 package org.apache.jmeter.gui;
 
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
 import java.util.function.Consumer;
 
 import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 
+@SafeType
 public final class GlobalUndoableEdit extends AbstractUndoableEdit {
 
     private static final long serialVersionUID = -4964577622742131354L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
@@ -262,6 +262,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      *
      * @return the GUI component corresponding to the specified test element
      */
+    @UIEffect
     public JMeterGUIComponent getGui(TestElement node, Class<?> guiClass, Class<?> testClass) {
         try {
             JMeterGUIComponent comp = nodesToGui.get(node);

--- a/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
@@ -62,6 +62,8 @@ import org.apache.jmeter.util.LocaleChangeListener;
 import org.apache.jorphan.collections.HashTree;
 import org.apache.jorphan.gui.JFactory;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeType;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +76,7 @@ import org.slf4j.LoggerFactory;
  * parts of the GUI.
  *
  */
+@SafeType
 public final class GuiPackage implements LocaleChangeListener, HistoryListener {
 
     private static final Logger log = LoggerFactory.getLogger(GuiPackage.class);
@@ -293,6 +296,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      *
      * @return the GUI component associated with the currently selected node
      */
+    @UIEffect
     public JMeterGUIComponent getCurrentGui() {
         try {
             updateCurrentNode();
@@ -335,6 +339,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      *            this GUI component.
      * @return the test element corresponding to the specified GUI class.
      */
+    @UIEffect
     public TestElement createTestElement(Class<?> guiClass, Class<?> testClass) {
         try {
             JMeterGUIComponent comp = getGuiFromCache(guiClass, testClass);
@@ -359,6 +364,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      *            TestBean subclass for which a TestBeanGUI is wanted.
      * @return the test element corresponding to the specified GUI class.
      */
+    @UIEffect
     public TestElement createTestElement(String objClass) {
         JMeterGUIComponent comp;
         Class<?> c;
@@ -409,6 +415,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      *             called
      * @throws ReflectiveOperationException when construction of guiClass fails
      */
+    @UIEffect
     private JMeterGUIComponent getGuiFromCache(Class<?> guiClass, Class<?> testClass) throws ReflectiveOperationException {
         JMeterGUIComponent comp;
         if (guiClass == TestBeanGUI.class) {
@@ -430,6 +437,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
         return comp;
     }
 
+    @UIEffect
     private void updateUi(JMeterGUIComponent comp) {
         if (!(comp instanceof JComponent)) {
             return;
@@ -457,6 +465,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      * This method does not update the current node from GUI at the
      * difference of {@link GuiPackage#updateCurrentGui()}
      */
+    @UIEffect
     public void refreshCurrentGui() {
         currentNode = treeListener.getCurrentNode();
         TestElement element = currentNode.getTestElement();

--- a/src/core/src/main/java/org/apache/jmeter/gui/JMeterGUIComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/JMeterGUIComponent.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Implementing this interface indicates that the class is a JMeter GUI
@@ -75,6 +76,7 @@ public interface JMeterGUIComponent extends ClearGui {
      * @see #getLabelResource()
      * @return GUI label for the component.
      */
+    @SafeEffect
     String getStaticLabel();
 
     /**
@@ -88,6 +90,7 @@ public interface JMeterGUIComponent extends ClearGui {
      *
      * @return the resource name
      */
+    @SafeEffect
     String getLabelResource();
 
     /**
@@ -96,6 +99,7 @@ public interface JMeterGUIComponent extends ClearGui {
      *
      * @return Document anchor (#ref) for the component.
      */
+    @SafeEffect
     String getDocAnchor();
 
     /**
@@ -218,12 +222,14 @@ public interface JMeterGUIComponent extends ClearGui {
      *
      * @see org.apache.jmeter.gui.util.MenuFactory
      */
+    @SafeEffect
     Collection<String> getMenuCategories();
 
     /**
      * Returns whether a component of this type can be added to the test plan.
      * @return true if the component can be added, false otherwise.
      */
+    @SafeEffect
     default boolean canBeAdded() {
         return true;
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -104,6 +104,8 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.ComponentUtil;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.SafeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -419,6 +421,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
         });
     }
 
+    @SafeEffect
     public void updateCounts() {
         SwingUtilities.invokeLater(() ->
                 activeAndTotalThreads.setText(
@@ -865,6 +868,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
     /**
      * ErrorsAndFatalsCounterLogTarget.
      */
+    @SafeType
     public final class ErrorsAndFatalsCounterLogTarget implements GuiLogEventListener, Clearable {
 
         @Override

--- a/src/core/src/main/java/org/apache/jmeter/gui/NamePanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/NamePanel.java
@@ -31,6 +31,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 public class NamePanel extends JPanel implements JMeterGUIComponent {
     private static final long serialVersionUID = 240L;
@@ -120,18 +121,21 @@ public class NamePanel extends JPanel implements JMeterGUIComponent {
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         return JMeterUtils.getResString(getLabelResource());
     }
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return LABEL_RESOURCE;
     }
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return null;
     }
@@ -159,6 +163,7 @@ public class NamePanel extends JPanel implements JMeterGUIComponent {
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getDocAnchor() {
         return null;
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/UndoHistory.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/UndoHistory.java
@@ -33,6 +33,7 @@ import org.apache.jmeter.gui.tree.JMeterTreeModel;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,6 +102,7 @@ public class UndoHistory implements TreeModelListener, Serializable {
      * @param treeModel JMeterTreeModel
      * @param comment   String
      */
+    @SafeEffect
     public void add(JMeterTreeModel treeModel, String comment) {
         if(!isEnabled()) {
             log.debug("undo.history.size is set to 0, undo/redo feature is disabled");
@@ -262,6 +264,7 @@ public class UndoHistory implements TreeModelListener, Serializable {
     /**
      * @return true if history is enabled
      */
+    @SafeEffect
     public static boolean isEnabled() {
         return HISTORY_SIZE > 0;
     }
@@ -270,6 +273,7 @@ public class UndoHistory implements TreeModelListener, Serializable {
      * Register HistoryListener
      * @param listener to add to our listeners
      */
+    @SafeEffect
     public void registerHistoryListener(HistoryListener listener) {
         listeners.add(listener);
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/menu/StaticJMeterGUIComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/menu/StaticJMeterGUIComponent.java
@@ -49,6 +49,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Visualizer;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Internal class to speedup the startup time.
@@ -110,11 +111,13 @@ public class StaticJMeterGUIComponent implements JMeterGUIComponent {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return labelResource;
     }
 
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         String labelResource = getLabelResource();
         if (resourceBundle == null) {
@@ -124,6 +127,7 @@ public class StaticJMeterGUIComponent implements JMeterGUIComponent {
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return groups;
     }
@@ -141,6 +145,7 @@ public class StaticJMeterGUIComponent implements JMeterGUIComponent {
     }
 
     @Override
+    @SafeEffect
     public String getDocAnchor() {
         throw new UnsupportedOperationException();
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@UIPackage
+package org.apache.jmeter.gui;
+
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
@@ -28,10 +28,12 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
 /**
  * Class to render the test tree - sets the enabled/disabled versions of the icons
  */
+@UIType
 public class JMeterCellRenderer extends DefaultTreeCellRenderer {
     private static final long serialVersionUID = 241L;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
@@ -38,9 +38,11 @@ import org.apache.jmeter.gui.MainFrame;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
 import org.apache.jmeter.gui.action.KeyStrokes;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@UIType
 public class JMeterTreeListener implements TreeSelectionListener, MouseListener, KeyListener {
     private static final Logger log = LoggerFactory.getLogger(JMeterTreeListener.class);
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeTransferHandler.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeTransferHandler.java
@@ -33,9 +33,11 @@ import javax.swing.tree.TreePath;
 
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@UIType
 public class JMeterTreeTransferHandler extends TransferHandler {
 
     private static final long serialVersionUID = 1L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/CheckBoxPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/CheckBoxPanel.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.gui.util;
 
+import org.checkerframework.checker.guieffect.qual.UIType;
+
 import javax.swing.Box;
 import javax.swing.JCheckBox;
 
@@ -26,6 +28,7 @@ import javax.swing.JCheckBox;
  * See <a href="https://bz.apache.org/bugzilla/show_bug.cgi?id=58810">Bug 58810</a><br>
  * Note: using a JPanel affects the alignment within the container
  */
+@UIType
 public class CheckBoxPanel {
 
     private CheckBoxPanel() {

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/EscapeDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/EscapeDialog.java
@@ -28,7 +28,9 @@ import javax.swing.JDialog;
 import javax.swing.JRootPane;
 
 import org.apache.jmeter.gui.action.KeyStrokes;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
+@UIType
 public class EscapeDialog extends JDialog {
 
     private static final long serialVersionUID = 1319421816741139938L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FileDialoger.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FileDialoger.java
@@ -27,12 +27,15 @@ import javax.swing.filechooser.FileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.JMeterFileFilter;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Class implementing a file open dialogue
  */
+@UIType
 public final class FileDialoger {
     /**
      * The last directory visited by the user while choosing Files.
@@ -289,6 +292,7 @@ public final class FileDialoger {
      *
      * @return The last directory visited by the user while choosing Files
      */
+    @SafeEffect
     public static String getLastJFCDirectory() {
         return lastJFCDirectory;
     }
@@ -297,6 +301,7 @@ public final class FileDialoger {
      *
      * @param lastJFCDirectory The last directory visited by the user while choosing Files
      */
+    @SafeEffect
     public static void setLastJFCDirectory(String lastJFCDirectory) {
         FileDialoger.lastJFCDirectory = lastJFCDirectory;
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FileListPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FileListPanel.java
@@ -42,7 +42,9 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
+@UIType
 public class FileListPanel extends JPanel implements ActionListener {
 
     private static final long serialVersionUID = 1L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FilePanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FilePanel.java
@@ -21,7 +21,9 @@ import javax.swing.BorderFactory;
 import javax.swing.event.ChangeListener;
 
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
+@UIType
 public class FilePanel extends FilePanelEntry {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FilePanelEntry.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FilePanelEntry.java
@@ -31,7 +31,9 @@ import javax.swing.event.ChangeListener;
 
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
+@UIType
 public class FilePanelEntry extends HorizontalPanel implements ActionListener {
     private static final long serialVersionUID = 280L;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/HeaderAsPropertyRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/HeaderAsPropertyRenderer.java
@@ -26,10 +26,12 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
 
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
 /**
  * Renders items in a JTable by converting from resource names.
  */
+@UIType
 public class HeaderAsPropertyRenderer extends DefaultTableCellRenderer {
 
     private static final long serialVersionUID = 241L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/HorizontalPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/HorizontalPanel.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.gui.util;
 
+import org.checkerframework.checker.guieffect.qual.UIType;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -25,6 +27,7 @@ import javax.swing.Box;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
+@UIType
 public class HorizontalPanel extends JPanel {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -57,9 +57,11 @@ import org.apache.jmeter.util.SSLManager;
 import org.apache.jorphan.reflect.ClassFinder;
 import org.apache.jorphan.util.JOrphanUtils;
 import org.apache.logging.log4j.Level;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@UIType
 public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
     private static final long serialVersionUID = 241L;
 
@@ -359,6 +361,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
         return lafMenu;
     }
 
+    @UIType
     private static class LangMenuHelper{
         final ActionRouter actionRouter = ActionRouter.getInstance();
         final JMenu languageMenu;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
@@ -39,6 +39,7 @@ import org.apache.jmeter.gui.action.ActionRouter;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.LocaleChangeEvent;
 import org.apache.jmeter.util.LocaleChangeListener;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,7 @@ import com.github.weisj.darklaf.ui.button.DarkButtonUI;
  * The JMeter main toolbar class
  *
  */
+@UIType
 public class JMeterToolBar extends JToolBar implements LocaleChangeListener {
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
@@ -28,6 +28,7 @@ import javax.swing.JToolBar;
 
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.fife.ui.rtextarea.SearchContext;
 import org.fife.ui.rtextarea.SearchEngine;
 
@@ -35,6 +36,7 @@ import org.fife.ui.rtextarea.SearchEngine;
  * Search toolbar associated to {@link JSyntaxTextArea}
  * @since 5.0
  */
+@UIType
 public final class JSyntaxSearchToolBar implements ActionListener {
     public static final Color LIGHT_RED = new Color(0xFF, 0x80, 0x80);
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -34,6 +34,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.gui.ui.TextComponentUI;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rsyntaxtextarea.Theme;
@@ -48,6 +49,7 @@ import com.github.weisj.darklaf.extensions.rsyntaxarea.DarklafRSyntaxTheme;
  * It's not currently possible to instantiate the RSyntaxTextArea class when running headless.
  * So we use getInstance methods to create the class and allow for headless testing.
  */
+@UIType
 public class JSyntaxTextArea extends RSyntaxTextArea {
 
     private static final long serialVersionUID = 211L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JTextScrollPane.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JTextScrollPane.java
@@ -17,6 +17,7 @@
 
 package org.apache.jmeter.gui.util;
 
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.fife.ui.rtextarea.RTextScrollPane;
 
 
@@ -25,6 +26,7 @@ import org.fife.ui.rtextarea.RTextScrollPane;
  * It's not currently possible to instantiate the RTextScrollPane class when running headless.
  * So we use getInstance methods to create the class and allow for headless testing.
  */
+@UIType
 public class JTextScrollPane extends RTextScrollPane {
 
     private static final long serialVersionUID = 210L;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/MenuFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/MenuFactory.java
@@ -61,9 +61,11 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Printable;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.reflect.ClassFinder;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@UIType
 public final class MenuFactory {
     private static final Logger log = LoggerFactory.getLogger(MenuFactory.class);
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaCellRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaCellRenderer.java
@@ -17,12 +17,15 @@
 
 package org.apache.jmeter.gui.util;
 
+import org.checkerframework.checker.guieffect.qual.UIType;
+
 import java.awt.Color;
 import java.awt.Component;
 
 import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
+@UIType
 public class TextAreaCellRenderer implements TableCellRenderer {
 
     private JSyntaxTextArea rend = createRenderer(""); //$NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaTableCellEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaTableCellEditor.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.gui.util;
 
+import org.checkerframework.checker.guieffect.qual.UIType;
+
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
@@ -34,6 +36,7 @@ import javax.swing.JTree;
 import javax.swing.table.TableCellEditor;
 import javax.swing.tree.TreeCellEditor;
 
+@UIType
 public class TextAreaTableCellEditor extends AbstractCellEditor implements TableCellEditor, TreeCellEditor {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaTableCellEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaTableCellEditor.java
@@ -211,6 +211,7 @@ public class TextAreaTableCellEditor extends AbstractCellEditor implements Table
     /**
      * The protected <code>EditorDelegate</code> class.
      */
+    @UIType
     protected class EditorDelegate implements FocusListener, Serializable {
         private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextBoxDialoger.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextBoxDialoger.java
@@ -178,6 +178,7 @@ public class TextBoxDialoger implements ActionListener {
      * when double click on a table's cell
      *
      */
+    @UIType
     public static class TextBoxDoubleClick extends MouseAdapter {
 
         private JTable table = null;
@@ -202,6 +203,7 @@ public class TextBoxDialoger implements ActionListener {
      * when double (pressed) click on a table's cell which is editable
      *
      */
+    @UIType
     public static class TextBoxDoubleClickPressed extends MouseAdapter {
 
         private JTable table = null;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextBoxDialoger.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextBoxDialoger.java
@@ -41,11 +41,13 @@ import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.action.KeyStrokes;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
 /**
  * Dialog text box to display some text in a box
  *
  */
+@UIType
 public class TextBoxDialoger implements ActionListener {
 
     private static final String CANCEL_COMMAND = "cancel_dialog"; // $NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TristateCheckBox.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TristateCheckBox.java
@@ -46,10 +46,12 @@ import javax.swing.plaf.metal.MetalLookAndFeel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.NullProperty;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
 /**
  * derived from: http://www.javaspecialists.eu/archive/Issue145.html
  */
+@UIType
 public final class TristateCheckBox extends JCheckBox {
     private static final long serialVersionUID = 1L;
     // Listener on model changes to maintain correct focusability

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TristateCheckBox.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TristateCheckBox.java
@@ -55,6 +55,7 @@ import org.checkerframework.checker.guieffect.qual.UIType;
 public final class TristateCheckBox extends JCheckBox {
     private static final long serialVersionUID = 1L;
     // Listener on model changes to maintain correct focusability
+    @UIType
     private final class TSCBChangeListener implements ChangeListener, Serializable {
         /**
          *

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/VerticalPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/VerticalPanel.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.gui.util;
 
+import org.checkerframework.checker.guieffect.qual.UIType;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -25,6 +27,7 @@ import javax.swing.Box;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
+@UIType
 public class VerticalPanel extends JPanel {
     private static final long serialVersionUID = 240L;
 

--- a/src/core/src/main/java/org/apache/jmeter/plugin/PluginManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/plugin/PluginManager.java
@@ -23,6 +23,7 @@ import javax.swing.GrayFilter;
 import javax.swing.ImageIcon;
 
 import org.apache.jmeter.gui.GUIFactory;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,7 @@ public final class PluginManager {
         }
     }
 
+    @UIEffect
     private void installPlugin(JMeterPlugin plugin) {
         String[][] icons = plugin.getIconMappings();
         ClassLoader classloader = plugin.getClass().getClassLoader();

--- a/src/core/src/main/java/org/apache/jmeter/processor/gui/AbstractPostProcessorGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/processor/gui/AbstractPostProcessorGui.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 
 import org.apache.jmeter.gui.AbstractScopedJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This is the base class for JMeter GUI components which manage PostProcessors.
@@ -37,6 +38,7 @@ public abstract class AbstractPostProcessorGui extends AbstractScopedJMeterGuiCo
     private static final long serialVersionUID = 240L;
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.POST_PROCESSORS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/processor/gui/AbstractPreProcessorGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/processor/gui/AbstractPreProcessorGui.java
@@ -24,6 +24,7 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 public abstract class AbstractPreProcessorGui extends AbstractJMeterGuiComponent {
 
@@ -35,6 +36,7 @@ public abstract class AbstractPreProcessorGui extends AbstractJMeterGuiComponent
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.PRE_PROCESSORS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultActionGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultActionGui.java
@@ -27,6 +27,7 @@ import org.apache.jmeter.processor.gui.AbstractPostProcessorGui;
 import org.apache.jmeter.reporters.ResultAction;
 import org.apache.jmeter.testelement.OnErrorTestElement;
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Create a Result Action Test Element
@@ -47,6 +48,7 @@ public class ResultActionGui extends AbstractPostProcessorGui {
      * @see org.apache.jmeter.gui.JMeterGUIComponent#getStaticLabel()
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "resultaction_title"; //$NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultSaverGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultSaverGui.java
@@ -36,6 +36,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Create a ResultSaver test element, which saves the sample information in set
@@ -74,6 +75,7 @@ public class ResultSaverGui extends AbstractListenerGui implements Clearable { /
      * @see org.apache.jmeter.gui.JMeterGUIComponent#getStaticLabel()
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "resultsaver_title"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/SummariserGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/SummariserGui.java
@@ -23,6 +23,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.reporters.Summariser;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Create a summariser test element GUI.
@@ -39,6 +40,7 @@ public class SummariserGui extends AbstractListenerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "summariser_title"; //$NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/Clearable.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/Clearable.java
@@ -17,16 +17,21 @@
 
 package org.apache.jmeter.samplers;
 
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+
 /**
  * Identifies an object which supports the clearing of run-time data
  * using the clearData() method.
  *
  * Intended for implementation by Listeners.
  */
+@PolyUIType
 public interface Clearable {
 
     /**
      * Clears the current data of the object.
      */
+    @PolyUIEffect
     void clearData();
 }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/gui/AbstractSamplerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/gui/AbstractSamplerGui.java
@@ -24,6 +24,7 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This is the base class for JMeter GUI components which manage samplers.
@@ -58,6 +59,7 @@ public abstract class AbstractSamplerGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.SAMPLERS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/gui/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@UIPackage
+package org.apache.jmeter.samplers.gui;
+
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/BooleanPropertyEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/BooleanPropertyEditor.java
@@ -17,12 +17,15 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
+
 import java.beans.PropertyEditorSupport;
 
 /**
  * Property Editor which handles Boolean properties.
  */
-public class BooleanPropertyEditor extends PropertyEditorSupport {
+public @UI class BooleanPropertyEditor extends PropertyEditorSupport {
 
     // These are the mixed-case values as returned by the RI JVM boolean property editor
     // However, they are different from the lower-case values returned by e.g. Boolean.FALSE.toString()
@@ -59,6 +62,7 @@ public class BooleanPropertyEditor extends PropertyEditorSupport {
     }
 
     @Override
+    @SafeEffect
     public String[] getTags() {
         return TAGS;
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
@@ -33,6 +33,9 @@ import javax.swing.text.JTextComponent;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.jmeter.gui.ClearGui;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.SafeType;
+import org.checkerframework.checker.guieffect.qual.UI;
 
 /**
  * This class implements a property editor for possibly null String properties
@@ -49,7 +52,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * </ul>
  *
  */
-class ComboStringEditor extends PropertyEditorSupport implements ItemListener, ClearGui {
+@UI class ComboStringEditor extends PropertyEditorSupport implements ItemListener, ClearGui {
 
     /**
      * The list of options to be offered by this editor.
@@ -148,6 +151,7 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public boolean supportsCustomEditor() {
         return true;
     }
@@ -258,6 +262,7 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String[] getTags() {
         return tags.clone();
     }
@@ -275,6 +280,7 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
      * actually amounts to making that string 'reserved'. I preferred to avoid
      * this by using a different type having a controlled .toString().
      */
+    @SafeType
     private static class UniqueObject {
         private final String propKey;
         private final String propValue;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/EnumEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/EnumEditor.java
@@ -26,6 +26,8 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
 
 import org.apache.jmeter.gui.ClearGui;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 
 /**
  * This class implements a property editor for String properties based on an enum
@@ -35,7 +37,7 @@ import org.apache.jmeter.gui.ClearGui;
  * The provided GUI is a combo box with an option for each value in the enum.
  * <p>
  */
-class EnumEditor extends PropertyEditorSupport implements ClearGui {
+@UI class EnumEditor extends PropertyEditorSupport implements ClearGui {
 
     private final JComboBox<String> combo;
 
@@ -60,6 +62,7 @@ class EnumEditor extends PropertyEditorSupport implements ClearGui {
     }
 
     @Override
+    @SafeEffect
     public boolean supportsCustomEditor() {
         return true;
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FieldStringEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FieldStringEditor.java
@@ -17,6 +17,9 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.UIType;
+
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -35,7 +38,8 @@ import javax.swing.JTextField;
  * The provided GUI is a simple text field.
  *
  */
-class FieldStringEditor extends PropertyEditorSupport implements ActionListener, FocusListener {
+@UIType
+@UI class FieldStringEditor extends @UI PropertyEditorSupport implements ActionListener, FocusListener {
 
     /**
      * This will hold the text editing component, either a plain JTextField (in

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FileEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FileEditor.java
@@ -37,6 +37,8 @@ import javax.swing.JPanel;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 
 /**
  * A property editor for File properties.
@@ -46,7 +48,7 @@ import org.apache.jmeter.util.JMeterUtils;
  * FileProperty).
  *
  */
-public class FileEditor implements PropertyEditor, ActionListener {
+public @UI class FileEditor implements PropertyEditor, ActionListener {
 
     /**
      * The editor's panel.
@@ -56,7 +58,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
     /**
      * The editor handling the text field inside:
      */
-    private final PropertyEditor editor;
+    private final @UI PropertyEditor editor;
 
     /**
      * @throws IntrospectionException
@@ -93,7 +95,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
         boolean notExpression = GenericTestBeanCustomizer.notExpression(descriptor);
         boolean notOther = GenericTestBeanCustomizer.notOther(descriptor);
         Object defaultValue = descriptor.getValue(GenericTestBeanCustomizer.DEFAULT);
-        FieldStringEditor cse = new FieldStringEditor();
+        @UI FieldStringEditor cse = new FieldStringEditor();
         editor = new WrapperEditor(this, new PropertyEditorSupport(), cse,
                 !notNull, // acceptsNull
                 !notExpression, // acceptsExpressions
@@ -131,7 +133,8 @@ public class FileEditor implements PropertyEditor, ActionListener {
      * {@inheritDoc}
      */
     @Override
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
+    @SafeEffect
+    public void addPropertyChangeListener(@UI PropertyChangeListener listener) {
         editor.addPropertyChangeListener(listener);
     }
 
@@ -147,6 +150,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
      * @return custom editor panel
      */
     @Override
+    @SafeEffect
     public Component getCustomEditor() {
         return panel;
     }
@@ -155,6 +159,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
      * @return the Java initialisation string
      */
     @Override
+    @SafeEffect
     public String getJavaInitializationString() {
         return editor.getJavaInitializationString();
     }
@@ -163,6 +168,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
      * @return the editor tags
      */
     @Override
+    @SafeEffect
     public String[] getTags() {
         return editor.getTags();
     }
@@ -179,6 +185,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
      * @return true if the editor is paintable
      */
     @Override
+    @SafeEffect
     public boolean isPaintable() {
         return editor.isPaintable();
     }
@@ -195,7 +202,8 @@ public class FileEditor implements PropertyEditor, ActionListener {
      * {@inheritDoc}
      */
     @Override
-    public void removePropertyChangeListener(PropertyChangeListener listener) {
+    @SafeEffect
+    public void removePropertyChangeListener(@UI PropertyChangeListener listener) {
         editor.removePropertyChangeListener(listener);
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -44,6 +44,7 @@ import org.apache.jmeter.gui.ClearGui;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.util.JMeterUtils;
 import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -180,7 +181,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      * Property editors -- or null if the property can't be edited. Unused if
      * customizerClass==null.
      */
-    private transient PropertyEditor[] editors;
+    private transient @UI PropertyEditor[] editors;
 
     /**
      * Message format for property field labels:
@@ -489,7 +490,6 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      */
     @SuppressWarnings("unchecked")
     @Override
-    @SafeEffect
     public void setObject(Object map) {
         propertyMap = (Map<String, Object>) map;
 
@@ -739,7 +739,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      */
     void saveGuiFields() {
         for (int i = 0; i < editors.length; i++) {
-            PropertyEditor propertyEditor=editors[i]; // might be null (e.g. in testing)
+            @UI PropertyEditor propertyEditor=editors[i]; // might be null (e.g. in testing)
             if (propertyEditor != null) {
                 Object value = propertyEditor.getValue();
                 String name = descriptors[i].getName();
@@ -756,7 +756,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
 
     void clearGuiFields() {
         for (int i = 0; i < editors.length; i++) {
-            PropertyEditor propertyEditor=editors[i]; // might be null (e.g. in testing)
+            @UI PropertyEditor propertyEditor=editors[i]; // might be null (e.g. in testing)
             if (propertyEditor != null) {
                 try {
                 if (propertyEditor instanceof ClearGui) {

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -43,6 +43,8 @@ import org.apache.commons.lang3.ClassUtils;
 import org.apache.jmeter.gui.ClearGui;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UIType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,6 +97,7 @@ import org.slf4j.LoggerFactory;
  * available (where <b><i>group</i></b> is the group name).
  * </dl>
  */
+@UIType
 public class GenericTestBeanCustomizer extends JPanel implements SharedCustomizer {
     private static final long serialVersionUID = 241L;
 
@@ -486,6 +489,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      */
     @SuppressWarnings("unchecked")
     @Override
+    @SafeEffect
     public void setObject(Object map) {
         propertyMap = (Map<String, Object>) map;
 
@@ -637,6 +641,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      * @param descriptor
      * @return the group String.
      */
+    @SafeEffect
     private static String group(PropertyDescriptor descriptor) {
         String group = (String) descriptor.getValue(GROUP);
         if (group == null){

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/IntegerPropertyEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/IntegerPropertyEditor.java
@@ -17,12 +17,16 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.AlwaysSafe;
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
 import java.beans.PropertyEditorSupport;
 
 /**
  * Property Editor which handles Integer properties.
  * Uses {@link Integer#decode(String)} so supports hex and octal input.
  */
+@SafeType
 public class IntegerPropertyEditor extends PropertyEditorSupport {
 
     @Override

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/LongPropertyEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/LongPropertyEditor.java
@@ -17,12 +17,15 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
 import java.beans.PropertyEditorSupport;
 
 /**
  * Property Editor which handles Long properties.
  * Uses {@link Long#decode(String)} so supports hex and octal input.
  */
+@SafeType
 public class LongPropertyEditor extends PropertyEditorSupport {
 
     @Override

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/PasswordEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/PasswordEditor.java
@@ -17,6 +17,9 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
+
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -34,7 +37,7 @@ import javax.swing.JPasswordField;
  * The provided GUI is a simple password field.
  *
  */
-public class PasswordEditor extends PropertyEditorSupport implements ActionListener, FocusListener {
+public @UI class PasswordEditor extends PropertyEditorSupport implements ActionListener, FocusListener {
 
     private JPasswordField textField;
 
@@ -86,6 +89,7 @@ public class PasswordEditor extends PropertyEditorSupport implements ActionListe
     }
 
     @Override
+    @SafeEffect
     public boolean supportsCustomEditor() {
         return true;
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/SharedCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/SharedCustomizer.java
@@ -17,6 +17,9 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+
 import java.beans.Customizer;
 
 /**
@@ -27,5 +30,6 @@ import java.beans.Customizer;
  * setElement can be called multiple times to change the element it works on.
  *
  */
+@PolyUIType
 public interface SharedCustomizer extends Customizer {
 }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.beans.PropertyDescriptor;
+import java.beans.PropertyEditor;
 import java.beans.PropertyEditorSupport;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -50,6 +51,8 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * <li>property type Collection of {@link String}s, where there is a single header entry</li>
  * </ul>
  */
-public class TableEditor extends PropertyEditorSupport implements FocusListener,TestBeanPropertyEditor,TableModelListener, ClearGui {
+public @UI class TableEditor extends PropertyEditorSupport implements FocusListener,TestBeanPropertyEditor,TableModelListener, ClearGui {
     private static final Logger log = LoggerFactory.getLogger(TableEditor.class);
 
     /**
@@ -189,6 +192,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
     }
 
     @Override
+    @SafeEffect
     public boolean supportsCustomEditor() {
         return true;
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
@@ -66,6 +66,7 @@ import org.apache.jmeter.util.LocaleChangeListener;
 import org.apache.jmeter.visualizers.Visualizer;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,6 +188,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         if (beanInfo == null){
             return "null";// $NON-NLS-1$
@@ -336,6 +338,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         BeanDescriptor bd = beanInfo.getBeanDescriptor();
 
@@ -436,6 +439,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         // @see getStaticLabel
         return null;
@@ -482,6 +486,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
      * @see org.apache.jmeter.gui.AbstractJMeterGuiComponent#getDocAnchor()
      */
     @Override
+    @SafeEffect
     public String getDocAnchor() {
         ResourceBundle resourceBundle = ResourceBundle.getBundle(
                 testBeanClass.getName() + "Resources",  // $NON-NLS-1$
@@ -492,6 +497,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
     }
 
     @Override
+    @SafeEffect
     public String toString() {
         return "TestBeanGUI:" + (testBeanClass == null ? "" : testBeanClass.getName());
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
@@ -67,6 +67,7 @@ import org.apache.jmeter.visualizers.Visualizer;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.util.JOrphanUtils;
 import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +111,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
      * needs to be limited, though, to avoid memory issues when editing very
      * large test plans.
      */
-    private final Map<TestElement, Customizer> customizers = new LRUMap<>(20);
+    private final Map<TestElement, @UI Customizer> customizers = new LRUMap<>(20);
 
     /** Index of the customizer in the JPanel's child component list: */
     private int customizerIndexInPanel;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanPropertyEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanPropertyEditor.java
@@ -17,10 +17,12 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+
 import java.beans.PropertyDescriptor;
 import java.beans.PropertyEditor;
 
-public interface TestBeanPropertyEditor extends PropertyEditor {
+public @PolyUI interface TestBeanPropertyEditor extends @PolyUI PropertyEditor {
 
     void setDescriptor(PropertyDescriptor descriptor);
 

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TextAreaEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TextAreaEditor.java
@@ -27,8 +27,10 @@ import java.beans.PropertyEditorSupport;
 
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 
-public class TextAreaEditor extends PropertyEditorSupport implements FocusListener, PropertyChangeListener {
+public @UI class TextAreaEditor extends PropertyEditorSupport implements FocusListener, PropertyChangeListener {
 
     private final JSyntaxTextArea textUI;
 
@@ -124,6 +126,7 @@ public class TextAreaEditor extends PropertyEditorSupport implements FocusListen
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public boolean supportsCustomEditor() {
         return true;
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TypeEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TypeEditor.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.testbeans.gui;
 
+import org.checkerframework.checker.guieffect.qual.UI;
+
 import java.beans.PropertyDescriptor;
 import java.beans.PropertyEditor;
 
@@ -26,35 +28,35 @@ import java.beans.PropertyEditor;
 public enum TypeEditor {
     FileEditor { // NOSONAR Keep naming for compatibility
         @Override
-        PropertyEditor getInstance(PropertyDescriptor descriptor) {
+        @UI PropertyEditor getInstance(PropertyDescriptor descriptor) {
             return new FileEditor(descriptor);
         }
     },
     PasswordEditor { // NOSONAR Keep naming for compatibility
         @Override
-        PropertyEditor getInstance(PropertyDescriptor descriptor) {
+        @UI PropertyEditor getInstance(PropertyDescriptor descriptor) {
             return new PasswordEditor();
         }
     },
     TableEditor { // NOSONAR Keep naming for compatibility
         @Override
-        PropertyEditor getInstance(PropertyDescriptor descriptor) {
+        @UI PropertyEditor getInstance(PropertyDescriptor descriptor) {
             return new TableEditor();
         }
     },
     TextAreaEditor { // NOSONAR Keep naming for compatibility
         @Override
-        PropertyEditor getInstance(PropertyDescriptor descriptor) {
+        @UI PropertyEditor getInstance(PropertyDescriptor descriptor) {
             return new TextAreaEditor(descriptor);
         }
     },
     ComboStringEditor { // NOSONAR Keep naming for compatibility
         @Override
-        PropertyEditor getInstance(PropertyDescriptor descriptor) {
+        @UI PropertyEditor getInstance(PropertyDescriptor descriptor) {
             return new ComboStringEditor(descriptor);
         }
     };
 
     // Some editors may need the descriptor
-    abstract PropertyEditor getInstance(PropertyDescriptor descriptor);
+    abstract @UI PropertyEditor getInstance(PropertyDescriptor descriptor);
 }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/WrapperEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/WrapperEditor.java
@@ -28,6 +28,8 @@ import javax.swing.JOptionPane;
 
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * they make valid property values).
  *
  */
-class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListener {
+@UI class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListener {
     private static final Logger log = LoggerFactory.getLogger(WrapperEditor.class);
 
     /** The type's property editor. */
@@ -85,7 +87,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
      * Constructor for use when a PropertyEditor is delegating to us.
      */
     WrapperEditor(
-            Object source, PropertyEditor typeEditor, PropertyEditor guiEditor,
+            @UI Object source, PropertyEditor typeEditor, @UI PropertyEditor guiEditor,
             boolean acceptsNull, boolean acceptsExpressions,
             boolean acceptsOther, Object defaultValue) {
         super();
@@ -146,6 +148,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
     }
 
     @Override
+    @SafeEffect
     public boolean supportsCustomEditor() {
         return true;
     }
@@ -156,6 +159,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
     }
 
     @Override
+    @SafeEffect
     public String[] getTags() {
         return guiEditor.getTags();
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/package-info.java
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-plugins {
-    // test-fixtures enable to share code across test modules
-    // See https://docs.gradle.org/5.6/userguide/java_testing.html#sec:java_test_fixtures
-    `java-test-fixtures`
-    id("build-logic.jvm-library")
-}
+@UIPackage
+package org.apache.jmeter.testbeans.gui;
 
-dependencies {
-    api("org.checkerframework:checker-qual")
-}
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/AbstractThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/AbstractThreadGroupGui.java
@@ -42,6 +42,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 public abstract class AbstractThreadGroupGui extends AbstractJMeterGuiComponent {
     private static final long serialVersionUID = 240L;
 
@@ -59,6 +61,7 @@ public abstract class AbstractThreadGroupGui extends AbstractJMeterGuiComponent 
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.THREADS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/PostThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/PostThreadGroupGui.java
@@ -22,6 +22,7 @@ import java.awt.event.ItemListener;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.PostThreadGroup;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "post_thread_group_title")
 public class PostThreadGroupGui extends ThreadGroupGui implements ItemListener {
@@ -32,9 +33,9 @@ public class PostThreadGroupGui extends ThreadGroupGui implements ItemListener {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "post_thread_group_title"; // $NON-NLS-1$
-
     }
 
     @Override

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/SetupThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/SetupThreadGroupGui.java
@@ -22,6 +22,7 @@ import java.awt.event.ItemListener;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.SetupThreadGroup;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "setup_thread_group_title")
 public class SetupThreadGroupGui extends ThreadGroupGui implements ItemListener {
@@ -32,9 +33,9 @@ public class SetupThreadGroupGui extends ThreadGroupGui implements ItemListener 
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "setup_thread_group_title"; // $NON-NLS-1$
-
     }
 
     @Override

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
@@ -40,6 +40,8 @@ import org.apache.jmeter.util.JMeterUtils;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 @TestElementMetadata(labelResource = "threadgroup")
 public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListener {
     private static final long serialVersionUID = 240L;
@@ -156,6 +158,7 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
 
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "threadgroup"; // $NON-NLS-1$
     }

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@UIPackage
+package org.apache.jmeter.threads.gui;
+
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/core/src/main/java/org/apache/jmeter/timers/gui/AbstractTimerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/timers/gui/AbstractTimerGui.java
@@ -24,6 +24,7 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This is the base class for JMeter GUI components which manage timers.
@@ -58,6 +59,7 @@ public abstract class AbstractTimerGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.TIMERS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -1274,6 +1274,7 @@ public class JMeterUtils implements UnitTestManager {
      * @param table the {@link JTable} which should be adapted for HiDPI mode
      */
     @API(since = "5.3", status = API.Status.DEPRECATED)
+    @UIEffect
     public static void applyHiDPI(JTable table) {
         JFactory.singleLineRowHeight(table);
     }
@@ -1319,6 +1320,7 @@ public class JMeterUtils implements UnitTestManager {
     /**
      * Refresh UI after LAF change or resizing
      */
+    @UIEffect
     public static void refreshUI() {
         GuiPackage.getInstance().updateUIForHiddenComponents();
         JFactory.refreshUI();

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -68,6 +68,8 @@ import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Compiler;
 import org.apache.oro.text.regex.Perl5Matcher;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -955,6 +957,7 @@ public class JMeterUtils implements UnitTestManager {
         });
     }
 
+    @UIEffect
     private static JScrollPane formatMessage(String errorMsg) {
         JTextArea ta = new JTextArea(10, 50);
         ta.setText(errorMsg);
@@ -971,6 +974,7 @@ public class JMeterUtils implements UnitTestManager {
      * @param resourceId resource ID to be used for retrieving label text
      * @return JLabel instance
      */
+    @UIEffect
     public static JLabel labelFor(Component component, String resourceId) {
         JLabel label = new JLabel(getResString(resourceId));
         label.setName(resourceId);
@@ -985,6 +989,7 @@ public class JMeterUtils implements UnitTestManager {
      * @param name JLabel name
      * @return JLabel instance
      */
+    @UIEffect
     public static JLabel labelFor(Component component, String labelValue, String name) {
         JLabel label = new JLabel(labelValue);
         label.setName(name);

--- a/src/core/src/main/java/org/apache/jmeter/util/ScopePanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/ScopePanel.java
@@ -30,12 +30,14 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
 import org.apache.jmeter.gui.util.HorizontalPanel;
+import org.checkerframework.checker.guieffect.qual.UIType;
 
 /**
  * Scope panel so users can choose whether
  * to apply the test element to the parent sample, the child samples or both.
  *
  */
+@UIType
 public class ScopePanel extends JPanel implements ActionListener, FocusListener {
 
     private static final long serialVersionUID = 240L;

--- a/src/core/src/main/java/org/apache/jmeter/util/ScriptingBeanInfoSupport.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/ScriptingBeanInfoSupport.java
@@ -31,6 +31,8 @@ import org.apache.jmeter.testbeans.BeanInfoSupport;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testbeans.gui.FileEditor;
 import org.apache.jmeter.testbeans.gui.TextAreaEditor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 
 /**
  * Parent class to define common GUI parameters for BSF and JSR223 test elements
@@ -123,7 +125,7 @@ public abstract class ScriptingBeanInfoSupport extends BeanInfoSupport {
 
     }
 
-    public static class JSR223ScriptCacheCheckboxEditor extends PropertyEditorSupport implements ActionListener, ClearGui {
+    public static @UI class JSR223ScriptCacheCheckboxEditor extends PropertyEditorSupport implements ActionListener, ClearGui {
 
         private final JCheckBox checkbox;
 
@@ -204,6 +206,7 @@ public abstract class ScriptingBeanInfoSupport extends BeanInfoSupport {
         }
 
         @Override
+        @SafeEffect
         public boolean supportsCustomEditor() {
             return true;
         }

--- a/src/core/src/main/java/org/apache/jmeter/visualizers/Printable.java
+++ b/src/core/src/main/java/org/apache/jmeter/visualizers/Printable.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.visualizers;
 
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+
 import javax.swing.JComponent;
 
 /**
@@ -25,5 +27,6 @@ import javax.swing.JComponent;
  * JComponent to save.
  */
 public interface Printable {
+    @UIEffect
     JComponent getPrintableComponent();
 }

--- a/src/core/src/main/java/org/apache/jmeter/visualizers/gui/AbstractListenerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/visualizers/gui/AbstractListenerGui.java
@@ -24,6 +24,7 @@ import javax.swing.JPopupMenu;
 
 import org.apache.jmeter.gui.AbstractJMeterGuiComponent;
 import org.apache.jmeter.gui.util.MenuFactory;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Basic Listener/Visualiser Gui class to correspond with AbstractPreProcessorGui etc.
@@ -58,6 +59,7 @@ public abstract class AbstractListenerGui extends AbstractJMeterGuiComponent {
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.LISTENERS);
     }

--- a/src/core/src/main/java/org/apache/jmeter/visualizers/gui/package-info.java
+++ b/src/core/src/main/java/org/apache/jmeter/visualizers/gui/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@UIPackage
+package org.apache.jmeter.visualizers.gui;
+
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/examples/src/main/java/org/apache/jmeter/examples/sampler/gui/ExampleSamplerGui.java
+++ b/src/examples/src/main/java/org/apache/jmeter/examples/sampler/gui/ExampleSamplerGui.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.examples.sampler.ExampleSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Example Sampler (non-Bean version)
@@ -52,6 +53,7 @@ public class ExampleSamplerGui extends AbstractSamplerGui {
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "example_title"; // $NON-NLS-1$
     }

--- a/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
+++ b/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
@@ -46,6 +46,7 @@ import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Workbench test element to create a test plan containing samples of each test element
@@ -70,21 +71,25 @@ public class GenerateTreeGui extends AbstractConfigGui
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "test_plan"; // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         return "Test Generator"; // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public String getDocAnchor() {
         return super.getDocAnchor();
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.NON_TEST_ELEMENTS);
     }

--- a/src/jorphan/build.gradle.kts
+++ b/src/jorphan/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 
 dependencies {
     api("org.apiguardian:apiguardian-api")
+    api("org.checkerframework:checker-qual")
     api("org.slf4j:slf4j-api")
 
     implementation("commons-io:commons-io")

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/AbstractTreeTableModel.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/AbstractTreeTableModel.java
@@ -27,7 +27,9 @@ import javax.swing.table.DefaultTableModel;
 import javax.swing.tree.TreeNode;
 
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeType;
 
+@SafeType
 public abstract class AbstractTreeTableModel extends DefaultTableModel implements TreeTableModel {
 
     private static final long serialVersionUID = 240L;

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/DynamicStyle.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/DynamicStyle.java
@@ -33,10 +33,12 @@ import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.UI;
 
 /**
  * By default, Swing does not provide a way to augment components when
@@ -60,7 +62,7 @@ public class DynamicStyle {
      * @return input component (e.g. for fluent APIs)
      */
     @API(since = "5.3", status = API.Status.EXPERIMENTAL)
-    public <T extends JComponent> T withDynamic(T component, Consumer<T> onUpdateUi) {
+    public <T extends JComponent> T withDynamic(T component, @UI Consumer<T> onUpdateUi) {
         // Explicit component update is required since the component already exists
         // and we can't want to wait for the next LaF change
         onUpdateUi.accept(component);
@@ -99,14 +101,14 @@ public class DynamicStyle {
      * @return a handle that can be used to un-register the listener
      */
     @API(since = "5.3", status = API.Status.EXPERIMENTAL)
-    public static Closeable onLaFChange(Runnable action) {
+    public static @UI Closeable onLaFChange(@UI Runnable action) {
         // Explicit component update is required since the component already exists
         // and we can't want to wait for the next LaF change
         action.run();
 
         PropertyChangeListener listener = evt -> {
             if ("lookAndFeel".equals(evt.getPropertyName())) { // $NON-NLS-1$
-                action.run();
+                SwingUtilities.invokeLater(action);
             }
         };
         UIManager.addPropertyChangeListener(listener);

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/JMeterUIDefaults.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/JMeterUIDefaults.java
@@ -35,6 +35,8 @@ import javax.swing.text.StyleContext;
 import org.apache.jorphan.gui.ui.TextAreaUIWithUndo;
 import org.apache.jorphan.gui.ui.TextFieldUIWithUndo;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.checkerframework.checker.guieffect.qual.UI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,11 +91,13 @@ public class JMeterUIDefaults {
     private float scale = 1.0f;
 
     @API(since = "5.3", status = API.Status.EXPERIMENTAL)
+    @SafeEffect
     public float getScale() {
         return scale;
     }
 
     @API(since = "5.3", status = API.Status.EXPERIMENTAL)
+    @SafeEffect
     public void setScale(float scale) {
         this.scale = scale;
     }

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/JMeterUIDefaults.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/JMeterUIDefaults.java
@@ -35,6 +35,7 @@ import javax.swing.text.StyleContext;
 import org.apache.jorphan.gui.ui.TextAreaUIWithUndo;
 import org.apache.jorphan.gui.ui.TextFieldUIWithUndo;
 import org.apiguardian.api.API;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,11 +151,11 @@ public class JMeterUIDefaults {
         addDerivedFont(defaults, output, input, f -> f.deriveFont(f.getSize2D() * scale));
     }
 
-    private static void addDerivedFont(UIDefaults defaults, String output, String input, Function<Font, Font> f) {
-        defaults.put(output, (UIDefaults.LazyValue) d -> map(d.getFont(input), f));
+    private static void addDerivedFont(UIDefaults defaults, String output, String input, @UI Function<Font, Font> f) {
+        defaults.put(output, (UIDefaults.@UI LazyValue) d -> map(d.getFont(input), f));
     }
 
-    private static Font map(Font input, Function<Font, Font> mapper) {
+    private static Font map(Font input, @UI Function<Font, Font> mapper) {
         Font output = mapper.apply(input);
         // Note: we drop UIResource here so LaF treats the font as user-provided rather than
         // LaF-provided.

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/MenuScroller.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/MenuScroller.java
@@ -17,6 +17,8 @@
 
 package org.apache.jorphan.gui;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -512,19 +514,6 @@ public class MenuScroller {
             menu.removeMouseWheelListener(mouseWheelListener);
             menu = null;
         }
-    }
-
-    /**
-     * Ensures that the <code>dispose</code> method of this MenuScroller is
-     * called when there are no more references to it.
-     *
-     * @see MenuScroller#dispose()
-     */
-    @Override
-    @SuppressWarnings("deprecation")
-    public void finalize() throws Throwable {
-        dispose();
-        super.finalize();
     }
 
     private void refreshMenu() {

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableModel.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableModel.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.swing.table.DefaultTableModel;
 
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
  * The ObjectTableModel is a TableModel whose rows are objects;
  * columns are defined as Functors on the object.
  */
+@SafeType
 public class ObjectTableModel extends DefaultTableModel {
     private static final Logger log = LoggerFactory.getLogger(ObjectTableModel.class);
 

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
@@ -32,17 +32,20 @@ import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.checkerframework.checker.guieffect.qual.SafeType;
 
 /**
  * Implementation of a {@link RowSorter} for {@link ObjectTableModel}
  * @since 3.2
  *
  */
+@SafeType
 public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
 
     /**
      * View row with model mapping. All data relates to model.
      */
+    @SafeType
     public class Row {
         private int index;
 
@@ -63,6 +66,7 @@ public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
         }
     }
 
+    @SafeType
     protected class PreserveLastRowComparator implements Comparator<Row> {
         @Override
         public int compare(Row o1, Row o2) {

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/layout/VerticalLayout.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/layout/VerticalLayout.java
@@ -17,6 +17,8 @@
 
 package org.apache.jorphan.gui.layout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
@@ -212,6 +214,7 @@ public class VerticalLayout implements LayoutManager, Serializable {
     }
 
     @Override
+    @SafeEffect
     public String toString() {
         return getClass().getName() + "[vgap=" + vgap + " align=" + alignment + " anchor=" + anchor + "]";
     }

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/layout/package-info.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/layout/package-info.java
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-plugins {
-    // test-fixtures enable to share code across test modules
-    // See https://docs.gradle.org/5.6/userguide/java_testing.html#sec:java_test_fixtures
-    `java-test-fixtures`
-    id("build-logic.jvm-library")
-}
+@UIPackage
+package org.apache.jorphan.gui.layout;
 
-dependencies {
-    api("org.checkerframework:checker-qual")
-}
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/package-info.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/package-info.java
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-plugins {
-    // test-fixtures enable to share code across test modules
-    // See https://docs.gradle.org/5.6/userguide/java_testing.html#sec:java_test_fixtures
-    `java-test-fixtures`
-    id("build-logic.jvm-library")
-}
+@UIPackage
+package org.apache.jorphan.gui;
 
-dependencies {
-    api("org.checkerframework:checker-qual")
-}
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/AddUndoableEditListenerPropertyChangeListener.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/AddUndoableEditListenerPropertyChangeListener.java
@@ -17,19 +17,28 @@
 
 package org.apache.jorphan.gui.ui;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.SafeType;
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
+import javax.swing.SwingUtilities;
 import javax.swing.text.Document;
 import javax.swing.undo.UndoManager;
 
+@UI
 class AddUndoableEditListenerPropertyChangeListener implements PropertyChangeListener {
     private final UndoManager manager;
 
+    @SafeEffect
     public AddUndoableEditListenerPropertyChangeListener(UndoManager manager) {
         this.manager = manager;
     }
 
+    @SafeEffect
     public final UndoManager getUndoManager() {
         return manager;
     }

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/DefaultUndoManager.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/DefaultUndoManager.java
@@ -22,6 +22,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.event.UndoableEditEvent;
 import javax.swing.undo.UndoManager;
 
+import org.checkerframework.checker.guieffect.qual.SafeType;
+
+@SafeType
 class DefaultUndoManager extends UndoManager {
     private final AtomicInteger undoEpoch;
     private int ourUndoEpoch;

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/package-info.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ui/package-info.java
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-plugins {
-    // test-fixtures enable to share code across test modules
-    // See https://docs.gradle.org/5.6/userguide/java_testing.html#sec:java_test_fixtures
-    `java-test-fixtures`
-    id("build-logic.jvm-library")
-}
+@UIPackage
+package org.apache.jorphan.gui.ui;
 
-dependencies {
-    api("org.checkerframework:checker-qual")
-}
+import org.checkerframework.checker.guieffect.qual.UIPackage;

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/JOrphanUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/JOrphanUtils.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.RandomStringGenerator;
+import org.checkerframework.checker.guieffect.qual.AlwaysSafe;
 
 /**
  * This class contains frequently-used static utility methods.
@@ -718,7 +719,7 @@ public final class JOrphanUtils {
      * @param setter        that gets called with the replaced value
      * @return number of matches that were replaced
      */
-    public static int replaceValue(String regex, String replaceBy, boolean caseSensitive, String value, Consumer<String> setter) {
+    public static int replaceValue(String regex, String replaceBy, boolean caseSensitive, String value, @AlwaysSafe Consumer<String> setter) {
         if (StringUtils.isBlank(value)) {
             return 0;
         }

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/config/gui/FtpConfigGui.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/config/gui/FtpConfigGui.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.protocol.ftp.sampler.FTPSampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "ftp_sample_title")
 public class FtpConfigGui extends AbstractConfigGui {
@@ -71,6 +72,7 @@ public class FtpConfigGui extends AbstractConfigGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ftp_sample_title"; // $NON-NLS-1$
     }

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/control/gui/FtpTestSamplerGui.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/control/gui/FtpTestSamplerGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.protocol.ftp.sampler.FTPSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "ftp_testing_title")
 public class FtpTestSamplerGui extends AbstractSamplerGui {
@@ -81,6 +82,7 @@ public class FtpTestSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ftp_testing_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -49,6 +49,8 @@ import org.apache.jorphan.gui.JFactory;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * GUI for Http Request defaults
  */
@@ -82,6 +84,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "url_config_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/AjpSamplerGui.java
@@ -21,6 +21,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.sampler.AjpSampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "ajp_sampler_title")
 public class AjpSamplerGui extends HttpTestSampleGui {
@@ -40,11 +41,13 @@ public class AjpSamplerGui extends HttpTestSampleGui {
 
     // Use this instead of getLabelResource() otherwise getDocAnchor() below does not work
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         return JMeterUtils.getResString("ajp_sampler_title"); // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public String getDocAnchor() {// reuse documentation
         return super.getStaticLabel().replace(' ', '_'); //$NON-NLS-1$ //$NON-NLS-2$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/GraphQLHTTPSamplerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/GraphQLHTTPSamplerGui.java
@@ -23,6 +23,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.config.gui.GraphQLUrlConfigGui;
 import org.apache.jmeter.protocol.http.config.gui.UrlConfigGui;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GraphQL HTTP Sampler GUI which extends {@link HttpTestSampleGui} in order to provide more convenient UI elements for
@@ -39,11 +40,13 @@ public class GraphQLHTTPSamplerGui extends HttpTestSampleGui {
 
     // Use this instead of getLabelResource() otherwise getDocAnchor() below does not work
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         return JMeterUtils.getResString("graphql_http_sampler_title"); // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public String getDocAnchor() {// reuse documentation
         return super.getStaticLabel().replace(' ', '_'); //$NON-NLS-1$ //$NON-NLS-2$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpMirrorControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpMirrorControlGui.java
@@ -40,6 +40,7 @@ import org.apache.jmeter.gui.util.MenuFactory;
 import org.apache.jmeter.protocol.http.control.HttpMirrorControl;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,11 +103,13 @@ public class HttpMirrorControlGui extends LogicControllerGui
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "httpmirror_title"; // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.NON_TEST_ELEMENTS);
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -46,6 +46,8 @@ import org.apache.jorphan.gui.JFactory;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * HTTP Sampler GUI
  */
@@ -160,6 +162,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
      * {@inheritDoc}
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "web_testing_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/RecordController.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/RecordController.java
@@ -33,6 +33,7 @@ import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.protocol.http.control.RecordingController;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,7 @@ public class RecordController extends LogicControllerGui implements ActionListen
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "record_controller_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
@@ -52,6 +52,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,6 +154,7 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "auth_manager_title"; //$NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CacheManagerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CacheManagerGui.java
@@ -33,6 +33,7 @@ import org.apache.jmeter.protocol.http.control.CacheManager;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The GUI for the HTTP Cache Manager {@link CacheManager}
@@ -54,6 +55,7 @@ public class CacheManagerGui extends AbstractConfigGui implements ActionListener
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "cache_manager_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
@@ -48,6 +48,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,6 +105,7 @@ public class CookiePanel extends AbstractConfigGui implements ActionListener {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "cookie_manager_title"; //$NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -43,6 +43,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,6 +125,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "dns_cache_manager_title";
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
@@ -45,6 +45,7 @@ import org.apache.jmeter.protocol.http.control.HeaderManager;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,6 +119,7 @@ public class HeaderPanel extends AbstractConfigGui implements ActionListener {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "header_manager_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/AnchorModifierGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/AnchorModifierGui.java
@@ -23,6 +23,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.processor.gui.AbstractPreProcessorGui;
 import org.apache.jmeter.protocol.http.modifier.AnchorModifier;
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "anchor_modifier_title")
 public class AnchorModifierGui extends AbstractPreProcessorGui {
@@ -33,6 +34,7 @@ public class AnchorModifierGui extends AbstractPreProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "anchor_modifier_title"; //$NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/RegExUserParametersGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/RegExUserParametersGui.java
@@ -32,6 +32,7 @@ import org.apache.jmeter.protocol.http.modifier.RegExUserParameters;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * GUI for {@link RegExUserParameters}
@@ -56,6 +57,7 @@ public class RegExUserParametersGui extends AbstractPreProcessorGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "regex_params_title"; //$NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/URLRewritingModifierGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/URLRewritingModifierGui.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.protocol.http.modifier.URLRewritingModifier;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "http_url_rewriting_modifier_title")
 public class URLRewritingModifierGui extends AbstractPreProcessorGui {
@@ -46,6 +47,7 @@ public class URLRewritingModifierGui extends AbstractPreProcessorGui {
     private JCheckBox encode;
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "http_url_rewriting_modifier_title"; // $NON-NLS-1$
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -91,6 +91,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.exec.KeyToolUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -372,12 +373,14 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "proxy_title"; // $NON-NLS-1$
     }
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.NON_TEST_ELEMENTS);
     }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
@@ -48,6 +48,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.reflect.ClassFinder;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,6 +108,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
 
     /** {@inheritDoc} */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "java_request_defaults"; // $NON-NLS-1$
     }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "bsh_sampler_title")
 public class BeanShellSamplerGui extends AbstractSamplerGui {
@@ -99,6 +100,7 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "bsh_sampler_title"; // $NON-NLS-1$
     }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/JavaTestSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/JavaTestSamplerGui.java
@@ -25,6 +25,7 @@ import org.apache.jmeter.protocol.java.config.gui.JavaConfigGui;
 import org.apache.jmeter.protocol.java.sampler.JavaSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * The <code>JavaTestSamplerGui</code> class provides the user interface for
@@ -47,6 +48,7 @@ public class JavaTestSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "java_request"; // $NON-NLS-1$
     }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPublisherGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPublisherGui.java
@@ -41,6 +41,8 @@ import org.apache.jorphan.gui.JLabeledTextField;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * This is the GUI for JMS Publisher
  */
@@ -133,6 +135,7 @@ public class JMSPublisherGui extends AbstractSamplerGui implements ChangeListene
      * the name of the property for the JMSPublisherGui is jms_publisher.
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "jms_publisher"; //$NON-NLS-1$
     }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 
 /**
@@ -318,6 +319,7 @@ public class JMSSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "jms_point_to_point"; //$NON-NLS-1$
     }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSubscriberGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSubscriberGui.java
@@ -37,6 +37,8 @@ import org.apache.jorphan.gui.JLabeledTextField;
 
 import net.miginfocom.swing.MigLayout;
 
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
+
 /**
  * This is the GUI for JMS Subscriber <br>
  *
@@ -115,6 +117,7 @@ public class JMSSubscriberGui extends AbstractSamplerGui implements ChangeListen
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "jms_subscriber_title"; // $NON-NLS-1$
     }

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
@@ -44,6 +44,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.reflect.ClassFinder;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -144,6 +145,7 @@ implements ChangeListener, ActionListener, ItemListener
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource()
     {
         return "junit_request"; //$NON-NLS-1$

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
@@ -42,6 +42,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * A GUI panel allowing the user to enter name-value argument pairs. These
@@ -106,11 +107,13 @@ public class LDAPArgumentsPanel extends AbstractConfigGui implements ActionListe
      *         constants defined in MenuFactory
      */
     @Override
+    @SafeEffect
     public Collection<String> getMenuCategories() {
         return null;
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ldapext_sample_title"; // $NON-NLS-1$
     }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * This class LdapConfigGui is user interface gui for getting all the
@@ -108,6 +109,7 @@ public class LdapConfigGui extends AbstractConfigGui implements ItemListener {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ldap_sample_title"; // $NON-NLS-1$
     }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
@@ -42,6 +42,7 @@ import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledChoice;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /*******************************************************************************
  * This class LdapConfigGui is user interface gui for getting all the
@@ -183,6 +184,7 @@ public class LdapExtConfigGui extends AbstractConfigGui implements ItemListener 
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ldapext_sample_title"; // $NON-NLS-1$
     }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapExtTestSamplerGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapExtTestSamplerGui.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.protocol.ldap.config.gui.LdapExtConfigGui;
 import org.apache.jmeter.protocol.ldap.sampler.LDAPExtSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /*******************************************************************************
  *
@@ -94,6 +95,7 @@ public class LdapExtTestSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ldapext_testing_title"; // $NON-NLS-1$
     }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapTestSamplerGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/control/gui/LdapTestSamplerGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.protocol.ldap.sampler.LDAPSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "ldap_testing_title")
 public class LdapTestSamplerGui extends AbstractSamplerGui {
@@ -90,6 +91,7 @@ public class LdapTestSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "ldap_testing_title"; // $NON-NLS-1$
     }

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
@@ -43,6 +43,7 @@ import org.apache.jmeter.protocol.smtp.sampler.gui.SecuritySettingsPanel;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "mail_reader_title")
 public class MailReaderSamplerGui extends AbstractSamplerGui implements ActionListener, FocusListener {
@@ -110,6 +111,7 @@ public class MailReaderSamplerGui extends AbstractSamplerGui implements ActionLi
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "mail_reader_title"; // $NON-NLS-1$
     }

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpSamplerGui.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 /**
  * Class to build superstructure-gui for SMTP-panel, sets/gets value for a JMeter's testElement-object (i.e. also for save/load-purposes).
@@ -53,6 +54,7 @@ public class SmtpSamplerGui extends AbstractSamplerGui {
      * @see org.apache.jmeter.gui.JMeterGUIComponent#getLabelResource()
      */
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "smtp_sampler_title";
     }

--- a/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
+++ b/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,11 +77,13 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "system_sampler_title"; // $NON-NLS-1$
     }
 
     @Override
+    @SafeEffect
     public String getStaticLabel() {
         return JMeterUtils.getResString(getLabelResource());
     }

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/config/gui/TCPConfigGui.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.protocol.tcp.sampler.TCPSampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "tcp_config_title")
 public class TCPConfigGui extends AbstractConfigGui {
@@ -75,6 +76,7 @@ public class TCPConfigGui extends AbstractConfigGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "tcp_config_title"; // $NON-NLS-1$
     }

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/control/gui/TCPSamplerGui.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/control/gui/TCPSamplerGui.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.protocol.tcp.sampler.TCPSampler;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.checkerframework.checker.guieffect.qual.SafeEffect;
 
 @TestElementMetadata(labelResource = "tcp_sample_title")
 public class TCPSamplerGui extends AbstractSamplerGui {
@@ -81,6 +82,7 @@ public class TCPSamplerGui extends AbstractSamplerGui {
     }
 
     @Override
+    @SafeEffect
     public String getLabelResource() {
         return "tcp_sample_title"; // $NON-NLS-1$
     }


### PR DESCRIPTION
## Description

See
* https://checkerframework.org/manual/#guieffect-checker
* https://homes.cs.washington.edu/~mernst/pubs/gui-thread-ecoop2013.pdf

## Motivation and Context

We should call UI methods from UI threads only.
Let's see if GUI Effect Checker could help with the verifications.

## Issues

* [x] https://github.com/typetools/checker-framework/issues/5821
  Functional interfaces should be annotated with `@PolyUIType` for use in `@UI` lambdas.
* [x] https://github.com/typetools/checker-framework/issues/5826
