### PR TITLE
Add errorprone verifications

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 max_line_length = 120
+ij_any_align_multiline_parameters = false
 
 [{*.sh,gradlew}]
 end_of_line = lf

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -66,7 +66,8 @@ buildParameters {
         description.set("Skip forbidden-apis verifications")
     }
     bool("enableErrorprone") {
-        defaultValue.set(true)
+        // By default, disable errorProne in CI so we don't perform the same checks in several jobs
+        defaultValue.set(System.getenv("CI") != "true")
         description.set("Enable ErrorProne verifications")
     }
     bool("skipJavadoc") {

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -55,6 +55,7 @@ if (buildParameters.enableErrorprone) {
                     "UnnecessaryDefaultInEnumSwitch",
                 )
                 warn(
+                    "FieldCanBeFinal",
                     "ForEachIterable",
                     "MethodCanBeStatic",
                 )

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -56,6 +56,7 @@ if (buildParameters.enableErrorprone) {
                 )
                 warn(
                     "ForEachIterable",
+                    "MethodCanBeStatic",
                 )
                 disable(
                     "ComplexBooleanConstant",

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -56,6 +56,7 @@ if (buildParameters.enableErrorprone) {
                 )
                 warn(
                     "FieldCanBeFinal",
+                    "FieldCanBeStatic",
                     "ForEachIterable",
                     "MethodCanBeStatic",
                 )

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -59,7 +59,6 @@ if (buildParameters.enableErrorprone) {
                     "BigDecimalEquals",
                     "EmptyBlockTag",
                     "Finalize",
-                    "LongDoubleConversion",
                     "MissingSummary",
                     "StringSplitter",
                     "BanJNDI",

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -46,7 +46,8 @@ if (buildParameters.enableErrorprone) {
             options.errorprone {
                 disableWarningsInGeneratedCode.set(true)
                 enable(
-                    "PackageLocation"
+                    "PackageLocation",
+                    "RedundantOverride"
                 )
                 disable(
                     "ComplexBooleanConstant",

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -51,7 +51,11 @@ if (buildParameters.enableErrorprone) {
                     "RedundantOverride",
                     "StronglyTypeTime",
                     "UnescapedEntity",
-                    "UnnecessaryDefaultInEnumSwitch"
+                    "UnnecessaryAnonymousClass",
+                    "UnnecessaryDefaultInEnumSwitch",
+                )
+                warn(
+                    "ForEachIterable",
                 )
                 disable(
                     "ComplexBooleanConstant",

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -58,7 +58,6 @@ if (buildParameters.enableErrorprone) {
                 disable(
                     "BigDecimalEquals",
                     "EmptyBlockTag",
-                    "Finalize",
                     "MissingSummary",
                     "StringSplitter",
                     "BanJNDI",

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -46,8 +46,12 @@ if (buildParameters.enableErrorprone) {
             options.errorprone {
                 disableWarningsInGeneratedCode.set(true)
                 enable(
+                    "MissingDefault",
                     "PackageLocation",
-                    "RedundantOverride"
+                    "RedundantOverride",
+                    "StronglyTypeTime",
+                    "UnescapedEntity",
+                    "UnnecessaryDefaultInEnumSwitch"
                 )
                 disable(
                     "ComplexBooleanConstant",

--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -38,6 +38,10 @@ if (buildParameters.enableErrorprone) {
             // Ignore warnings in test code
             options.errorprone.isEnabled.set(false)
         } else {
+            // Errorprone requires Java 11+
+            options.errorprone.isEnabled.set(
+                javaCompiler.map { it.metadata.languageVersion.canCompileOrRun(11) }
+            )
             options.compilerArgs.addAll(listOf("-Xmaxerrs", "10000", "-Xmaxwarns", "10000"))
             options.errorprone {
                 disableWarningsInGeneratedCode.set(true)

--- a/build-logic/verification/src/main/kotlin/build-logic.style.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.style.gradle.kts
@@ -42,7 +42,7 @@ plugins.withId("java-base") {
     if (buildParameters.enableCheckerframework) {
         apply(plugin = "build-logic.checkerframework")
     }
-    if (!buildParameters.enableErrorprone) {
+    if (buildParameters.enableErrorprone) {
         apply(plugin = "build-logic.errorprone")
     }
     if (buildParameters.spotbugs) {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -109,7 +109,6 @@
       <property name="classes" value="java.lang.Boolean"/>
     </module>
     <module name="IllegalThrows"/>
-    <module name="MissingSwitchDefault"/>
     <module name="ModifiedControlVariable"/>
     <module name="MultipleVariableDeclarations"/>
     <module name="NestedForDepth"/>

--- a/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
@@ -55,6 +55,7 @@ public class BSFAssertion extends BSFTestElement implements Cloneable, Assertion
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/CompareAssertion.java
@@ -126,7 +126,7 @@ public class CompareAssertion extends AbstractTestElement implements Assertion, 
         }
     }
 
-    private void markContentFailure(CompareAssertionResult result, String prevContent, SampleResult prevResult,
+    private static void markContentFailure(CompareAssertionResult result, String prevContent, SampleResult prevResult,
             SampleResult currentResult, String currentContent) {
         result.setFailure(true);
         StringBuilder sb = new StringBuilder();
@@ -140,7 +140,7 @@ public class CompareAssertion extends AbstractTestElement implements Assertion, 
         result.setFailureMessage(JMeterUtils.getResString("comparison_differ_content")); //$NON-NLS-1$
     }
 
-    private void appendResultDetails(StringBuilder buf, SampleResult result) {
+    private static void appendResultDetails(StringBuilder buf, SampleResult result) {
         final String samplerData = result.getSamplerData();
         if (samplerData != null) {
             buf.append(samplerData.trim());

--- a/src/components/src/main/java/org/apache/jmeter/assertions/HTMLAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/HTMLAssertion.java
@@ -264,7 +264,7 @@ public class HTMLAssertion extends AbstractTestElement implements Serializable, 
         setProperty(new BooleanProperty(ERRORS_ONLY_KEY, inErrorsOnly));
     }
 
-    private long capToZero(long value) {
+    private static long capToZero(long value) {
         if (value == Long.MAX_VALUE) {
             return 0;
         }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSONPathAssertion.java
@@ -56,7 +56,7 @@ public class JSONPathAssertion extends AbstractTestElement implements Serializab
     private static final boolean USE_JAVA_REGEX = !JMeterUtils.getPropDefault(
             "jmeter.regex.engine", "oro").equalsIgnoreCase("oro");
 
-    private static ThreadLocal<DecimalFormat> decimalFormatter =
+    private static final ThreadLocal<DecimalFormat> decimalFormatter =
             ThreadLocal.withInitial(JSONPathAssertion::createDecimalFormat);
 
     private static DecimalFormat createDecimalFormat() {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
@@ -58,6 +58,7 @@ public class JSR223Assertion extends JSR223TestElement implements Cloneable, Ass
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/XMLSchemaAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/XMLSchemaAssertion.java
@@ -80,7 +80,7 @@ public class XMLSchemaAssertion extends AbstractTestElement implements Serializa
         return getPropertyAsString(XSD_FILENAME_KEY);
     }
 
-    private void setSchemaResult(AssertionResult result, String xmlStr, String xsdFileName) {
+    private static void setSchemaResult(AssertionResult result, String xmlStr, String xsdFileName) {
         try {
             DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
             parserFactory.setValidating(true);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/AssertionGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/AssertionGui.java
@@ -370,20 +370,20 @@ public class AssertionGui extends AbstractAssertionGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JToggleButton button, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JToggleButton button, GridBagConstraints gbc) {
         panel.add(button, gbc.clone());
         gbc.gridx++;
         gbc.fill=GridBagConstraints.HORIZONTAL;
     }
 
     // Next line
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2Panel.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/XPath2Panel.java
@@ -102,7 +102,7 @@ public class XPath2Panel extends JPanel {
 
         return panel;
     }
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
@@ -110,7 +110,7 @@ public class XPath2Panel extends JPanel {
         gbc.fill = GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/jmespath/JMESPathAssertion.java
@@ -122,7 +122,7 @@ public class JMESPathAssertion extends AbstractTestElement implements Serializab
         return message.toString();
     }
 
-    private void addNegation(boolean invert, StringBuilder message) {
+    private static void addNegation(boolean invert, StringBuilder message) {
         if (invert) {
             message.append(" not");
         }

--- a/src/components/src/main/java/org/apache/jmeter/config/CSVDataSet.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/CSVDataSet.java
@@ -242,7 +242,7 @@ public class CSVDataSet extends ConfigTestElement
      * trim content of array varNames
      * @param varsNames
      */
-    private void trimVarNames(String[] varsNames) {
+    private static void trimVarNames(String[] varsNames) {
         for (int i = 0; i < varsNames.length; i++) {
             varsNames[i] = varsNames[i].trim();
         }

--- a/src/components/src/main/java/org/apache/jmeter/config/CSVDataSetBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/CSVDataSetBeanInfo.java
@@ -131,7 +131,7 @@ public class CSVDataSetBeanInfo extends BeanInfoSupport {
      * list from https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
      * @return a String[] with the list of file encoding
      */
-    private String[] getListFileEncoding() {
+    private static String[] getListFileEncoding() {
         return JOrphanUtils.split(JMeterUtils.getPropDefault("csvdataset.file.encoding_list", ""), "|"); //$NON-NLS-1$
     }
 }

--- a/src/components/src/main/java/org/apache/jmeter/control/IncludeController.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/IncludeController.java
@@ -172,7 +172,7 @@ public class IncludeController extends GenericController implements ReplaceableC
      * @param tree HashTree included Test Plan
      * @return HashTree Subset within Test Fragment or Empty HashTree
      */
-    private HashTree getProperBranch(HashTree tree) {
+    private static HashTree getProperBranch(HashTree tree) {
         for (Object o : new ArrayList<>(tree.list())) {
             TestElement item = (TestElement) o;
 
@@ -192,7 +192,7 @@ public class IncludeController extends GenericController implements ReplaceableC
     }
 
 
-    private void removeDisabledItems(HashTree tree) {
+    private static void removeDisabledItems(HashTree tree) {
         for (Object o : new ArrayList<>(tree.list())) {
             TestElement item = (TestElement) o;
             if (!item.isEnabled()) {

--- a/src/components/src/main/java/org/apache/jmeter/control/ModuleController.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/ModuleController.java
@@ -193,7 +193,7 @@ public class ModuleController extends GenericController implements ReplaceableCo
     }
 
     @SuppressWarnings("JdkObsolete")
-    private void createSubTree(HashTree tree, JMeterTreeNode node) {
+    private static void createSubTree(HashTree tree, JMeterTreeNode node) {
         Enumeration<?> e = node.children();
         while (e.hasMoreElements()) {
             JMeterTreeNode subNode = (JMeterTreeNode)e.nextElement();

--- a/src/components/src/main/java/org/apache/jmeter/control/gui/ModuleControllerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/gui/ModuleControllerGui.java
@@ -203,7 +203,7 @@ public class ModuleControllerGui extends AbstractControllerGui implements Action
         reinitialize();
     }
 
-    private String renderPath(Collection<?> path) {
+    private static String renderPath(Collection<?> path) {
         Iterator<?> iter = path.iterator();
         StringBuilder buf = new StringBuilder();
         boolean first = true;
@@ -316,7 +316,7 @@ public class ModuleControllerGui extends AbstractControllerGui implements Action
      *
      * @return path of a found element
      */
-    private TreeNode[] findPathInTreeModel(
+    private static TreeNode[] findPathInTreeModel(
             int level, TreeNode[] testPlanPath, DefaultMutableTreeNode parent)
     {
         if (level >= testPlanPath.length) {
@@ -356,7 +356,7 @@ public class ModuleControllerGui extends AbstractControllerGui implements Action
         DefaultMutableTreeNode root = (DefaultMutableTreeNode) moduleToRunTreeNodes.getModel().getRoot();
         //treepath of test plan tree and module to run tree cannot be compared directly - moduleToRunTreeModel.getPathToRoot()
         //custom method for finding an JMeterTreeNode element in DefaultMutableTreeNode have to be used
-        TreeNode[] dmtnPath = this.findPathInTreeModel(1, filteredPath, root);
+        TreeNode[] dmtnPath = ModuleControllerGui.findPathInTreeModel(1, filteredPath, root);
         if (dmtnPath.length > 0) {
             TreePath treePath = new TreePath(dmtnPath);
             moduleToRunTreeNodes.setSelectionPath(treePath);

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessor.java
@@ -49,6 +49,7 @@ public class BSFPostProcessor extends BSFTestElement implements Cloneable, PostP
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BeanShellPostProcessor.java
@@ -73,6 +73,7 @@ public class BeanShellPostProcessor extends BeanShellTestElement
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -162,7 +162,7 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
      * @param matches List of String
      * @return 0 if there is only one match, else the number of matches, this is used to remove
      */
-    private int saveMatches(JMeterVariables vars, String refName, int matchNumber, List<String> matches) {
+    private static int saveMatches(JMeterVariables vars, String refName, int matchNumber, List<String> matches) {
         if (matchNumber >=0 && matches.isEmpty()) {
             return 0;
         }
@@ -178,14 +178,14 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         return matchCount;
     }
 
-    private void saveRandomMatch(JMeterVariables vars, String refName, List<String> matches) {
+    private static void saveRandomMatch(JMeterVariables vars, String refName, List<String> matches) {
         String match = matches.get(JMeterUtils.getRandomInt(matches.size()));
         if (match != null) {
             vars.put(refName, match);
         }
     }
 
-    private void saveOneMatch(JMeterVariables vars, String refName, List<String> matches) {
+    private static void saveOneMatch(JMeterVariables vars, String refName, List<String> matches) {
         if (matches.size() == 1) { // if not then invalid matchNum was likely supplied
             String match = matches.get(0);
             if (match != null) {
@@ -194,7 +194,7 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         }
     }
 
-    private void saveAllMatches(JMeterVariables vars, String refName, List<String> matches) {
+    private static void saveAllMatches(JMeterVariables vars, String refName, List<String> matches) {
         vars.put(refName + REF_MATCH_NR, Integer.toString(matches.size()));
         for (int i = 0; i < matches.size(); i++) {
             String match = matches.get(i);
@@ -236,7 +236,7 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         return result.getResponseDataAsString(); // Bug 36898
     }
 
-    private List<String> extract(
+    private static List<String> extract(
             String leftBoundary, String rightBoundary, int matchNumber, Stream<String> previousResults) {
         boolean allItems = matchNumber <= 0;
         return previousResults
@@ -257,7 +257,7 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
      * @param inputString   text in which to look for the fragments
      * @return list where the found text fragments will be placed
      */
-    private List<String> extract(String leftBoundary, String rightBoundary, int matchNumber, String inputString) {
+    private static List<String> extract(String leftBoundary, String rightBoundary, int matchNumber, String inputString) {
         if (StringUtils.isBlank(inputString)) {
             return Collections.emptyList();
         }
@@ -302,7 +302,7 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         return Collections.unmodifiableList(matches);
     }
 
-    public List<String> extractAll(
+    public static List<String> extractAll(
             String leftBoundary, String rightBoundary, String textToParse) {
         return extract(leftBoundary, rightBoundary, -1, textToParse);
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/DebugPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/DebugPostProcessor.java
@@ -97,7 +97,7 @@ public class DebugPostProcessor extends AbstractTestElement implements PostProce
         threadContext.getPreviousResult().addSubResult(sr);
     }
 
-    private void formatPropertyIterator(StringBuilder sb, PropertyIterator iter) {
+    private static void formatPropertyIterator(StringBuilder sb, PropertyIterator iter) {
         Map<String, String> map = new HashMap<>();
         while (iter.hasNext()) {
             JMeterProperty item = iter.next();
@@ -106,7 +106,7 @@ public class DebugPostProcessor extends AbstractTestElement implements PostProce
         formatSet(sb, map.entrySet());
     }
 
-    private void formatSet(StringBuilder sb, @SuppressWarnings("rawtypes") Set s) {
+    private static void formatSet(StringBuilder sb, @SuppressWarnings("rawtypes") Set s) {
         @SuppressWarnings("unchecked")
         List<Map.Entry<Object, Object>> al = new ArrayList<>(s);
         al.sort(AlphaNumericKeyComparator.INSTANCE);

--- a/src/components/src/main/java/org/apache/jmeter/extractor/HtmlExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/HtmlExtractor.java
@@ -145,7 +145,7 @@ public class HtmlExtractor extends AbstractScopedTestElement implements PostProc
      * @param entry   the entry number in the list
      * @return MatchResult
      */
-    private String getCorrectMatch(List<String> matches, int entry) {
+    private static String getCorrectMatch(List<String> matches, int entry) {
         int matchSize = matches.size();
 
         if (matchSize <= 0 || entry > matchSize){

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
@@ -49,6 +49,7 @@ public class JSR223PostProcessor extends JSR223TestElement implements Cloneable,
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSoupExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSoupExtractor.java
@@ -78,7 +78,7 @@ public class JSoupExtractor implements Extractor {
      * @param element Element
      * @return String value
      */
-    private String extractValue(String attribute, Element element) {
+    private static String extractValue(String attribute, Element element) {
         if (!JOrphanUtils.isBlank(attribute)) {
             return element.attr(attribute);
         } else {

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JoddExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JoddExtractor.java
@@ -94,7 +94,7 @@ public class JoddExtractor implements Extractor {
     }
 
 
-    private String extractValue(String attribute, Node element) {
+    private static String extractValue(String attribute, Node element) {
         if (!JOrphanUtils.isBlank(attribute)) {
             return element.getAttribute(attribute);
         } else {

--- a/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/RegexExtractor.java
@@ -312,7 +312,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         return Collections.unmodifiableList(matches);
     }
 
-    private int matchStrings(int matchNumber, Perl5Matcher matcher,
+    private static int matchStrings(int matchNumber, Perl5Matcher matcher,
             Pattern pattern, List<MatchResult> matches, int found,
             String inputString) {
         PatternMatcherInput input = new PatternMatcherInput(inputString);
@@ -328,9 +328,9 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         return found;
     }
 
-    private int matchStrings(int matchNumber, java.util.regex.Pattern pattern,
-                             List<java.util.regex.MatchResult> matches, int found,
-                             String inputString) {
+    private static int matchStrings(int matchNumber, java.util.regex.Pattern pattern,
+            List<java.util.regex.MatchResult> matches, int found,
+            String inputString) {
         Matcher matcher = pattern.matcher(inputString);
         while (matchNumber <=0 || found != matchNumber) {
             if (matcher.find()) {
@@ -349,7 +349,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
      * basename_gn, where n=0...# of groups<br/>
      * basename_g = number of groups (apart from g0)
      */
-    private void saveGroups(JMeterVariables vars, String basename, MatchResult match) {
+    private static void saveGroups(JMeterVariables vars, String basename, MatchResult match) {
         StringBuilder buf = new StringBuilder();
         buf.append(basename);
         buf.append("_g"); // $NON-NLS-1$
@@ -378,7 +378,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         }
     }
 
-    private void saveGroups(JMeterVariables vars, String basename, java.util.regex.MatchResult match) {
+    private static void saveGroups(JMeterVariables vars, String basename, java.util.regex.MatchResult match) {
         StringBuilder buf = new StringBuilder();
         buf.append(basename);
         buf.append("_g"); // $NON-NLS-1$
@@ -412,7 +412,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
      * basename_gn, where n=0...# of groups<br/>
      * basename_g = number of groups (apart from g0)
      */
-    private void removeGroups(JMeterVariables vars, String basename) {
+    private static void removeGroups(JMeterVariables vars, String basename) {
         StringBuilder buf = new StringBuilder();
         buf.append(basename);
         buf.append("_g"); // $NON-NLS-1$
@@ -513,7 +513,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
      *            the entry number in the list
      * @return MatchResult
      */
-    private MatchResult getCorrectMatch(List<MatchResult> matches, int entry) {
+    private static MatchResult getCorrectMatch(List<MatchResult> matches, int entry) {
         int matchSize = matches.size();
 
         if (matchSize <= 0 || entry > matchSize){
@@ -528,7 +528,7 @@ public class RegexExtractor extends AbstractScopedTestElement implements PostPro
         return matches.get(entry - 1);
     }
 
-    private java.util.regex.MatchResult getCorrectMatchJavaRegex(List<java.util.regex.MatchResult> matches, int entry) {
+    private static java.util.regex.MatchResult getCorrectMatchJavaRegex(List<java.util.regex.MatchResult> matches, int entry) {
         int matchSize = matches.size();
 
         if (matchSize <= 0 || entry > matchSize){

--- a/src/components/src/main/java/org/apache/jmeter/extractor/XPath2Extractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/XPath2Extractor.java
@@ -75,11 +75,11 @@ public class XPath2Extractor
     private static final String MATCH_NUMBER    = "XPathExtractor2.matchNumber"; // $NON-NLS-1$
     //- JMX file attributes
 
-    private String concat(String s1,String s2){
+    private static String concat(String s1, String s2){
         return s1 + "_" + s2; // $NON-NLS-1$
     }
 
-    private String concat(String s1, int i){
+    private static String concat(String s1, int i){
         return s1 + "_" + i; // $NON-NLS-1$
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/XPathExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/XPathExtractor.java
@@ -90,11 +90,11 @@ public class XPathExtractor extends AbstractScopedTestElement implements
     //- JMX file attributes
 
 
-    private String concat(String s1,String s2){
+    private static String concat(String s1, String s2){
         return s1 + "_" + s2; // $NON-NLS-1$
     }
 
-    private String concat(String s1, int i){
+    private static String concat(String s1, int i){
         return s1 + "_" + i; // $NON-NLS-1$
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/BoundaryExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/BoundaryExtractorGui.java
@@ -259,7 +259,7 @@ public class BoundaryExtractorGui extends AbstractPostProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -269,14 +269,14 @@ public class BoundaryExtractorGui extends AbstractPostProcessorGui {
     }
 
     // Next line
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/HtmlExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/HtmlExtractorGui.java
@@ -210,7 +210,7 @@ public class HtmlExtractorGui extends AbstractPostProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -220,14 +220,14 @@ public class HtmlExtractorGui extends AbstractPostProcessorGui {
     }
 
     // Next line
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/RegexExtractorGui.java
@@ -244,7 +244,7 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -254,14 +254,14 @@ public class RegexExtractorGui extends AbstractPostProcessorGui {
     }
 
     // Next line
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/gui/XPathExtractorGui.java
@@ -152,7 +152,7 @@ public class XPathExtractorGui extends AbstractPostProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -161,14 +161,14 @@ public class XPathExtractorGui extends AbstractPostProcessorGui {
         panel.add(item.get(1), gbc.clone());
     }
 
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathExtractor.java
@@ -115,12 +115,12 @@ public class JMESPathExtractor extends AbstractScopedTestElement
         }
     }
 
-    private void handleSingleResult(JMeterVariables vars, String refName, int matchNumber, List<String> resultList) {
+    private static void handleSingleResult(JMeterVariables vars, String refName, int matchNumber, List<String> resultList) {
         String suffix = (matchNumber < 0) ? "_1" : "";
         placeObjectIntoVars(vars, refName + suffix, resultList, 0);
     }
 
-    private void handleListResult(JMeterVariables vars, String refName, String defaultValue, int matchNumber,
+    private static void handleListResult(JMeterVariables vars, String refName, String defaultValue, int matchNumber,
             List<String> resultList) {
         if (matchNumber < 0) {
             // Extract all
@@ -149,7 +149,7 @@ public class JMESPathExtractor extends AbstractScopedTestElement
         }
     }
 
-    private void handleNullResult(JMeterVariables vars, String refName, String defaultValue, int matchNumber) {
+    private static void handleNullResult(JMeterVariables vars, String refName, String defaultValue, int matchNumber) {
         vars.put(refName, defaultValue);
         vars.put(refName + REF_MATCH_NR, "0"); //$NON-NLS-1$
         if (matchNumber < 0) {
@@ -214,7 +214,7 @@ public class JMESPathExtractor extends AbstractScopedTestElement
         }
     }
 
-    private void placeObjectIntoVars(JMeterVariables vars, String refName, List<String> extractedValues, int matchNr) {
+    private static void placeObjectIntoVars(JMeterVariables vars, String refName, List<String> extractedValues, int matchNr) {
         vars.put(refName, extractedValues.get(matchNr));
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/gui/JMESPathExtractorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/gui/JMESPathExtractorGui.java
@@ -144,7 +144,7 @@ public class JMESPathExtractorGui extends AbstractPostProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -153,14 +153,14 @@ public class JMESPathExtractorGui extends AbstractPostProcessorGui {
         panel.add(item.get(1), gbc.clone());
     }
 
-    private void nextLine(GridBagConstraints gbc) {
+    private static void nextLine(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill = GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONManager.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONManager.java
@@ -88,7 +88,7 @@ public class JSONManager {
     }
 
     @SuppressWarnings("unchecked")
-    private String stringifyJSONObject(Object obj) {
+    private static String stringifyJSONObject(Object obj) {
         if (obj instanceof Map) {
             return new JSONObject((Map<String, ?>) obj).toJSONString();
         }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
@@ -108,7 +108,7 @@ public class JSONPostProcessor
         }
     }
 
-    private List<Object> extractValues(List<String> jsonResponses, String currentJsonPath) throws ParseException {
+    private static List<Object> extractValues(List<String> jsonResponses, String currentJsonPath) throws ParseException {
         List<Object> extractedValues = new ArrayList<>();
         for (String jsonResponse: jsonResponses) {
             extractedValues.addAll(localMatcher.get().extractWithJsonPath(jsonResponse, currentJsonPath));
@@ -130,7 +130,7 @@ public class JSONPostProcessor
         }
     }
 
-    private void validateSameLengthOfArguments(String[] refNames, String[] jsonPathExpressions,
+    private static void validateSameLengthOfArguments(String[] refNames, String[] jsonPathExpressions,
             String[] defaultValues) {
         if (refNames.length != jsonPathExpressions.length ||
                 refNames.length != defaultValues.length) {
@@ -236,20 +236,20 @@ public class JSONPostProcessor
         return Collections.emptyList();
     }
 
-    private void clearOldRefVars(JMeterVariables vars, String refName) {
+    private static void clearOldRefVars(JMeterVariables vars, String refName) {
         vars.remove(refName + REF_MATCH_NR);
         for (int i=1; vars.get(refName + "_" + i) != null; i++) {
             vars.remove(refName + "_" + i);
         }
     }
 
-    private void placeObjectIntoVars(JMeterVariables vars, String currentRefName,
+    private static void placeObjectIntoVars(JMeterVariables vars, String currentRefName,
             List<Object> extractedValues, int matchNr, String defaultValue) {
         vars.put(currentRefName,
                 StringUtils.defaultString(stringify(extractedValues.get(matchNr)), defaultValue));
     }
 
-    private String stringify(Object obj) {
+    private static String stringify(Object obj) {
         return obj == null ? null : obj.toString();
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/gui/JSONPostProcessorGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/gui/JSONPostProcessorGui.java
@@ -152,7 +152,7 @@ public class JSONPostProcessorGui extends AbstractPostProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -161,7 +161,7 @@ public class JSONPostProcessorGui extends AbstractPostProcessorGui {
         panel.add(item.get(1), gbc.clone());
     }
 
-    private void addField(JPanel panel, JLabel label, JCheckBox checkBox, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabel label, JCheckBox checkBox, GridBagConstraints gbc) {
         panel.add(label, gbc.clone());
         gbc.gridx++;
         gbc.weightx = 1;
@@ -169,14 +169,14 @@ public class JSONPostProcessorGui extends AbstractPostProcessorGui {
         panel.add(checkBox, gbc.clone());
     }
 
-    private void nextLine(GridBagConstraints gbc) {
+    private static void nextLine(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill = GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/render/RenderAsJsonRenderer.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/render/RenderAsJsonRenderer.java
@@ -70,7 +70,7 @@ public class RenderAsJsonRenderer extends AbstractRenderAsJsonRenderer {
         }
     }
 
-    private List<Object> extractWithTechnology(String textToParse, String expression) throws Exception {
+    private static List<Object> extractWithTechnology(String textToParse, String expression) throws Exception {
         JSONManager jsonManager = new JSONManager();
         return jsonManager.extractWithJsonPath(textToParse, expression);
     }

--- a/src/components/src/main/java/org/apache/jmeter/gui/action/ExportTransactionAndSamplerNames.java
+++ b/src/components/src/main/java/org/apache/jmeter/gui/action/ExportTransactionAndSamplerNames.java
@@ -157,7 +157,7 @@ public class ExportTransactionAndSamplerNames extends AbstractAction implements 
      * @param event {@link ActionEvent}
      * @param result String
      */
-    private final void showResult(ActionEvent event, String result) {
+    private static void showResult(ActionEvent event, String result) {
         EscapeDialog messageDialog = new EscapeDialog(getParentFrame(event),
                 JMeterUtils.getResString("export_transactions_title"), false); //$NON-NLS-1$
         Container contentPane = messageDialog.getContentPane();

--- a/src/components/src/main/java/org/apache/jmeter/gui/action/ExportTransactionAndSamplerNames.java
+++ b/src/components/src/main/java/org/apache/jmeter/gui/action/ExportTransactionAndSamplerNames.java
@@ -80,7 +80,7 @@ public class ExportTransactionAndSamplerNames extends AbstractAction implements 
      * Visitor to collect nodes matching the name
      */
     private static class SamplerAndTransactionNameVisitor implements HashTreeTraverser {
-        private Set<String> listOfTransactions = new TreeSet<>();
+        private final Set<String> listOfTransactions = new TreeSet<>();
         public SamplerAndTransactionNameVisitor() {
             super();
         }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessor.java
@@ -52,6 +52,7 @@ public class BSFPreProcessor extends BSFTestElement implements Cloneable, PrePro
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
@@ -68,6 +68,7 @@ public class BeanShellPreProcessor extends BeanShellTestElement
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
@@ -49,6 +49,7 @@ public class JSR223PreProcessor extends JSR223TestElement implements Cloneable, 
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/SampleTimeout.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/SampleTimeout.java
@@ -168,11 +168,11 @@ public class SampleTimeout extends AbstractTestElement implements Serializable, 
         return JMeterUtils.getResString("sample_timeout_memo"); //$NON-NLS-1$
     }
 
-    private String whoAmI(String id, TestElement o) {
+    private static String whoAmI(String id, TestElement o) {
         return id + " @" + System.identityHashCode(o)+ " '"+ o.getName() + "' " + (log.isDebugEnabled() ?  Thread.currentThread().getName() : "");
     }
 
-    private String getInfo(TestElement o) {
+    private static String getInfo(TestElement o) {
         return whoAmI(o.getClass().getSimpleName(), o);
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
@@ -71,7 +71,7 @@ public class UserParametersGui extends AbstractPreProcessorGui {
 
     private PowerTableModel tableModel;
 
-    private int numUserColumns = 1;
+    private final int numUserColumns = 1;
 
     private JButton addParameterButton;
     private JButton addUserButton;

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
@@ -71,7 +71,7 @@ public class UserParametersGui extends AbstractPreProcessorGui {
 
     private PowerTableModel tableModel;
 
-    private final int numUserColumns = 1;
+    private static final int numUserColumns = 1;
 
     private JButton addParameterButton;
     private JButton addUserButton;

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/gui/UserParametersGui.java
@@ -182,7 +182,7 @@ public class UserParametersGui extends AbstractPreProcessorGui {
         perIterationCheck.setSelected(false);
     }
 
-    private String getUserColName(int user){
+    private static String getUserColName(int user){
         return USER_COL_RESOURCE+UNDERSCORE+user;
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/sampler/DebugSampler.java
+++ b/src/components/src/main/java/org/apache/jmeter/sampler/DebugSampler.java
@@ -88,7 +88,7 @@ public class DebugSampler extends AbstractSampler implements TestBean {
         return res;
     }
 
-    private void formatSet(StringBuilder sb, @SuppressWarnings("rawtypes") Set s) {
+    private static void formatSet(StringBuilder sb, @SuppressWarnings("rawtypes") Set s) {
         @SuppressWarnings("unchecked")
         List<Map.Entry<Object, Object>> al = new ArrayList<>(s);
         al.sort(AlphaNumericKeyComparator.INSTANCE);

--- a/src/components/src/main/java/org/apache/jmeter/timers/BSFTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BSFTimer.java
@@ -55,6 +55,7 @@ public class BSFTimer extends BSFTestElement implements Cloneable, Timer, TestBe
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
@@ -71,6 +71,7 @@ public class BeanShellTimer extends BeanShellTestElement implements Cloneable, T
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/ConstantThroughputTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/ConstantThroughputTimer.java
@@ -217,7 +217,7 @@ public class ConstantThroughputTimer extends AbstractTestElement implements Time
         return delay;
     }
 
-    private long calculateSharedDelay(ThroughputInfo info, long milliSecPerRequest) {
+    private static long calculateSharedDelay(ThroughputInfo info, long milliSecPerRequest) {
         final long now = System.currentTimeMillis();
         final long calculatedDelay;
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
@@ -53,6 +53,7 @@ public class JSR223Timer extends JSR223TestElement implements Cloneable, Timer, 
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/timers/poissonarrivals/ConstantPoissonProcessGenerator.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/poissonarrivals/ConstantPoissonProcessGenerator.java
@@ -145,7 +145,7 @@ public class ConstantPoissonProcessGenerator implements EventProducer {
         return events.get(events.position() - 1);
     }
 
-    private boolean valuesAreEqualWithPrecision(double throughput, double lastThroughput) {
+    private static boolean valuesAreEqualWithPrecision(double throughput, double lastThroughput) {
         return Math.abs(throughput - lastThroughput) < PRECISION;
     }
 }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/AssertionVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/AssertionVisualizer.java
@@ -72,7 +72,7 @@ public class AssertionVisualizer extends AbstractVisualizer implements Clearable
         textArea.setText(""); // $NON-NLS-1$
     }
 
-    private String getAssertionResult(SampleResult res) {
+    private static String getAssertionResult(SampleResult res) {
         if (res != null) {
             StringBuilder display = new StringBuilder();
             AssertionResult[] assertionResults = res.getAssertionResults();

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/AxisGraph.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/AxisGraph.java
@@ -320,7 +320,7 @@ public class AxisGraph extends JPanel {
         }
     }
 
-    private double findMax(double[][] _data) {
+    private static double findMax(double[][] _data) {
         double max = _data[0][0];
         for (double[] dArray : _data) {
             for (double d : dArray) {
@@ -332,7 +332,7 @@ public class AxisGraph extends JPanel {
         return max;
     }
 
-    private String squeeze(String input, int _maxLength) {
+    private static String squeeze(String input, int _maxLength) {
         if (input.length() > _maxLength) {
             return input.substring(0,_maxLength-ELLIPSIS_LEN)+ELLIPSIS;
         }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListener.java
@@ -82,6 +82,7 @@ public class BSFListener extends BSFTestElement
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListener.java
@@ -92,6 +92,7 @@ public class BeanShellListener extends BeanShellTestElement
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/GraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/GraphVisualizer.java
@@ -297,7 +297,7 @@ public class GraphVisualizer extends AbstractVisualizer implements ImageVisualiz
      * @return a panel containing both the dynamic and static parts of a Y axis
      *         label
      */
-    private JPanel createYAxisPanel(String labelResourceName, JTextField field) {
+    private static JPanel createYAxisPanel(String labelResourceName, JTextField field) {
         JPanel panel = new JPanel(new FlowLayout());
         JLabel label = new JLabel(JMeterUtils.getResString(labelResourceName));
 
@@ -437,7 +437,7 @@ public class GraphVisualizer extends AbstractVisualizer implements ImageVisualiz
      * @param field
      *            the field this label is being created for.
      */
-    private JLabel createInfoLabel(String labelResourceName, JTextField field) {
+    private static JLabel createInfoLabel(String labelResourceName, JTextField field) {
         JLabel label = new JLabel(JMeterUtils.getResString(labelResourceName));
         label.setForeground(field.getForeground());
         label.setLabelFor(field);
@@ -469,7 +469,7 @@ public class GraphVisualizer extends AbstractVisualizer implements ImageVisualiz
      *            parameter is null, this section of the panel will be left
      *            blank.
      */
-    private Box createInfoColumn(JLabel label1, JTextField field1, JLabel label2, JTextField field2) {
+    private static Box createInfoColumn(JLabel label1, JTextField field1, JLabel label2, JTextField field2) {
         // This column actually consists of a row with two sub-columns
         // The first column contains the labels, and the second
         // column contains the fields.

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
@@ -78,6 +78,7 @@ public class JSR223Listener extends JSR223TestElement
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/MailerVisualizer.java
@@ -419,7 +419,7 @@ public class MailerVisualizer extends AbstractVisualizer implements ActionListen
     /**
      * Shows a message using a DialogBox.
      */
-    private void displayMessage(String message, boolean isError) {
+    private static void displayMessage(String message, boolean isError) {
         int type = isError ? JOptionPane.ERROR_MESSAGE : JOptionPane.INFORMATION_MESSAGE;
         JOptionPane.showMessageDialog(null, message, isError ?
                 JMeterUtils.getResString("mailer_msg_title_error") :  // $NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXML.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXML.java
@@ -111,8 +111,8 @@ public class RenderAsXML extends SamplerResultTab
     private static class ExpandPopupMenu extends JPopupMenu implements ActionListener {
 
         private static final long serialVersionUID = 1L;
-        private JMenuItem expand;
-        private JMenuItem collapse;
+        private final JMenuItem expand;
+        private final JMenuItem collapse;
         private JTree tree;
 
         ExpandPopupMenu() {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXML.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXML.java
@@ -149,7 +149,7 @@ public class RenderAsXML extends SamplerResultTab
         }
 
         @SuppressWarnings("JdkObsolete")
-        private void applyToChildren(TreePath parent, Consumer<TreePath> method) {
+        private static void applyToChildren(TreePath parent, Consumer<TreePath> method) {
             TreeNode node = (TreeNode) parent.getLastPathComponent();
             Enumeration<?> e = node.children();
             while (e.hasMoreElements()) {
@@ -201,7 +201,7 @@ public class RenderAsXML extends SamplerResultTab
          *
          * @param parent {@link Node}
          */
-        private Node getFirstElement(Node parent) {
+        private static Node getFirstElement(Node parent) {
             NodeList childNodes = parent.getChildNodes();
             Node toReturn = parent; // Must return a valid node, or may generate an NPE
             for (int i = 0; i < childNodes.getLength(); i++) {
@@ -241,7 +241,7 @@ public class RenderAsXML extends SamplerResultTab
             /**
              * get the html
              */
-            private String getHTML(String str, String separator, int maxChar) {
+            private static String getHTML(String str, String separator, int maxChar) {
                 StringBuilder strBuf = new StringBuilder("<html><body bgcolor=\"yellow\"><b>"); // $NON-NLS-1$
                 char[] chars = str.toCharArray();
                 for (int i = 0; i < chars.length; i++) {
@@ -257,7 +257,7 @@ public class RenderAsXML extends SamplerResultTab
 
             }
 
-            private String encode(char c) {
+            private static String encode(char c) {
                 String toReturn = String.valueOf(c);
                 switch (c) {
                     case '<': // $NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath.java
@@ -157,7 +157,7 @@ public class RenderAsXPath implements ResultRenderer, ActionListener {
      * @return Document
      *
      */
-    private Document parseResponse(String unicodeData, XPathExtractor extractor)
+    private static Document parseResponse(String unicodeData, XPathExtractor extractor)
       throws IOException, ParserConfigurationException,SAXException,TidyException
     {
       //TODO: validate contentType for reasonable types?

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath2.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath2.java
@@ -143,7 +143,7 @@ public class RenderAsXPath2 implements ResultRenderer, ActionListener {
     }
 
 
-    private String getDocumentNamespaces(String textToParse) {
+    private static String getDocumentNamespaces(String textToParse) {
         StringBuilder result = new StringBuilder();
         try {
             List<String[]> namespaces = XPathUtil.getNamespaces(textToParse);
@@ -280,7 +280,7 @@ public class RenderAsXPath2 implements ResultRenderer, ActionListener {
         return panel;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.gridheight = 1;
         gbc.gridwidth = 1;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphChart.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphChart.java
@@ -369,7 +369,7 @@ public class RespTimeGraphChart extends JPanel {
         }
     }
 
-    private int getTopValue(double value, RoundingMode roundingMode) {
+    private static int getTopValue(double value, RoundingMode roundingMode) {
         String maxStr = String.valueOf(Math.round(value));
         StringBuilder divValueStr = new StringBuilder(maxStr.length()+1);
         divValueStr.append("1");
@@ -399,7 +399,7 @@ public class RespTimeGraphChart extends JPanel {
      * @param datas array of positive or NaN doubles
      * @return double
      */
-    private double findMax(double[][] datas) {
+    private static double findMax(double[][] datas) {
         double max = 0;
         for (double[] data : datas) {
             for (final double value : data) {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -278,7 +278,7 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
         init();
     }
 
-    private String[] keys(Map<String, ?> map) {
+    private static String[] keys(Map<String, ?> map) {
         return map.keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SamplerResultTab.java
@@ -646,7 +646,7 @@ public abstract class SamplerResultTab implements ResultRenderer {
         this.backGround = backGround;
     }
 
-    private void setFirstColumnPreferredSize(JTable table) {
+    private static void setFirstColumnPreferredSize(JTable table) {
         TableColumn column = table.getColumnModel().getColumn(0);
         column.setMaxWidth(300);
         column.setPreferredWidth(180);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTextExtension.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTextExtension.java
@@ -64,7 +64,7 @@ public class SearchTextExtension implements ActionListener, DocumentListener {
 
     private String lastTextTofind;
 
-    private ISearchTextExtensionProvider searchProvider;
+    private final ISearchTextExtensionProvider searchProvider;
 
     private JToolBar toolBar;
 
@@ -244,11 +244,11 @@ public class SearchTextExtension implements ActionListener, DocumentListener {
      */
     public static class JEditorPaneSearchProvider implements ISearchTextExtensionProvider {
 
-        private static volatile int LAST_POSITION_DEFAULT = 0;
+        private static final int LAST_POSITION_DEFAULT = 0;
         private static final Color HIGHLIGHT_COLOR = Color.GREEN;
-        private JEditorPane results;
-        private Highlighter selection;
-        private Highlighter.HighlightPainter painter;
+        private final JEditorPane results;
+        private final Highlighter selection;
+        private final Highlighter.HighlightPainter painter;
         private int lastPosition = LAST_POSITION_DEFAULT;
 
         public JEditorPaneSearchProvider(JEditorPane results) {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTreePanel.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTreePanel.java
@@ -151,7 +151,7 @@ public class SearchTreePanel extends JPanel implements ActionListener {
     /**
      * @param searchableTreeNode
      */
-    private void doResetSearch(SearchableTreeNode searchableTreeNode) {
+    private static void doResetSearch(SearchableTreeNode searchableTreeNode) {
         searchableTreeNode.reset();
         searchableTreeNode.updateState();
         for (int i = 0; i < searchableTreeNode.getChildCount(); i++) {
@@ -178,7 +178,7 @@ public class SearchTreePanel extends JPanel implements ActionListener {
      * @param searcher
      * @param node
      */
-    private boolean searchInNode(Searcher searcher, SearchableTreeNode node) {
+    private static boolean searchInNode(Searcher searcher, SearchableTreeNode node) {
         node.reset();
         Object userObject = node.getUserObject();
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SearchableTreeNode.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SearchableTreeNode.java
@@ -41,7 +41,7 @@ public class SearchableTreeNode extends DefaultMutableTreeNode {
 
     private boolean childrenNodesHaveMatched;
 
-    private transient DefaultTreeModel treeModel;
+    private final transient DefaultTreeModel treeModel;
 
     public SearchableTreeNode() {
         this((SampleResult) null, null);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -206,9 +206,9 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
 
     private boolean saveGraphToFile = false;
 
-    private final int defaultWidth = 400;
+    private static final int defaultWidth = 400;
 
-    private final int defaultHeight = 300;
+    private static final int defaultHeight = 300;
 
     private final JComboBox<String> columnsList = new JComboBox<>(getLabels(GRAPH_COLUMNS, getGraphColumnsMsgParameters()));
 
@@ -253,7 +253,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
     // Default checked
     private final JCheckBox valueLabelsVertical = new JCheckBox(JMeterUtils.getResString("aggregate_graph_value_labels_vertical"), true); // $NON-NLS-1$
 
-    private final Color colorBarGraph = Color.YELLOW;
+    private final static Color colorBarGraph = Color.YELLOW;
 
     private Color colorForeGraph = Color.BLACK;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -336,7 +336,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
         };
     }
 
-    private String[] keys(Map<String, ?> map) {
+    private static String[] keys(Map<String, ?> map) {
         return map.keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -146,7 +146,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
 
     private JScrollPane myScrollPane;
 
-    private transient ObjectTableModel model;
+    private final transient ObjectTableModel model;
 
     /**
      * Lock used to protect tableRows update + model update
@@ -161,99 +161,99 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
 
     private JSplitPane spane = null;
 
-    private JTabbedPane tabbedGraph = new JTabbedPane(SwingConstants.TOP);
+    private final JTabbedPane tabbedGraph = new JTabbedPane(SwingConstants.TOP);
 
-    private JButton displayButton =
+    private final JButton displayButton =
         new JButton(JMeterUtils.getResString("aggregate_graph_display"));                //$NON-NLS-1$
 
-    private JButton saveGraph =
+    private final JButton saveGraph =
         new JButton(JMeterUtils.getResString("aggregate_graph_save"));                    //$NON-NLS-1$
 
-    private JButton saveTable =
+    private final JButton saveTable =
         new JButton(JMeterUtils.getResString("aggregate_graph_save_table"));            //$NON-NLS-1$
 
-    private JButton chooseForeColor =
+    private final JButton chooseForeColor =
         new JButton(JMeterUtils.getResString("aggregate_graph_choose_foreground_color"));            //$NON-NLS-1$
 
-    private JButton syncWithName =
+    private final JButton syncWithName =
         new JButton(JMeterUtils.getResString("aggregate_graph_sync_with_name"));            //$NON-NLS-1$
 
-    private JCheckBox saveHeaders = // should header be saved with the data?
+    private final JCheckBox saveHeaders = // should header be saved with the data?
         new JCheckBox(JMeterUtils.getResString("aggregate_graph_save_table_header"));    //$NON-NLS-1$
 
-    private JLabeledTextField graphTitle =
+    private final JLabeledTextField graphTitle =
         new JLabeledTextField(JMeterUtils.getResString("aggregate_graph_user_title"));    //$NON-NLS-1$
 
-    private JLabeledTextField maxLengthXAxisLabel =
+    private final JLabeledTextField maxLengthXAxisLabel =
         new JLabeledTextField(JMeterUtils.getResString("aggregate_graph_max_length_xaxis_label"), 8);//$NON-NLS-1$
 
-    private JLabeledTextField maxValueYAxisLabel =
+    private final JLabeledTextField maxValueYAxisLabel =
         new JLabeledTextField(JMeterUtils.getResString("aggregate_graph_yaxis_max_value"), 8);//$NON-NLS-1$
 
     /**
      * checkbox for use dynamic graph size
      */
-    private JCheckBox dynamicGraphSize = new JCheckBox(JMeterUtils.getResString("aggregate_graph_dynamic_size")); // $NON-NLS-1$
+    private final JCheckBox dynamicGraphSize = new JCheckBox(JMeterUtils.getResString("aggregate_graph_dynamic_size")); // $NON-NLS-1$
 
-    private JLabeledTextField graphWidth =
+    private final JLabeledTextField graphWidth =
         new JLabeledTextField(JMeterUtils.getResString("aggregate_graph_width"), 6);        //$NON-NLS-1$
-    private JLabeledTextField graphHeight =
+    private final JLabeledTextField graphHeight =
         new JLabeledTextField(JMeterUtils.getResString("aggregate_graph_height"), 6);        //$NON-NLS-1$
 
-    private String yAxisLabel = JMeterUtils.getResString("aggregate_graph_response_time");//$NON-NLS-1$
+    private final String yAxisLabel = JMeterUtils.getResString("aggregate_graph_response_time");//$NON-NLS-1$
 
-    private String yAxisTitle = JMeterUtils.getResString("aggregate_graph_ms");        //$NON-NLS-1$
+    private final String yAxisTitle = JMeterUtils.getResString("aggregate_graph_ms");        //$NON-NLS-1$
 
     private boolean saveGraphToFile = false;
 
-    private int defaultWidth = 400;
+    private final int defaultWidth = 400;
 
-    private int defaultHeight = 300;
+    private final int defaultHeight = 300;
 
-    private JComboBox<String> columnsList = new JComboBox<>(getLabels(GRAPH_COLUMNS, getGraphColumnsMsgParameters()));
+    private final JComboBox<String> columnsList = new JComboBox<>(getLabels(GRAPH_COLUMNS, getGraphColumnsMsgParameters()));
 
-    private List<BarGraph> eltList = new ArrayList<>();
+    private final List<BarGraph> eltList = new ArrayList<>();
 
-    private JCheckBox columnSelection = new JCheckBox(JMeterUtils.getResString("aggregate_graph_column_selection"), false); //$NON-NLS-1$
+    private final JCheckBox columnSelection = new JCheckBox(JMeterUtils.getResString("aggregate_graph_column_selection"), false); //$NON-NLS-1$
 
-    private JTextField columnMatchLabel = new JTextField();
+    private final JTextField columnMatchLabel = new JTextField();
 
-    private JButton applyFilterBtn = new JButton(JMeterUtils.getResString("graph_apply_filter")); // $NON-NLS-1$
+    private final JButton applyFilterBtn = new JButton(JMeterUtils.getResString("graph_apply_filter")); // $NON-NLS-1$
 
-    private JCheckBox caseChkBox = new JCheckBox(JMeterUtils.getResString("search_text_chkbox_case"), false); // $NON-NLS-1$
+    private final JCheckBox caseChkBox = new JCheckBox(JMeterUtils.getResString("search_text_chkbox_case"), false); // $NON-NLS-1$
 
-    private JCheckBox regexpChkBox = new JCheckBox(JMeterUtils.getResString("search_text_chkbox_regexp"), true); // $NON-NLS-1$
+    private final JCheckBox regexpChkBox = new JCheckBox(JMeterUtils.getResString("search_text_chkbox_regexp"), true); // $NON-NLS-1$
 
-    private JComboBox<String> titleFontNameList = new JComboBox<>(keys(StatGraphProperties.getFontNameMap()));
+    private final JComboBox<String> titleFontNameList = new JComboBox<>(keys(StatGraphProperties.getFontNameMap()));
 
-    private JComboBox<String> titleFontSizeList = new JComboBox<>(StatGraphProperties.getFontSize());
+    private final JComboBox<String> titleFontSizeList = new JComboBox<>(StatGraphProperties.getFontSize());
 
-    private JComboBox<String> titleFontStyleList = new JComboBox<>(keys(StatGraphProperties.getFontStyleMap()));
+    private final JComboBox<String> titleFontStyleList = new JComboBox<>(keys(StatGraphProperties.getFontStyleMap()));
 
-    private JComboBox<String> valueFontNameList = new JComboBox<>(keys(StatGraphProperties.getFontNameMap()));
+    private final JComboBox<String> valueFontNameList = new JComboBox<>(keys(StatGraphProperties.getFontNameMap()));
 
-    private JComboBox<String> valueFontSizeList = new JComboBox<>(StatGraphProperties.getFontSize());
+    private final JComboBox<String> valueFontSizeList = new JComboBox<>(StatGraphProperties.getFontSize());
 
-    private JComboBox<String> valueFontStyleList = new JComboBox<>(keys(StatGraphProperties.getFontStyleMap()));
+    private final JComboBox<String> valueFontStyleList = new JComboBox<>(keys(StatGraphProperties.getFontStyleMap()));
 
-    private JComboBox<String> fontNameList = new JComboBox<>(keys(StatGraphProperties.getFontNameMap()));
+    private final JComboBox<String> fontNameList = new JComboBox<>(keys(StatGraphProperties.getFontNameMap()));
 
-    private JComboBox<String> fontSizeList = new JComboBox<>(StatGraphProperties.getFontSize());
+    private final JComboBox<String> fontSizeList = new JComboBox<>(StatGraphProperties.getFontSize());
 
-    private JComboBox<String> fontStyleList = new JComboBox<>(keys(StatGraphProperties.getFontStyleMap()));
+    private final JComboBox<String> fontStyleList = new JComboBox<>(keys(StatGraphProperties.getFontStyleMap()));
 
-    private JComboBox<String> legendPlacementList = new JComboBox<>(keys(StatGraphProperties.getPlacementNameMap()));
-
-    // Default checked
-    private JCheckBox drawOutlinesBar = new JCheckBox(JMeterUtils.getResString("aggregate_graph_draw_outlines"), true); // $NON-NLS-1$
+    private final JComboBox<String> legendPlacementList = new JComboBox<>(keys(StatGraphProperties.getPlacementNameMap()));
 
     // Default checked
-    private JCheckBox numberShowGrouping = new JCheckBox(JMeterUtils.getResString("aggregate_graph_number_grouping"), true); // $NON-NLS-1$
+    private final JCheckBox drawOutlinesBar = new JCheckBox(JMeterUtils.getResString("aggregate_graph_draw_outlines"), true); // $NON-NLS-1$
 
     // Default checked
-    private JCheckBox valueLabelsVertical = new JCheckBox(JMeterUtils.getResString("aggregate_graph_value_labels_vertical"), true); // $NON-NLS-1$
+    private final JCheckBox numberShowGrouping = new JCheckBox(JMeterUtils.getResString("aggregate_graph_number_grouping"), true); // $NON-NLS-1$
 
-    private Color colorBarGraph = Color.YELLOW;
+    // Default checked
+    private final JCheckBox valueLabelsVertical = new JCheckBox(JMeterUtils.getResString("aggregate_graph_value_labels_vertical"), true); // $NON-NLS-1$
+
+    private final Color colorBarGraph = Color.YELLOW;
 
     private Color colorForeGraph = Color.BLACK;
 
@@ -261,7 +261,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
 
     private Pattern pattern = null;
 
-    private Deque<SamplingStatCalculator> newRows = new ConcurrentLinkedDeque<>();
+    private final Deque<SamplingStatCalculator> newRows = new ConcurrentLinkedDeque<>();
 
     public StatGraphVisualizer() {
         super();

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatVisualizer.java
@@ -79,14 +79,14 @@ public class StatVisualizer extends AbstractVisualizer implements Clearable, Act
     private final JCheckBox useGroupName = new JCheckBox(
             JMeterUtils.getResString("aggregate_graph_use_group_name")); //$NON-NLS-1$
 
-    private transient ObjectTableModel model;
+    private final transient ObjectTableModel model;
 
     /** Lock used to protect tableRows update + model update */
     private final transient Object lock = new Object();
 
     private final Map<String, SamplingStatCalculator> tableRows = new ConcurrentHashMap<>();
 
-    private Deque<SamplingStatCalculator> newRows = new ConcurrentLinkedDeque<>();
+    private final Deque<SamplingStatCalculator> newRows = new ConcurrentLinkedDeque<>();
 
     private volatile boolean dataChanged;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SummaryReport.java
@@ -123,7 +123,7 @@ public class SummaryReport extends AbstractVisualizer implements Clearable, Acti
     private final JCheckBox useGroupName =
         new JCheckBox(JMeterUtils.getResString("aggregate_graph_use_group_name"));            //$NON-NLS-1$
 
-    private transient ObjectTableModel model;
+    private final transient ObjectTableModel model;
 
     /**
      * Lock used to protect tableRows update + model update

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/TableVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/TableVisualizer.java
@@ -115,9 +115,9 @@ public class TableVisualizer extends AbstractVisualizer implements Clearable {
 
     private final transient Calculator calc = new Calculator();
 
-    private Format format = new SimpleDateFormat("HH:mm:ss.SSS"); //$NON-NLS-1$
+    private final Format format = new SimpleDateFormat("HH:mm:ss.SSS"); //$NON-NLS-1$
 
-    private Deque<SampleResult> newRows = new ConcurrentLinkedDeque<>();
+    private final Deque<SampleResult> newRows = new ConcurrentLinkedDeque<>();
 
     // Column renderers
     private static final TableCellRenderer[] RENDERERS =

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -234,7 +234,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         return oldSelectedElement;
     }
 
-    private TreePath checkExpandedOrSelected(List<TreeNode> path,
+    private static TreePath checkExpandedOrSelected(List<TreeNode> path,
             Object item, Object oldSelectedObject,
             Set<Object> oldExpandedObjects, Set<TreePath> newExpandedPaths,
             TreePath defaultPath) {
@@ -248,7 +248,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         return result;
     }
 
-    private TreePath checkExpandedOrSelected(List<TreeNode> path,
+    private static TreePath checkExpandedOrSelected(List<TreeNode> path,
             Object item, Object oldSelectedObject,
             Set<Object> oldExpandedObjects, Set<TreePath> newExpandedPaths,
             TreePath defaultPath, DefaultMutableTreeNode extensionNode) {
@@ -262,7 +262,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         return result;
     }
 
-    private Set<Object> extractExpandedObjects(final Enumeration<TreePath> expandedElements) {
+    private static Set<Object> extractExpandedObjects(final Enumeration<TreePath> expandedElements) {
         if (expandedElements != null) {
             final List<TreePath> list = EnumerationUtils.toList(expandedElements);
             log.debug("Expanded: {}", list);
@@ -310,11 +310,11 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         return result;
     }
 
-    private TreePath toTreePath(List<TreeNode> newPath) {
+    private static TreePath toTreePath(List<TreeNode> newPath) {
         return new TreePath(newPath.toArray(new TreeNode[newPath.size()]));
     }
 
-    private TreePath toTreePath(List<TreeNode> path,
+    private static TreePath toTreePath(List<TreeNode> path,
             DefaultMutableTreeNode extensionNode) {
         TreeNode[] result = path.toArray(new TreeNode[path.size() + 1]);
         result[result.length - 1] = extensionNode;
@@ -490,7 +490,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         }
         if (VIEWERS_ORDER.length() > 0) {
             Arrays.stream(VIEWERS_ORDER.split(","))
-                    .map(this::expandToClassname)
+                    .map(ViewResultsFullVisualizer::expandToClassname)
                     .forEach(key -> {
                         ResultRenderer renderer = map.remove(key);
                         if (renderer != null) {
@@ -509,7 +509,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
         return selectRenderPanel;
     }
 
-    private String expandToClassname(String name) {
+    private static String expandToClassname(String name) {
         if (name.startsWith(".")) {
             return "org.apache.jmeter.visualizers" + name; // $NON-NLS-1$
         }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/XMLDefaultMutableTreeNode.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/XMLDefaultMutableTreeNode.java
@@ -85,7 +85,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      * @param mTreeNode
      * @throws SAXException
      */
-    private void initNode(Node node, XMLDefaultMutableTreeNode mTreeNode) throws SAXException {
+    private static void initNode(Node node, XMLDefaultMutableTreeNode mTreeNode) throws SAXException {
 
         switch (node.getNodeType()) {
         case Node.ELEMENT_NODE:
@@ -118,7 +118,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      * @param mTreeNode
      * @throws SAXException
      */
-    private void initElementNode(Node node, DefaultMutableTreeNode mTreeNode) throws SAXException {
+    private static void initElementNode(Node node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String nodeName = node.getNodeName();
 
         NodeList childNodes = node.getChildNodes();
@@ -140,7 +140,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      * @param mTreeNode
      * @throws SAXException
      */
-    private void initAttributeNode(Node node, DefaultMutableTreeNode mTreeNode) throws SAXException {
+    private static void initAttributeNode(Node node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         NamedNodeMap nm = node.getAttributes();
         for (int i = 0; i < nm.getLength(); i++) {
             Attr nmNode = (Attr) nm.item(i);
@@ -158,7 +158,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      * @param mTreeNode
      * @throws SAXException
      */
-    private void initCommentNode(Comment node, DefaultMutableTreeNode mTreeNode) throws SAXException {
+    private static void initCommentNode(Comment node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String data = node.getData();
         if (data != null && data.length() > 0) {
             String value = "<!--" + node.getData() + "-->"; // $NON-NLS-1$ $NON-NLS-2$
@@ -174,7 +174,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      * @param mTreeNode
      * @throws SAXException
      */
-    private void initCDATASectionNode(CDATASection node, DefaultMutableTreeNode mTreeNode) throws SAXException {
+    private static void initCDATASectionNode(CDATASection node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String data = node.getData();
         if (data != null && data.length() > 0) {
             String value = "<!-[CDATA" + node.getData() + "]]>"; // $NON-NLS-1$ $NON-NLS-2$
@@ -190,7 +190,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      * @param mTreeNode
      * @throws SAXException
      */
-    private void initTextNode(Text node, DefaultMutableTreeNode mTreeNode) throws SAXException {
+    private static void initTextNode(Text node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String text = node.getNodeValue().trim();
         if (text != null && text.length() > 0) {
             XMLDefaultMutableTreeNode textNode = new XMLDefaultMutableTreeNode(text, node);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/AbstractBackendListenerClient.java
@@ -53,9 +53,9 @@ public abstract class AbstractBackendListenerClient implements BackendListenerCl
 
     private static final Logger log = LoggerFactory.getLogger(AbstractBackendListenerClient.class);
 
-    private UserMetric userMetrics = new UserMetric();
+    private final UserMetric userMetrics = new UserMetric();
 
-    private ConcurrentHashMap<String, SamplerMetric> metricsPerSampler = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SamplerMetric> metricsPerSampler = new ConcurrentHashMap<>();
 
     /* Implements BackendListenerClient.setupTest(BackendListenerContext) */
     @Override

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -192,7 +192,7 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
     }
 
 
-    private Arguments copyDefaultArguments(Map<String, String> currArgsMap, Arguments defaultArgs) {
+    private static Arguments copyDefaultArguments(Map<String, String> currArgsMap, Arguments defaultArgs) {
         Arguments newArgs = new Arguments();
         if (defaultArgs != null) {
             for (JMeterProperty jMeterProperty : defaultArgs.getArguments()) {
@@ -217,7 +217,7 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
     }
 
 
-    private Arguments extractDefaultArguments(BackendListenerClient client, Map<String, String> userArgMap,
+    private static Arguments extractDefaultArguments(BackendListenerClient client, Map<String, String> userArgMap,
             Arguments currentUserArguments) {
         Arguments defaultArgs = null;
         try {
@@ -234,7 +234,7 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
     }
 
 
-    private BackendListenerClient createBackendListenerClient(String newClassName)
+    private static BackendListenerClient createBackendListenerClient(String newClassName)
             throws ReflectiveOperationException {
         return Class.forName(newClassName, true,
                 Thread.currentThread().getContextClassLoader())

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/SamplerMetric.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/SamplerMetric.java
@@ -187,8 +187,6 @@ public class SamplerMetric {
                 stat.clear();
             }
             break;
-        default:
-            // This cannot happen
         }
         errors.clear();
         successes = 0;

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/SamplerMetric.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/SamplerMetric.java
@@ -42,27 +42,27 @@ public class SamplerMetric {
     /**
      * Response times for OK samples
      */
-    private DescriptiveStatistics okResponsesStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(LARGE_SLIDING_WINDOW_SIZE);
+    private final DescriptiveStatistics okResponsesStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(LARGE_SLIDING_WINDOW_SIZE);
     /**
      * Response times for KO samples
      */
-    private DescriptiveStatistics koResponsesStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(LARGE_SLIDING_WINDOW_SIZE);
+    private final DescriptiveStatistics koResponsesStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(LARGE_SLIDING_WINDOW_SIZE);
     /**
      * Response times for All samples
      */
-    private DescriptiveStatistics allResponsesStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(LARGE_SLIDING_WINDOW_SIZE);
+    private final DescriptiveStatistics allResponsesStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(LARGE_SLIDING_WINDOW_SIZE);
     /**
      *  OK, KO, ALL stats
      */
-    private List<DescriptiveStatistics> windowedStats = initWindowedStats();
+    private final List<DescriptiveStatistics> windowedStats = initWindowedStats();
     /**
      * Timeboxed percentiles don't makes sense
      */
-    private DescriptiveStatistics pctResponseStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(SLIDING_WINDOW_SIZE);
+    private final DescriptiveStatistics pctResponseStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(SLIDING_WINDOW_SIZE);
     private int successes;
     private int failures;
     private int hits;
-    private Map<ErrorMetric, Integer> errors = new HashMap<>();
+    private final Map<ErrorMetric, Integer> errors = new HashMap<>();
     private long sentBytes;
     private long receivedBytes;
 

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/SamplerMetric.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/SamplerMetric.java
@@ -127,14 +127,14 @@ public class SamplerMetric {
             errors.put(error, errors.getOrDefault(error, 0) + result.getErrorCount() );
         }
         long time = result.getTime();
-        allResponsesStats.addValue(time);
-        pctResponseStats.addValue(time);
+        allResponsesStats.addValue((double) time);
+        pctResponseStats.addValue((double) time);
         if(result.isSuccessful()) {
             // Should we also compute KO , all response time ?
             // only take successful requests for time computing
-            okResponsesStats.addValue(time);
+            okResponsesStats.addValue((double) time);
         }else {
-            koResponsesStats.addValue(time);
+            koResponsesStats.addValue((double) time);
         }
         addHits(result, isCumulated);
         addNetworkData(result, isCumulated);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/UserMetric.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/UserMetric.java
@@ -32,7 +32,7 @@ public class UserMetric {
     private static final int SLIDING_WINDOW_SIZE = JMeterUtils.getPropDefault("backend_metrics_window", 100); //$NON-NLS-1$
 
     // Limit to sliding window of SLIDING_WINDOW_SIZE values
-    private DescriptiveStatistics usersStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(SLIDING_WINDOW_SIZE);
+    private final DescriptiveStatistics usersStats = DescriptiveStatisticsFactory.createDescriptiveStatistics(SLIDING_WINDOW_SIZE);
 
     /**
      *

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -132,7 +132,7 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
      * @return {@link HttpPost}
      * @throws URISyntaxException
      */
-    private HttpPost createRequest(URL url, String token) throws URISyntaxException {
+    private static HttpPost createRequest(URL url, String token) throws URISyntaxException {
         RequestConfig defaultRequestConfig = RequestConfig.custom()
                 .setConnectTimeout(JMeterUtils.getPropDefault("backend_influxdb.connection_timeout", 1000))
                 .setSocketTimeout(JMeterUtils.getPropDefault("backend_influxdb.socket_timeout", 3000))

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
@@ -116,7 +116,7 @@ public class InfluxDBRawBackendListenerClient implements BackendListenerClient {
         influxDBMetricsManager.addMetric(measurement, tags, fields, timestamp);
     }
 
-    private String createTags(SampleResult sampleResult) {
+    private static String createTags(SampleResult sampleResult) {
         boolean isError = sampleResult.getErrorCount() != 0;
         String status = isError ? TAG_KO : TAG_OK;
         // remove surrounding quotes and spaces from sample label
@@ -128,7 +128,7 @@ public class InfluxDBRawBackendListenerClient implements BackendListenerClient {
                 + ",threadName=" + threadName;
     }
 
-    private String createFields(SampleResult sampleResult) {
+    private static String createFields(SampleResult sampleResult) {
         long duration = sampleResult.getTime();
         long latency = sampleResult.getLatency();
         long connectTime = sampleResult.getConnectTime();

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient implements Runnable {
 
     private static final Logger log = LoggerFactory.getLogger(InfluxdbBackendListenerClient.class);
-    private ConcurrentHashMap<String, SamplerMetric> metricsPerSampler = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, SamplerMetric> metricsPerSampler = new ConcurrentHashMap<>();
     // Name of the measurement
     private static final String EVENTS_FOR_ANNOTATION = "events";
 

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -508,7 +508,7 @@ public class JMeter implements JMeterPlugin {
      * @param deleteReportFolder true means delete report folder
      * @throws IllegalArgumentException
      */
-    private void extractAndSetReportOutputFolder(CLArgsParser parser, boolean deleteReportFolder) {
+    private static void extractAndSetReportOutputFolder(CLArgsParser parser, boolean deleteReportFolder) {
         CLOption reportOutputFolderOpt = parser
                 .getArgumentById(REPORT_OUTPUT_FOLDER_OPT);
         if(reportOutputFolderOpt != null) {
@@ -525,7 +525,7 @@ public class JMeter implements JMeterPlugin {
     /**
      * Displays as ASCII Art Apache JMeter version + Copyright notice
      */
-    private void displayAsciiArt() {
+    private static void displayAsciiArt() {
         try (InputStream inputStream = JMeter.class.getResourceAsStream("jmeter_as_ascii_art.txt")) {
             if(inputStream != null) {
                 String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
@@ -538,13 +538,13 @@ public class JMeter implements JMeterPlugin {
     }
 
     // Update classloader if necessary
-    private void updateClassLoader() throws MalformedURLException {
+    private static void updateClassLoader() throws MalformedURLException {
         updatePath("search_paths",";", true); //$NON-NLS-1$//$NON-NLS-2$
         updatePath("user.classpath",File.pathSeparator, true);//$NON-NLS-1$
         updatePath("plugin_dependency_paths",";", false);//$NON-NLS-1$
     }
 
-    private void updatePath(String property, String sep, boolean cp) throws MalformedURLException {
+    private static void updatePath(String property, String sep, boolean cp) throws MalformedURLException {
         String userpath= JMeterUtils.getPropDefault(property,"");// $NON-NLS-1$
         if (userpath.length() <= 0) {
             return;
@@ -571,7 +571,7 @@ public class JMeter implements JMeterPlugin {
     /**
      *
      */
-    private void startOptionalServers() {
+    private static void startOptionalServers() {
         int bshport = JMeterUtils.getPropDefault("beanshell.server.port", 0);// $NON-NLS-1$
         String bshfile = JMeterUtils.getPropDefault("beanshell.server.file", "");// $NON-NLS-1$ $NON-NLS-2$
         if (bshport > 0) {
@@ -600,7 +600,7 @@ public class JMeter implements JMeterPlugin {
     /**
      * Runs user configured init scripts
      */
-    void runInitScripts() {
+    static void runInitScripts() {
         // Should we run a beanshell script on startup?
         String bshinit = JMeterUtils.getProperty("beanshell.init.file");// $NON-NLS-1$
         if (bshinit != null){
@@ -650,7 +650,7 @@ public class JMeter implements JMeterPlugin {
     }
 
 
-    private Map<String, List<String>> getEnginesAndExtensions(ScriptEngineManager scriptEngineManager) {
+    private static Map<String, List<String>> getEnginesAndExtensions(ScriptEngineManager scriptEngineManager) {
         return scriptEngineManager.getEngineFactories().stream()
                 .collect(Collectors.toMap(
                         f -> f.getLanguageName() + " (" + f.getLanguageVersion() + ")",
@@ -661,7 +661,7 @@ public class JMeter implements JMeterPlugin {
      * Sets a proxy server for the JVM if the command line arguments are
      * specified.
      */
-    private void setProxy(CLArgsParser parser) throws IllegalUserActionException {
+    private static void setProxy(CLArgsParser parser) throws IllegalUserActionException {
         if (parser.getArgumentById(PROXY_USERNAME) != null) {
             Properties jmeterProps = JMeterUtils.getJMeterProperties();
             if (parser.getArgumentById(PROXY_PASSWORD) != null) {
@@ -879,7 +879,7 @@ public class JMeter implements JMeterPlugin {
      * Checks for LAST or LASTsuffix.
      * Returns the LAST name with .JMX replaced by suffix.
      */
-    private String processLAST(final String jmlogfile, final String suffix) {
+    private static String processLAST(final String jmlogfile, final String suffix) {
         if (USE_LAST_JMX.equals(jmlogfile) || USE_LAST_JMX.concat(suffix).equals(jmlogfile)){
             String last = LoadRecentProject.getRecentFile(0);// most recent
             if (last.toUpperCase(Locale.ENGLISH).endsWith(JMX_SUFFIX)){
@@ -1273,7 +1273,7 @@ public class JMeter implements JMeterPlugin {
          * Runs daemon thread which waits a short while;
          * if JVM does not exit, lists remaining non-daemon threads on stdout.
          */
-        private void checkForRemainingThreads() {
+        private static void checkForRemainingThreads() {
             // This cannot be a JMeter class variable, because properties
             // are not initialised until later.
             final int pauseToCheckForRemainingThreads =

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -1167,13 +1167,13 @@ public class JMeter implements JMeterPlugin {
 
         private AtomicInteger startedRemoteEngines = new AtomicInteger(0);
 
-        private ConcurrentLinkedQueue<JMeterEngine> remoteEngines = new ConcurrentLinkedQueue<>();
+        private final ConcurrentLinkedQueue<JMeterEngine> remoteEngines = new ConcurrentLinkedQueue<>();
 
         private final ReportGenerator reportGenerator;
 
-        private RunMode runMode;
+        private final RunMode runMode;
 
-        private boolean remoteStop;
+        private final boolean remoteStop;
 
         /**
          * Listener for remote test

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -38,7 +38,6 @@ import java.time.format.FormatStyle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -971,13 +970,11 @@ public class JMeter implements JMeterPlugin {
             if (deleteResultFile) {
                 SearchByClass<ResultCollector> resultListeners = new SearchByClass<>(ResultCollector.class);
                 clonedTree.traverse(resultListeners);
-                Iterator<ResultCollector> irc = resultListeners.getSearchResults().iterator();
-                while (irc.hasNext()) {
-                    ResultCollector rc = irc.next();
+                for (ResultCollector rc : resultListeners.getSearchResults()) {
                     File resultFile = new File(rc.getFilename());
                     if (resultFile.exists() && !resultFile.delete()) {
                         throw new IllegalStateException("Could not delete results file " + resultFile.getAbsolutePath()
-                            + "(canRead:"+resultFile.canRead()+", canWrite:"+resultFile.canWrite()+")");
+                                + "(canRead:" + resultFile.canRead() + ", canWrite:" + resultFile.canWrite() + ")");
                     }
                 }
             }

--- a/src/core/src/main/java/org/apache/jmeter/ProxyAuthenticator.java
+++ b/src/core/src/main/java/org/apache/jmeter/ProxyAuthenticator.java
@@ -60,8 +60,6 @@ public class ProxyAuthenticator extends Authenticator {
                 return new PasswordAuthentication(userName, password);
             case SERVER:
                 break;
-            default:
-                break;
         }
         return null;
     }

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -66,7 +66,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
     private static final long serialVersionUID = 241L;
 
     /** The title label for this component. */
-    private JLabel tableLabel;
+    private final JLabel tableLabel;
 
     /** The table containing the list of arguments. */
     private transient JTable table;
@@ -85,7 +85,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
     /**
      * Added background support for reporting tool
      */
-    private Color background;
+    private final Color background;
 
     /**
      * Boolean indicating whether this component is a standalone component or it

--- a/src/core/src/main/java/org/apache/jmeter/control/IfController.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/IfController.java
@@ -123,7 +123,7 @@ public class IfController extends GenericController implements Serializable, Thr
         }
     }
 
-    private static JsEvaluator JAVASCRIPT_EVALUATOR = USE_RHINO_ENGINE ? new RhinoJsEngine() : new NashornJsEngine();
+    private static final JsEvaluator JAVASCRIPT_EVALUATOR = USE_RHINO_ENGINE ? new RhinoJsEngine() : new NashornJsEngine();
 
     /**
      * Initialization On Demand Holder pattern

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -210,7 +210,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         runningTest.get(duration.toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    private String formatLikeDate(Instant instant) {
+    private static String formatLikeDate(Instant instant) {
         return DateTimeFormatter
                 .ofLocalizedDateTime(FormatStyle.LONG)
                 .withLocale(Locale.ROOT)
@@ -218,7 +218,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
                 .format(instant);
     }
 
-    private void removeThreadGroups(List<?> elements) {
+    private static void removeThreadGroups(List<?> elements) {
         Iterator<?> iter = elements.iterator();
         while (iter.hasNext()) { // Can't use for loop here because we remove elements
             Object item = iter.next();
@@ -607,7 +607,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         }
     }
 
-    private void pause(long ms){
+    private static void pause(long ms){
         try {
             TimeUnit.MILLISECONDS.sleep(ms);
         } catch (InterruptedException e) {

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/FunctionParser.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/FunctionParser.java
@@ -162,7 +162,7 @@ class FunctionParser {
         return buffer.toString();
     }
 
-    private char firstNonSpace(StringReader reader, char defaultResult) throws IOException {
+    private static char firstNonSpace(StringReader reader, char defaultResult) throws IOException {
         char[] current = new char[1];
         while (reader.read(current) == 1) {
             if (!Character.isSpaceChar(current[0])) {

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -133,7 +133,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
      * @param value given by user
      * @return regex surrounded by boundary character matches, if value is not included in parens
      */
-    private String constructPattern(String value) {
+    private static String constructPattern(String value) {
         if (value.startsWith("(") && value.endsWith(")")) {
             return value;
         }

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/SimpleVariable.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/SimpleVariable.java
@@ -60,7 +60,7 @@ public class SimpleVariable {
         return ret;
     }
 
-    private JMeterVariables getVariables() {
+    private static JMeterVariables getVariables() {
         JMeterContext context = JMeterContextService.getContext();
         return context.getVariables();
     }

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ValueReplacer.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ValueReplacer.java
@@ -81,7 +81,7 @@ public class ValueReplacer {
         setProperties(el, newProps);
     }
 
-    private void setProperties(TestElement el, Collection<JMeterProperty> newProps) {
+    private static void setProperties(TestElement el, Collection<JMeterProperty> newProps) {
         el.clear();
         for (JMeterProperty jmp : newProps) {
             el.setProperty(jmp);
@@ -155,7 +155,7 @@ public class ValueReplacer {
      * @return a new {@link Collection} with all the transformed {@link JMeterProperty}s
      * @throws InvalidVariableException when <code>transform</code> throws an {@link InvalidVariableException} while transforming a value
      */
-    private Collection<JMeterProperty> replaceValues(PropertyIterator iter, ValueTransformer transform) throws InvalidVariableException {
+    private static Collection<JMeterProperty> replaceValues(PropertyIterator iter, ValueTransformer transform) throws InvalidVariableException {
         List<JMeterProperty> props = new ArrayList<>();
         while (iter.hasNext()) {
             JMeterProperty val = iter.next();

--- a/src/core/src/main/java/org/apache/jmeter/functions/gui/FunctionHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/functions/gui/FunctionHelper.java
@@ -266,13 +266,13 @@ public class FunctionHelper extends JDialog implements ActionListener, ChangeLis
         }
     }
 
-    private String variablesToString(JMeterVariables jMeterVariables) {
+    private static String variablesToString(JMeterVariables jMeterVariables) {
         StringBuilder sb = new StringBuilder();
         jMeterVariables.entrySet().forEach(e->sb.append(e.getKey()).append("=").append(e.getValue()).append("\r\n"));
         return sb.toString();
     }
 
-    private String buildFunctionCallString(String functionName, Arguments args) {
+    private static String buildFunctionCallString(String functionName, Arguments args) {
         StringBuilder functionCall = new StringBuilder("${");
         functionCall.append(functionName);
         if (args.getArguments().size() > 0) {
@@ -301,7 +301,7 @@ public class FunctionHelper extends JDialog implements ActionListener, ChangeLis
      * @param arg string that should be escaped
      * @return escaped string
      */
-    private String escapeCommata(String arg) {
+    private static String escapeCommata(String arg) {
         int level = 0;
         StringBuilder result = new StringBuilder(arg.length());
         try (Reader r = new StringReader(arg)) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
@@ -102,19 +102,19 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      * to their corresponding GUI components.
      * <p>This enables to associate {@link UnsharedComponent} UIs with their {@link TestElement}.</p>
      */
-    private Map<TestElement, JMeterGUIComponent> nodesToGui = new HashMap<>();
+    private final Map<TestElement, JMeterGUIComponent> nodesToGui = new HashMap<>();
 
     /**
      * Map from Class to JMeterGUIComponent, mapping the Class of a GUI
      * component to an instance of that component.
      */
-    private Map<Class<?>, JMeterGUIComponent> guis = new HashMap<>();
+    private final Map<Class<?>, JMeterGUIComponent> guis = new HashMap<>();
 
     /**
      * Map from Class to TestBeanGUI, mapping the Class of a TestBean to an
      * instance of TestBeanGUI to be used to edit such components.
      */
-    private Map<Class<?>, JMeterGUIComponent> testBeanGUIs = new HashMap<>();
+    private final Map<Class<?>, JMeterGUIComponent> testBeanGUIs = new HashMap<>();
 
     /**
      * Tracks the number of times Look and Feel was changed.
@@ -149,13 +149,13 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
     private LoggerPanel loggerPanel;
 
     /** History for tree states */
-    private UndoHistory undoHistory = new UndoHistory();
+    private final UndoHistory undoHistory = new UndoHistory();
 
     /** GUI Logging Event Bus. */
-    private GuiLogEventBus logEventBus = new GuiLogEventBus();
+    private final GuiLogEventBus logEventBus = new GuiLogEventBus();
 
     /** Listeners for events on test plan */
-    private List<TestPlanListener> testPlanListeners = Collections.synchronizedList(new ArrayList<>());
+    private final List<TestPlanListener> testPlanListeners = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Private constructor to permit instantiation only from within this class.

--- a/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/GuiPackage.java
@@ -904,7 +904,7 @@ public final class GuiPackage implements LocaleChangeListener, HistoryListener {
      * @param el {@link TestElement}
      * @return int checksum
      */
-    private int getTestElementCheckSum(TestElement el) {
+    private static int getTestElementCheckSum(TestElement el) {
         int ret = el.getClass().hashCode();
         PropertyIterator it = el.propertyIterator();
         while (it.hasNext()) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/HtmlReportAction.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/HtmlReportAction.java
@@ -34,7 +34,7 @@ import org.apache.jmeter.gui.plugin.MenuCreator;
 import org.apache.jmeter.util.JMeterUtils;
 
 public class HtmlReportAction extends AbstractAction implements MenuCreator {
-    private static Set<String> commands = new HashSet<>();
+    private static final Set<String> commands = new HashSet<>();
     private HtmlReportUI htmlReportPanel;
 
     static {

--- a/src/core/src/main/java/org/apache/jmeter/gui/HtmlReportUI.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/HtmlReportUI.java
@@ -52,7 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class HtmlReportUI implements ActionListener {
-    private static Set<String> commands = new HashSet<>();
+    private static final Set<String> commands = new HashSet<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(HtmlReportUI.class);
 
     private static final String CREATE_REQUEST = "CREATE_REQUEST";
@@ -166,7 +166,7 @@ public class HtmlReportUI implements ActionListener {
     }
 
     private class ReportGenerationWorker extends SwingWorker<List<String>, String> {
-        private JButton reportLaunchButton;
+        private final JButton reportLaunchButton;
 
         public ReportGenerationWorker(JButton reportLaunchButton) {
             this.reportLaunchButton = reportLaunchButton;

--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -187,12 +187,12 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
     /** LogTarget that receives ERROR or FATAL */
     private transient ErrorsAndFatalsCounterLogTarget errorsAndFatalsCounterLogTarget;
 
-    private javax.swing.Timer computeTestDurationTimer = new javax.swing.Timer(1000,
+    private final javax.swing.Timer computeTestDurationTimer = new javax.swing.Timer(1000,
             this::computeTestDuration);
 
-    private AtomicInteger errorOrFatal = new AtomicInteger(0);
+    private final AtomicInteger errorOrFatal = new AtomicInteger(0);
 
-    private javax.swing.Timer refreshErrorsTimer = new javax.swing.Timer(1000,
+    private final javax.swing.Timer refreshErrorsTimer = new javax.swing.Timer(1000,
             this::refreshErrors);
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -627,7 +627,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
      *
      * @return the main scroll pane
      */
-    private JScrollPane createMainPanel() {
+    private static JScrollPane createMainPanel() {
         return new JScrollPane();
     }
 
@@ -635,7 +635,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
      * Create at the down of the left a Console for Log events
      * @return {@link LoggerPanel}
      */
-    private LoggerPanel createLoggerPanel() {
+    private static LoggerPanel createLoggerPanel() {
         LoggerPanel loggerPanel = new LoggerPanel();
         loggerPanel.setMinimumSize(new Dimension(0, 100));
         loggerPanel.setPreferredSize(new Dimension(0, 150));
@@ -703,7 +703,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
         return treevar;
     }
 
-    private void addQuickComponentHotkeys(JTree treevar) {
+    private static void addQuickComponentHotkeys(JTree treevar) {
         Action quickComponent = new QuickComponent("Quick Component");
 
         InputMap inputMap = treevar.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
@@ -722,7 +722,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
      *
      * @return a renderer to draw the test tree nodes
      */
-    private TreeCellRenderer getCellRenderer() {
+    private static TreeCellRenderer getCellRenderer() {
         return new JMeterCellRenderer();
     }
 
@@ -767,7 +767,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
          * Bug 62336: On Windows CTRL+6 doesn't give us an actionCommand, so
          * we have to try harder and read the KeyEvent from the EventQueue
          */
-        private String getCurrentKey(ActionEvent actionEvent) {
+        private static String getCurrentKey(ActionEvent actionEvent) {
             String actionCommand = actionEvent.getActionCommand();
             if (actionCommand != null) {
                 return actionCommand;
@@ -904,7 +904,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
     /**
      * Define AWT window title (WM_CLASS string) (useful on Gnome 3 / Linux)
      */
-    private void setWindowTitle() {
+    private static void setWindowTitle() {
         Class<?> xtoolkit = Toolkit.getDefaultToolkit().getClass();
         if (xtoolkit.getName().equals("sun.awt.X11.XToolkit")) { // NOSONAR (we don't want to depend on native LAF) $NON-NLS-1$
             try {

--- a/src/core/src/main/java/org/apache/jmeter/gui/OnErrorPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/OnErrorPanel.java
@@ -65,7 +65,7 @@ public class OnErrorPanel extends JPanel {
         return panel;
     }
 
-    private JRadioButton addRadioButton(String labelKey, ButtonGroup group, JPanel panel) {
+    private static JRadioButton addRadioButton(String labelKey, ButtonGroup group, JPanel panel) {
         JRadioButton radioButton = new JRadioButton(JMeterUtils.getResString(labelKey));
         group.add(radioButton);
         panel.add(radioButton);

--- a/src/core/src/main/java/org/apache/jmeter/gui/UndoHistory.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/UndoHistory.java
@@ -61,7 +61,7 @@ public class UndoHistory implements TreeModelListener, Serializable {
     private boolean working = false;
 
     /** History listeners */
-    private List<HistoryListener> listeners = new ArrayList<>();
+    private final List<HistoryListener> listeners = new ArrayList<>();
 
     private final UndoManager manager = new UndoManager();
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AboutCommand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AboutCommand.java
@@ -65,7 +65,7 @@ public class AboutCommand extends AbstractAction {
     @Override
     public void doAction(ActionEvent e) {
         if (e.getActionCommand().equals(ActionNames.ABOUT)) {
-            this.about();
+            AboutCommand.about();
         }
     }
 
@@ -82,7 +82,7 @@ public class AboutCommand extends AbstractAction {
      * the product image and the copyright notice. The dialog box is centered
      * over the MainFrame.
      */
-    private void about() {
+    private static void about() {
         JFrame mainFrame = GuiPackage.getInstance().getMainFrame();
         JDialog dialog = initDialog(mainFrame);
 
@@ -98,7 +98,7 @@ public class AboutCommand extends AbstractAction {
      * @param mainFrame {@link JFrame}
      * @return {@link JDialog} initializing it if necessary
      */
-    private JDialog initDialog(JFrame mainFrame) {
+    private static JDialog initDialog(JFrame mainFrame) {
         if (about != null) {
             return about;
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AbstractAction.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AbstractAction.java
@@ -144,7 +144,7 @@ public abstract class AbstractAction implements Command {
      * @param event {@link ActionEvent}
      * @return parent Window
      */
-    protected final JFrame getParentFrame(ActionEvent event) {
+    protected static JFrame getParentFrame(ActionEvent event) {
         JFrame parent = null;
         Object source = event.getSource();
         if (source instanceof JMenuItem) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AbstractAction.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AbstractAction.java
@@ -102,7 +102,6 @@ public abstract class AbstractAction implements Command {
                             return false;
                         }
                     case ASK:
-                    default:
                         String[] option = new String[]{JMeterUtils.getResString("concat_result"),
                                 JMeterUtils.getResString("dont_start"), JMeterUtils.getResString("replace_file")};
                         String question = MessageFormat.format(

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/ActionRouter.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/ActionRouter.java
@@ -221,7 +221,7 @@ public final class ActionRouter implements ActionListener {
      * @param listener {@link ActionListener}
      * @param actionListeners {@link Set} of {@link ActionListener}
      */
-    private void removeActionListener(Class<?> action, ActionListener listener, Map<String, Set<ActionListener>> actionListeners) {
+    private static void removeActionListener(Class<?> action, ActionListener listener, Map<String, Set<ActionListener>> actionListeners) {
         if (action != null) {
             Set<ActionListener> set = actionListeners.get(action.getName());
             if (set != null) {
@@ -251,7 +251,7 @@ public final class ActionRouter implements ActionListener {
      * @param listener {@link ActionListener}
      * @param actionListeners {@link Set}
      */
-    private void addActionListener(Class<?> action, ActionListener listener, Map<String, Set<ActionListener>> actionListeners) {
+    private static void addActionListener(Class<?> action, ActionListener listener, Map<String, Set<ActionListener>> actionListeners) {
         if (action != null) {
             Set<ActionListener> set = actionListeners.get(action.getName());
             if (set == null) {
@@ -297,7 +297,7 @@ public final class ActionRouter implements ActionListener {
      * @param e {@link ActionEvent}
      * @param actionListeners {@link Set}
      */
-    private void actionPerformed(Class<? extends Command> action, ActionEvent e, Map<String, Set<ActionListener>> actionListeners) {
+    private static void actionPerformed(Class<? extends Command> action, ActionEvent e, Map<String, Set<ActionListener>> actionListeners) {
         if (action != null) {
             Set<ActionListener> listenerSet = actionListeners.get(action.getName());
             if (listenerSet != null && !listenerSet.isEmpty()) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AddParent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AddParent.java
@@ -62,7 +62,7 @@ public class AddParent extends AbstractAction {
         return commands;
     }
 
-    protected void addParentToTree(TestElement newParent) {
+    protected static void addParentToTree(TestElement newParent) {
         GuiPackage guiPackage = GuiPackage.getInstance();
         JMeterTreeNode newNode = new JMeterTreeNode(newParent, guiPackage.getTreeModel());
         JMeterTreeNode currentNode = guiPackage.getTreeListener().getCurrentNode();
@@ -75,7 +75,7 @@ public class AddParent extends AbstractAction {
         }
     }
 
-    private void moveNode(GuiPackage guiPackage, JMeterTreeNode node, JMeterTreeNode newParentNode) {
+    private static void moveNode(GuiPackage guiPackage, JMeterTreeNode node, JMeterTreeNode newParentNode) {
         guiPackage.getTreeModel().removeNodeFromParent(node);
         guiPackage.getTreeModel().insertNodeInto(node, newParentNode, newParentNode.getChildCount());
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AddThinkTimeBetweenEachStep.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AddThinkTimeBetweenEachStep.java
@@ -82,8 +82,8 @@ public class AddThinkTimeBetweenEachStep extends AbstractAction {
      * @param parentNode Parent node of elements on which we add think times
      * @throws IllegalUserActionException
      */
-    private void addThinkTimeToChildren(GuiPackage guiPackage,
-            JMeterTreeNode parentNode) throws IllegalUserActionException {
+    private static void addThinkTimeToChildren(GuiPackage guiPackage,
+                                               JMeterTreeNode parentNode) throws IllegalUserActionException {
         guiPackage.updateCurrentNode();
         boolean insertThinkTime;
         try {
@@ -118,7 +118,7 @@ public class AddThinkTimeBetweenEachStep extends AbstractAction {
      * @param childNodes Child nodes
      * @param index insertion index
      */
-    private void addNodesToTreeHierachically(GuiPackage guiPackage,
+    private static void addNodesToTreeHierachically(GuiPackage guiPackage,
             JMeterTreeNode parentNode,
             JMeterTreeNode[] childNodes,
             int index) {
@@ -134,7 +134,7 @@ public class AddThinkTimeBetweenEachStep extends AbstractAction {
      * @throws ReflectiveOperationException when class instantiation for {@value #DEFAULT_IMPLEMENTATION} fails
      * @throws IllegalUserActionException when {@link ThinkTimeCreator#createThinkTime(GuiPackage, JMeterTreeNode)} throws this
      */
-    private JMeterTreeNode[] createThinkTime(GuiPackage guiPackage, JMeterTreeNode parentNode)
+    private static JMeterTreeNode[] createThinkTime(GuiPackage guiPackage, JMeterTreeNode parentNode)
             throws ReflectiveOperationException, IllegalUserActionException  {
         Class<?> clazz = Class.forName(DEFAULT_IMPLEMENTATION);
         ThinkTimeCreator thinkTimeCreator = (ThinkTimeCreator) clazz.getDeclaredConstructor().newInstance();

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/ApplyNamingConvention.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/ApplyNamingConvention.java
@@ -80,7 +80,7 @@ public class ApplyNamingConvention extends AbstractAction {
      * @param currentNode Parent node of elements on which we apply naming policy
      */
     @SuppressWarnings("JdkObsolete")
-    private void applyNamingPolicyToCurrentNode(GuiPackage guiPackage,
+    private static void applyNamingPolicyToCurrentNode(GuiPackage guiPackage,
             JMeterTreeNode currentNode) {
         TreeNodeNamingPolicy namingPolicy = guiPackage.getNamingPolicy();
         guiPackage.updateCurrentNode();

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/ChangeParent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/ChangeParent.java
@@ -78,7 +78,7 @@ public class ChangeParent extends AbstractAction {
         return commands;
     }
 
-    private void changeParent(TestElement newParent, GuiPackage guiPackage, JMeterTreeNode currentNode) {
+    private static void changeParent(TestElement newParent, GuiPackage guiPackage, JMeterTreeNode currentNode) {
 
         // keep the old name if it was not the default one
         Controller currentController = (Controller) currentNode.getUserObject();

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/CollapseExpandTreeBranch.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/CollapseExpandTreeBranch.java
@@ -79,7 +79,7 @@ public class CollapseExpandTreeBranch extends AbstractAction {
     }
 
     @SuppressWarnings("JdkObsolete")
-    private void expandCollapseNode(JTree jTree, TreePath parent, boolean collapse) {
+    private static void expandCollapseNode(JTree jTree, TreePath parent, boolean collapse) {
         TreeNode node = (TreeNode) parent.getLastPathComponent();
         if (node.isLeaf()) {
             return;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/EnableComponent.java
@@ -59,7 +59,7 @@ public class EnableComponent extends AbstractAction {
         }
     }
 
-    private void enableComponents(JMeterTreeNode[] nodes, boolean enable) {
+    private static void enableComponents(JMeterTreeNode[] nodes, boolean enable) {
         GuiPackage pack = GuiPackage.getInstance();
         for (JMeterTreeNode node : nodes) {
             node.setEnabled(enable);
@@ -67,7 +67,7 @@ public class EnableComponent extends AbstractAction {
         }
     }
 
-    private void toggleComponents(JMeterTreeNode[] nodes) {
+    private static void toggleComponents(JMeterTreeNode[] nodes) {
         GuiPackage pack = GuiPackage.getInstance();
         for (JMeterTreeNode node : nodes) {
             boolean enable = !node.isEnabled();

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/HtmlReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/HtmlReportGenerator.java
@@ -162,7 +162,7 @@ public class HtmlReportGenerator {
      * @param fileToCheck the directory to check
      * @return the error message or null if the file is ok
      */
-    private String checkFile(File fileToCheck) {
+    private static String checkFile(File fileToCheck) {
         if (fileToCheck.exists() && fileToCheck.canRead() && fileToCheck.isFile()) {
             return null;
         } else {
@@ -176,7 +176,7 @@ public class HtmlReportGenerator {
      * @param directoryToCheck the directory to check
      * @return the error message or an empty string if the directory is fine
      */
-    private String checkDirectory(File directoryToCheck) {
+    private static String checkDirectory(File directoryToCheck) {
         if (directoryToCheck.exists()) {
             String[] files = directoryToCheck.list();
             if (files != null && files.length > 0) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/HtmlReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/HtmlReportGenerator.java
@@ -43,9 +43,9 @@ public class HtmlReportGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(HtmlReportGenerator.class);
     private static final long COMMAND_TIMEOUT = JMeterUtils.getPropDefault("generate_report_ui.generation_timeout", 300_000L);
 
-    private String csvFilePath;
-    private String userPropertiesFilePath;
-    private String outputDirectoryPath;
+    private final String csvFilePath;
+    private final String userPropertiesFilePath;
+    private final String outputDirectoryPath;
 
     public HtmlReportGenerator(String csvFilePath, String userPropertiesFilePath, String outputDirectoryPath) {
         this.csvFilePath = csvFilePath;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/LoadRecentProject.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/LoadRecentProject.java
@@ -74,7 +74,7 @@ public class LoadRecentProject extends Load {
     /**
      * Get the recent file for the menu item
      */
-    private File getRecentFile(ActionEvent e) {
+    private static File getRecentFile(ActionEvent e) {
         JMenuItem menuItem = (JMenuItem)e.getSource();
         // Get the preference for the recent files
         return new File(getRecentFile(Integer.parseInt(menuItem.getName())));

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Move.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Move.java
@@ -100,7 +100,7 @@ public class Move extends AbstractAction {
         GuiPackage.getInstance().getMainFrame().repaint();
     }
 
-    private JMeterTreeNode getParentNode(JMeterTreeNode currentNode) {
+    private static JMeterTreeNode getParentNode(JMeterTreeNode currentNode) {
         JMeterTreeNode parentNode = (JMeterTreeNode) currentNode.getParent();
         TestElement te = currentNode.getTestElement();
         if (te instanceof TestPlan) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/OpenLinkAction.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/OpenLinkAction.java
@@ -90,7 +90,7 @@ public class OpenLinkAction extends AbstractAction {
         return commands;
     }
 
-    private void showBrowserWarning(String url) {
+    private static void showBrowserWarning(String url) {
         String problemSolver;
         if (url.startsWith(LINK_MAP.get(ActionNames.LINK_COMP_REF))
                 || url.startsWith(LINK_MAP.get(ActionNames.LINK_FUNC_REF))) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Paste.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Paste.java
@@ -76,7 +76,7 @@ public class Paste extends AbstractAction {
         GuiPackage.getInstance().getMainFrame().repaint();
     }
 
-    private void addNode(JMeterTreeNode parent, JMeterTreeNode node) {
+    private static void addNode(JMeterTreeNode parent, JMeterTreeNode node) {
         try {
             // Add this node
             JMeterTreeNode newNode = GuiPackage.getInstance().getTreeModel().addComponent(node.getTestElement(), parent);

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/RawTextSearcher.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/RawTextSearcher.java
@@ -25,8 +25,8 @@ import org.apache.commons.lang3.StringUtils;
  * Searcher implementation that searches text as is
  */
 public class RawTextSearcher implements Searcher {
-    private boolean caseSensitive;
-    private String textToSearch;
+    private final boolean caseSensitive;
+    private final String textToSearch;
 
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/RegexpSearcher.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/RegexpSearcher.java
@@ -28,8 +28,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class RegexpSearcher implements Searcher {
 
-    private boolean caseSensitive;
-    private String regexp;
+    private final boolean caseSensitive;
+    private final String regexp;
     /**
      * Constructor
      * @param caseSensitive is search case sensitive

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/RemoteStart.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/RemoteStart.java
@@ -54,7 +54,7 @@ public class RemoteStart extends AbstractAction {
         commands.add(ActionNames.REMOTE_EXIT_ALL);
     }
 
-    private DistributedRunner distributedRunner = new DistributedRunner();
+    private final DistributedRunner distributedRunner = new DistributedRunner();
 
     public RemoteStart() {
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/RemoteStart.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/RemoteStart.java
@@ -97,7 +97,7 @@ public class RemoteStart extends AbstractAction {
         }
     }
 
-    private List<String> getRemoteHosts() {
+    private static List<String> getRemoteHosts() {
         String remoteHostsString = JMeterUtils.getPropDefault(REMOTE_HOSTS, LOCAL_HOST);
         StringTokenizer st = new StringTokenizer(remoteHostsString, REMOTE_HOSTS_SEPARATOR);
         List<String> list = new ArrayList<>();
@@ -112,7 +112,7 @@ public class RemoteStart extends AbstractAction {
         return commands;
     }
 
-    private HashTree getTestTree() {
+    private static HashTree getTestTree() {
         GuiPackage gui = GuiPackage.getInstance();
         HashTree testTree = gui.getTreeModel().getTestPlan();
         HashTree tree = JMeter.convertSubTree(testTree, true);

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SSLManagerCommand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SSLManagerCommand.java
@@ -67,7 +67,7 @@ public class SSLManagerCommand extends AbstractAction {
     @Override
     public void doAction(ActionEvent e) {
         if (e.getActionCommand().equals(ActionNames.SSL_MANAGER)) {
-            this.sslManager();
+            SSLManagerCommand.sslManager();
         }
     }
 
@@ -83,7 +83,7 @@ public class SSLManagerCommand extends AbstractAction {
      * Called by sslManager button. Raises sslManager dialog.
      * I.e. a FileChooser for PCSI12 (.p12|.P12) or JKS files.
      */
-    private void sslManager() {
+    private static void sslManager() {
         SSLManager.reset();
 
         JFileChooser keyStoreChooser = new JFileChooser(System.getProperty("user.dir")); //$NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
@@ -463,7 +463,7 @@ public class Save extends AbstractAction {
 
     private static class PrivatePatternFileFilter implements IOFileFilter {
 
-        private Pattern pattern;
+        private final Pattern pattern;
 
         public PrivatePatternFileFilter(Pattern pattern) {
             if(pattern == null) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Save.java
@@ -180,7 +180,7 @@ public class Save extends AbstractAction {
      * @param nodes Array of {@link JMeterTreeNode}
      * @return {@link HashTree} new test plan
      */
-    private HashTree createTestFragmentNode(JMeterTreeNode[] nodes) {
+    private static HashTree createTestFragmentNode(JMeterTreeNode[] nodes) {
         TestElement element = GuiPackage.getInstance().createTestElement(TestFragmentControllerGui.class.getName());
         HashTree hashTree = new ListedHashTree();
         HashTree tfTree = hashTree.add(new JMeterTreeNode(element, null));
@@ -197,7 +197,7 @@ public class Save extends AbstractAction {
     /**
      * @return String new file name or null if user want to cancel
      */
-    private String computeFileName() {
+    private static String computeFileName() {
         JFileChooser chooser = FileDialoger.promptToSaveFile(GuiPackage.getInstance().getTreeListener()
                 .getCurrentNode().getName()
                 + JMX_FILE_EXTENSION);
@@ -334,7 +334,7 @@ public class Save extends AbstractAction {
      *         properties and that should be deleted after the save operation
      *         has performed successfully
      */
-    private List<File> createBackupFile(File fileToBackup) {
+    private static List<File> createBackupFile(File fileToBackup) {
         if (!BACKUP_ENABLED || !fileToBackup.exists()) {
             return EMPTY_FILE_LIST;
         }
@@ -397,7 +397,7 @@ public class Save extends AbstractAction {
      * @param backupFiles
      *            {@link List} of {@link File}
      */
-    private int getHighestVersionNumber(Pattern backupPattern, List<File> backupFiles) {
+    private static int getHighestVersionNumber(Pattern backupPattern, List<File> backupFiles) {
         return backupFiles.stream().map(backupFile -> backupPattern.matcher(backupFile.getName()))
                 .filter(matcher -> matcher.find() && matcher.groupCount() > 0)
                 .mapToInt(matcher -> Integer.parseInt(matcher.group(1))).max().orElse(0);
@@ -411,7 +411,7 @@ public class Save extends AbstractAction {
      * @return list of files to be deleted based upon properties described
      *         {@link #createBackupFile(File)}
      */
-    private List<File> backupFilesToDelete(List<File> backupFiles) {
+    private static List<File> backupFilesToDelete(List<File> backupFiles) {
         List<File> filesToDelete = new ArrayList<>();
         if (BACKUP_MAX_HOURS > 0) {
             filesToDelete.addAll(expiredBackupFiles(backupFiles));
@@ -431,7 +431,7 @@ public class Save extends AbstractAction {
      * @param backupFiles {@link List} of {@link File} to filter
      * @return {@link List} of {@link File} that are expired
      */
-    private List<File> expiredBackupFiles(List<File> backupFiles) {
+    private static List<File> expiredBackupFiles(List<File> backupFiles) {
         if (BACKUP_MAX_HOURS > 0) {
             final long expiryMillis = System.currentTimeMillis() - (1L * BACKUP_MAX_HOURS * MS_PER_HOUR);
             return backupFiles.stream().filter(file -> file.lastModified() < expiryMillis).collect(Collectors.toList());

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SaveGraphics.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SaveGraphics.java
@@ -90,7 +90,7 @@ public class SaveGraphics extends AbstractAction {
         }
     }
 
-    private void saveImage(JComponent comp) {
+    private static void saveImage(JComponent comp) {
 
         String filename;
         JFileChooser chooser = FileDialoger.promptToSaveFile(

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeCommand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeCommand.java
@@ -54,7 +54,7 @@ public class SearchTreeCommand extends AbstractAction {
      * @return A freshly created search dialog with the parent frame that could be
      *         found, or no parent otherwise.
      */
-    private SearchTreeDialog createSearchDialog(ActionEvent event) {
+    private static SearchTreeDialog createSearchDialog(ActionEvent event) {
         JFrame parent = getParentFrame(event);
         return new SearchTreeDialog(parent);
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeDialog.java
@@ -226,7 +226,7 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
         ComponentUtil.centerComponentInWindow(this);
     }
 
-    private JButton createButton(String messageKey) {
+    private static JButton createButton(String messageKey) {
         return new JButton(JMeterUtils.getResString(messageKey));
     }
 
@@ -387,7 +387,7 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
      * @param expand true if we want to expand
      * @param nodes Set of {@link JMeterTreeNode} to mark
      */
-    private void markConcernedNodes(boolean expand, Set<JMeterTreeNode> nodes) {
+    private static void markConcernedNodes(boolean expand, Set<JMeterTreeNode> nodes) {
         GuiPackage guiInstance = GuiPackage.getInstance();
         JTree jTree = guiInstance.getMainFrame().getTree();
         for (JMeterTreeNode jMeterTreeNode : nodes) {
@@ -451,7 +451,7 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
      * @param caseSensitiveReplacement boolean if search is case sensitive
      * @return null if no replacement occurred or Pair of (number of replacement, current tree node)
      */
-    private Pair<Integer, JMeterTreeNode> doReplacementInCurrentNode(JMeterTreeNode jMeterTreeNode,
+    private static Pair<Integer, JMeterTreeNode> doReplacementInCurrentNode(JMeterTreeNode jMeterTreeNode,
             String regex, String replaceBy, boolean caseSensitiveReplacement) {
         try {
             if (jMeterTreeNode.getUserObject() instanceof Replaceable) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SearchTreeDialog.java
@@ -105,7 +105,7 @@ public class SearchTreeDialog extends JDialog implements ActionListener { // NOS
 
     private transient Triple<String, Boolean, Boolean> lastSearchConditions = null;
 
-    private List<JMeterTreeNode> lastSearchResult = new ArrayList<>();
+    private final List<JMeterTreeNode> lastSearchResult = new ArrayList<>();
     private int currentSearchIndex;
 
     @VisibleForTesting

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
@@ -205,7 +205,7 @@ public class SelectTemplatesDialog extends JDialog implements ChangeListener, Ac
      * @param actionEvent {@link ActionEvent}
      * @return true if plan is not dirty or has been saved
      */
-    private boolean checkDirty(final ActionEvent actionEvent) {
+    private static boolean checkDirty(final ActionEvent actionEvent) {
         ActionRouter.getInstance().doActionNow(new ActionEvent(actionEvent.getSource(), actionEvent.getID(), ActionNames.CHECK_DIRTY));
         GuiPackage guiPackage = GuiPackage.getInstance();
         if (guiPackage.isDirty()) {
@@ -320,7 +320,7 @@ public class SelectTemplatesDialog extends JDialog implements ChangeListener, Ac
      * @param template {@link Template}
      * @return true if template has not parameter
      */
-    private boolean hasParameters(Template template) {
+    private static boolean hasParameters(Template template) {
         return !(template.getParameters() == null || template.getParameters().isEmpty());
     }
 
@@ -397,7 +397,7 @@ public class SelectTemplatesDialog extends JDialog implements ChangeListener, Ac
         return panel;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0,0,5,0);
         gbc.fill = GridBagConstraints.NONE;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SelectTemplatesDialog.java
@@ -96,9 +96,9 @@ public class SelectTemplatesDialog extends JDialog implements ChangeListener, Ac
 
     private final JButton validateButton = new JButton();
 
-    private Map<String, JLabeledTextField> parametersTextFields = new LinkedHashMap<>();
+    private final Map<String, JLabeledTextField> parametersTextFields = new LinkedHashMap<>();
 
-    private JPanel actionBtnBar = new JPanel(new FlowLayout());
+    private final JPanel actionBtnBar = new JPanel(new FlowLayout());
 
     public SelectTemplatesDialog() {
         super((JFrame) null, JMeterUtils.getResString("template_title"), true); //$NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Start.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Start.java
@@ -157,7 +157,7 @@ public class Start extends AbstractAction {
      * @param currentNodes jmeter tree nodes
      * @return the thread groups
      */
-    private AbstractThreadGroup[] keepOnlyThreadGroups(JMeterTreeNode[] currentNodes) {
+    private static AbstractThreadGroup[] keepOnlyThreadGroups(JMeterTreeNode[] currentNodes) {
         List<AbstractThreadGroup> nodes = new ArrayList<>();
         for (JMeterTreeNode jMeterTreeNode : currentNodes) {
             if(jMeterTreeNode.getTestElement() instanceof AbstractThreadGroup) {
@@ -229,7 +229,7 @@ public class Start extends AbstractAction {
      * @param testTree {@link HashTree}
      * @param threadGroupsToKeep Array of {@link AbstractThreadGroup} to keep
      */
-    private void keepOnlySelectedThreadGroupsInHashTree(HashTree testTree, AbstractThreadGroup[] threadGroupsToKeep) {
+    private static void keepOnlySelectedThreadGroupsInHashTree(HashTree testTree, AbstractThreadGroup[] threadGroupsToKeep) {
         for (Object o : new ArrayList<>(testTree.list())) {
             TestElement item = (TestElement) o;
             if (o instanceof AbstractThreadGroup) {
@@ -259,7 +259,7 @@ public class Start extends AbstractAction {
      * @param threadGroups Array of {@link AbstractThreadGroup}
      * @return true if item is in threadGroups array
      */
-    private boolean isInThreadGroups(TestElement item, AbstractThreadGroup[] threadGroups) {
+    private static boolean isInThreadGroups(TestElement item, AbstractThreadGroup[] threadGroups) {
         for (AbstractThreadGroup abstractThreadGroup : threadGroups) {
             if(item == abstractThreadGroup) {
                 return true;
@@ -275,7 +275,7 @@ public class Start extends AbstractAction {
      * @param runMode {@link RunMode} how plan will be run
      * @return {@link TreeCloner}
      */
-    private ListedHashTree cloneTree(HashTree testTree, RunMode runMode) {
+    private static ListedHashTree cloneTree(HashTree testTree, RunMode runMode) {
         TreeCloner cloner = null;
         switch (runMode) {
             case VALIDATION:

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Start.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Start.java
@@ -285,7 +285,6 @@ public class Start extends AbstractAction {
                 cloner = new TreeClonerNoTimer(false);
                 break;
             case AS_IS:
-            default:
                 cloner = new TreeCloner(false);
                 break;
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
@@ -188,7 +188,7 @@ public class TemplateManager {
      * @param templates Map of {@link Template} referenced by name
      * @param templateNode {@link Node} the xml template node
      */
-    void parseTemplateNode(Map<String, Template> templates, Node templateNode) {
+    static void parseTemplateNode(Map<String, Template> templates, Node templateNode) {
         if (templateNode.getNodeType() == Node.ELEMENT_NODE) {
             Template template = new Template();
             Element element =  (Element) templateNode;
@@ -206,11 +206,11 @@ public class TemplateManager {
         }
     }
 
-    private String textOfFirstTag(Element element, String tagName) {
+    private static String textOfFirstTag(Element element, String tagName) {
         return element.getElementsByTagName(tagName).item(0).getTextContent();
     }
 
-    private Map<String, String> parseParameterNodes(NodeList parameterNodes) {
+    private static Map<String, String> parseParameterNodes(NodeList parameterNodes) {
         Map<String, String> parametersMap = new HashMap<>();
         for (int i = 0; i < parameterNodes.getLength(); i++) {
             Element element =  (Element) parameterNodes.item(i);

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
@@ -124,8 +124,8 @@ public class TemplateManager {
     }
 
     public static final class LoggingErrorHandler implements ErrorHandler {
-        private Logger logger;
-        private File file;
+        private final Logger logger;
+        private final File file;
 
         public LoggingErrorHandler(Logger logger, File file) {
             this.logger = logger;

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventBus.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventBus.java
@@ -29,7 +29,7 @@ public class GuiLogEventBus {
     /**
      * Registered GUI log event listeners array.
      */
-    private List<GuiLogEventListener> listeners = new ArrayList<>();
+    private final List<GuiLogEventListener> listeners = new ArrayList<>();
 
     /**
      * Default constructor.

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/LogEventObject.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/LogEventObject.java
@@ -31,7 +31,7 @@ public class LogEventObject extends EventObject {
     private static final long serialVersionUID = 1L;
 
     private Level level;
-    private String seralizedString;
+    private final String seralizedString;
 
     public LogEventObject(Object source) {
         this(source, null);

--- a/src/core/src/main/java/org/apache/jmeter/gui/menu/StaticJMeterGUIComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/menu/StaticJMeterGUIComponent.java
@@ -75,7 +75,7 @@ public class StaticJMeterGUIComponent implements JMeterGUIComponent {
         this.groups = getGroups(c, metadata);
     }
 
-    private List<String> getGroups(Class<?> c, TestElementMetadata metadata) {
+    private static List<String> getGroups(Class<?> c, TestElementMetadata metadata) {
         String[] groups = metadata.actionGroups();
         if (groups.length == 1 && groups[0].equals("")) {
             // Annotations can't hold null values, so we use empty string instead

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
@@ -236,7 +236,7 @@ public class JMeterTreeListener implements TreeSelectionListener, MouseListener,
     public void keyTyped(KeyEvent e) {
     }
 
-    private boolean isRightClick(MouseEvent e) {
+    private static boolean isRightClick(MouseEvent e) {
         return e.isPopupTrigger() ||
                 (InputEvent.BUTTON2_DOWN_MASK & e.getModifiersEx()) > 0 ||
                 (InputEvent.BUTTON3_DOWN_MASK == e.getModifiersEx());

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeModel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeModel.java
@@ -135,7 +135,7 @@ public class JMeterTreeModel extends DefaultTreeModel {
     }
 
     @SuppressWarnings("deprecation")
-    private boolean isWorkbench(TestElement item) {
+    private static boolean isWorkbench(TestElement item) {
         return item instanceof org.apache.jmeter.testelement.WorkBench;
     }
 
@@ -185,7 +185,7 @@ public class JMeterTreeModel extends DefaultTreeModel {
     }
 
     @SuppressWarnings("JdkObsolete")
-    private void traverseAndFind(Class<?> type, JMeterTreeNode node, List<JMeterTreeNode> nodeList) {
+    private static void traverseAndFind(Class<?> type, JMeterTreeNode node, List<JMeterTreeNode> nodeList) {
         if (type.isInstance(node.getUserObject())) {
             nodeList.add(node);
         }
@@ -197,7 +197,7 @@ public class JMeterTreeModel extends DefaultTreeModel {
     }
 
     @SuppressWarnings("JdkObsolete")
-    private JMeterTreeNode traverseAndFind(TestElement userObject, JMeterTreeNode node) {
+    private static JMeterTreeNode traverseAndFind(TestElement userObject, JMeterTreeNode node) {
         if (userObject == node.getUserObject()) {
             return node;
         }
@@ -324,7 +324,7 @@ public class JMeterTreeModel extends DefaultTreeModel {
      * </ul>
      * @param node
      */
-    private boolean isNonTestElement(Object node) {
+    private static boolean isNonTestElement(Object node) {
         JMeterTreeNode treeNode = new JMeterTreeNode((TestElement) node, null);
         Collection<String> categories = treeNode.getMenuCategories();
         if (categories != null) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeNode.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeNode.java
@@ -47,7 +47,7 @@ public class JMeterTreeNode extends DefaultMutableTreeNode implements NamedTreeN
     private static final int TEST_PLAN_LEVEL = 1;
 
     // See Bug 54648
-    private transient Optional<JMeterTreeModel> treeModel;
+    private final transient Optional<JMeterTreeModel> treeModel;
 
     private boolean markedBySearch;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeTransferHandler.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeTransferHandler.java
@@ -43,7 +43,7 @@ public class JMeterTreeTransferHandler extends TransferHandler {
     private static final Logger log = LoggerFactory.getLogger(JMeterTreeTransferHandler.class);
 
     private DataFlavor nodeFlavor;
-    private DataFlavor[] jMeterTreeNodeDataFlavors = new DataFlavor[1];
+    private final DataFlavor[] jMeterTreeNodeDataFlavors = new DataFlavor[1];
 
     // hold the nodes that should be removed on drop
     private List<JMeterTreeNode> nodesForRemoval = null;
@@ -278,7 +278,7 @@ public class JMeterTreeTransferHandler extends TransferHandler {
     }
 
     private class NodesTransferable implements Transferable {
-        JMeterTreeNode[] nodes;
+        private final JMeterTreeNode[] nodes;
 
         public NodesTransferable(JMeterTreeNode[] nodes) {
             this.nodes = nodes;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FileListPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FileListPanel.java
@@ -55,15 +55,15 @@ public class FileListPanel extends JPanel implements ActionListener {
 
     private static final String LABEL_LIBRARY = "library"; // $NON-NLS-1$
 
-    private JButton browse = new JButton(JMeterUtils.getResString(ACTION_BROWSE));
+    private final JButton browse = new JButton(JMeterUtils.getResString(ACTION_BROWSE));
 
-    private JButton clear = new JButton(JMeterUtils.getResString("clear")); // $NON-NLS-1$
+    private final JButton clear = new JButton(JMeterUtils.getResString("clear")); // $NON-NLS-1$
 
-    private JButton delete = new JButton(JMeterUtils.getResString("delete")); // $NON-NLS-1$
+    private final JButton delete = new JButton(JMeterUtils.getResString("delete")); // $NON-NLS-1$
 
-    private List<ChangeListener> listeners = new ArrayList<>();
+    private final List<ChangeListener> listeners = new ArrayList<>();
 
-    private String title;
+    private final String title;
 
     private String filetype;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/HeaderAsPropertyRendererWrapper.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/HeaderAsPropertyRendererWrapper.java
@@ -32,7 +32,7 @@ import javax.swing.table.TableCellRenderer;
  */
 public class HeaderAsPropertyRendererWrapper implements TableCellRenderer {
 
-    private TableCellRenderer delegate;
+    private final TableCellRenderer delegate;
 
     /**
      * @param renderer {@link TableCellRenderer} to delegate to

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -217,7 +217,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
         this.add(helpMenu);
     }
 
-    private List<MenuCreator> findMenuCreators() {
+    private static List<MenuCreator> findMenuCreators() {
         List<MenuCreator> creators = new ArrayList<>();
         try {
             List<String> listClasses = ClassFinder.findClassesThatExtend(
@@ -342,7 +342,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
         addPluginsMenuItems(optionsMenu, menuCreators, MENU_LOCATION.OPTIONS);
     }
 
-    private JMenu createLaFMenu() {
+    private static JMenu createLaFMenu() {
         JMenu lafMenu = makeMenuRes("appearance", 'L');
         ButtonGroup lafGroup = new ButtonGroup();
         String currentLafCommand = LookAndFeelCommand.getPreferredLafCommand();
@@ -590,7 +590,7 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
      * @param menuCreators
      * @param location
      */
-    private void addPluginsMenuItems(JMenu menu, List<MenuCreator> menuCreators, MENU_LOCATION location) {
+    private static void addPluginsMenuItems(JMenu menu, List<MenuCreator> menuCreators, MENU_LOCATION location) {
         for (MenuCreator menuCreator : menuCreators) {
             JMenuItem[] menuItems = menuCreator.getMenuItemsAtLocation(location);
             if (menuItems.length != 0) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -78,19 +78,19 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
     private JMenuItem runStart;
     private JMenuItem runStartNoTimers;
     private JMenu remoteStart;
-    private Collection<JMenuItem> remoteEngineStart;
+    private final Collection<JMenuItem> remoteEngineStart;
     private JMenuItem runStop;
     private JMenuItem runShut;
     private JMenu remoteStop;
     private JMenu remoteShut;
-    private Collection<JMenuItem> remoteEngineStop;
-    private Collection<JMenuItem> remoteEngineShut;
+    private final Collection<JMenuItem> remoteEngineStop;
+    private final Collection<JMenuItem> remoteEngineShut;
     private JMenu optionsMenu;
     private JMenu helpMenu;
     private JMenu toolsMenu;
     private String[] remoteHosts;
     private JMenu remoteExit;
-    private Collection<JMenuItem> remoteEngineExit;
+    private final Collection<JMenuItem> remoteEngineExit;
     private JMenu searchMenu;
     private List<MenuCreator> menuCreators;
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
@@ -51,7 +51,7 @@ public final class JSyntaxSearchToolBar implements ActionListener {
     /**
      * The component where we Search
      */
-    private JSyntaxTextArea dataField;
+    private final JSyntaxTextArea dataField;
 
     /**
      * @param dataField {@link JSyntaxTextArea} to use for searching

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxSearchToolBar.java
@@ -114,7 +114,7 @@ public final class JSyntaxSearchToolBar implements ActionListener {
         }
     }
 
-    private SearchContext createSearchContext(String text, boolean forward, boolean matchCase,
+    private static SearchContext createSearchContext(String text, boolean forward, boolean matchCase,
             boolean isRegex) {
         SearchContext context = new SearchContext();
         context.setSearchFor(text);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/MenuInfo.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/MenuInfo.java
@@ -47,7 +47,7 @@ public class MenuInfo {
         sortOrder = getSortOrderFromName(classFullName);
     }
 
-    private int getSortOrderFromName(String classFullName) {
+    private static int getSortOrderFromName(String classFullName) {
         try {
             GUIMenuSortOrder menuSortOrder = Class.forName(classFullName, false, MenuInfo.class.getClassLoader())
                     .getDeclaredAnnotation(GUIMenuSortOrder.class);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaCellRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TextAreaCellRenderer.java
@@ -50,7 +50,7 @@ public class TextAreaCellRenderer implements TableCellRenderer {
      * @param value initial value
      * @return {@link JSyntaxTextArea}
      */
-    private JSyntaxTextArea createRenderer(String value) {
+    private static JSyntaxTextArea createRenderer(String value) {
         JSyntaxTextArea textArea = JSyntaxTextArea.getInstance(2, 50);
         textArea.setLanguage("text"); //$NON-NLS-1$
         textArea.setInitialText(value);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/TristateCheckBox.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/TristateCheckBox.java
@@ -343,7 +343,7 @@ public final class TristateCheckBox extends JCheckBox {
             g.drawLine(left, height - 1, right, height - 1);
         }
 
-        private void drawFlush3DBorder(Graphics g, int x, int y, int w, int h) {
+        private static void drawFlush3DBorder(Graphics g, int x, int y, int w, int h) {
             g.translate(x, y);
             g.setColor(MetalLookAndFeel.getControlDarkShadow());
             g.drawRect(0, 0, w - 2, h - 2);
@@ -355,7 +355,7 @@ public final class TristateCheckBox extends JCheckBox {
             g.translate(-x, -y);
         }
 
-        private void drawPressed3DBorder(Graphics g, int x, int y, int w, int h) {
+        private static void drawPressed3DBorder(Graphics g, int x, int y, int w, int h) {
             g.translate(x, y);
             drawFlush3DBorder(g, 0, 0, w, h);
             g.setColor(MetalLookAndFeel.getControlShadow());

--- a/src/core/src/main/java/org/apache/jmeter/plugin/PluginManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/plugin/PluginManager.java
@@ -27,8 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class PluginManager {
-    private static final PluginManager instance = new PluginManager();
-
     private static final Logger log = LoggerFactory.getLogger(PluginManager.class);
 
     private PluginManager() {
@@ -44,11 +42,11 @@ public final class PluginManager {
      */
     public static void install(JMeterPlugin plugin, boolean useGui) {
         if (useGui) {
-            instance.installPlugin(plugin);
+            PluginManager.installPlugin(plugin);
         }
     }
 
-    private void installPlugin(JMeterPlugin plugin) {
+    private static void installPlugin(JMeterPlugin plugin) {
         String[][] icons = plugin.getIconMappings();
         ClassLoader classloader = plugin.getClass().getClassLoader();
 

--- a/src/core/src/main/java/org/apache/jmeter/report/config/ReportGeneratorConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/ReportGeneratorConfiguration.java
@@ -281,8 +281,8 @@ public class ReportGeneratorConfiguration {
     private Map<String, Long[]> apdexPerTransaction = new HashMap<>();
     private Pattern filteredSamplesPattern;
     private boolean ignoreTCFromTop5ErrorsBySampler;
-    private Map<String, ExporterConfiguration> exportConfigurations = new HashMap<>();
-    private Map<String, GraphConfiguration> graphConfigurations = new HashMap<>();
+    private final Map<String, ExporterConfiguration> exportConfigurations = new HashMap<>();
+    private final Map<String, GraphConfiguration> graphConfigurations = new HashMap<>();
 
     /**
      * Gets the overall sample filter.

--- a/src/core/src/main/java/org/apache/jmeter/report/config/SubConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/SubConfiguration.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class SubConfiguration {
 
-    private HashMap<String, String> properties = new HashMap<>();
+    private final HashMap<String, String> properties = new HashMap<>();
 
     /**
      * Gets the properties of the item.

--- a/src/core/src/main/java/org/apache/jmeter/report/core/AbstractSampleWriter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/AbstractSampleWriter.java
@@ -51,7 +51,7 @@ public abstract class AbstractSampleWriter extends SampleWriter {
 
     private static final String CHARSET = SaveService.getFileEncoding(StandardCharsets.UTF_8.displayName());
 
-    private static Logger log = LoggerFactory.getLogger(AbstractSampleWriter.class);
+    private static final Logger log = LoggerFactory.getLogger(AbstractSampleWriter.class);
 
     /** output writer to write samples to */
     protected PrintWriter writer;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvFile.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvFile.java
@@ -32,7 +32,7 @@ public class CsvFile extends File {
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 4721600093557427167L;
-    private char separator;
+    private final char separator;
 
     public CsvFile(File parent, String child, char separator) {
         super(parent, child);

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleReader.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleReader.java
@@ -61,19 +61,19 @@ public class CsvSampleReader implements Closeable{
                             SampleSaveConfiguration.DEFAULT_DELIMITER))
                     .charAt(0);
 
-    private File file;
+    private final File file;
     private InputStream fis;
     private Reader isr;
     private BufferedReader reader;
-    private char separator;
+    private final char separator;
     private long row;
-    private SampleMetadata metadata;
-    private int columnCount;
+    private final SampleMetadata metadata;
+    private final int columnCount;
     private Sample lastSampleRead;
     /**
      * Number of sample_variables if csv file has no header
      */
-    private int numberOfSampleVariablesInCsv;
+    private final int numberOfSampleVariablesInCsv;
 
     /**
      * Instantiates a new csv sample reader.

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleWriter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleWriter.java
@@ -38,13 +38,13 @@ import org.apache.jmeter.save.CSVSaveService;
 public class CsvSampleWriter extends AbstractSampleWriter {
 
     /** The number of columns for each row */
-    private int columnCount;
+    private final int columnCount;
 
     /** The separator to be used in between data on each row */
     private char separator;
 
     /** Description of the columns */
-    private SampleMetadata metadata;
+    private final SampleMetadata metadata;
 
     /** Number of samples written */
     private long sampleCount;

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleBuilder.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleBuilder.java
@@ -50,9 +50,9 @@ public class SampleBuilder {
 
     private final SampleMetadata metadata;
 
-    private String[] data;
+    private final String[] data;
 
-    private NumberFormat floatFormatter;
+    private final NumberFormat floatFormatter;
 
     private int k = 0;
 

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetadata.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetadata.java
@@ -42,7 +42,7 @@ public class SampleMetadata {
     List<String> columns;
 
     /** Index to map column names to their corresponding indexes */
-    private TreeMap<String, Integer> index = new TreeMap<>();
+    private final TreeMap<String, Integer> index = new TreeMap<>();
 
     /** character separator used for separating columns */
     private char separator;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
@@ -96,7 +96,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
      * @param value Value
      * @param context {@link DataContext}
      */
-    private void addToContext(String key, Object value, DataContext context) {
+    private static void addToContext(String key, Object value, DataContext context) {
         if (value instanceof String) {
             value = '"' + (String) value + '"';
         }
@@ -275,7 +275,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
         }
     }
 
-    private boolean htmlReportFileFilter(File file) {
+    private static boolean htmlReportFileFilter(File file) {
         String fileName = file.getName();
         boolean isIndexHtmlFile = file.isFile() && fileName.equals("index.html");
         boolean isContentOrAdmin = fileName.equals("content") || fileName.startsWith("sbadmin2-");
@@ -324,7 +324,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
             outputDir = new File(globallyDefinedOutputDir);
         }
 
-        JOrphanUtils.canSafelyWriteToFolder(outputDir, this::htmlReportFileFilter);
+        JOrphanUtils.canSafelyWriteToFolder(outputDir, HtmlTemplateExporter::htmlReportFileFilter);
 
         if (log.isInfoEnabled()) {
             log.info("Will generate dashboard in folder: {}", outputDir.getAbsolutePath());
@@ -463,13 +463,13 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
         log.debug("End of template processing");
     }
 
-    private <T> void addResultToContext(
+    private static <T> void addResultToContext(
             String resultKey, Map<String, Object> storage,
             DataContext dataContext, ResultDataVisitor<T> visitor) {
         addResultToContext(resultKey, storage, dataContext, visitor, null, null);
     }
 
-    private <T> void addResultToContext(
+    private static <T> void addResultToContext(
             String resultKey, Map<String, Object> storage, DataContext dataContext,
             ResultDataVisitor<T> visitor, ResultCustomizer customizer, ResultChecker checker) {
         Object data = storage.get(resultKey);
@@ -485,7 +485,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
         }
     }
 
-    private long formatTimestamp(String key, DataContext context) {
+    private static long formatTimestamp(String key, DataContext context) {
         // FIXME Why convert to double then long (rounding ?)
         double result = Double.parseDouble((String) context.get(key));
         long timestamp = (long) result;

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/JsonExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/JsonExporter.java
@@ -115,7 +115,7 @@ public class JsonExporter extends AbstractDataExporter {
         return outputDir;
     }
 
-    private void createStatistic(Map<String, SamplingStatistic> statistics, MapResultData resultData) {
+    private static void createStatistic(Map<String, SamplingStatistic> statistics, MapResultData resultData) {
         LOGGER.debug("Creating statistics for result data:{}", resultData);
         SamplingStatistic statistic = new SamplingStatistic();
         ListResultData listResultData = (ListResultData) resultData.getResult("data");

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/ReportGenerator.java
@@ -296,7 +296,7 @@ public class ReportGenerator {
         return dateRangeFilter;
     }
 
-    private void removeTempDir(File tmpDir, boolean tmpDirCreated) {
+    private static void removeTempDir(File tmpDir, boolean tmpDirCreated) {
         if (tmpDirCreated) {
             try {
                 FileUtils.deleteDirectory(tmpDir);
@@ -306,7 +306,7 @@ public class ReportGenerator {
         }
     }
 
-    private boolean createTempDir(File tmpDir) throws GenerationException {
+    private static boolean createTempDir(File tmpDir) throws GenerationException {
         if (tmpDir.exists()) {
             return false;
         }
@@ -322,7 +322,7 @@ public class ReportGenerator {
         return true;
     }
 
-    private void addGraphConsumer(FilterConsumer nameFilter,
+    private static void addGraphConsumer(FilterConsumer nameFilter,
             FilterConsumer excludeControllerFilter,
             Map.Entry<String, GraphConfiguration> entryGraphCfg)
             throws GenerationException {
@@ -389,13 +389,13 @@ public class ReportGenerator {
         }
     }
 
-    private ErrorsSummaryConsumer createErrorsSummaryConsumer() {
+    private static ErrorsSummaryConsumer createErrorsSummaryConsumer() {
         ErrorsSummaryConsumer errorsSummaryConsumer = new ErrorsSummaryConsumer();
         errorsSummaryConsumer.setName(ERRORS_SUMMARY_CONSUMER_NAME);
         return errorsSummaryConsumer;
     }
 
-    private FilterConsumer createExcludeControllerFilter() {
+    private static FilterConsumer createExcludeControllerFilter() {
         FilterConsumer excludeControllerFilter = new FilterConsumer();
         excludeControllerFilter
                 .setName(START_INTERVAL_CONTROLLER_FILTER_CONSUMER_NAME);
@@ -406,7 +406,7 @@ public class ReportGenerator {
         return excludeControllerFilter;
     }
 
-    private SampleConsumer createTop5ErrorsConsumer(ReportGeneratorConfiguration configuration) {
+    private static SampleConsumer createTop5ErrorsConsumer(ReportGeneratorConfiguration configuration) {
         Top5ErrorsBySamplerConsumer top5ErrorsBySamplerConsumer = new Top5ErrorsBySamplerConsumer();
         top5ErrorsBySamplerConsumer.setName(TOP5_ERRORS_BY_SAMPLER_CONSUMER_NAME);
         top5ErrorsBySamplerConsumer.setHasOverallResult(true);
@@ -414,14 +414,14 @@ public class ReportGenerator {
         return top5ErrorsBySamplerConsumer;
     }
 
-    private StatisticsSummaryConsumer createStatisticsSummaryConsumer() {
+    private static StatisticsSummaryConsumer createStatisticsSummaryConsumer() {
         StatisticsSummaryConsumer statisticsSummaryConsumer = new StatisticsSummaryConsumer();
         statisticsSummaryConsumer.setName(STATISTICS_SUMMARY_CONSUMER_NAME);
         statisticsSummaryConsumer.setHasOverallResult(true);
         return statisticsSummaryConsumer;
     }
 
-    private RequestsSummaryConsumer createRequestsSummaryConsumer() {
+    private static RequestsSummaryConsumer createRequestsSummaryConsumer() {
         RequestsSummaryConsumer requestsSummaryConsumer = new RequestsSummaryConsumer();
         requestsSummaryConsumer.setName(REQUESTS_SUMMARY_CONSUMER_NAME);
         return requestsSummaryConsumer;
@@ -459,7 +459,7 @@ public class ReportGenerator {
         return apdexSummaryConsumer;
     }
 
-    private boolean isMatching(String sampleName, String keyName) {
+    private static boolean isMatching(String sampleName, String keyName) {
         if (sampleName == null) {
             return false;
         }
@@ -497,7 +497,7 @@ public class ReportGenerator {
     /**
      * @return Consumer that compute the end date of the test
      */
-    private AggregateConsumer createEndDateConsumer() {
+    private static AggregateConsumer createEndDateConsumer() {
         AggregateConsumer endDateConsumer = new AggregateConsumer(
                 new MaxAggregator(), sample -> (double) sample.getEndTime());
         endDateConsumer.setName(END_DATE_CONSUMER_NAME);
@@ -507,7 +507,7 @@ public class ReportGenerator {
     /**
      * @return Consumer that compute the begining date of the test
      */
-    private AggregateConsumer createBeginDateConsumer() {
+    private static AggregateConsumer createBeginDateConsumer() {
         AggregateConsumer beginDateConsumer = new AggregateConsumer(
                 new MinAggregator(), sample -> (double) sample.getStartTime());
         beginDateConsumer.setName(BEGIN_DATE_CONSUMER_NAME);
@@ -528,7 +528,7 @@ public class ReportGenerator {
      * @throws GenerationException    if conversion of the property value fails or reflection
      *                                throws an InvocationTargetException
      */
-    private void setProperty(String className, Object obj, Method[] methods,
+    private static void setProperty(String className, Object obj, Method[] methods,
             String propertyName, String propertyValue, String setterName)
             throws IllegalAccessException, GenerationException {
         try {

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleConsumer.java
@@ -60,7 +60,7 @@ public abstract class AbstractSampleConsumer extends AbstractSampleProcessor
      * index of sample metadata consumed by this consumer. Indexed by channel
      * numbers
      */
-    private Map<Integer, SampleMetadata> consumedMetadata = new TreeMap<>();
+    private final Map<Integer, SampleMetadata> consumedMetadata = new TreeMap<>();
 
     /**
      * Gets the data identified by the specified key from the current sample

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleProcessor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AbstractSampleProcessor.java
@@ -30,7 +30,7 @@ public class AbstractSampleProcessor implements SampleProcessor {
 
     private SampleContext sampleContext;
 
-    private ArrayList<ChannelContext> channelContexts = new ArrayList<>();
+    private final ArrayList<ChannelContext> channelContexts = new ArrayList<>();
 
     /*
      * (non-Javadoc)

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/AggregateConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/AggregateConsumer.java
@@ -32,10 +32,10 @@ public class AggregateConsumer extends AbstractSampleConsumer {
     private static final String MUST_NOT_BE_NULL = "%s must not be null";
 
     /** The aggregator. */
-    private Aggregator aggregator;
+    private final Aggregator aggregator;
 
     /** The selector. */
-    private SampleSelector<Double> selector;
+    private final SampleSelector<Double> selector;
 
     /**
      * Gets the aggregator.

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryConsumer.java
@@ -141,7 +141,7 @@ public class ApdexSummaryConsumer extends
 
     }
 
-    private double getApdex(ApdexSummaryData data) {
+    private static double getApdex(ApdexSummaryData data) {
         return (data.getSatisfiedCount() + (double) data.getToleratedCount() / 2)
                 / data.getTotalCount();
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
@@ -141,7 +141,7 @@ public class CsvFileSampleSource extends AbstractSampleSource {
     /**
      * Get the current time in milliseconds
      */
-    private long now() {
+    private static long now() {
         return System.currentTimeMillis();
     }
 
@@ -151,7 +151,7 @@ public class CsvFileSampleSource extends AbstractSampleSource {
      *
      * @return A readable string that displays the time provided as milliseconds
      */
-    private String time(long t) {
+    private static String time(long t) {
         return TimeHelper.time(t);
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
@@ -69,13 +69,13 @@ public class CsvFileSampleSource extends AbstractSampleSource {
     private static final Logger LOG = LoggerFactory.getLogger(CsvFileSampleSource.class);
 
     /** input csv files to be produced */
-    private File[] inputFiles;
+    private final File[] inputFiles;
 
     /** csv readers corresponding to the input files */
-    private CsvSampleReader[] csvReaders;
+    private final CsvSampleReader[] csvReaders;
 
     /** mock producer to produce samples to its consumers */
-    private PrivateProducer producer;
+    private final PrivateProducer producer;
 
     /**
      * Build a sample source from the specified input file and character

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ExternalSampleSorter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ExternalSampleSorter.java
@@ -91,9 +91,9 @@ public class ExternalSampleSorter extends AbstractSampleConsumer {
 
     private final BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>();
 
-    private ThreadPoolExecutor pool;
+    private final ThreadPoolExecutor pool;
 
-    private volatile int nbProcessors;
+    private final int nbProcessors;
 
     private boolean parallelize;
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ListResultData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ListResultData.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class ListResultData implements ResultData, Iterable<ResultData> {
 
-    private List<ResultData> items = new ArrayList<>();
+    private final List<ResultData> items = new ArrayList<>();
 
     /*
      * (non-Javadoc)

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MapResultData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MapResultData.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public class MapResultData implements ResultData {
 
-    private Map<String, ResultData> map = new HashMap<>();
+    private final Map<String, ResultData> map = new HashMap<>();
 
     /*
      * (non-Javadoc)

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/MeanAggregator.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/MeanAggregator.java
@@ -26,7 +26,7 @@ import org.apache.commons.math3.stat.descriptive.moment.Mean;
  */
 public class MeanAggregator implements Aggregator {
 
-    private Mean mean = new Mean();
+    private final Mean mean = new Mean();
 
     /*
      * (non-Javadoc)

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/SampleContext.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/SampleContext.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class SampleContext {
 
     private File workingDirectory;
-    private Map<String, Object> data = new HashMap<>();
+    private final Map<String, Object> data = new HashMap<>();
 
     /**
      * Return the root directory that consumers are authorized to use for

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryConsumer.java
@@ -68,7 +68,7 @@ public class StatisticsSummaryConsumer extends
      * @param data {@link StatisticsSummaryData}
      * @param isOverall boolean indicating if aggregation concerns the Overall results in which case we ignore Transaction Controller's SampleResult
      */
-    private void aggregateSample(Sample sample, StatisticsSummaryData data, boolean isOverall) {
+    private static void aggregateSample(Sample sample, StatisticsSummaryData data, boolean isOverall) {
         if(isOverall && sample.isController()) {
             return;
         }
@@ -201,7 +201,7 @@ public class StatisticsSummaryConsumer extends
         return titles;
     }
 
-    private String formatPercentile(String percentileLabel) {
+    private static String formatPercentile(String percentileLabel) {
         return String.format(JMeterUtils.getResString("reportgenerator_summary_statistics_percentile_fmt"),
                 percentileLabel);
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/StatisticsSummaryConsumer.java
@@ -81,11 +81,11 @@ public class StatisticsSummaryConsumer extends
         }
 
         long elapsedTime = sample.getElapsedTime();
-        data.getPercentile1().addValue(elapsedTime);
-        data.getPercentile2().addValue(elapsedTime);
-        data.getPercentile3().addValue(elapsedTime);
-        data.getMean().addValue(elapsedTime);
-        data.getMedian().addValue(elapsedTime);
+        data.getPercentile1().addValue((double) elapsedTime);
+        data.getPercentile2().addValue((double) elapsedTime);
+        data.getPercentile3().addValue((double) elapsedTime);
+        data.getMean().addValue((double) elapsedTime);
+        data.getMedian().addValue((double) elapsedTime);
         data.setMin(elapsedTime);
         data.setMax(elapsedTime);
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/TaggerConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/TaggerConsumer.java
@@ -38,7 +38,7 @@ public class TaggerConsumer<TIndex> extends AbstractSampleConsumer {
     public static final String DEFAULT_TAG_LABEL = "Tag";
 
     // Collection of sample builders for channels
-    private ArrayList<SampleBuilder> builders = new ArrayList<>();
+    private final ArrayList<SampleBuilder> builders = new ArrayList<>();
     private SampleIndexer<TIndex> sampleIndexer;
     private String tagLabel = DEFAULT_TAG_LABEL;
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsSummaryData.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsSummaryData.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class Top5ErrorsSummaryData {
 
     private static final Long ONE = 1L;
-    private Map<String, Long> countPerError;
+    private final Map<String, Long> countPerError;
     private long total;
     private long errors;
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphConsumer.java
@@ -216,13 +216,13 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
 
     protected abstract Map<String, GroupInfo> createGroupInfos();
 
-    private void setMinResult(MapResultData result, String name, Double value) {
+    private static void setMinResult(MapResultData result, String name, Double value) {
         ValueResultData valueResult = (ValueResultData) result.getResult(name);
         valueResult.setValue(Math.min((Double) valueResult.getValue(),
                 value));
     }
 
-    private void setMaxResult(MapResultData result, String name, Double value) {
+    private static void setMaxResult(MapResultData result, String name, Double value) {
         ValueResultData valueResult = (ValueResultData) result.getResult(name);
         valueResult.setValue(Math.max((Double) valueResult.getValue(),
                 value));
@@ -375,8 +375,8 @@ public abstract class AbstractGraphConsumer extends AbstractSampleConsumer {
     /**
      * Aggregate a value to the aggregator defined by the specified parameters.
      */
-    private void aggregateValue(AggregatorFactory factory, SeriesData data,
-                                Double key, double value) {
+    private static void aggregateValue(AggregatorFactory factory, SeriesData data,
+                                       Double key, double value) {
         Map<Double, Aggregator> aggInfo = data.getAggregatorInfo();
 
         // Get or create aggregator

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphValueSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractGraphValueSelector.java
@@ -24,7 +24,7 @@ import org.apache.jmeter.samplers.SampleResult;
  * Base class allowing to select whether we ignore or not TC Sample Results
  */
 abstract class AbstractGraphValueSelector implements GraphValueSelector {
-    private boolean ignoreTransactionController;
+    private final boolean ignoreTransactionController;
 
     /**
      *

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractVersusRequestsGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractVersusRequestsGraphConsumer.java
@@ -207,9 +207,9 @@ public abstract class AbstractVersusRequestsGraphConsumer extends
         }
 
         // Collection of sample builders for channels
-        private ArrayList<SampleBuilder> builders = new ArrayList<>();
-        private ArrayList<FileInfo> fileInfos = new ArrayList<>();
-        private Map<Long, Long> counts = new HashMap<>();
+        private final ArrayList<SampleBuilder> builders = new ArrayList<>();
+        private final ArrayList<FileInfo> fileInfos = new ArrayList<>();
+        private final Map<Long, Long> counts = new HashMap<>();
         boolean createdWorkDir = false;
         private final AbstractVersusRequestsGraphConsumer parent;
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/BytesThroughputGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/BytesThroughputGraphConsumer.java
@@ -90,18 +90,6 @@ public class BytesThroughputGraphConsumer extends AbstractOverTimeGraphConsumer 
                 new GroupInfo(new TimeRateAggregatorFactory(), seriesSelector, graphValueSelector, false, false));
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.jmeter.report.csv.processor.impl.AbstractOverTimeGraphConsumer
-     * #setGranularity(long)
-     */
-    @Override
-    public void setGranularity(long granularity) {
-        super.setGranularity(granularity);
-    }
-
     @Override
     public void initialize() {
         super.initialize();

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CodesPerSecondGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CodesPerSecondGraphConsumer.java
@@ -78,16 +78,4 @@ public class CodesPerSecondGraphConsumer extends AbstractOverTimeGraphConsumer {
                 .getAggregatorFactory())
                 .setGranularity(getGranularity());
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.jmeter.report.csv.processor.impl.AbstractOverTimeGraphConsumer
-     * #setGranularity(long)
-     */
-    @Override
-    public void setGranularity(long granularity) {
-        super.setGranularity(granularity);
-    }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/HitsPerSecondGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/HitsPerSecondGraphConsumer.java
@@ -66,19 +66,6 @@ public class HitsPerSecondGraphConsumer extends AbstractOverTimeGraphConsumer {
                         new CountValueSelector(true), false, false));
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.jmeter.report.csv.processor.impl.AbstractOverTimeGraphConsumer
-     * #setGranularity(long)
-     */
-    @Override
-    public void setGranularity(long granularity) {
-        super.setGranularity(granularity);
-
-    }
-
     @Override
     public void initialize() {
         super.initialize();
@@ -90,17 +77,5 @@ public class HitsPerSecondGraphConsumer extends AbstractOverTimeGraphConsumer {
         ((StaticSeriesSelector) getGroupInfos().get(
                 AbstractGraphConsumer.DEFAULT_GROUP).getSeriesSelector())
                 .setSeriesName(getName());
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.jmeter.report.csv.processor.AbstractSampleConsumer#setName
-     * (java.lang.String)
-     */
-    @Override
-    public void setName(String name) {
-        super.setName(name);
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePerSampleGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePerSampleGraphConsumer.java
@@ -72,7 +72,7 @@ public class ResponseTimePerSampleGraphConsumer extends AbstractGraphConsumer {
      * @param defaultValue the default value
      * @return the group info
      */
-    private GroupInfo createGroupInfo(String propertyKey, int defaultValue) {
+    private static GroupInfo createGroupInfo(String propertyKey, int defaultValue) {
         int property = JMeterUtils.getPropDefault(propertyKey, defaultValue);
         PercentileAggregatorFactory factory = new PercentileAggregatorFactory();
         factory.setPercentileIndex(property);

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesOverTimeGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/ResponseTimePercentilesOverTimeGraphConsumer.java
@@ -74,29 +74,29 @@ public class ResponseTimePercentilesOverTimeGraphConsumer
         return groupInfos;
     }
 
-    private String formatPercentile(String percentileLabel) {
+    private static String formatPercentile(String percentileLabel) {
         return String.format("%sth percentile", percentileLabel);
     }
 
-    private GroupInfo createMinGroupInfo() {
+    private static GroupInfo createMinGroupInfo() {
         StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
         seriesSelector.setSeriesName("Min");
         return createGroupInfo(new MinAggregatorFactory(), seriesSelector);
     }
 
-    private GroupInfo createMaxGroupInfo() {
+    private static GroupInfo createMaxGroupInfo() {
         StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
         seriesSelector.setSeriesName("Max");
         return createGroupInfo(new MaxAggregatorFactory(), seriesSelector);
     }
 
-    private GroupInfo createMedianGroupInfo() {
+    private static GroupInfo createMedianGroupInfo() {
         StaticSeriesSelector seriesSelector = new StaticSeriesSelector();
         seriesSelector.setSeriesName("Median");
         return createGroupInfo(new MedianAggregatorFactory(), seriesSelector);
     }
 
-    private GroupInfo createPercentileGroupInfo(String propKey, String label) {
+    private static GroupInfo createPercentileGroupInfo(String propKey, String label) {
         String seriesName = formatPercentile(label);
         double defaultValue = new BigDecimal(label).setScale(2, RoundingMode.CEILING).doubleValue();
         double property = JMeterUtils.getPropDefault(propKey, defaultValue);
@@ -108,7 +108,7 @@ public class ResponseTimePercentilesOverTimeGraphConsumer
         return createGroupInfo(factory, seriesSelector);
     }
 
-    private GroupInfo createGroupInfo(AggregatorFactory aggregationFactory, StaticSeriesSelector seriesSelector) {
+    private static GroupInfo createGroupInfo(AggregatorFactory aggregationFactory, StaticSeriesSelector seriesSelector) {
         return new GroupInfo(
                 aggregationFactory,
                 seriesSelector,

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TotalTPSGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/TotalTPSGraphConsumer.java
@@ -82,18 +82,6 @@ public class TotalTPSGraphConsumer extends AbstractOverTimeGraphConsumer {
                         new CountValueSelector(false), false, false));
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.jmeter.report.csv.processor.impl.AbstractOverTimeGraphConsumer
-     * #setGranularity(long)
-     */
-    @Override
-    public void setGranularity(long granularity) {
-        super.setGranularity(granularity);
-    }
-
     @Override
     protected void initializeExtraResults(MapResultData parentResult) {
         super.initializeExtraResults(parentResult);

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
@@ -341,22 +341,6 @@ public class ResultSaver extends AbstractTestElement implements NoThreadClone, S
         int num;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj);
-    }
-
     public void setAddTimestamp(boolean selected) {
         setProperty(ADD_TIMESTAMP, selected, false);
     }

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultSaver.java
@@ -223,7 +223,7 @@ public class ResultSaver extends AbstractTestElement implements NoThreadClone, S
      * Create path hierarchy to parentFile
      * @param parentFile
      */
-    private void createFoldersIfNeeded(File parentFile) {
+    private static void createFoldersIfNeeded(File parentFile) {
         if(parentFile == null) {
             return;
         }

--- a/src/core/src/main/java/org/apache/jmeter/reporters/Summariser.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/Summariser.java
@@ -319,7 +319,7 @@ public class Summariser extends AbstractTestElement
         }
     }
 
-    private void formatAndWriteToLog(String name, SummariserRunningSample summariserRunningSample, String type) {
+    private static void formatAndWriteToLog(String name, SummariserRunningSample summariserRunningSample, String type) {
         if (TOOUT || (TOLOG && log.isInfoEnabled())) {
             String formattedMessage = format(name, summariserRunningSample, type);
             if (TOLOG) {

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultSaverGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/ResultSaverGui.java
@@ -217,13 +217,13 @@ public class ResultSaverGui extends AbstractListenerGui implements Clearable { /
         // NOOP
     }
 
-    private void addField(JPanel panel, JCheckBox field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JCheckBox field, GridBagConstraints gbc) {
         gbc.weightx = 2;
         gbc.fill=GridBagConstraints.HORIZONTAL;
         panel.add(field, gbc.clone());
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -233,14 +233,14 @@ public class ResultSaverGui extends AbstractListenerGui implements Clearable { /
     }
 
     // Next line
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/core/src/main/java/org/apache/jmeter/reporters/gui/SummariserGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/gui/SummariserGui.java
@@ -43,11 +43,6 @@ public class SummariserGui extends AbstractListenerGui {
         return "summariser_title"; //$NON-NLS-1$
     }
 
-    @Override
-    public void configure(TestElement el) {
-        super.configure(el);
-    }
-
     /**
      * @see org.apache.jmeter.gui.JMeterGUIComponent#createTestElement()
      */

--- a/src/core/src/main/java/org/apache/jmeter/rmi/SSLRMIClientSocketFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/rmi/SSLRMIClientSocketFactory.java
@@ -117,7 +117,7 @@ public class SSLRMIClientSocketFactory
         return factory.createSocket(host, port);
     }
 
-    private KeyStore loadStore(String location, char[] passphrase, String type)
+    private static KeyStore loadStore(String location, char[] passphrase, String type)
             throws IOException {
         try {
             KeyStore store = KeyStore.getInstance(type);

--- a/src/core/src/main/java/org/apache/jmeter/rmi/SSLRMIServerSocketFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/rmi/SSLRMIServerSocketFactory.java
@@ -142,7 +142,7 @@ public class SSLRMIServerSocketFactory implements RMIServerSocketFactory, Serial
         return socket;
     }
 
-    private KeyStore loadStore(String location, char[] passphrase, String type)
+    private static KeyStore loadStore(String location, char[] passphrase, String type)
             throws IOException {
         try (FileInputStream fileInputStream = new FileInputStream(location)){
             KeyStore store = KeyStore.getInstance(type);

--- a/src/core/src/main/java/org/apache/jmeter/samplers/DataStrippingSampleSender.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/DataStrippingSampleSender.java
@@ -107,7 +107,7 @@ public class DataStrippingSampleSender extends AbstractSampleSender implements S
         }
     }
 
-    private void stripContent(SampleResult result, int level) {
+    private static void stripContent(SampleResult result, int level) {
         if (level < 0) {
             return;
         }
@@ -123,7 +123,7 @@ public class DataStrippingSampleSender extends AbstractSampleSender implements S
      * Strip response but fill in bytes field.
      * @param result {@link SampleResult}
      */
-    private void stripResponse(SampleResult result) {
+    private static void stripResponse(SampleResult result) {
         result.setBytes(result.getBytesAsLong());
         result.setResponseData(EMPTY_BA);
     }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/Entry.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/Entry.java
@@ -84,7 +84,7 @@ public class Entry {
         }
     }
 
-    private ConfigElement cloneIfNecessary(ConfigElement config) {
+    private static ConfigElement cloneIfNecessary(ConfigElement config) {
         if (config.expectsModification()) {
             return config;
         }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/Entry.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/Entry.java
@@ -28,11 +28,11 @@ import org.apache.jmeter.config.ConfigElement;
 // TODO - the class contents are not used at present - could perhaps be removed
 public class Entry {
 
-    private Map<Class<?>, ConfigElement> configSet;
+    private final Map<Class<?>, ConfigElement> configSet;
 
     private Class<?> sampler;
 
-    private List<Assertion> assertions;
+    private final List<Assertion> assertions;
 
     public Entry() {
         configSet = new HashMap<>();

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleSaveConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleSaveConfiguration.java
@@ -464,6 +464,8 @@ public class SampleSaveConfiguration implements Cloneable, Serializable {
     private boolean idleTime = IDLE_TIME;
 
     // Does not appear to be used (yet)
+    // it is
+    @SuppressWarnings("FieldCanBeStatic")
     private final int assertionsResultsToSave = ASSERTIONS_RESULT_TO_SAVE;
 
     // Don't save this, as it is derived from the time format

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleSaveConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleSaveConfiguration.java
@@ -464,7 +464,7 @@ public class SampleSaveConfiguration implements Cloneable, Serializable {
     private boolean idleTime = IDLE_TIME;
 
     // Does not appear to be used (yet)
-    private int assertionsResultsToSave = ASSERTIONS_RESULT_TO_SAVE;
+    private final int assertionsResultsToSave = ASSERTIONS_RESULT_TO_SAVE;
 
     // Don't save this, as it is derived from the time format
     private boolean printMilliseconds = PRINT_MILLISECONDS;

--- a/src/core/src/main/java/org/apache/jmeter/samplers/StatisticalSampleSender.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/StatisticalSampleSender.java
@@ -51,7 +51,7 @@ public class StatisticalSampleSender extends AbstractSampleSender implements Ser
             DEFAULT_TIME_THRESHOLD);
 
     // should the samples be aggregated on thread name or thread group (default) ?
-    private static boolean KEY_ON_THREADNAME = JMeterUtils.getPropDefault("key_on_threadname", false);
+    private static final boolean KEY_ON_THREADNAME = JMeterUtils.getPropDefault("key_on_threadname", false);
 
     // Instance fields are constructed by the client when the instance is create in the test plan
     // and the field values are then transferred to the server copy by RMI serialisation/deserialisation

--- a/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
@@ -1075,8 +1075,6 @@ public final class CSVSaveService {
                                     + baos.toString() + "]");
                 }
                 break;
-            default:
-                throw new IllegalStateException("Unexpected state " + state);
             } // switch(state)
             if (push) {
                 if (ch == '\r') {// Remove following \n if present

--- a/src/core/src/main/java/org/apache/jmeter/save/SaveGraphicsService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/SaveGraphicsService.java
@@ -148,7 +148,7 @@ public class SaveGraphicsService {
      * @param filename
      * @return output stream created from the filename
      */
-    private FileOutputStream createFile(File filename) {
+    private static FileOutputStream createFile(File filename) {
         try {
             return new FileOutputStream(filename);
         } catch (FileNotFoundException e) {

--- a/src/core/src/main/java/org/apache/jmeter/save/ScriptWrapperConverter.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/ScriptWrapperConverter.java
@@ -97,7 +97,7 @@ public class ScriptWrapperConverter implements Converter {
         return wrap;
     }
 
-    private ConversionException createConversionException(Throwable e) {
+    private static ConversionException createConversionException(Throwable e) {
         final ConversionException conversionException = new ConversionException(e);
         StackTraceElement[] ste = e.getStackTrace();
         if (ste!=null){

--- a/src/core/src/main/java/org/apache/jmeter/save/converters/SampleSaveConfigurationConverter.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/converters/SampleSaveConfigurationConverter.java
@@ -145,7 +145,7 @@ public class SampleSaveConfigurationConverter  extends ReflectionConverter {
     }
 
     // Helper method to simplify marshall routine. Save if and only if true.
-    private void createNode(HierarchicalStreamWriter writer, boolean save, String node) {
+    private static void createNode(HierarchicalStreamWriter writer, boolean save, String node) {
         if (!save) {
             return;
         }

--- a/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
+++ b/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
@@ -419,7 +419,7 @@ public class FileServer {
         }
     }
 
-    private BufferedReader createBufferedReader(FileEntry fileEntry) throws IOException {
+    private static BufferedReader createBufferedReader(FileEntry fileEntry) throws IOException {
         if (!fileEntry.file.canRead() || !fileEntry.file.isFile()) {
             throw new IllegalArgumentException("File "+ fileEntry.file.getName()+ " must exist and be readable");
         }
@@ -455,7 +455,7 @@ public class FileServer {
         }
     }
 
-    private BufferedWriter createBufferedWriter(FileEntry fileEntry) throws IOException {
+    private static BufferedWriter createBufferedWriter(FileEntry fileEntry) throws IOException {
         OutputStream fos = Files.newOutputStream(fileEntry.file.toPath());
         OutputStreamWriter osw;
         // If file encoding is specified, write using that encoding, otherwise use default platform encoding
@@ -486,7 +486,7 @@ public class FileServer {
         closeFile(name, fileEntry);
     }
 
-    private void closeFile(String name, FileEntry fileEntry) throws IOException {
+    private static void closeFile(String name, FileEntry fileEntry) throws IOException {
         if (fileEntry != null && fileEntry.inputOutputObject != null) {
             log.info("Close: {}", name);
             fileEntry.inputOutputObject.close();

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/BooleanPropertyEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/BooleanPropertyEditor.java
@@ -38,7 +38,7 @@ public class BooleanPropertyEditor extends PropertyEditorSupport {
         return value instanceof Boolean ?  toString((Boolean) value) : null;
     }
 
-    private String toString(Boolean value) {
+    private static String toString(Boolean value) {
         return value ? TRUE : FALSE;
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FileEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/FileEditor.java
@@ -120,7 +120,7 @@ public class FileEditor implements PropertyEditor, ActionListener {
         setValue(toUnix(chooser.getSelectedFile()));
     }
 
-    private String toUnix(final File selectedFile) {
+    private static String toUnix(final File selectedFile) {
         if (File.separatorChar == '\\') {
             return FilenameUtils.separatorsToUnix(selectedFile.getPath());
         }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -380,7 +380,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      * @param descriptor
      * @return the wrapper editor
      */
-    private WrapperEditor createWrapperEditor(PropertyEditor typeEditor, PropertyDescriptor descriptor) {
+    private static WrapperEditor createWrapperEditor(PropertyEditor typeEditor, PropertyDescriptor descriptor) {
         String[] editorTags = typeEditor.getTags();
         String[] additionalTags = (String[]) descriptor.getValue(TAGS);
         String[] tags;
@@ -720,7 +720,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
          * @param d
          * @return the property's order attribute (zero by default)
          */
-        private Integer propertyOrder(PropertyDescriptor d) {
+        private static Integer propertyOrder(PropertyDescriptor d) {
             Integer order = (Integer) d.getValue(ORDER);
             if (order == null) {
                 order = 0;

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/PasswordEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/PasswordEditor.java
@@ -36,7 +36,7 @@ import javax.swing.JPasswordField;
  */
 public class PasswordEditor extends PropertyEditorSupport implements ActionListener, FocusListener {
 
-    private JPasswordField textField;
+    private final JPasswordField textField;
 
     /**
      * Value on which we started the editing. Used to avoid firing

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
@@ -176,7 +176,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
         this.firePropertyChange();
     }
 
-    private Collection<Object> convertCollection(Collection<?> values) {
+    private static Collection<Object> convertCollection(Collection<?> values) {
         List<Object> l = new ArrayList<>();
         for(Object obj : values) {
             if(obj instanceof TestElementProperty) {
@@ -240,14 +240,14 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
         table.addFocusListener(this);
     }
 
-    private Functor[] createWriters(List<String> propNames) {
+    private static Functor[] createWriters(List<String> propNames) {
         return propNames.stream()
                 .map(propName -> "set" + propName) // $NON-NLS-1$
                 .map(Functor::new)
                 .toArray(Functor[]::new);
     }
 
-    private Functor[] createReaders(Class<?> c, List<String> propNames) {
+    private static Functor[] createReaders(Class<?> c, List<String> propNames) {
         List<String> methodNames = Arrays.stream(c.getMethods())
                 .map(Method::getName)
                 .collect(Collectors.toList());
@@ -257,7 +257,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
                 .toArray(Functor[]::new);
     }
 
-    private Class<?>[] getArgsForWriter(Class<?> c, List<String> propNames) {
+    private static Class<?>[] getArgsForWriter(Class<?> c, List<String> propNames) {
         return propNames.stream()
                 .map(propName -> Arrays.stream(c.getMethods())
                         .filter(m -> m.getName().equals("set" + propName)) // $NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
@@ -260,7 +260,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
      * @param element
      * @param name
      */
-    private void setPropertyInElement(TestElement element, String name, Object value) {
+    private static void setPropertyInElement(TestElement element, String name, Object value) {
         JMeterProperty jprop = AbstractProperty.createProperty(value);
         jprop.setName(name);
         element.setProperty(jprop);

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/WrapperEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/WrapperEditor.java
@@ -226,7 +226,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
      * @throws Error
      *             always throws an error.
      */
-    private void shouldNeverHappen(String msg) {
+    private static void shouldNeverHappen(String msg) {
         throw new Error(msg); // Programming error: bail out.
     }
 
@@ -238,7 +238,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
      * @throws Error
      *             always throws one.
      */
-    private void shouldNeverHappen(Exception e) {
+    private static void shouldNeverHappen(Exception e) {
         throw new Error(e.toString()); // Programming error: bail out.
     }
 
@@ -249,7 +249,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
      * containing "${" as a valid expression.
      * TODO: improve, but keep returning true for "${}".
      */
-    private boolean isExpression(String text) {
+    private static boolean isExpression(String text) {
         return text.contains("${");//$NON-NLS-1$
     }
 
@@ -259,7 +259,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
      * @param text
      * @return true if text is a String and isExpression(text).
      */
-    private boolean isExpression(Object text) {
+    private static boolean isExpression(Object text) {
         return text instanceof String && isExpression((String) text);
     }
 
@@ -354,7 +354,7 @@ class WrapperEditor extends PropertyEditorSupport implements PropertyChangeListe
      * Fix bug in JVMs that return true/false rather than True/False
      * from the type editor getAsText() method
      */
-    private String fixGetAsTextBug(String asText) {
+    private static String fixGetAsTextBug(String asText) {
         if (asText == null){
             return null;
         }

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractScopedTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractScopedTestElement.java
@@ -162,12 +162,12 @@ public abstract class AbstractScopedTestElement extends AbstractTestElement {
         return sampleList;
     }
 
-    private void recurseResults(List<SampleResult> resultList, SampleResult sampleResult) {
+    private static void recurseResults(List<SampleResult> resultList, SampleResult sampleResult) {
         Collections.addAll(resultList, sampleResult.getSubResults());
         recurseResults(resultList, sampleResult.getSubResults(), 3);
     }
 
-    private void recurseResults(List<SampleResult> resultList, SampleResult[] sampleResult, int level) {
+    private static void recurseResults(List<SampleResult> resultList, SampleResult[] sampleResult, int level) {
         if (level < 0) {
             return;
         }

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -557,7 +557,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
     // It doesn't merge the inner properties one by one as MultiProperty would do.
     // Therefore we must not mark the enclosed properties of TestElementProperty as
     // temporary (Bug 65336)
-    private boolean isMergingEnclosedProperties(JMeterProperty property) {
+    private static boolean isMergingEnclosedProperties(JMeterProperty property) {
         return property instanceof MultiProperty && !(property instanceof TestElementProperty);
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterContext.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterContext.java
@@ -51,7 +51,7 @@ public class JMeterContext {
     private AbstractThreadGroup threadGroup;
     private int threadNum;
     private TestLogicalAction testLogicalAction = TestLogicalAction.CONTINUE;
-    private ConcurrentHashMap<String, Object> samplerContext = new ConcurrentHashMap<>(5);
+    private final ConcurrentHashMap<String, Object> samplerContext = new ConcurrentHashMap<>(5);
     private boolean recording;
 
     JMeterContext() {

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
@@ -446,7 +446,7 @@ public class JMeterThread implements Runnable, Interruptible {
      * the following method will try to find the sampler that really generate an error
      * @return {@link Sampler}
      */
-    private Sampler findRealSampler(Sampler sampler) {
+    private static Sampler findRealSampler(Sampler sampler) {
         Sampler realSampler = sampler;
         while (realSampler instanceof TransactionSampler) {
             realSampler = ((TransactionSampler) realSampler).getSubSampler();
@@ -685,7 +685,7 @@ public class JMeterThread implements Runnable, Interruptible {
      * @param transactionSampler
      * @return the listeners who should receive the sample result
      */
-    private List<SampleListener> getSampleListeners(SamplePackage samplePack, SamplePackage transactionPack, TransactionSampler transactionSampler) {
+    private static List<SampleListener> getSampleListeners(SamplePackage samplePack, SamplePackage transactionPack, TransactionSampler transactionSampler) {
         List<SampleListener> sampleListeners = samplePack.getSampleListeners();
         // Do not send subsamples to listeners which receive the transaction sample
         if(transactionSampler != null) {
@@ -713,7 +713,7 @@ public class JMeterThread implements Runnable, Interruptible {
     /**
      * Store {@link JMeterThread#LAST_SAMPLE_OK} in JMeter Variables context
      */
-    private void setLastSampleOk(JMeterVariables variables, boolean value) {
+    private static void setLastSampleOk(JMeterVariables variables, boolean value) {
         variables.put(LAST_SAMPLE_OK, Boolean.toString(value));
     }
 
@@ -894,7 +894,7 @@ public class JMeterThread implements Runnable, Interruptible {
         log.info("Stop Thread detected by thread: {}", threadName);
     }
 
-    private void checkAssertions(List<Assertion> assertions, SampleResult parent, JMeterContext threadContext) {
+    private static void checkAssertions(List<Assertion> assertions, SampleResult parent, JMeterContext threadContext) {
         for (Assertion assertion : assertions) {
             TestBeanHelper.prepare((TestElement) assertion);
             if (assertion instanceof AbstractScopedAssertion) {
@@ -916,7 +916,7 @@ public class JMeterThread implements Runnable, Interruptible {
         setLastSampleOk(threadContext.getVariables(), parent.isSuccessful());
     }
 
-    private void recurseAssertionChecks(SampleResult parent, Assertion assertion, int level) {
+    private static void recurseAssertionChecks(SampleResult parent, Assertion assertion, int level) {
         if (level < 0) {
             return;
         }
@@ -938,7 +938,7 @@ public class JMeterThread implements Runnable, Interruptible {
         }
     }
 
-    private void processAssertion(SampleResult result, Assertion assertion) {
+    private static void processAssertion(SampleResult result, Assertion assertion) {
         AssertionResult assertionResult;
         try {
             assertionResult = assertion.getResult(result);
@@ -962,14 +962,14 @@ public class JMeterThread implements Runnable, Interruptible {
         result.addAssertionResult(assertionResult);
     }
 
-    private void runPostProcessors(List<PostProcessor> extractors) {
+    private static void runPostProcessors(List<PostProcessor> extractors) {
         for (PostProcessor ex : extractors) {
             TestBeanHelper.prepare((TestElement) ex);
             ex.process();
         }
     }
 
-    private void runPreProcessors(List<PreProcessor> preProcessors) {
+    private static void runPreProcessors(List<PreProcessor> preProcessors) {
         for (PreProcessor ex : preProcessors) {
             if (log.isDebugEnabled()) {
                 log.debug("Running preprocessor: {}", ((AbstractTestElement) ex).getName());

--- a/src/core/src/main/java/org/apache/jmeter/threads/SamplePackage.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/SamplePackage.java
@@ -95,7 +95,7 @@ public class SamplePackage {
         sampler.setRunningVersion(running);
     }
 
-    private void setRunningVersion(List<?> list, boolean running) {
+    private static void setRunningVersion(List<?> list, boolean running) {
         @SuppressWarnings("unchecked") // all implementations extend TestElement
         List<TestElement> telist = (List<TestElement>)list;
         for (TestElement te : telist) {
@@ -103,7 +103,7 @@ public class SamplePackage {
         }
     }
 
-    private void recoverRunningVersion(List<?> list) {
+    private static void recoverRunningVersion(List<?> list) {
         @SuppressWarnings("unchecked") // All implementations extend TestElement
         List<TestElement> telist = (List<TestElement>)list;
         for (TestElement te : telist) {

--- a/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
@@ -172,7 +172,7 @@ public class TestCompiler implements HashTreeTraverser {
         }
     }
 
-    private void trackIterationListeners(LinkedList<TestElement> pStack) {
+    private static void trackIterationListeners(LinkedList<TestElement> pStack) {
         TestElement child = pStack.getLast();
         if (child instanceof LoopIterationListener) {
             ListIterator<TestElement> iter = pStack.listIterator(pStack.size());
@@ -271,7 +271,7 @@ public class TestCompiler implements HashTreeTraverser {
      * @param controllers
      * @param maybeController
      */
-    private void addDirectParentControllers(List<Controller> controllers, TestElement maybeController) {
+    private static void addDirectParentControllers(List<Controller> controllers, TestElement maybeController) {
         if (maybeController instanceof Controller) {
             log.debug("adding controller: {} to sampler config", maybeController);
             controllers.add((Controller) maybeController);
@@ -304,7 +304,7 @@ public class TestCompiler implements HashTreeTraverser {
         }
     }
 
-    private void configureWithConfigElements(Sampler sam, List<ConfigTestElement> configs) {
+    private static void configureWithConfigElements(Sampler sam, List<ConfigTestElement> configs) {
         sam.clearTestElementChildren();
         for (ConfigTestElement config  : configs) {
             if (!(config instanceof NoConfigMerge))

--- a/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
@@ -330,7 +330,7 @@ public class ThreadGroup extends AbstractThreadGroup {
      * @param jvmThread {@link Thread}
      * @param interrupt Interrupt thread or not
      */
-    private void stopThread(JMeterThread jmeterThread, Thread jvmThread, boolean interrupt) {
+    private static void stopThread(JMeterThread jmeterThread, Thread jvmThread, boolean interrupt) {
         jmeterThread.stop();
         jmeterThread.interrupt(); // interrupt sampler if possible
         if (interrupt && jvmThread != null) { // Bug 49734
@@ -434,7 +434,7 @@ public class ThreadGroup extends AbstractThreadGroup {
      * @param thread Thread
      * @return boolean
      */
-    private boolean verifyThreadStopped(Thread thread) {
+    private static boolean verifyThreadStopped(Thread thread) {
         boolean stopped = true;
         if (thread != null && thread.isAlive()) {
             try {
@@ -465,7 +465,7 @@ public class ThreadGroup extends AbstractThreadGroup {
          * we have to check if allThreads is really empty before stopping
          */
         while (!allThreads.isEmpty()) {
-            allThreads.values().forEach(this::waitThreadStopped);
+            allThreads.values().forEach(ThreadGroup::waitThreadStopped);
         }
 
     }
@@ -474,7 +474,7 @@ public class ThreadGroup extends AbstractThreadGroup {
      * Wait for thread to stop
      * @param thread Thread
      */
-    private void waitThreadStopped(Thread thread) {
+    private static void waitThreadStopped(Thread thread) {
         if (thread == null) {
             return;
         }

--- a/src/core/src/main/java/org/apache/jmeter/threads/UnmodifiableJMeterVariables.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/UnmodifiableJMeterVariables.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * @since 3.3
  */
 class UnmodifiableJMeterVariables extends JMeterVariables {
-    private JMeterVariables variables;
+    private final JMeterVariables variables;
 
     /**
      * Wrap the {@code variables} to make them unmodifiable.

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/AbstractThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/AbstractThreadGroupGui.java
@@ -82,7 +82,7 @@ public abstract class AbstractThreadGroupGui extends AbstractJMeterGuiComponent 
         return pop;
     }
 
-    private JMenuItem createMenuItem(String name, String actionCommand) {
+    private static JMenuItem createMenuItem(String name, String actionCommand) {
         JMenuItem addThinkTimesToChildren = new JMenuItem(JMeterUtils.getResString(name));
         addThinkTimesToChildren.setName(name);
         addThinkTimesToChildren.addActionListener(ActionRouter.getInstance());
@@ -90,7 +90,7 @@ public abstract class AbstractThreadGroupGui extends AbstractJMeterGuiComponent 
         return addThinkTimesToChildren;
     }
 
-    private JMenu createAddMenu() {
+    private static JMenu createAddMenu() {
         String addAction = ActionNames.ADD;
         JMenu addMenu = new JMenu(JMeterUtils.getResString("add")); // $NON-NLS-1$
         addMenu.add(MenuFactory.makeMenu(MenuFactory.SAMPLERS, addAction));

--- a/src/core/src/main/java/org/apache/jmeter/util/BSFJavaScriptEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/BSFJavaScriptEngine.java
@@ -157,7 +157,7 @@ public class BSFJavaScriptEngine extends BSFEngineImpl {
      * @param t {@link Throwable}
      * @throws BSFException
      */
-    private void handleError(Throwable t) throws BSFException {
+    private static void handleError(Throwable t) throws BSFException {
         Throwable target = t;
         if (t instanceof WrappedException) {
             target = ((WrappedException) t).getWrappedException();

--- a/src/core/src/main/java/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
@@ -67,7 +67,7 @@ public class HttpSSLProtocolSocketFactory
     }
 
 
-    private void configureSocket(Socket socket){
+    private static void configureSocket(Socket socket){
         if (!(socket instanceof SSLSocket)) {
             throw new IllegalArgumentException("Expected SSLSocket");
         }
@@ -95,7 +95,7 @@ public class HttpSSLProtocolSocketFactory
         }
     }
 
-    private String join(String[] strings) {
+    private static String join(String[] strings) {
         StringBuilder sb = new StringBuilder();
         for (int i=0;i<strings.length;i++){
             if (i>0) {
@@ -106,7 +106,7 @@ public class HttpSSLProtocolSocketFactory
         return sb.toString();
     }
 
-    private SSLSocketFactory getSSLSocketFactory() throws IOException {
+    private static SSLSocketFactory getSSLSocketFactory() throws IOException {
         try {
             SSLContext sslContext = ((JsseSSLManager)SSLManager.getInstance()).getContext();
             return sslContext.getSocketFactory();

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolverForXpath2.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
  * jmeter property xpath.namespace.config
  */
 public class PropertiesBasedPrefixResolverForXpath2 extends PrefixResolverDefault {
-    private Map<String, String> namespaceMap = new HashMap<>();
+    private final Map<String, String> namespaceMap = new HashMap<>();
 
     /**
      * @param xpathExpressionContext Node

--- a/src/core/src/main/java/org/apache/jmeter/util/TemplateUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/TemplateUtil.java
@@ -36,7 +36,7 @@ import freemarker.template.TemplateExceptionHandler;
  */
 public final class TemplateUtil {
 
-    private static Configuration templateConfiguration = init();
+    private static final Configuration templateConfiguration = init();
 
     private TemplateUtil() {
         super();

--- a/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
@@ -179,7 +179,7 @@ public final class JmeterKeyStore {
             "directoryName", "ediPartyName", "uniformResourceIdentifier", "iPAddress", "registeredID");
 
     @SuppressWarnings("JdkObsolete")
-    private void logDetailsOnKeystore(KeyStore keystore) {
+    private static void logDetailsOnKeystore(KeyStore keystore) {
         Enumeration<String> aliases;
         try {
             aliases = keystore.aliases();
@@ -225,7 +225,7 @@ public final class JmeterKeyStore {
         }
     }
 
-    private String decodeSanList(Collection<List<?>> subjectAlternativeNames) {
+    private static String decodeSanList(Collection<List<?>> subjectAlternativeNames) {
         List<Pair<String, String>> decodedEntries = new ArrayList<>();
         for (List<?> entry : subjectAlternativeNames) {
             Object indexData = entry.get(0);
@@ -242,14 +242,14 @@ public final class JmeterKeyStore {
                 .collect(Collectors.joining(", "));
     }
 
-    private String sanDataToString(Object data) {
+    private static String sanDataToString(Object data) {
         if (data instanceof String) {
             return (String) data;
         }
         return Hex.encodeHexString((byte[]) data);
     }
 
-    private String sanGeneralNameIndexToName(Integer index) {
+    private static String sanGeneralNameIndexToName(Integer index) {
         String description;
         if (index < SAN_GENERAL_NAMES.size()) {
             description = SAN_GENERAL_NAMES.get(index);
@@ -259,7 +259,7 @@ public final class JmeterKeyStore {
         return description;
     }
 
-    private X509Certificate[] toX509Certificates(Certificate[] chain) {
+    private static X509Certificate[] toX509Certificates(Certificate[] chain) {
         X509Certificate[] x509certs = new X509Certificate[chain.length];
         for (int i = 0; i < x509certs.length; i++) {
             x509certs[i] = (X509Certificate) chain[i];
@@ -271,7 +271,7 @@ public final class JmeterKeyStore {
         return index >= startIndex && (endIndex == -1 || index <= endIndex);
     }
 
-    private char[] toCharArrayOrNull(String pword) {
+    private static char[] toCharArrayOrNull(String pword) {
         if (pword == null) {
             return null; // NOSONAR the api used requires null for "no password used"
         }

--- a/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
@@ -64,7 +64,7 @@ public final class JmeterKeyStore {
     private final int endIndex;
 
     /** name of the default alias */
-    private String clientCertAliasVarName;
+    private final String clientCertAliasVarName;
 
     private String[] names = new String[0];
     private Map<String, PrivateKey> privateKeyByAlias = new HashMap<>();

--- a/src/core/src/main/java/org/apache/jmeter/visualizers/SamplingStatCalculator.java
+++ b/src/core/src/main/java/org/apache/jmeter/visualizers/SamplingStatCalculator.java
@@ -34,7 +34,7 @@ public class SamplingStatCalculator {
 
     private long firstTime;
 
-    private String label;
+    private final String label;
 
     private volatile Sample currentSample;
 

--- a/src/examples/src/main/java/org/apache/jmeter/examples/sampler/ExampleSampler.java
+++ b/src/examples/src/main/java/org/apache/jmeter/examples/sampler/ExampleSampler.java
@@ -47,7 +47,7 @@ public class ExampleSampler extends AbstractSampler {
     // The name of the property used to hold our data
     public static final String DATA = "ExampleSampler.data"; //$NON-NLS-1$
 
-    private static AtomicInteger classCount = new AtomicInteger(0); // keep track of classes created
+    private static final AtomicInteger classCount = new AtomicInteger(0); // keep track of classes created
 
     // (for instructional purposes only!)
 

--- a/src/functions/src/main/java/org/apache/jmeter/functions/ChangeCase.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/ChangeCase.java
@@ -90,8 +90,6 @@ public class ChangeCase extends AbstractFunction {
             case CAPITALIZE:
                 targetString = StringUtils.capitalize(originalString);
                 break;
-            default:
-                // default not doing nothing to string
             }
         } else {
             LOGGER.error("Unknown mode {}, returning {} unchanged", mode, targetString);

--- a/src/functions/src/main/java/org/apache/jmeter/functions/DigestEncodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/DigestEncodeFunction.java
@@ -97,7 +97,7 @@ public class DigestEncodeFunction extends AbstractFunction {
      * @param index
      * @return
      */
-    private String uppercase(String encodedString, CompoundVariable[] values, int index) {
+    private static String uppercase(String encodedString, CompoundVariable[] values, int index) {
         String shouldUpperCase = values.length > index ? values[index].execute() : null;
         if (Boolean.parseBoolean(shouldUpperCase)) {
             return encodedString.toUpperCase();

--- a/src/functions/src/main/java/org/apache/jmeter/functions/IterationCounter.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/IterationCounter.java
@@ -42,9 +42,9 @@ public class IterationCounter extends AbstractFunction implements ThreadListener
 
     private Object[] variables;
 
-    private AtomicInteger globalCounter = new AtomicInteger();
+    private final AtomicInteger globalCounter = new AtomicInteger();
 
-    private ThreadLocal<AtomicInteger> perThreadInt = ThreadLocal.withInitial(AtomicInteger::new);
+    private final ThreadLocal<AtomicInteger> perThreadInt = ThreadLocal.withInitial(AtomicInteger::new);
 
     static {
         desc.add(JMeterUtils.getResString("iteration_counter_arg_1")); //$NON-NLS-1$

--- a/src/functions/src/main/java/org/apache/jmeter/functions/JavaScript.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/JavaScript.java
@@ -118,7 +118,7 @@ public class JavaScript extends AbstractFunction {
      * @return result as String
      * @throws InvalidVariableException
      */
-    private String executeWithNashorn(SampleResult previousResult,
+    private static String executeWithNashorn(SampleResult previousResult,
             Sampler currentSampler, JMeterContext jmctx, JMeterVariables vars,
             String script, String varName)
             throws InvalidVariableException {
@@ -160,7 +160,7 @@ public class JavaScript extends AbstractFunction {
      * @return result as String
      * @throws InvalidVariableException
      */
-    private String executeWithRhino(SampleResult previousResult,
+    private static String executeWithRhino(SampleResult previousResult,
             Sampler currentSampler, JMeterContext jmctx, JMeterVariables vars,
             String script, String varName)
             throws InvalidVariableException {

--- a/src/functions/src/main/java/org/apache/jmeter/functions/LogFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/LogFunction.java
@@ -175,8 +175,6 @@ public class LogFunction extends AbstractFunction {
                 case TRACE:
                     logger.trace("{} {} {}", threadName, separator, stringToLog, throwable);
                     break;
-                default:
-                    throw new IllegalStateException("Invalid log level");
             }
         }
     }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
@@ -75,7 +75,7 @@ public class RandomDate extends AbstractFunction {
 
     // Ensure that these are set, even if no parameters are provided
     private Locale locale = JMeterUtils.getLocale(); // $NON-NLS-1$
-    private final ZoneId systemDefaultZoneID = ZoneId.systemDefault(); // $NON-NLS-1$
+    private static final ZoneId systemDefaultZoneID = ZoneId.systemDefault(); // $NON-NLS-1$
     private CompoundVariable[] values;
 
     private static final class LocaleFormatObject {

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
@@ -203,7 +203,7 @@ public class RandomDate extends AbstractFunction {
     }
 
     @SuppressWarnings("JavaTimeDefaultTimeZone")
-    private DateTimeFormatter createFormatter(LocaleFormatObject format) {
+    private static DateTimeFormatter createFormatter(LocaleFormatObject format) {
         log.debug("Create a new instance of DateTimeFormatter for format '{}' in the cache", format);
         return new DateTimeFormatterBuilder().appendPattern(format.getFormat())
                 // TODO: what if year changes? (e.g. the year changes as the test executes)

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
@@ -75,13 +75,13 @@ public class RandomDate extends AbstractFunction {
 
     // Ensure that these are set, even if no parameters are provided
     private Locale locale = JMeterUtils.getLocale(); // $NON-NLS-1$
-    private ZoneId systemDefaultZoneID = ZoneId.systemDefault(); // $NON-NLS-1$
+    private final ZoneId systemDefaultZoneID = ZoneId.systemDefault(); // $NON-NLS-1$
     private CompoundVariable[] values;
 
     private static final class LocaleFormatObject {
 
-        private String format;
-        private Locale locale;
+        private final String format;
+        private final Locale locale;
 
         public LocaleFormatObject(String format, Locale locale) {
             this.format = format;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomFromMultipleVars.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomFromMultipleVars.java
@@ -108,7 +108,7 @@ public class RandomFromMultipleVars extends AbstractFunction {
      * @param vars {@link JMeterVariables}
      * @param results {@link List} where results are stored
      */
-    private void extractVariableValuesToList(String variableName,
+    private static void extractVariableValuesToList(String variableName,
             JMeterVariables vars, List<String> results) {
         String matchNumberAsStr = vars.get(variableName+"_matchNr");
         int matchNumber = 0;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -290,13 +290,13 @@ public class RegexFunction extends AbstractFunction {
         }
     }
 
-    private void saveGroups(java.util.regex.MatchResult result, String namep, JMeterVariables vars) {
+    private static void saveGroups(java.util.regex.MatchResult result, String namep, JMeterVariables vars) {
         for (int x = 0; x <= result.groupCount(); x++) {
             vars.put(namep + "_g" + x, result.group(x)); //$NON-NLS-1$
         }
     }
 
-    private void saveGroups(MatchResult result, String namep, JMeterVariables vars) {
+    private static void saveGroups(MatchResult result, String namep, JMeterVariables vars) {
         for (int x = 0; x < result.groups(); x++) {
             vars.put(namep + "_g" + x, result.group(x)); //$NON-NLS-1$
         }
@@ -308,7 +308,7 @@ public class RegexFunction extends AbstractFunction {
         return desc;
     }
 
-    private String generateResult(MatchResult match, String namep, Object[] template, JMeterVariables vars) {
+    private static String generateResult(MatchResult match, String namep, Object[] template, JMeterVariables vars) {
         saveGroups(match, namep, vars);
         StringBuilder result = new StringBuilder();
         for (Object t : template) {
@@ -324,8 +324,8 @@ public class RegexFunction extends AbstractFunction {
         return result.toString();
     }
 
-    private String generateResult(java.util.regex.MatchResult match, String namep, Object[] template,
-                                  JMeterVariables vars) {
+    private static String generateResult(java.util.regex.MatchResult match, String namep, Object[] template,
+            JMeterVariables vars) {
         saveGroups(match, namep, vars);
         StringBuilder result = new StringBuilder();
         for (Object t : template) {
@@ -361,7 +361,7 @@ public class RegexFunction extends AbstractFunction {
         return generateTemplateWithOroRegex(rawTemplate);
     }
 
-    private Object[] generateTemplateWithJavaRegex(String rawTemplate) {
+    private static Object[] generateTemplateWithJavaRegex(String rawTemplate) {
         // String or Integer
         List<Object> pieces = new ArrayList<>();
         Matcher matcher = templatePatternJava.matcher(rawTemplate);
@@ -411,7 +411,7 @@ public class RegexFunction extends AbstractFunction {
         return combined.toArray();
     }
 
-    private boolean isFirstElementGroup(String rawData) {
+    private static boolean isFirstElementGroup(String rawData) {
         if (USE_JAVA_REGEX) {
             return FIRST_ELEMENT_PATTERN.matcher(rawData).find();
         } else {

--- a/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
@@ -80,7 +80,7 @@ public class TimeShift extends AbstractFunction {
     private CompoundVariable amountToShiftCompound; // $NON-NLS-1$
     private Locale locale = JMeterUtils.getLocale(); // $NON-NLS-1$
     private String variableName = ""; //$NON-NLS-1$
-    private final ZoneId systemDefaultZoneID = ZoneId.systemDefault();
+    private static final ZoneId systemDefaultZoneID = ZoneId.systemDefault();
 
 
     private static final class LocaleFormatObject {

--- a/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
@@ -80,13 +80,13 @@ public class TimeShift extends AbstractFunction {
     private CompoundVariable amountToShiftCompound; // $NON-NLS-1$
     private Locale locale = JMeterUtils.getLocale(); // $NON-NLS-1$
     private String variableName = ""; //$NON-NLS-1$
-    private ZoneId systemDefaultZoneID = ZoneId.systemDefault();
+    private final ZoneId systemDefaultZoneID = ZoneId.systemDefault();
 
 
     private static final class LocaleFormatObject {
 
-        private String format;
-        private Locale locale;
+        private final String format;
+        private final Locale locale;
 
         public LocaleFormatObject(String format, Locale locale) {
             this.format = format;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
@@ -146,7 +146,7 @@ public class TimeShift extends AbstractFunction {
         if (!StringUtils.isEmpty(format)) {
             try {
                 LocaleFormatObject lfo = new LocaleFormatObject(format, locale);
-                formatter = dateTimeFormatterCache.get(lfo, this::createFormatter);
+                formatter = dateTimeFormatterCache.get(lfo, TimeShift::createFormatter);
             } catch (IllegalArgumentException ex) {
                 log.error("Format date pattern '{}' is invalid "
                         + "(see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)",
@@ -198,7 +198,7 @@ public class TimeShift extends AbstractFunction {
     }
 
     @SuppressWarnings("JavaTimeDefaultTimeZone")
-    private DateTimeFormatter createFormatter(LocaleFormatObject format) {
+    private static DateTimeFormatter createFormatter(LocaleFormatObject format) {
         log.debug("Create a new instance of DateTimeFormatter for format '{}' in the cache", format);
         return new DateTimeFormatterBuilder().appendPattern(format.getFormat())
                 .parseDefaulting(ChronoField.NANO_OF_SECOND, 0)

--- a/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
+++ b/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
@@ -62,7 +62,7 @@ public class GenerateTreeGui extends AbstractConfigGui
 
     private static final long serialVersionUID = 1L;
 
-    private JButton generateButton = new JButton("Generate");
+    private final JButton generateButton = new JButton("Generate");
 
     public GenerateTreeGui() {
         super();

--- a/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
+++ b/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
@@ -80,11 +80,6 @@ public class GenerateTreeGui extends AbstractConfigGui
     }
 
     @Override
-    public String getDocAnchor() {
-        return super.getDocAnchor();
-    }
-
-    @Override
     public Collection<String> getMenuCategories() {
         return Arrays.asList(MenuFactory.NON_TEST_ELEMENTS);
     }

--- a/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
+++ b/src/generator/src/main/java/org/apache/jmeter/visualizers/GenerateTreeGui.java
@@ -104,7 +104,7 @@ public class GenerateTreeGui extends AbstractConfigGui
         addElements(MenuFactory.LISTENERS,       "Listeners",       guiPackage, treeModel, myTarget);
     }
 
-    private void addElements(
+    private static void addElements(
             String menuKey, String title, GuiPackage guiPackage,
             JMeterTreeModel treeModel, JMeterTreeNode myTarget) {
 
@@ -172,7 +172,7 @@ public class GenerateTreeGui extends AbstractConfigGui
      * @param name  A name for the Controller
      * @return the new node
      */
-    private JMeterTreeNode addSimpleController(JMeterTreeModel model, JMeterTreeNode node, String name) {
+    private static JMeterTreeNode addSimpleController(JMeterTreeModel model, JMeterTreeNode node, String name) {
         final TestElement sc = new GenericController();
         sc.setProperty(TestElement.GUI_CLASS, LOGIC_CONTROLLER_GUI);
         sc.setProperty(TestElement.NAME, name); // Use old style
@@ -202,7 +202,7 @@ public class GenerateTreeGui extends AbstractConfigGui
         }
     }
 
-    private JMeterTreeNode addToTree(final JMeterTreeModel model,
+    private static JMeterTreeNode addToTree(final JMeterTreeModel model,
             final JMeterTreeNode node, final TestElement sc) {
         RunGUI runnable = new RunGUI(model, node, sc);
         if(SwingUtilities.isEventDispatchThread()) {
@@ -227,7 +227,7 @@ public class GenerateTreeGui extends AbstractConfigGui
      * @return the first node of the given type in the test component tree, or
      * <code>null</code> if none was found.
      */
-    private JMeterTreeNode findFirstNodeOfType(Class<?> type, JMeterTreeModel treeModel) {
+    private static JMeterTreeNode findFirstNodeOfType(Class<?> type, JMeterTreeModel treeModel) {
         return treeModel.getNodesOfType(type).stream()
                 .filter(JMeterTreeNode::isEnabled)
                 .findFirst()

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLArgsParser.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLArgsParser.java
@@ -193,7 +193,7 @@ public final class CLArgsParser {
      *            the Option Descriptor
      * @return the state
      */
-    private int getStateFor(final CLOptionDescriptor descriptor) {
+    private static int getStateFor(final CLOptionDescriptor descriptor) {
         final int flags = descriptor.getFlags();
         if ((flags & CLOptionDescriptor.ARGUMENTS_REQUIRED_2) == CLOptionDescriptor.ARGUMENTS_REQUIRED_2) {
             return STATE_REQUIRE_2ARGS;
@@ -341,7 +341,7 @@ public final class CLArgsParser {
      *            the cut-point in element of array
      * @return the result array
      */
-    private String[] subArray(final String[] array, final int index, final int charIndex) {
+    private static String[] subArray(final String[] array, final int index, final int charIndex) {
         final int remaining = array.length - index;
         final String[] result = new String[remaining];
 
@@ -487,7 +487,7 @@ public final class CLArgsParser {
         return new Token(TOKEN_STRING, sb.toString());
     }
 
-    private boolean isSeparator(final char ch, final char[] separators) {
+    private static boolean isSeparator(final char ch, final char[] separators) {
         for (char separator : separators) {
             if (ch == separator) {
                 return true;

--- a/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLArgsParser.java
+++ b/src/jorphan/src/main/java/org/apache/commons/cli/avalon/CLArgsParser.java
@@ -78,7 +78,7 @@ public final class CLArgsParser {
     // variables used while parsing options.
     private char ch;
 
-    private String[] args;
+    private final String[] args;
 
     private boolean isLong;
 

--- a/src/jorphan/src/main/java/org/apache/jorphan/exec/SystemCommand.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/exec/SystemCommand.java
@@ -223,7 +223,7 @@ public class SystemCommand {
      * @return proc exit value
      * @throws TimeoutException when timeout is reached while execution
      */
-    private int waitForEndWithTimeout(Process proc, long timeoutInMillis) throws InterruptedException, TimeoutException {
+    private static int waitForEndWithTimeout(Process proc, long timeoutInMillis) throws InterruptedException, TimeoutException {
         if (timeoutInMillis <= 0L) {
             return proc.waitFor();
         }

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/JLabeledTextField.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/JLabeledTextField.java
@@ -41,9 +41,9 @@ import javax.swing.event.ChangeListener;
 public class JLabeledTextField extends JPanel implements JLabeledField, FocusListener {
     private static final long serialVersionUID = 240L;
 
-    private JLabel mLabel;
+    private final JLabel mLabel;
 
-    private JTextField mTextField;
+    private final JTextField mTextField;
 
     private final ArrayList<ChangeListener> mChangeListeners = new ArrayList<>(3);
 

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/JMeterUIDefaults.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/JMeterUIDefaults.java
@@ -164,7 +164,7 @@ public class JMeterUIDefaults {
         return output;
     }
 
-    private void scaleIntProperties(UIDefaults defaults, float scale) {
+    private static void scaleIntProperties(UIDefaults defaults, float scale) {
         // Below are both standard and custom properties in a sorted order
         scaleIntProperty(defaults, "ArrowButton.size", scale); // $NON-NLS-1$
         scaleIntProperty(defaults, "ComboBox:\"ComboBox.arrowButton\".size", scale); // $NON-NLS-1$
@@ -173,7 +173,7 @@ public class JMeterUIDefaults {
         scaleIntProperty(defaults, "Spinner:\"Spinner.nextButton\".size", scale); // $NON-NLS-1$
     }
 
-    private void configureRowHeight(UIDefaults defaults, float scale, String rowHeight, String font) {
+    private static void configureRowHeight(UIDefaults defaults, float scale, String rowHeight, String font) {
         if (defaults.getInt(rowHeight) == 0) {
             return;
         }
@@ -196,14 +196,14 @@ public class JMeterUIDefaults {
     }
 
 
-    private void scaleControlsProperties(UIDefaults defaults, float scale) {
+    private static void scaleControlsProperties(UIDefaults defaults, float scale) {
         scaleIntProperty(defaults, "ScrollBar.thumbHeight", scale); // $NON-NLS-1$
         scaleIntProperty(defaults, "ScrollBar.width", scale); // $NON-NLS-1$
         scaleIntProperty(defaults, "ScrollBar:\"ScrollBar.button\".size", scale); // $NON-NLS-1$
         scaleIntProperty(defaults, "SplitPane.size", scale); // $NON-NLS-1$
     }
 
-    private void scaleIntProperty(UIDefaults defaults, String key, float scale) {
+    private static void scaleIntProperty(UIDefaults defaults, String key, float scale) {
         int value = defaults.getInt(key);
         if (value != 0) {
             defaults.put(key, Math.round(value * scale));

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/MenuScroller.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/MenuScroller.java
@@ -514,19 +514,6 @@ public class MenuScroller {
         }
     }
 
-    /**
-     * Ensures that the <code>dispose</code> method of this MenuScroller is
-     * called when there are no more references to it.
-     *
-     * @see MenuScroller#dispose()
-     */
-    @Override
-    @SuppressWarnings("deprecation")
-    public void finalize() throws Throwable {
-        dispose();
-        super.finalize();
-    }
-
     private void refreshMenu() {
         if (menuItems != null && menuItems.length > 0 && scrollCount <= menuItems.length) {
             firstIndex = Math.max(topFixedCount, firstIndex);

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/MenuScroller.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/MenuScroller.java
@@ -55,8 +55,8 @@ public class MenuScroller {
 
     private JPopupMenu menu;
     private Component[] menuItems;
-    private MenuScrollItem upItem;
-    private MenuScrollItem downItem;
+    private final MenuScrollItem upItem;
+    private final MenuScrollItem downItem;
     private final MenuScrollListener menuListener = new MenuScrollListener();
     private final MouseWheelListener mouseWheelListener = new MouseScrollListener();
     private int scrollCount;

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
@@ -44,7 +44,7 @@ public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
      * View row with model mapping. All data relates to model.
      */
     public class Row {
-        private int index;
+        private final int index;
 
         protected Row(int index) {
             this.index = index;
@@ -74,15 +74,15 @@ public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
         }
     }
 
-    private ObjectTableModel model;
+    private final ObjectTableModel model;
     private SortKey sortkey;
 
     private Comparator<Row> comparator  = null;
-    private ArrayList<Row>  viewToModel = new ArrayList<>();
+    private final ArrayList<Row>  viewToModel = new ArrayList<>();
     private int[]           modelToView = new int[0];
 
     private Comparator<Row>  primaryComparator = null;
-    private Comparator<?>[]  valueComparators;
+    private final Comparator<?>[]  valueComparators;
     private Comparator<Row>  fallbackComparator;
 
     public ObjectTableSorter(ObjectTableModel model) {

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/layout/VerticalLayout.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/layout/VerticalLayout.java
@@ -72,16 +72,16 @@ public class VerticalLayout implements LayoutManager, Serializable {
     public static final int BOTTOM = 2;
 
     /** The vertical vgap between components...defaults to 5. */
-    private int vgap;
+    private final int vgap;
 
     /** LEFT, RIGHT, CENTER or BOTH...how the components are justified. */
-    private int alignment;
+    private final int alignment;
 
     /**
      * TOP, BOTTOM or CENTER ...where are the components positioned in an
      * overlarge space.
      */
-    private int anchor;
+    private final int anchor;
 
     // Constructors
     /**

--- a/src/jorphan/src/main/java/org/apache/jorphan/reflect/ClassFinder.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/reflect/ClassFinder.java
@@ -94,7 +94,7 @@ public final class ClassFinder {
          * @param contextClassLoader the classloader to use
          * @return true if the class is a non-abstract, non-interface instance of at least one of the parent classes
          */
-        private boolean isChildOf(
+        private static boolean isChildOf(
                 Class<?>[] parentClasses, String strClassName, ClassLoader contextClassLoader) {
             try {
                 Class<?> targetClass = Class.forName(strClassName, false, contextClassLoader);
@@ -143,7 +143,7 @@ public final class ClassFinder {
             return false;
         }
 
-        private boolean hasAnnotationOnMethod(
+        private static boolean hasAnnotationOnMethod(
                 Class<? extends Annotation>[] annotations,
                 String classInQuestion,
                 ClassLoader contextClassLoader) {

--- a/src/jorphan/src/main/java/org/apache/jorphan/reflect/Functor.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/reflect/Functor.java
@@ -427,7 +427,7 @@ public class Functor {
         return sb.toString();
     }
 
-    private void typesToString(StringBuilder sb,Class<?>[] _types) {
+    private static void typesToString(StringBuilder sb, Class<?>[] _types) {
         sb.append("(");
         if (_types != null){
             for(int i=0; i < _types.length; i++){
@@ -440,13 +440,13 @@ public class Functor {
         sb.append(")");
     }
 
-    private String typesToString(Class<?>[] argTypes) {
+    private static String typesToString(Class<?>[] argTypes) {
         StringBuilder sb = new StringBuilder();
         typesToString(sb,argTypes);
         return sb.toString();
     }
 
-    private Class<?> getPrimitive(Class<?> t) {
+    private static Class<?> getPrimitive(Class<?> t) {
         if (t == null) {
             return null;
         }
@@ -472,7 +472,7 @@ public class Functor {
         return c;
     }
 
-    private Class<?>[] getNewArray(int i, Class<?> replacement, Class<?>[] orig) {
+    private static Class<?>[] getNewArray(int i, Class<?> replacement, Class<?>[] orig) {
         Class<?>[] newArray = new Class[orig.length];
         for (int j = 0; j < newArray.length; j++) {
             if (j == i) {

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/AlphaNumericComparator.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/AlphaNumericComparator.java
@@ -84,7 +84,7 @@ public class AlphaNumericComparator<T> implements Comparator<T> {
         return 1;
     }
 
-    private int compareOneEmptyPart(String numberPart1, String numberPart2) {
+    private static int compareOneEmptyPart(String numberPart1, String numberPart2) {
         if (numberPart1.isEmpty()) {
             if (numberPart2.isEmpty()) {
                 return 0;
@@ -96,7 +96,7 @@ public class AlphaNumericComparator<T> implements Comparator<T> {
         throw new IllegalArgumentException("At least one of the parameters have to be empty");
     }
 
-    private String trimLeadingZeroes(String numberPart) {
+    private static String trimLeadingZeroes(String numberPart) {
         int length = numberPart.length();
         for (int i = 0; i < length; i++) {
             if (numberPart.charAt(i) != '0') {

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/AlphaNumericComparator.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/AlphaNumericComparator.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 public class AlphaNumericComparator<T> implements Comparator<T> {
 
-    private Function<T, String> converter;
+    private final Function<T, String> converter;
 
     /**
      * Constructs a comparator with a converter function

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/AlphaNumericKeyComparator.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/AlphaNumericKeyComparator.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class AlphaNumericKeyComparator implements Comparator<Map.Entry<Object, Object>> {
 
     public static final AlphaNumericKeyComparator INSTANCE = new AlphaNumericKeyComparator();
-    private AlphaNumericComparator<Map.Entry<Object, Object>> comparator;
+    private final AlphaNumericComparator<Map.Entry<Object, Object>> comparator;
 
     private AlphaNumericKeyComparator() {
         // don't instantiate this class on your own.

--- a/src/jorphan/src/main/java/org/apache/log/ContextMap.java
+++ b/src/jorphan/src/main/java/org/apache/log/ContextMap.java
@@ -53,7 +53,7 @@ public final class ContextMap
     private final ContextMap m_parent;
 
     ///Container to hold map of elements
-    private Hashtable m_map = new Hashtable();
+    private final Hashtable m_map = new Hashtable();
 
     ///Flag indicating whether this map should be readonly
     private transient boolean m_readOnly;

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
@@ -118,7 +118,7 @@ public class BoltSampler extends AbstractBoltTestElement implements Sampler, Tes
         }
     }
 
-    private SampleResult handleException(SampleResult res, Exception ex) {
+    private static SampleResult handleException(SampleResult res, Exception ex) {
         res.setResponseMessage(ex.toString());
         if (ex instanceof Neo4jException) {
             res.setResponseCode(((Neo4jException)ex).code());

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltTestElementBeanInfoSupport.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltTestElementBeanInfoSupport.java
@@ -63,7 +63,7 @@ public abstract class BoltTestElementBeanInfoSupport extends BeanInfoSupport {
         propertyDescriptor.setValue(DEFAULT, 60);
     }
 
-    private String[] getListAccessModes() {
+    private static String[] getListAccessModes() {
         return Arrays.stream(AccessMode.values()).map(Enum::toString).toArray(String[]::new);
     }
 }

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/sampler/FTPSampler.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/sampler/FTPSampler.java
@@ -305,7 +305,7 @@ public class FTPSampler extends AbstractSampler implements Interruptible {
         return res;
     }
 
-    private void saveResponse(SampleResult res, boolean binaryTransfer, ByteArrayOutputStream baos) {
+    private static void saveResponse(SampleResult res, boolean binaryTransfer, ByteArrayOutputStream baos) {
         res.setResponseData(baos.toByteArray());
         if (!binaryTransfer) {
             res.setDataType(SampleResult.TEXT);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
@@ -176,7 +176,7 @@ public class GraphQLUrlConfigGui extends UrlConfigGui {
         return paramPanel;
     }
 
-    private HTTPArgument createHTTPArgument(final String name, final String value, final boolean alwaysEncoded) {
+    private static HTTPArgument createHTTPArgument(final String name, final String value, final boolean alwaysEncoded) {
         final HTTPArgument arg = new HTTPArgument(name, value);
         arg.setUseEquals(true);
         arg.setEnabled(true);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -322,7 +322,7 @@ public class HttpDefaultsGui extends AbstractConfigGui {
         return embeddedRsrcPanel;
     }
 
-    private JTextField addTextFieldWithLabel(JPanel panel, String labelText) {
+    private static JTextField addTextFieldWithLabel(JPanel panel, String labelText) {
         JLabel label = new JLabel(labelText); // $NON-NLS-1$
         JTextField field = new JTextField(100);
         label.setLabelFor(field);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -66,13 +66,13 @@ public class HttpDefaultsGui extends AbstractConfigGui {
     private JTextField embeddedAllowRE; // regular expression used to match against embedded resource URLs to allow
     private JTextField embeddedExcludeRE; // regular expression used to match against embedded resource URLs to discard
     private JTextField sourceIpAddr; // does not apply to Java implementation
-    private JComboBox<String> sourceIpType = new JComboBox<>(HTTPSamplerBase.getSourceTypeList());
+    private final JComboBox<String> sourceIpType = new JComboBox<>(HTTPSamplerBase.getSourceTypeList());
     private JTextField proxyScheme;
     private JTextField proxyHost;
     private JTextField proxyPort;
     private JTextField proxyUser;
     private JPasswordField proxyPass;
-    private JComboBox<String> httpImplementation = new JComboBox<>(HTTPSamplerFactory.getImplementations());
+    private final JComboBox<String> httpImplementation = new JComboBox<>(HTTPSamplerFactory.getImplementations());
     private JTextField connectTimeOut;
     private JTextField responseTimeOut;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
@@ -107,8 +107,8 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
     // Tabbed pane that contains parameters and raw body
     private AbstractValidationTabbedPane postContentTabbedPane;
 
-    private boolean showRawBodyPane;
-    private boolean showFileUploadPane;
+    private final boolean showRawBodyPane;
+    private final boolean showFileUploadPane;
 
     /**
      * Constructor which is setup to show HTTP implementation, raw body pane and

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
@@ -472,7 +472,7 @@ public class AuthManager extends ConfigTestElement implements TestStateListener,
      * @param credentialsProvider provider which should be set up
      * @param localhost name of the workstation to be used for {@link NTCredentials}
      */
-    public void setupCredentials(Authorization auth, URL url,
+    public static void setupCredentials(Authorization auth, URL url,
             HttpClientContext localContext,
             CredentialsProvider credentialsProvider,
             String localhost) {
@@ -503,7 +503,7 @@ public class AuthManager extends ConfigTestElement implements TestStateListener,
      * @param url to be checked
      * @return <code>true</code> when port should omitted in SPN
      */
-    private boolean isStripPort(URL url) {
+    private static boolean isStripPort(URL url) {
         if (STRIP_PORT) {
             return true;
         }
@@ -518,7 +518,7 @@ public class AuthManager extends ConfigTestElement implements TestStateListener,
      * @param b {@link Authorization}
      * @return true if a and b match
      */
-    private boolean match(Authorization a, Authorization b){
+    private static boolean match(Authorization a, Authorization b){
         return
                 a.getURL().equals(b.getURL())&&
                 a.getDomain().equals(b.getDomain())&&

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
@@ -135,7 +135,7 @@ public class AuthManager extends ConfigTestElement implements TestStateListener,
         }
     }
 
-    private KerberosManager kerberosManager = new KerberosManager();
+    private final KerberosManager kerberosManager = new KerberosManager();
 
     /**
      * Default Constructor.

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CacheManager.java
@@ -197,7 +197,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         }
     }
 
-    private boolean anyNotBlank(String... values) {
+    private static boolean anyNotBlank(String... values) {
         for (String value: values) {
             if (StringUtils.isNotBlank(value)) {
                 return true;
@@ -206,7 +206,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         return false;
     }
 
-    private Pair<String, String> getVaryHeader(String headerName, Header[] reqHeaders) {
+    private static Pair<String, String> getVaryHeader(String headerName, Header[] reqHeaders) {
         if (headerName == null) {
             return null;
         }
@@ -292,7 +292,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         }
     }
 
-    private Date extractExpiresDateFromExpires(String expires) {
+    private static Date extractExpiresDateFromExpires(String expires) {
         Date expiresDate;
         try {
             expiresDate = org.apache.http.client.utils.DateUtils
@@ -308,7 +308,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
     }
 
     @SuppressWarnings("JavaUtilDate")
-    private Date extractExpiresDateFromCacheControl(String lastModified,
+    private static Date extractExpiresDateFromCacheControl(String lastModified,
             String cacheControl, String expires, String etag, String url,
             String date, final String maxAge, Date defaultExpiresDate) {
         // the max-age directive overrides the Expires header,
@@ -328,7 +328,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
     }
 
     @SuppressWarnings("JavaUtilDate")
-    private Date calcExpiresDate(String lastModified, String cacheControl,
+    private static Date calcExpiresDate(String lastModified, String cacheControl,
             String expires, String etag, String url, String date) {
         if(!StringUtils.isEmpty(lastModified) && !StringUtils.isEmpty(date)) {
             try {
@@ -360,7 +360,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
     }
 
     // Apache HttpClient
-    private String getHeader(HttpResponse method, String name) {
+    private static String getHeader(HttpResponse method, String name) {
         org.apache.http.Header hdr = method.getLastHeader(name);
         return hdr != null ? hdr.getValue() : null;
     }
@@ -369,7 +369,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
      * Is the sample result OK to cache?
      * i.e is it in the 2xx range or equal to 304, and is it a cacheable method?
      */
-    private boolean isCacheable(HTTPSampleResult res, String varyHeader){
+    private static boolean isCacheable(HTTPSampleResult res, String varyHeader){
         if ("*".equals(varyHeader)) {
             return false;
         }
@@ -380,7 +380,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
                     || "304".equals(responseCode));  // $NON-NLS-1$
     }
 
-    private boolean isCacheableMethod(HTTPSampleResult res) {
+    private static boolean isCacheableMethod(HTTPSampleResult res) {
         final String resMethod = res.getHTTPMethod();
         for(String method : CACHEABLE_METHODS) {
             if (method.equalsIgnoreCase(resMethod)) {
@@ -471,7 +471,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         return entryStillValid(url, getEntry(url.toString(), asHeaders(allHeaders)));
     }
 
-    private Header[] asHeaders(
+    private static Header[] asHeaders(
             org.apache.jmeter.protocol.http.control.Header[] allHeaders) {
         final List<Header> result = new ArrayList<>(allHeaders.length);
         for (org.apache.jmeter.protocol.http.control.Header header: allHeaders) {
@@ -480,7 +480,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         return result.toArray(new Header[result.size()]);
     }
 
-    private Header[] asHeaders(String allHeaders) {
+    private static Header[] asHeaders(String allHeaders) {
         List<Header> result = new ArrayList<>();
         for (String line: allHeaders.split("\\n")) {
             String[] splitted = line.split(": ", 2);
@@ -517,7 +517,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
     }
 
     @SuppressWarnings("JavaUtilDate")
-    private boolean entryStillValid(URL url, CacheEntry entry) {
+    private static boolean entryStillValid(URL url, CacheEntry entry) {
         log.debug("Check if entry {} is still valid for url {}", entry, url);
         if (entry != null && entry.getVaryHeader() == null) {
             final Date expiresDate = entry.getExpires();
@@ -562,7 +562,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
         return null;
     }
 
-    private String varyUrl(String url, String headerName, String headerValue) {
+    private static String varyUrl(String url, String headerName, String headerValue) {
         return "vary-" + headerName + "-" + headerValue + "-" + url;
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CookieManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CookieManager.java
@@ -257,7 +257,7 @@ public class CookieManager extends ConfigTestElement implements TestStateListene
         }
     }
 
-    private String cookieToString(Cookie c){
+    private static String cookieToString(Cookie c){
         StringBuilder sb=new StringBuilder(80);
         sb.append(c.getDomain());
         //flag - if all machines within a given domain can access the variable.
@@ -369,7 +369,7 @@ public class CookieManager extends ConfigTestElement implements TestStateListene
      * @param b
      * @return true if cookies match
      */
-    private boolean match(Cookie a, Cookie b){
+    private static boolean match(Cookie a, Cookie b){
         return
         a.getName().equals(b.getName())
         &&

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DNSCacheManager.java
@@ -163,7 +163,7 @@ public class DNSCacheManager extends ConfigTestElement implements TestIterationL
         }
     }
 
-    private void logCache(String hitOrMiss, String host, InetAddress[] addresses) {
+    private static void logCache(String hitOrMiss, String host, InetAddress[] addresses) {
         if (log.isDebugEnabled()) {
             log.debug("Cache {} thread#{}: {} => {}", hitOrMiss, JMeterContextService.getContext().getThreadNum(), host,
                     Arrays.toString(addresses));
@@ -226,7 +226,7 @@ public class DNSCacheManager extends ConfigTestElement implements TestIterationL
         return new InetAddress[0];
     }
 
-    private void addAsLiteralAddress(List<InetAddress> addresses, String address) {
+    private static void addAsLiteralAddress(List<InetAddress> addresses, String address) {
         try {
             addresses.add(InetAddress.getByName(address));
         } catch (UnknownHostException e) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DynamicKerberosSchemeFactory.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DynamicKerberosSchemeFactory.java
@@ -57,7 +57,7 @@ public class DynamicKerberosSchemeFactory extends KerberosSchemeFactory {
         return new KerberosScheme(stripPort, isUseCanonicalHostname());
     }
 
-    private boolean isEnabled(Object contextAttribute, boolean defaultValue) {
+    private static boolean isEnabled(Object contextAttribute, boolean defaultValue) {
         if (contextAttribute instanceof Boolean) {
             return (Boolean) contextAttribute;
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DynamicSPNegoSchemeFactory.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/DynamicSPNegoSchemeFactory.java
@@ -57,7 +57,7 @@ public class DynamicSPNegoSchemeFactory extends SPNegoSchemeFactory {
         return new SPNegoScheme(stripPort, isUseCanonicalHostname());
     }
 
-    private boolean isEnabled(Object contextAttribute, boolean defaultValue) {
+    private static boolean isEnabled(Object contextAttribute, boolean defaultValue) {
         if (contextAttribute instanceof Boolean) {
             return (Boolean) contextAttribute;
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
@@ -241,7 +241,7 @@ public class HC4CookieHandler implements CookieHandler {
      * Create an HttpClient cookie from a JMeter cookie
      */
     @SuppressWarnings("JavaUtilDate")
-    private org.apache.http.cookie.Cookie makeCookie(Cookie jmc) {
+    private static org.apache.http.cookie.Cookie makeCookie(Cookie jmc) {
         long exp = jmc.getExpiresMillis();
         BasicClientCookie ret = new BasicClientCookie(jmc.getName(),
                 jmc.getValue());

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
@@ -72,7 +72,7 @@ public class HC4CookieHandler implements CookieHandler {
 
     private static final PublicSuffixMatcher publicSuffixMatcher = PublicSuffixMatcherLoader.getDefault();
     @SuppressWarnings("deprecation")
-    private static Registry<CookieSpecProvider> registry  =
+    private static final Registry<CookieSpecProvider> registry  =
             RegistryBuilder.<CookieSpecProvider>create()
             // case is ignored bug registry as it converts to lowerCase(Locale.US)
             .register(CookieSpecs.BEST_MATCH, new DefaultCookieSpecProvider(publicSuffixMatcher))

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorServer.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorServer.java
@@ -92,8 +92,8 @@ public class HttpMirrorServer extends Thread implements Stoppable, NonTestElemen
     private volatile Exception except;
 
     private final int daemonPort;
-    private int maxThreadPoolSize;
-    private int maxQueueSize;
+    private final int maxThreadPoolSize;
+    private final int maxQueueSize;
 
     /**
      * Create a new Daemon with the specified port and target.

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -306,7 +306,7 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         return embeddedRsrcPanel;
     }
 
-    private JTextField addTextFieldWithLabel(JPanel panel, String labelText) {
+    private static JTextField addTextFieldWithLabel(JPanel panel, String labelText) {
         JLabel label = new JLabel(labelText); // $NON-NLS-1$
         JTextField field = new JTextField(100);
         label.setLabelFor(field);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -63,13 +63,13 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
     private JTextField embeddedAllowRE; // regular expression used to match against embedded resource URLs to allow
     private JTextField embeddedExcludeRE; // regular expression used to match against embedded resource URLs to exclude
     private JTextField sourceIpAddr; // does not apply to Java implementation
-    private JComboBox<String> sourceIpType = new JComboBox<>(HTTPSamplerBase.getSourceTypeList());
+    private final JComboBox<String> sourceIpType = new JComboBox<>(HTTPSamplerBase.getSourceTypeList());
     private JTextField proxyScheme;
     private JTextField proxyHost;
     private JTextField proxyPort;
     private JTextField proxyUser;
     private JPasswordField proxyPass;
-    private JComboBox<String> httpImplementation = new JComboBox<>(HTTPSamplerFactory.getImplementations());
+    private final JComboBox<String> httpImplementation = new JComboBox<>(HTTPSamplerFactory.getImplementations());
     private JTextField connectTimeOut;
     private JTextField responseTimeOut;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
@@ -913,7 +913,7 @@ public class BasicCurlParser {
     * @param mechanism     the mechanism of authorization
     * @param authorization the object of authorization
     */
-   private void setAuthMechanism(String mechanism, Authorization authorization) {
+   private static void setAuthMechanism(String mechanism, Authorization authorization) {
        switch (mechanism.toLowerCase()) {
        case "basic":
            authorization.setMechanism(Mechanism.BASIC);
@@ -932,7 +932,7 @@ public class BasicCurlParser {
     * @param request                       http request
     * @param originalProxyServerParameters the parameters of proxy server
     */
-   private void setProxyServer(Request request, String originalProxyServerParameters) {
+   private static void setProxyServer(Request request, String originalProxyServerParameters) {
        String proxyServerParameters = originalProxyServerParameters;
        if (!proxyServerParameters.contains("://")) {
            proxyServerParameters = "http://" + proxyServerParameters;
@@ -960,7 +960,7 @@ public class BasicCurlParser {
     * @param request               http request
     * @param authentication        the username and password of proxy server
     */
-   private void setProxyServerUserInfo(Request request, String authentication) {
+   private static void setProxyServerUserInfo(Request request, String authentication) {
        if (authentication.contains(":")) {
            String[] userInfo = authentication.split(":", 2);
            request.setProxyServer("username", userInfo[0]);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
@@ -126,7 +126,7 @@ public class BasicCurlParser {
     public static final class Request {
         private boolean compressed;
         private String url;
-        private List<Pair<String, String>> headers = new ArrayList<>();
+        private final List<Pair<String, String>> headers = new ArrayList<>();
         private String method = "GET";
         private String postData;
         private String interfaceName;
@@ -134,17 +134,17 @@ public class BasicCurlParser {
         private String cookies = "";
         private String cookieInHeaders = "";
         private String filepathCookie="";
-        private Authorization authorization = new Authorization();
+        private final Authorization authorization = new Authorization();
         private String caCert = "";
-        private List<Pair<String, ArgumentHolder>> formData = new ArrayList<>();
-        private List<Pair<String, String>> formStringData = new ArrayList<>();
-        private Set<String> dnsServers = new HashSet<>();
+        private final List<Pair<String, ArgumentHolder>> formData = new ArrayList<>();
+        private final List<Pair<String, String>> formStringData = new ArrayList<>();
+        private final Set<String> dnsServers = new HashSet<>();
         private boolean isKeepAlive = true;
         private double maxTime = -1;
-        private List<String> optionsIgnored = new ArrayList<>();
-        private List<String> optionsNoSupport = new ArrayList<>();
-        private List<String> optionsInProperties = new ArrayList<>();
-        private Map<String, String> proxyServer = new LinkedHashMap<>();
+        private final List<String> optionsIgnored = new ArrayList<>();
+        private final List<String> optionsNoSupport = new ArrayList<>();
+        private final List<String> optionsInProperties = new ArrayList<>();
+        private final Map<String, String> proxyServer = new LinkedHashMap<>();
         private String dnsResolver;
         private int limitRate = 0;
         private String noproxy;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/FileArgumentHolder.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/FileArgumentHolder.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class FileArgumentHolder implements ArgumentHolder {
-    private String name;
-    private Map<String, String> metadata;
+    private final String name;
+    private final Map<String, String> metadata;
 
     private FileArgumentHolder(String name, Map<String, String> metadata) {
         this.name = name;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/StringArgumentHolder.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/StringArgumentHolder.java
@@ -45,8 +45,8 @@ public class StringArgumentHolder implements ArgumentHolder {
         return Objects.equals(metadata, other.metadata) && Objects.equals(name, other.name);
     }
 
-    private String name;
-    private Map<String, String> metadata;
+    private final String name;
+    private final Map<String, String> metadata;
 
     private StringArgumentHolder(String name, Map<String, String> metadata) {
         this.name = name;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
@@ -76,7 +76,7 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
 
     private static final String CONTROLLED_BY_THREADGROUP = "Controlled_By_ThreadGroup"; //$NON-NLS-1$
 
-    private InnerTableModel tableModel;
+    private final InnerTableModel tableModel;
 
     private JCheckBox clearEachIteration;
 
@@ -449,7 +449,7 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
 
     private static class PasswordCellRenderer extends JPasswordField implements TableCellRenderer {
         private static final long serialVersionUID = 5169856333827579927L;
-        private Border myBorder;
+        private final Border myBorder;
 
         public PasswordCellRenderer() {
             super();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/CookiePanel.java
@@ -238,7 +238,7 @@ public class CookiePanel extends AbstractConfigGui implements ActionListener {
         saveButton.setEnabled(hasRows);
     }
 
-    private Cookie createCookie(Object[] rowData) {
+    private static Cookie createCookie(Object[] rowData) {
         Cookie cookie = new Cookie(
                 (String) rowData[0],
                 (String) rowData[1],

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -103,7 +103,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
     private JButton addHostButton;
     private JButton deleteHostButton;
 
-    private ButtonGroup providerDNSradioGroup = new ButtonGroup();
+    private final ButtonGroup providerDNSradioGroup = new ButtonGroup();
 
     private static final String[] COLUMN_RESOURCE_NAMES = {
         JMeterUtils.getResString("dns_hostname_or_ip"), //$NON-NLS-1$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -364,7 +364,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         }
     }
 
-    private void enableTable(boolean custEnabled, boolean sysEnabled, JTable table, PowerTableModel model,
+    private static void enableTable(boolean custEnabled, boolean sysEnabled, JTable table, PowerTableModel model,
             JButton addButton, JButton deleteButton) {
         table.setEnabled(custEnabled);
         Color greyColor = new Color(240, 240, 240);
@@ -379,7 +379,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         }
     }
 
-    private void addTableRow(JTable table, PowerTableModel model, JButton button) {
+    private static void addTableRow(JTable table, PowerTableModel model, JButton button) {
         // If a table cell is being edited, we should accept the current
         // value and stop the editing before adding a new row.
         GuiUtils.stopTableEditing(table);
@@ -396,7 +396,7 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         table.setRowSelectionInterval(rowToSelect, rowToSelect);
     }
 
-    private void deleteTableRow(JTable table, PowerTableModel model, JButton button) {
+    private static void deleteTableRow(JTable table, PowerTableModel model, JButton button) {
         if (model.getRowCount() > 0) {
             // If a table cell is being edited, we must cancel the editing
             // before deleting the row.

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPFileArgsPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPFileArgsPanel.java
@@ -312,7 +312,7 @@ public class HTTPFileArgsPanel extends JPanel implements ActionListener {
      *
      * @return a new File object
      */
-    private String browseAndGetFilePath() {
+    private static String browseAndGetFilePath() {
         String path = ""; //$NON-NLS-1$
         JFileChooser chooser = FileDialoger.promptToOpenFile();
         if (chooser != null) {
@@ -413,7 +413,7 @@ public class HTTPFileArgsPanel extends JPanel implements ActionListener {
         table.revalidate();
     }
 
-    private JScrollPane makeScrollPane(Component comp) {
+    private static JScrollPane makeScrollPane(Component comp) {
         JScrollPane pane = new JScrollPane(comp);
         pane.setPreferredSize(pane.getMinimumSize());
         return GuiUtils.emptyBorder(pane);
@@ -542,7 +542,7 @@ public class HTTPFileArgsPanel extends JPanel implements ActionListener {
         }
     }
 
-    private HTTPFileArg createHTTPFileArgFromClipboard(String[] clipboardCols) {
+    private static HTTPFileArg createHTTPFileArgFromClipboard(String[] clipboardCols) {
         if (clipboardCols.length == 1) {
             return new HTTPFileArg(clipboardCols[0]);
         } else if (clipboardCols.length == 2) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HeaderPanel.java
@@ -313,7 +313,7 @@ public class HeaderPanel extends AbstractConfigGui implements ActionListener {
     private static class InnerTableModel extends AbstractTableModel {
         private static final long serialVersionUID = 240L;
 
-        private HeaderManager manager;
+        private final HeaderManager manager;
 
         public InnerTableModel(HeaderManager man) {
             manager = man;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -192,12 +192,12 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
      * @return the first node of the given type in the test component tree, or
      *         <code>null</code> if none was found.
      */
-    private JMeterTreeNode findFirstNodeOfType(Class<?> type) {
+    private static JMeterTreeNode findFirstNodeOfType(Class<?> type) {
         JMeterTreeModel treeModel = GuiPackage.getInstance().getTreeModel();
         return treeModel.getNodesOfType(type).stream().filter(JMeterTreeNode::isEnabled).findFirst().orElse(null);
     }
 
-    private DNSCacheManager findNodeOfTypeDnsCacheManagerByType(boolean isCustom) {
+    private static DNSCacheManager findNodeOfTypeDnsCacheManagerByType(boolean isCustom) {
         JMeterTreeModel treeModel = GuiPackage.getInstance().getTreeModel();
         List<JMeterTreeNode> res = treeModel.getNodesOfType(DNSCacheManager.class);
         for (JMeterTreeNode jm : res) {
@@ -336,7 +336,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         return httpSampler;
     }
 
-    private void configureTimeout(Request request, HTTPSamplerProxy httpSampler) {
+    private static void configureTimeout(Request request, HTTPSamplerProxy httpSampler) {
         double connectTimeout = request.getConnectTimeout();
         double maxTime = request.getMaxTime();
         if (connectTimeout >= 0) {
@@ -355,7 +355,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
      * @param request {@link Request}
      * @return {@link HeaderManager} element
      */
-    private HeaderManager createHeaderManager(Request request) {
+    private static HeaderManager createHeaderManager(Request request) {
         HeaderManager headerManager = new HeaderManager();
         headerManager.setProperty(TestElement.GUI_CLASS, HeaderPanel.class.getName());
         headerManager.setProperty(TestElement.NAME, "HTTP HeaderManager");
@@ -409,7 +409,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         }
     }
 
-    private KeystoreConfig createKeystoreConfiguration() {
+    private static KeystoreConfig createKeystoreConfiguration() {
         KeystoreConfig keystoreConfig = new KeystoreConfig();
         keystoreConfig.setProperty(TestElement.GUI_CLASS, TestBeanGUI.class.getName());
         keystoreConfig.setProperty(TestElement.NAME, "Keystore Configuration");
@@ -422,7 +422,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
      *
      * @param request {@link Request}
      */
-    private void createAuthManager(Request request, AuthManager authManager) {
+    private static void createAuthManager(Request request, AuthManager authManager) {
         Authorization auth = request.getAuthorization();
         authManager.setProperty(TestElement.GUI_CLASS, AuthPanel.class.getName());
         authManager.setProperty(TestElement.NAME, "HTTP AuthorizationManager");
@@ -437,7 +437,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
      * @param authManager {@link AuthManager} element
      * @return whether to update Authorization Manager in http request
      */
-    private boolean canAddAuthManagerInHttpRequest(Request request, AuthManager authManager) {
+    private static boolean canAddAuthManagerInHttpRequest(Request request, AuthManager authManager) {
         Authorization auth = request.getAuthorization();
         for (int i = 0; i < authManager.getAuthObjects().size(); i++) {
             if (!authManager.getAuthObjectAt(i).getUser().equals(auth.getUser())
@@ -456,7 +456,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
      * @param authManager {@link AuthManager} element
      * @return whether to update Authorization Manager in Thread Group
      */
-    private boolean canUpdateAuthManagerInThreadGroup(Request request, AuthManager authManager) {
+    private static boolean canUpdateAuthManagerInThreadGroup(Request request, AuthManager authManager) {
         Authorization auth = request.getAuthorization();
         for (int i = 0; i < authManager.getAuthObjects().size(); i++) {
             if (auth.getURL().equals(authManager.getAuthObjectAt(i).getURL())) {
@@ -466,7 +466,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         return true;
     }
 
-    private void createDnsServer(Request request, DNSCacheManager dnsCacheManager) {
+    private static void createDnsServer(Request request, DNSCacheManager dnsCacheManager) {
         Set<String> dnsServers = request.getDnsServers();
         dnsCacheManager.setProperty(TestElement.GUI_CLASS, DNSCachePanel.class.getName());
         dnsCacheManager.setProperty(TestElement.NAME, "DNS Cache Manager");
@@ -477,7 +477,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         }
     }
 
-    private boolean canAddDnsServerInHttpRequest(Request request, DNSCacheManager dnsCacheManager) {
+    private static boolean canAddDnsServerInHttpRequest(Request request, DNSCacheManager dnsCacheManager) {
         Set<String> currentDnsServers =new HashSet<>();
         Set<String> newDnsServers = request.getDnsServers();
         for (int i = 0; i < dnsCacheManager.getServers().size(); i++) {
@@ -486,7 +486,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         return !(newDnsServers.size() == currentDnsServers.size() && newDnsServers.containsAll(currentDnsServers));
     }
 
-    private void createDnsResolver(Request request, DNSCacheManager dnsCacheManager) {
+    private static void createDnsResolver(Request request, DNSCacheManager dnsCacheManager) {
         dnsCacheManager.setProperty(TestElement.GUI_CLASS, DNSCachePanel.class.getName());
         dnsCacheManager.setProperty(TestElement.NAME, "DNS Cache Manager");
         dnsCacheManager.setCustomResolver(true);
@@ -510,7 +510,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         return "Created from cURL on " + LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
     }
 
-    private boolean canAddDnsResolverInHttpRequest(Request request, DNSCacheManager dnsCacheManager) {
+    private static boolean canAddDnsResolverInHttpRequest(Request request, DNSCacheManager dnsCacheManager) {
         if (dnsCacheManager.getHosts().size() != 1) {
             return true;
         } else {
@@ -573,7 +573,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         }
     }
 
-    private void createProxyServer(Request request, HTTPSamplerProxy httpSampler) {
+    private static void createProxyServer(Request request, HTTPSamplerProxy httpSampler) {
         Map<String, String> proxyServer = request.getProxyServer();
         for (Map.Entry<String, String> proxyPara : proxyServer.entrySet()) {
             String key = proxyPara.getKey();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/AnchorModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/AnchorModifier.java
@@ -104,7 +104,7 @@ public class AnchorModifier extends AbstractTestElement implements PreProcessor,
         }
     }
 
-    private void modifyArgument(Argument arg, Arguments args) {
+    private static void modifyArgument(Argument arg, Arguments args) {
         if (log.isDebugEnabled()) {
             log.debug("Modifying argument: " + arg);
         }
@@ -136,7 +136,7 @@ public class AnchorModifier extends AbstractTestElement implements PreProcessor,
     public void addConfigElement(ConfigElement config) {
     }
 
-    private void addFormUrls(Document html, HTTPSampleResult result, HTTPSamplerBase config,
+    private static void addFormUrls(Document html, HTTPSampleResult result, HTTPSamplerBase config,
             List<HTTPSamplerBase> potentialLinks) {
         NodeList rootList = html.getChildNodes();
         List<HTTPSamplerBase> urls = new ArrayList<>();
@@ -155,7 +155,7 @@ public class AnchorModifier extends AbstractTestElement implements PreProcessor,
         }
     }
 
-    private void addAnchorUrls(Document html, HTTPSampleResult result, HTTPSamplerBase config,
+    private static void addAnchorUrls(Document html, HTTPSampleResult result, HTTPSamplerBase config,
             List<HTTPSamplerBase> potentialLinks) {
         String base = "";
         NodeList baseList = html.getElementsByTagName("base"); // $NON-NLS-1$
@@ -190,8 +190,8 @@ public class AnchorModifier extends AbstractTestElement implements PreProcessor,
         }
     }
 
-    private void addFramesetUrls(Document html, HTTPSampleResult result,
-       HTTPSamplerBase config, List<HTTPSamplerBase> potentialLinks) {
+    private static void addFramesetUrls(Document html, HTTPSampleResult result,
+            HTTPSamplerBase config, List<HTTPSamplerBase> potentialLinks) {
        String base = "";
        NodeList baseList = html.getElementsByTagName("base"); // $NON-NLS-1$
        if (baseList.getLength() > 0) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -169,14 +169,14 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         // quick hack anyway, so who cares.
     }
 
-    private Function<String, String> generateExtractor(String regex) {
+    private static Function<String, String> generateExtractor(String regex) {
         if (USE_JAVA_REGEX) {
             return generateExtractorWithJavaRegex(regex);
         }
         return generateExtractorWithOroRegex(regex);
     }
 
-    private Function<String, String> generateExtractorWithJavaRegex(String regex) {
+    private static Function<String, String> generateExtractorWithJavaRegex(String regex) {
         java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
                 regex,
                 java.util.regex.Pattern.MULTILINE);
@@ -189,7 +189,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         };
     }
 
-    private Function<String, String> generateExtractorWithOroRegex(String regex) {
+    private static Function<String, String> generateExtractorWithOroRegex(String regex) {
         Pattern pattern = JMeterUtils.getPatternCache().getPattern(
                 regex,
                 Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);
@@ -203,14 +203,14 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         };
     }
 
-    private Function<String, String> generateFirstMatchExtractor(String regex) {
+    private static Function<String, String> generateFirstMatchExtractor(String regex) {
         if (USE_JAVA_REGEX) {
             return generateFirstMatchExtractorWithJavaRegex(regex);
         }
         return generateFirstMatchExtractorWithOroRegex(regex);
     }
 
-    private Function<String, String> generateFirstMatchExtractorWithJavaRegex(String regex) {
+    private static Function<String, String> generateFirstMatchExtractorWithJavaRegex(String regex) {
         java.util.regex.Pattern pattern = JMeterUtils.compilePattern(
                 regex,
                 java.util.regex.Pattern.MULTILINE);
@@ -228,7 +228,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
         };
     }
 
-    private Function<String, String> generateFirstMatchExtractorWithOroRegex(String regex) {
+    private static Function<String, String> generateFirstMatchExtractorWithOroRegex(String regex) {
         Pattern pattern = JMeterUtils.getPatternCache().getPattern(
                 regex,
                 Perl5Compiler.MULTILINE_MASK | Perl5Compiler.READ_ONLY_MASK);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/RegExUserParametersGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/gui/RegExUserParametersGui.java
@@ -136,7 +136,7 @@ public class RegExUserParametersGui extends AbstractPreProcessorGui {
         return panel;
     }
 
-    private void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabeledTextField field, GridBagConstraints gbc) {
         List<JComponent> item = field.getComponentList();
         panel.add(item.get(0), gbc.clone());
         gbc.gridx++;
@@ -146,14 +146,14 @@ public class RegExUserParametersGui extends AbstractPreProcessorGui {
     }
 
     // Next line
-    private void resetContraints(GridBagConstraints gbc) {
+    private static void resetContraints(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
         gbc.fill=GridBagConstraints.NONE;
     }
 
-    private void initConstraints(GridBagConstraints gbc) {
+    private static void initConstraints(GridBagConstraints gbc) {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridheight = 1;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/CssParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/CssParser.java
@@ -75,7 +75,7 @@ public class CssParser implements LinkExtractorParser {
         }
     }
 
-    private URLCollection orDefault(URLCollection urlCollection,
+    private static URLCollection orDefault(URLCollection urlCollection,
             URLCollection defaultValue) {
         if (urlCollection == null) {
             return Validate.notNull(defaultValue);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParser.java
@@ -190,7 +190,7 @@ public abstract class HTMLParser extends BaseParser {
      * @param ieVersion Float IE version
      * @return true if IE version &lt; IE v10
      */
-    protected final boolean isEnableConditionalComments(Float ieVersion) {
+    protected static boolean isEnableConditionalComments(Float ieVersion) {
         // Conditional comment have been dropped in IE10
         // http://msdn.microsoft.com/en-us/library/ie/hh801214%28v=vs.85%29.aspx
         return ieVersion != null && ieVersion < IE_10;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
@@ -75,7 +75,7 @@ class JTidyHTMLParser extends HTMLParser {
      *
      * @return new base URL
      */
-    private URL scanNodes(Node node, URLCollection urls, URL baseUrl) throws HTMLParseException {
+    private static URL scanNodes(Node node, URLCollection urls, URL baseUrl) throws HTMLParseException {
         if (node == null) {
             return baseUrl;
         }
@@ -201,7 +201,7 @@ class JTidyHTMLParser extends HTMLParser {
      * Helper method to get an attribute value, if it exists @param attrs list
      * of attributes @param attname attribute name @return
      */
-    private String getValue(NamedNodeMap attrs, String attname) {
+    private static String getValue(NamedNodeMap attrs, String attname) {
         String v = null;
         Node n = attrs.getNamedItem(attname);
         if (n != null) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
@@ -49,8 +49,8 @@ public class JsoupBasedHtmlParser extends HTMLParser {
 
     private static final class JMeterNodeVisitor implements NodeVisitor {
 
-        private URLCollection urls;
-        private URLPointer baseUrl;
+        private final URLCollection urls;
+        private final URLPointer baseUrl;
 
         /**
          * @param baseUrl base url to extract possibly missing information from urls found in <code>urls</code>

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
@@ -181,8 +181,6 @@ public class LagartoBasedHtmlParser extends HTMLParser {
                 break;
             case END:
                 break;
-            default:
-                throw new IllegalStateException("Unexpected tagType " + tagType);
             }
         }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
@@ -61,10 +61,10 @@ public class LagartoBasedHtmlParser extends HTMLParser {
 
     private static final class JMeterTagVisitor extends EmptyTagVisitor {
         private HtmlCCommentExpressionMatcher htmlCCommentExpressionMatcher;
-        private URLCollection urls;
-        private URLPointer baseUrl;
-        private Float ieVersion;
-        private Deque<Boolean> enabled = new ArrayDeque<>();
+        private final URLCollection urls;
+        private final URLPointer baseUrl;
+        private final Float ieVersion;
+        private final Deque<Boolean> enabled = new ArrayDeque<>();
 
         /**
          * @param baseUrl base url to add possibly missing information to urls found in <code>urls</code>

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/RegexpHTMLParser.java
@@ -136,15 +136,15 @@ class RegexpHTMLParser extends HTMLParser {
      */
     @Override
     public Iterator<URL> getEmbeddedResourceURLs(String userAgent, byte[] html, URL baseUrl,
-                                                 URLCollection urls, String encoding) throws HTMLParseException {
+            URLCollection urls, String encoding) throws HTMLParseException {
         if (USE_JAVA_REGEX) {
             return getEmbeddedResourceURLsWithJavaRegex(html, baseUrl, urls, encoding);
         }
         return getEmbeddedResourceURLsWithOroRegex(html, baseUrl, urls, encoding);
     }
 
-    private Iterator<URL> getEmbeddedResourceURLsWithJavaRegex(byte[] html, URL baseUrl, URLCollection urls,
-                                                               String encoding) throws HTMLParseException {
+    private static Iterator<URL> getEmbeddedResourceURLsWithJavaRegex(byte[] html, URL baseUrl, URLCollection urls,
+            String encoding) throws HTMLParseException {
         try {
 
             // TODO: find a way to avoid the cost of creating a String here --
@@ -190,8 +190,8 @@ class RegexpHTMLParser extends HTMLParser {
         }
     }
 
-    private Iterator<URL> getEmbeddedResourceURLsWithOroRegex(byte[] html, URL baseUrl, URLCollection urls,
-                                                              String encoding) throws HTMLParseException {
+    private static Iterator<URL> getEmbeddedResourceURLsWithOroRegex(byte[] html, URL baseUrl, URLCollection urls,
+            String encoding) throws HTMLParseException {
         Pattern pattern= null;
         Perl5Matcher matcher = null;
         try {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/AbstractSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/AbstractSamplerCreator.java
@@ -58,7 +58,7 @@ public abstract class AbstractSamplerCreator implements SamplerCreator {
     private static final boolean NUMBER_REQUESTS =
         JMeterUtils.getPropDefault("proxy.number.requests", true); // $NON-NLS-1$
 
-    private static AtomicInteger REQUEST_NUMBER = new AtomicInteger(0);// running number
+    private static final AtomicInteger REQUEST_NUMBER = new AtomicInteger(0);// running number
 
 
     static {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -136,7 +136,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
         }
     }
 
-    private void detectAndModifySamplerOnGraphQLRequest(final HTTPSamplerBase sampler, final HttpRequestHdr request) {
+    private static void detectAndModifySamplerOnGraphQLRequest(final HTTPSamplerBase sampler, final HttpRequestHdr request) {
         final String method = request.getMethod();
         final Header header = request.getHeaderManager().getFirstHeaderNamed("Content-Type");
         final boolean graphQLContentType = header != null
@@ -354,7 +354,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
      * @param sampler {@link HTTPSamplerBase}
      * @param request {@link HttpRequestHdr}
      */
-    protected void computeSamplerName(HTTPSamplerBase sampler,
+    protected static void computeSamplerName(HTTPSamplerBase sampler,
             HttpRequestHdr request) {
         String prefix = StringUtils.defaultString(request.getPrefix(), "");
         int httpSampleNameMode = request.getHttpSampleNameMode();
@@ -366,7 +366,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
         }
     }
 
-    private String getFormat(int httpSampleNameMode, String format) {
+    private static String getFormat(int httpSampleNameMode, String format) {
         if (httpSampleNameMode == SAMPLER_NAME_NAMING_MODE_FORMATTER) {
             return format.replaceAll("#\\{name([,}])", "{0$1")
                     .replaceAll("#\\{path([,}])", "{1$1")
@@ -387,7 +387,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
         return "{1}";
     }
 
-    private String getNumberedFormat(int httpSampleNameMode) {
+    private static String getNumberedFormat(int httpSampleNameMode) {
         if (httpSampleNameMode == SAMPLER_NAME_NAMING_MODE_PREFIX) {
             return "{0}{1}-{2}";
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
@@ -298,11 +298,11 @@ public class HttpRequestHdr {
         return null;
     }
 
-    private boolean isMultipart(String contentType) {
+    private static boolean isMultipart(String contentType) {
         return contentType != null && contentType.startsWith(HTTPConstants.MULTIPART_FORM_DATA);
     }
 
-    public MultipartUrlConfig getMultipartConfig(String contentType) {
+    public static MultipartUrlConfig getMultipartConfig(String contentType) {
         if(isMultipart(contentType)) {
             // Get the boundary string for the multiparts from the content type
             String boundaryString = contentType.substring(contentType.toLowerCase(java.util.Locale.ENGLISH).indexOf("boundary=") + "boundary=".length());
@@ -416,7 +416,7 @@ public class HttpRequestHdr {
      *            String that is partially tokenized.
      * @return The remainder
      */
-    private String getToken(StringTokenizer tk) {
+    private static String getToken(StringTokenizer tk) {
         if (tk.hasMoreTokens()) {
             return tk.nextToken();
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
@@ -81,11 +81,11 @@ public class HttpRequestHdr {
 
     private String firstLine; // saved copy of first line for error reports
 
-    private String prefix;
+    private final String prefix;
 
-    private int httpSampleNameMode;
+    private final int httpSampleNameMode;
 
-    private String httpSampleNameFormat;
+    private final String httpSampleNameFormat;
 
     private boolean detectGraphQLRequest;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
@@ -404,7 +404,7 @@ public class Proxy extends Thread {
      * @return the keystore entry or {@code null} if no match found
      * @throws KeyStoreException
      */
-    private String getDomainMatch(KeyStore keyStore, String host) throws KeyStoreException {
+    private static String getDomainMatch(KeyStore keyStore, String host) throws KeyStoreException {
         if (keyStore.containsAlias(host)) {
             return host;
         }
@@ -479,7 +479,7 @@ public class Proxy extends Thread {
         }
     }
 
-    private SampleResult generateErrorResult(SampleResult result, HttpRequestHdr request, Exception e) {
+    private static SampleResult generateErrorResult(SampleResult result, HttpRequestHdr request, Exception e) {
         return generateErrorResult(result, request, e, "");
     }
 
@@ -537,7 +537,7 @@ public class Proxy extends Thread {
      *
      * @return updated headers to be sent to client
      */
-    private String messageResponseHeaders(SampleResult res) {
+    private static String messageResponseHeaders(SampleResult res) {
         String headers = res.getResponseHeaders();
         String[] headerLines = headers.split(NEW_LINE, 0); // drop empty trailing content
         int contentLengthIndex = -1;
@@ -647,7 +647,7 @@ public class Proxy extends Thread {
         }
     }
 
-    private boolean isNotHtmlType(String contentType) {
+    private static boolean isNotHtmlType(String contentType) {
         for (String mimeType: NOT_HTML_TEXT_TYPES) {
             if (contentType.startsWith(mimeType)) {
                 return true;
@@ -656,7 +656,7 @@ public class Proxy extends Thread {
         return false;
     }
 
-    private String getUrlWithoutQuery(URL url) {
+    private static String getUrlWithoutQuery(URL url) {
         String fullUrl = url.toString();
         String urlWithoutQuery = fullUrl;
         String query = url.getQuery();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -271,7 +271,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
 
     private volatile boolean regexMatch = false;
 
-    private Set<Class<?>> addableInterfaces = new HashSet<>(
+    private final Set<Class<?>> addableInterfaces = new HashSet<>(
             Arrays.asList(Visualizer.class, ConfigElement.class,
                     Assertion.class, Timer.class, PreProcessor.class,
                     PostProcessor.class, SampleListener.class));
@@ -288,7 +288,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
 
     private JMeterTreeModel nonGuiTreeModel;
 
-    private ArrayDeque<SamplerInfo> sampleQueue = new ArrayDeque<>();
+    private final ArrayDeque<SamplerInfo> sampleQueue = new ArrayDeque<>();
 
     // accessed from Swing-Thread, only
     private String oldPrefix = null;
@@ -1721,12 +1721,12 @@ public class ProxyControl extends GenericController implements NonTestElement {
      */
     private static class SamplerInfo implements Serializable {
         private static final long serialVersionUID = 1L;
-        private HTTPSamplerBase sampler;
-        private transient TestElement[] testElements;
-        private JMeterTreeNode target;
-        private String prefix;
-        private int groupingMode;
-        private long recordedAt;
+        private final HTTPSamplerBase sampler;
+        private final transient TestElement[] testElements;
+        private final JMeterTreeNode target;
+        private final String prefix;
+        private final int groupingMode;
+        private final long recordedAt;
 
         public SamplerInfo(HTTPSamplerBase sampler, TestElement[] testElements, JMeterTreeNode target, String prefix, int groupingMode) {
             this.sampler = sampler;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -1532,8 +1532,6 @@ public class ProxyControl extends GenericController implements NonTestElement {
             break;
         case NONE:
             throw new IOException("Cannot find keytool application and no keystore was provided");
-        default:
-            throw new IllegalStateException("Impossible case: " + KEYSTORE_MODE);
         }
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -674,7 +674,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @param result       {@link HTTPSampleResult}
      * @return {@link Authorization}
      */
-    private Authorization createAuthorization(final TestElement[] testElements, SampleResult result) {
+    private static Authorization createAuthorization(final TestElement[] testElements, SampleResult result) {
         Header authHeader;
         Authorization authorization = null;
         // Iterate over subconfig elements searching for HeaderManager
@@ -744,7 +744,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         return authorization;
     }
 
-    private String computeAuthUrl(String url) {
+    private static String computeAuthUrl(String url) {
         int index = url.lastIndexOf('/');
         if (index >=0) {
             return url.substring(0, index+1);
@@ -871,7 +871,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @param sampleContentType content to check
      * @return boolean true if Matching expression
      */
-    private boolean testPattern(String expression, String sampleContentType, boolean expectedToMatch) {
+    private static boolean testPattern(String expression, String sampleContentType, boolean expectedToMatch) {
         if (expression == null || expression.isEmpty()) {
             return true;
         }
@@ -897,12 +897,12 @@ public class ProxyControl extends GenericController implements NonTestElement {
         return true;
     }
 
-    private boolean isContainedWithJavaRegex(String expression, String sampleContentType) {
+    private static boolean isContainedWithJavaRegex(String expression, String sampleContentType) {
         java.util.regex.Pattern pattern = JMeterUtils.compilePattern(expression);
         return pattern.matcher(sampleContentType).find();
     }
 
-    private boolean isContainedWithOroRegex(String expression, String sampleContentType) {
+    private static boolean isContainedWithOroRegex(String expression, String sampleContentType) {
         Pattern pattern = JMeterUtils.getPatternCache().getPattern(expression,
                 Perl5Compiler.READ_ONLY_MASK | Perl5Compiler.SINGLELINE_MASK);
         return JMeterUtils.getMatcher().contains(sampleContentType, pattern);
@@ -944,7 +944,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * Helper method to add a Response Assertion
      * Called from AWT Event thread
      */
-    private void addAssertion(JMeterTreeModel model, JMeterTreeNode node) throws IllegalUserActionException {
+    private static void addAssertion(JMeterTreeModel model, JMeterTreeNode node) throws IllegalUserActionException {
         ResponseAssertion ra = new ResponseAssertion();
         ra.setProperty(TestElement.GUI_CLASS, ASSERTION_GUI);
         ra.setName(JMeterUtils.getResString("assertion_title")); // $NON-NLS-1$
@@ -953,7 +953,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     }
 
     /** Construct a new AuthManager with the provided authorization */
-    private AuthManager newAuthorizationManager(Authorization authorization) {
+    private static AuthManager newAuthorizationManager(Authorization authorization) {
         AuthManager authManager = new AuthManager();
         authManager.setProperty(TestElement.GUI_CLASS, AUTH_PANEL);
         authManager.setProperty(TestElement.TEST_CLASS, AUTH_MANAGER);
@@ -966,14 +966,14 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * Helper method to add a Divider
      * Called from Application Thread that needs to update GUI (JMeterTreeModel)
      */
-    private void addDivider(final JMeterTreeModel model, final JMeterTreeNode node) {
+    private static void addDivider(final JMeterTreeModel model, final JMeterTreeNode node) {
         final GenericController sc = new GenericController();
         sc.setProperty(TestElement.GUI_CLASS, LOGIC_CONTROLLER_GUI);
         sc.setName("-------------------"); // $NON-NLS-1$
         safelyAddComponent(model, node, sc);
     }
 
-    private void safelyAddComponent(
+    private static void safelyAddComponent(
             final JMeterTreeModel model,
             final JMeterTreeNode node,
             final GenericController controller) {
@@ -995,7 +995,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @param node  Node in the tree where we will add the Controller
      * @param name  A name for the Controller
      */
-    private void addSimpleController(final JMeterTreeModel model, final JMeterTreeNode node, String name) {
+    private static void addSimpleController(final JMeterTreeModel model, final JMeterTreeNode node, String name) {
         final GenericController sc = new GenericController();
         sc.setProperty(TestElement.GUI_CLASS, LOGIC_CONTROLLER_GUI);
         sc.setName(name);
@@ -1010,7 +1010,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @param node  Node in the tree where we will add the Controller
      * @param name  A name for the Controller
      */
-    private void addTransactionController(final JMeterTreeModel model, final JMeterTreeNode node, String name) {
+    private static void addTransactionController(final JMeterTreeModel model, final JMeterTreeNode node, String name) {
         final TransactionController sc = new TransactionController();
         sc.setIncludeTimers(false);
         sc.setProperty(TestElement.GUI_CLASS, TRANSACTION_CONTROLLER_GUI);
@@ -1271,7 +1271,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         return false;
     }
 
-    private JMeterTreeNode getTargetNode(JMeterTreeNode origTarget, int cachedGroupingMode) {
+    private static JMeterTreeNode getTargetNode(JMeterTreeNode origTarget, int cachedGroupingMode) {
         if (cachedGroupingMode == GROUPING_IN_SIMPLE_CONTROLLERS ||
                 cachedGroupingMode == GROUPING_IN_TRANSACTION_CONTROLLERS) {
             // Find the last controller in the target to store the
@@ -1306,7 +1306,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         }
     }
 
-    private boolean hasCorrectInterface(Object obj, Set<Class<?>> klasses) {
+    private static boolean hasCorrectInterface(Object obj, Set<Class<?>> klasses) {
         for (Class<?> klass: klasses) {
             if (klass != null && klass.isInstance(obj)) {
                 return true;
@@ -1324,7 +1324,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @param sampler        Sampler to remove values from.
      * @param configurations ConfigTestElements in descending priority.
      */
-    private void removeValuesFromSampler(HTTPSamplerBase sampler, Collection<ConfigTestElement> configurations) {
+    private static void removeValuesFromSampler(HTTPSamplerBase sampler, Collection<ConfigTestElement> configurations) {
         PropertyIterator props = sampler.propertyIterator();
         while (props.hasNext()) {
             JMeterProperty prop = props.next();
@@ -1355,7 +1355,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         }
     }
 
-    private String generateMatchUrl(HTTPSamplerBase sampler) {
+    private static String generateMatchUrl(HTTPSamplerBase sampler) {
         StringBuilder buf = new StringBuilder(sampler.getDomain());
         buf.append(':'); // $NON-NLS-1$
         buf.append(sampler.getPort());
@@ -1367,14 +1367,14 @@ public class ProxyControl extends GenericController implements NonTestElement {
         return buf.toString();
     }
 
-    private boolean matchesPatterns(String url, CollectionProperty patterns) {
+    private static boolean matchesPatterns(String url, CollectionProperty patterns) {
         if (USE_JAVA_REGEX) {
             return matchesPatternsWithJavaRegex(url, patterns);
         }
         return matchesPatternsWithOroRegex(url, patterns);
     }
 
-    private boolean matchesPatternsWithJavaRegex(String url, CollectionProperty patterns) {
+    private static boolean matchesPatternsWithJavaRegex(String url, CollectionProperty patterns) {
         for (JMeterProperty jMeterProperty : patterns) {
             String item = jMeterProperty.getStringValue();
             try {
@@ -1389,7 +1389,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         return false;
     }
 
-    private boolean matchesPatternsWithOroRegex(String url, CollectionProperty patterns) {
+    private static boolean matchesPatternsWithOroRegex(String url, CollectionProperty patterns) {
         for (JMeterProperty jMeterProperty : patterns) {
             String item = jMeterProperty.getStringValue();
             try {
@@ -1634,7 +1634,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     }
 
     @SuppressWarnings("deprecation")
-    private boolean isValid(String subject) {
+    private static boolean isValid(String subject) {
         String[] parts = subject.split("\\.");
         return !parts[0].endsWith("*") // not a wildcard
                 || parts.length >= 3
@@ -1685,7 +1685,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
         }
     }
 
-    private KeyStore getKeyStore(char[] password) throws GeneralSecurityException, IOException {
+    private static KeyStore getKeyStore(char[] password) throws GeneralSecurityException, IOException {
         try (InputStream in = new BufferedInputStream(new FileInputStream(CERT_PATH))) {
             log.debug("Opened Keystore file: {}", CERT_PATH_ABS);
             KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
@@ -1695,11 +1695,11 @@ public class ProxyControl extends GenericController implements NonTestElement {
         }
     }
 
-    private String getPassword() {
+    private static String getPassword() {
         return PREFERENCES.get(USER_PASSWORD_KEY, null);
     }
 
-    private void setPassword(String password) {
+    private static void setPassword(String password) {
         PREFERENCES.put(USER_PASSWORD_KEY, password);
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -363,7 +363,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         element.setExcludeList(excludeList);
     }
 
-    private List<String> getDataList(PowerTableModel pModel, String colName) {
+    private static List<String> getDataList(PowerTableModel pModel, String colName) {
         String[] dataArray = pModel.getData().getColumn(colName);
         List<String> list = new ArrayList<>();
         Collections.addAll(list, dataArray);
@@ -417,7 +417,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         repaint();
     }
 
-    private void populateTable(PowerTableModel pModel, PropertyIterator iter) {
+    private static void populateTable(PowerTableModel pModel, PropertyIterator iter) {
         pModel.clearData();
         while (iter.hasNext()) {
             pModel.addRow(new Object[] { iter.next().getStringValue() });
@@ -1037,7 +1037,7 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
         destPanel.add(targetNodes, "growx, span");
     }
 
-    private JScrollPane findScrollPane(JPopupMenu popup) {
+    private static JScrollPane findScrollPane(JPopupMenu popup) {
         Component[] components = popup.getComponents();
         for (Component component : components) {
             if(component instanceof JScrollPane) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
@@ -308,7 +308,7 @@ public class AjpSampler extends HTTPSamplerBase implements Interruptible {
         return hbuf.toString();
     }
 
-    private String encode(String value)  {
+    private static String encode(String value)  {
         StringBuilder newValue = new StringBuilder();
         char[] chars = value.toCharArray();
         for (char c : chars) {
@@ -335,7 +335,7 @@ public class AjpSampler extends HTTPSamplerBase implements Interruptible {
         return cookieHeader;
     }
 
-    private int translateHeader(String n) {
+    private static int translateHeader(String n) {
         for(int i=0; i < HEADER_TRANS_ARRAY.length; i++) {
             if(HEADER_TRANS_ARRAY[i].equalsIgnoreCase(n)) {
                 return i+1;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
@@ -246,7 +246,6 @@ public abstract class HTTPAbstractImpl implements Interruptible, HTTPConstantsIn
                 ipClass = Inet6Address.class;
                 break;
             case HOSTNAME:
-            default:
                 return InetAddress.getByName(ipSource);
             }
 
@@ -596,10 +595,8 @@ public abstract class HTTPAbstractImpl implements Interruptible, HTTPConstantsIn
                 res.setResponseMessage(RETURN_CUSTOM_STATUS_MESSAGE);
                 res.setSuccessful(true);
                 return res;
-            default:
-                // Cannot happen
-                throw new IllegalStateException("Unknown CACHED_RESOURCE_MODE");
         }
+        throw new IllegalStateException("Unknown CACHED_RESOURCE_MODE: " + CACHED_RESOURCE_MODE);
     }
 
     protected final void configureSampleLabel(SampleResult res, URL url) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -209,9 +209,9 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
     private static final InputStreamFactory BROTLI = BrotliInputStream::new;
 
     private static final class ManagedCredentialsProvider implements CredentialsProvider {
-        private AuthManager authManager;
-        private Credentials proxyCredentials;
-        private AuthScope proxyAuthScope;
+        private final AuthManager authManager;
+        private final Credentials proxyCredentials;
+        private final AuthScope proxyAuthScope;
 
         public ManagedCredentialsProvider(AuthManager authManager, AuthScope proxyAuthScope, Credentials proxyCredentials) {
             this.authManager = authManager;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -273,7 +273,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
             return null;
         }
 
-        private int getPort(URL url) {
+        private static int getPort(URL url) {
             if (url.getPort() == -1) {
                 return url.getProtocol().equals("https") ? 443 : 80;
             }
@@ -356,7 +356,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
          * @param authCache
          * @param authScope
          */
-        private void fillAuthCache(HttpHost targetHost, Authorization authorization, AuthCache authCache,
+        private static void fillAuthCache(HttpHost targetHost, Authorization authorization, AuthCache authCache,
                 AuthScope authScope) {
             @SuppressWarnings("deprecation")
             Mechanism basicDigest = Mechanism.BASIC_DIGEST;
@@ -771,7 +771,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param triple {@link MutableTriple}
      * @param localContext {@link HttpContext}
      */
-    private void saveProxyAuth(
+    private static void saveProxyAuth(
             MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager> triple,
             HttpContext localContext) {
         triple.setMiddle((AuthState) localContext.getAttribute(HttpClientContext.PROXY_AUTH_STATE));
@@ -782,8 +782,8 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param triple {@link MutableTriple} May be null if first request
      * @param localContext {@link HttpContext}
      */
-    private void setupProxyAuthState(MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager> triple,
-                                HttpContext localContext) {
+    private static void setupProxyAuthState(MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager> triple,
+            HttpContext localContext) {
         if (triple != null) {
             AuthState proxyAuthState = triple.getMiddle();
             localContext.setAttribute(HttpClientContext.PROXY_AUTH_STATE, proxyAuthState);
@@ -837,7 +837,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param jMeterVariables {@link JMeterVariables}
      * @param localContext {@link HttpContext}
      */
-    private void extractClientContextAfterSample(JMeterVariables jMeterVariables, HttpContext localContext) {
+    private static void extractClientContextAfterSample(JMeterVariables jMeterVariables, HttpContext localContext) {
         Object userToken = localContext.getAttribute(HttpClientContext.USER_TOKEN);
         if(userToken != null) {
             log.debug("Extracted from HttpContext user token:{} storing it as JMeter variable:{}", userToken, JMETER_VARIABLE_USER_TOKEN);
@@ -854,7 +854,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param jMeterVariables {@link JMeterVariables}
      * @param localContext {@link HttpContext}
      */
-    private void setupClientContextBeforeSample(JMeterVariables jMeterVariables, HttpContext localContext) {
+    private static void setupClientContextBeforeSample(JMeterVariables jMeterVariables, HttpContext localContext) {
         Object userToken = null;
         // During recording JMeterContextService.getContext().getVariables() is null
         if(jMeterVariables != null) {
@@ -993,7 +993,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
         }
 
         // Allow for null strings
-        private int getHash(String s) {
+        private static int getHash(String s) {
             return s == null ? 0 : s.hashCode();
         }
 
@@ -1223,7 +1223,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param clientContext {@link HttpClientContext}
      * @param mapHttpClientPerHttpClientKey Map of {@link MutableTriple} holding {@link CloseableHttpClient} and {@link PoolingHttpClientConnectionManager}
      */
-    private void resetStateIfNeeded(
+    private static void resetStateIfNeeded(
             MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager> triple,
             JMeterVariables jMeterVariables,
             HttpClientContext clientContext,
@@ -1244,7 +1244,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
     /**
      * @param mapHttpClientPerHttpClientKey
      */
-    private void closeCurrentConnections(
+    private static void closeCurrentConnections(
             Map<HttpClientKey, MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager>> mapHttpClientPerHttpClientKey) {
         for (MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager> triple :
                 mapHttpClientPerHttpClientKey.values()) {
@@ -1334,7 +1334,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param response containing the headers
      * @return string containing the headers, one per line
      */
-    private String getResponseHeaders(HttpResponse response) {
+    private static String getResponseHeaders(HttpResponse response) {
         Header[] rh = response.getAllHeaders();
 
         StringBuilder headerBuf = new StringBuilder(40 * (rh.length+1));
@@ -1352,7 +1352,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param headerBuffer {@link StringBuilder}
      * @param header {@link Header}
      */
-    private void writeHeader(StringBuilder headerBuffer, Header header) {
+    private static void writeHeader(StringBuilder headerBuffer, Header header) {
         if(header instanceof BufferedHeader) {
             CharArrayBuffer buffer = ((BufferedHeader)header).getBuffer();
             headerBuffer.append(buffer.buffer(), 0, buffer.length()).append('\n'); // $NON-NLS-1$
@@ -1396,7 +1396,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      *                      for this <code>UrlConfig</code>
      * @param cacheManager  the CacheManager (may be null)
      */
-    protected void setConnectionHeaders(HttpRequestBase request, URL url, HeaderManager headerManager, CacheManager cacheManager) {
+    protected static void setConnectionHeaders(HttpRequestBase request, URL url, HeaderManager headerManager, CacheManager cacheManager) {
         if (headerManager != null) {
             CollectionProperty headers = headerManager.getHeaders();
             if (headers != null) {
@@ -1441,7 +1441,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      *                        hostHeaderValue
      * @return integer representing the port for the host header
      */
-    private int getPortFromHostHeader(String hostHeaderValue, int defaultValue) {
+    private static int getPortFromHostHeader(String hostHeaderValue, int defaultValue) {
         String[] hostParts = hostHeaderValue.split(":");
         if (hostParts.length > 1) {
             String portString = hostParts[hostParts.length - 1];
@@ -1458,7 +1458,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param method <code>HttpMethod</code> which represents the request
      * @return the headers as a string
      */
-    private String getAllHeadersExceptCookie(HttpRequest method) {
+    private static String getAllHeadersExceptCookie(HttpRequest method) {
         return getFromHeadersMatchingPredicate(method, ALL_EXCEPT_COOKIE);
     }
 
@@ -1468,7 +1468,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param method <code>HttpMethod</code> which represents the request
      * @return the headers as a string
      */
-    private String getOnlyCookieFromHeaders(HttpRequest method) {
+    private static String getOnlyCookieFromHeaders(HttpRequest method) {
         String cookieHeader= getFromHeadersMatchingPredicate(method, ONLY_COOKIE).trim();
         if(!cookieHeader.isEmpty()) {
             return cookieHeader.substring(HTTPConstants.HEADER_COOKIE_IN_REQUEST.length()).trim();
@@ -1483,7 +1483,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @param method <code>HttpMethod</code> which represents the request
      * @return the headers as a string
      */
-    private String getFromHeadersMatchingPredicate(HttpRequest method, Predicate<String> predicate) {
+    private static String getFromHeadersMatchingPredicate(HttpRequest method, Predicate<String> predicate) {
         if(method != null) {
             // Get all the request headers
             StringBuilder hdrs = new StringBuilder(150);
@@ -1681,7 +1681,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @throws IOException
      * @throws UnsupportedEncodingException
      */
-    private void writeEntityToSB(final StringBuilder postedBody, final HttpEntity entity,
+    private static void writeEntityToSB(final StringBuilder postedBody, final HttpEntity entity,
             final ViewableFileBody[] fileBodies, final String contentEncoding)
                     throws IOException {
         if (entity.isRepeatable()){
@@ -1845,7 +1845,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
         }
     }
 
-    private void saveConnectionCookies(HttpResponse method, URL u, CookieManager cookieManager) {
+    private static void saveConnectionCookies(HttpResponse method, URL u, CookieManager cookieManager) {
         if (cookieManager != null) {
             Header[] hdrs = method.getHeaders(HTTPConstants.HEADER_SET_COOKIE);
             for (Header hdr : hdrs) {
@@ -1878,7 +1878,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
         closeThreadLocalConnections();
     }
 
-    private void closeThreadLocalConnections() {
+    private static void closeThreadLocalConnections() {
         // Does not need to be synchronised, as all access is from same thread
         Map<HttpClientKey, MutableTriple<CloseableHttpClient, AuthState, PoolingHttpClientConnectionManager>>
             mapHttpClientPerHttpClientKey = HTTPCLIENTS_CACHE_PER_THREAD_AND_HTTPCLIENTKEY.get();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
@@ -336,7 +336,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      *            the <code>CookieManager</code> containing all the cookies
      *            for this <code>UrlConfig</code>
      */
-    private String setConnectionCookie(HttpURLConnection conn, URL u, CookieManager cookieManager) {
+    private static String setConnectionCookie(HttpURLConnection conn, URL u, CookieManager cookieManager) {
         String cookieHeader = null;
         if (cookieManager != null) {
             cookieHeader = cookieManager.getCookieHeaderForURL(u);
@@ -361,7 +361,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      *            for this <code>UrlConfig</code>
      * @param cacheManager the CacheManager (may be null)
      */
-    private void setConnectionHeaders(HttpURLConnection conn, URL u,
+    private static void setConnectionHeaders(HttpURLConnection conn, URL u,
             HeaderManager headerManager, CacheManager cacheManager) {
         // Add all the headers from the HeaderManager
         Header[] arrayOfHeaders = null;
@@ -393,7 +393,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      * @param securityHeaders Map of security Header
      * @return the headers as a string
      */
-    private String getOnlyCookieFromHeaders(HttpURLConnection conn, Map<String, String> securityHeaders) {
+    private static String getOnlyCookieFromHeaders(HttpURLConnection conn, Map<String, String> securityHeaders) {
         String cookieHeader= getFromConnectionHeaders(conn, securityHeaders, ONLY_COOKIE, false).trim();
         if(!cookieHeader.isEmpty()) {
             return cookieHeader.substring(HTTPConstants.HEADER_COOKIE_IN_REQUEST.length()).trim();
@@ -410,7 +410,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      * @param securityHeaders Map of security Header
      * @return the headers as a string
      */
-    private String getAllHeadersExceptCookie(HttpURLConnection conn, Map<String, String> securityHeaders) {
+    private static String getAllHeadersExceptCookie(HttpURLConnection conn, Map<String, String> securityHeaders) {
         return getFromConnectionHeaders(conn, securityHeaders, ALL_EXCEPT_COOKIE, true);
     }
 
@@ -424,7 +424,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      * @param predicate {@link Predicate}
      * @return the headers as a string
      */
-    private String getFromConnectionHeaders(HttpURLConnection conn, Map<String, String> securityHeaders,
+    private static String getFromConnectionHeaders(HttpURLConnection conn, Map<String, String> securityHeaders,
             Predicate<String> predicate, boolean addSecurityHeaders) {
         // Get all the request properties, which are the headers set on the connection
         StringBuilder hdrs = new StringBuilder(100);
@@ -465,7 +465,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      *            this <code>UrlConfig</code>
      * @return String Authorization header value or null if not set
      */
-    private Map<String, String> setConnectionAuthorization(HttpURLConnection conn, URL u, AuthManager authManager) {
+    private static Map<String, String> setConnectionAuthorization(HttpURLConnection conn, URL u, AuthManager authManager) {
         if (authManager != null) {
             Authorization auth = authManager.getAuthForURL(u);
             if (auth != null) {
@@ -662,7 +662,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
         }
     }
 
-    private Header[] getHeaders(HeaderManager headerManager) {
+    private static Header[] getHeaders(HeaderManager headerManager) {
         if (headerManager != null) {
             final CollectionProperty headers = headerManager.getHeaders();
             if (headers != null) {
@@ -700,7 +700,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      *            the <code>CookieManager</code> containing all the cookies
      *            for this <code>UrlConfig</code>
      */
-    private void saveConnectionCookies(HttpURLConnection conn, URL u, CookieManager cookieManager) {
+    private static void saveConnectionCookies(HttpURLConnection conn, URL u, CookieManager cookieManager) {
         if (cookieManager != null) {
             for (int i = 1; conn.getHeaderFieldKey(i) != null; i++) {
                 if (conn.getHeaderFieldKey(i).equalsIgnoreCase(HTTPConstants.HEADER_SET_COOKIE)) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -442,7 +442,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         return getDoMultipart() || (files.length>0 && hasNoMissingFile(files) && !getSendFileAsPostBody());
     }
 
-    private boolean hasNoMissingFile(HTTPFileArg[] files) {
+    private static boolean hasNoMissingFile(HTTPFileArg[] files) {
         for (HTTPFileArg httpFileArg : files) {
             if(StringUtils.isEmpty(httpFileArg.getPath())) {
                 log.warn("File {} is invalid as no path is defined", httpFileArg);
@@ -1476,7 +1476,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         return res;
     }
 
-    private Predicate<URL> generateMatcherPredicate(String regex, String explanation, boolean defaultAnswer) {
+    private static Predicate<URL> generateMatcherPredicate(String regex, String explanation, boolean defaultAnswer) {
         if (StringUtils.isEmpty(regex)) {
             return s -> defaultAnswer;
         }
@@ -1511,7 +1511,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @return {@link LinkExtractorParser}
      * @throws LinkExtractorParseException
      */
-    private LinkExtractorParser getParser(HTTPSampleResult res)
+    private static LinkExtractorParser getParser(HTTPSampleResult res)
             throws LinkExtractorParseException {
         String parserClassName =
                 PARSERS_FOR_CONTENT_TYPE.get(res.getMediaType());
@@ -1525,7 +1525,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @param url URL to escape
      * @return escaped url
      */
-    private URL escapeIllegalURLCharacters(java.net.URL url) {
+    private static URL escapeIllegalURLCharacters(java.net.URL url) {
         if (url == null || "file".equals(url.getProtocol())) {
             return url;
         }
@@ -1542,7 +1542,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @param sampleResult HTTPSampleResult
      * @return User Agent part
      */
-    private String getUserAgent(HTTPSampleResult sampleResult) {
+    private static String getUserAgent(HTTPSampleResult sampleResult) {
         String res = sampleResult.getRequestHeaders();
         int index = res.indexOf(USER_AGENT);
         if (index >= 0) {
@@ -1569,7 +1569,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @param res {@link HTTPSampleResult}
      * @param initialValue boolean
      */
-    private void setParentSampleSuccess(HTTPSampleResult res, boolean initialValue) {
+    private static void setParentSampleSuccess(HTTPSampleResult res, boolean initialValue) {
         if (!IGNORE_FAILED_EMBEDDED_RESOURCES) {
             res.setSuccessful(initialValue);
             if (!initialValue) {
@@ -1733,7 +1733,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @param initialMethod the initial HTTP Method
      * @return the new HTTP Method as per RFC
      */
-    private String computeMethodForRedirect(String initialMethod) {
+    private static String computeMethodForRedirect(String initialMethod) {
         if (!HTTPConstants.HEAD.equalsIgnoreCase(initialMethod)) {
             return HTTPConstants.GET;
         }
@@ -1996,7 +1996,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @param w {@link OutputStream}
      * @return byte array
      */
-    private byte[] toByteArray(OutputStream w) {
+    private static byte[] toByteArray(OutputStream w) {
         if(w instanceof DirectAccessByteArrayOutputStream) {
             return ((DirectAccessByteArrayOutputStream) w).toByteArray();
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
@@ -373,7 +373,7 @@ public class PostWriter {
      *
      * @return the bytes used to end the multipart request
      */
-    private byte[] getMultipartEndDivider(){
+    private static byte[] getMultipartEndDivider(){
         byte[] ending = DASH_DASH_BYTES;
         byte[] completeEnding = new byte[ending.length + CRLF.length];
         System.arraycopy(ending, 0, completeEnding, 0, ending.length);
@@ -385,7 +385,7 @@ public class PostWriter {
      * Write the start of a file multipart, up to the point where the
      * actual file content should be written
      */
-    private void writeStartFileMultipart(OutputStream out, String filename,
+    private static void writeStartFileMultipart(OutputStream out, String filename,
             String nameField, String mimetype)
             throws IOException {
         write(out, "Content-Disposition: form-data; name=\""); // $NON-NLS-1$
@@ -437,14 +437,14 @@ public class PostWriter {
         out.write(getMultipartDivider());
     }
 
-    private void write(OutputStream out, String value)
+    private static void write(OutputStream out, String value)
     throws UnsupportedEncodingException, IOException
     {
         out.write(value.getBytes(ENCODING));
     }
 
 
-    private void writeln(OutputStream out, String value)
+    private static void writeln(OutputStream out, String value)
     throws UnsupportedEncodingException, IOException
     {
         out.write(value.getBytes(ENCODING));

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LaxDeflateInputStream.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LaxDeflateInputStream.java
@@ -80,7 +80,7 @@ public class LaxDeflateInputStream extends DeflateInputStream {
      * @return -1 if relax
      * @throws EOFException
      */
-    private int handleRelaxMode(final EOFException ex, final boolean relaxMode) throws EOFException {
+    private static int handleRelaxMode(final EOFException ex, final boolean relaxMode) throws EOFException {
         if(relaxMode) {
             return -1;
         } else {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LaxGZIPInputStream.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/hc/LaxGZIPInputStream.java
@@ -79,7 +79,7 @@ public class LaxGZIPInputStream extends GZIPInputStream {
      * @return -1 if relax
      * @throws EOFException
      */
-    private int handleRelaxMode(final EOFException ex, final boolean relaxMode) throws EOFException {
+    private static int handleRelaxMode(final EOFException ex, final boolean relaxMode) throws EOFException {
         if(relaxMode) {
             return -1;
         } else {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/EncoderCache.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/EncoderCache.java
@@ -29,7 +29,7 @@ public class EncoderCache {
     /** The encoding which should be usd for URLs, according to HTTP specification */
     public static final String URL_ARGUMENT_ENCODING = StandardCharsets.UTF_8.name();
 
-    private Cache cache;
+    private final Cache cache;
 
     public EncoderCache(int cacheSize) {
         cache = new CacheLRU(cacheSize);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
@@ -53,7 +53,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
     /** temporary storage area for the body header. */
     private String header;
 
-    private static Tika tika = createTika();
+    private static final Tika tika = createTika();
 
     /**
      * Constructor for an empty HTTPFileArg object

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
@@ -103,7 +103,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
         }
     }
 
-    private String detectMimeType(String path, String mimetype) {
+    private static String detectMimeType(String path, String mimetype) {
         if (StringUtils.isNotBlank(mimetype)) {
             return mimetype;
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPResultConverter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPResultConverter.java
@@ -107,7 +107,7 @@ public class HTTPResultConverter extends SampleResultConverter {
         return res;
     }
 
-    private void retrieveHTTPItem(HierarchicalStreamReader reader,
+    private static void retrieveHTTPItem(HierarchicalStreamReader reader,
             HTTPSampleResult res, Object subItem) {
         if (subItem instanceof URL) {
             res.setURL((URL) subItem);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/LoopbackHTTPSocket.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/LoopbackHTTPSocket.java
@@ -42,7 +42,7 @@ public class LoopbackHTTPSocket extends Socket {
 
     // wrap read() methods to track output buffer
     static class LoopBackInputStream extends ByteArrayInputStream{
-        private LoopbackOutputStream os;
+        private final LoopbackOutputStream os;
         @Override
         public synchronized int read() {
             buf=os.getBuffer();   // make sure buffer details

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/LogFilter.java
@@ -100,9 +100,9 @@ public class LogFilter implements Filter, Serializable {
 
     protected boolean PTRNFILTER = false;
 
-    private List<String> excludePatternStrings = new ArrayList<>();
+    private final List<String> excludePatternStrings = new ArrayList<>();
 
-    private  List<String> includePatternStrings = new ArrayList<>();
+    private final List<String> includePatternStrings = new ArrayList<>();
 
     protected ArrayList<Pattern> EXCPATTERNS = new ArrayList<>();
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/accesslog/SessionFilter.java
@@ -91,14 +91,14 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
         return false;
     }
 
-    protected String getIpAddress(String logLine) {
+    protected static String getIpAddress(String logLine) {
         if (USE_JAVA_REGEX) {
             return getIpAddressWithJavaRegex(logLine);
         }
         return getIpAddressWithOroRegex(logLine);
     }
 
-    private String getIpAddressWithJavaRegex(String logLine) {
+    private static String getIpAddressWithJavaRegex(String logLine) {
         Matcher matcher = IP_PATTERN.matcher(logLine);
         if (matcher.find()) {
             return matcher.group(0);
@@ -106,7 +106,7 @@ public class SessionFilter implements Filter, Serializable, TestCloneable,Thread
         return "";
     }
 
-    private String getIpAddressWithOroRegex(String logLine) {
+    private static String getIpAddressWithOroRegex(String logLine) {
         Pattern incIp = JMeterUtils.getPatternCache().getPattern("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}",
                 Perl5Compiler.READ_ONLY_MASK | Perl5Compiler.SINGLELINE_MASK);
         Perl5Matcher matcher = JMeterUtils.getMatcher();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -255,7 +255,7 @@ public class RequestViewHTTP implements RequestView {
      * @param contentType the content type header
      * @return  the boundary string
      */
-    private String extractBoundary(String contentType) {
+    private static String extractBoundary(String contentType) {
         // Get the boundary string for the multiparts from the content type
         String boundaryString = contentType.substring(contentType.toLowerCase(java.util.Locale.ENGLISH).indexOf("boundary=") + "boundary=".length());
         //TODO check in the RFC if other char can be used as separator
@@ -271,7 +271,7 @@ public class RequestViewHTTP implements RequestView {
      * @param headers the http request headers
      * @return true if the request is multipart
      */
-    private boolean isMultipart(LinkedHashMap<String, String> headers) {
+    private static boolean isMultipart(LinkedHashMap<String, String> headers) {
         String contentType = headers.get(HTTPConstants.HEADER_CONTENT_TYPE);
         return contentType != null && contentType.startsWith(HTTPConstants.MULTIPART_FORM_DATA);
     }
@@ -406,7 +406,7 @@ public class RequestViewHTTP implements RequestView {
         return panel;
     }
 
-    private void setFirstColumnPreferredAndMaxWidth(JTable table) {
+    private static void setFirstColumnPreferredAndMaxWidth(JTable table) {
         TableColumn column = table.getColumnModel().getColumn(0);
         column.setMaxWidth(300);
         column.setPreferredWidth(160);

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -95,6 +95,7 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
     }
 
     @Override
+    @SuppressWarnings("RedundantOverride")
     public Object clone() {
         return super.clone();
     }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JavaSamplerContext.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JavaSamplerContext.java
@@ -239,7 +239,7 @@ public class JavaSamplerContext {
      * Returns {@link JMeterVariables} for the current thread.
      * @return {@link JMeterVariables} for the current thread.
      */
-    public final JMeterVariables getJMeterVariables() {
+    public static JMeterVariables getJMeterVariables() {
         return JMeterContextService.getContext().getVariables();
     }
 
@@ -247,7 +247,7 @@ public class JavaSamplerContext {
      * Returns JMeter properties.
      * @return {@link Properties} JMeter properties
      */
-    public final Properties getJMeterProperties() {
+    public static Properties getJMeterProperties() {
         return JMeterUtils.getJMeterProperties();
     }
 

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/JavaTest.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/JavaTest.java
@@ -334,7 +334,7 @@ public class JavaTest extends AbstractJavaSamplerClient implements Serializable,
      * @param context
      *            the context which contains the initialization parameters.
      */
-    private void listParameters(JavaSamplerContext context) {
+    private static void listParameters(JavaSamplerContext context) {
         Iterator<String> argsIt = context.getParameterNamesIterator();
         while (argsIt.hasNext()) {
             String name = argsIt.next();

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/SleepTest.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/SleepTest.java
@@ -198,7 +198,7 @@ public class SleepTest extends AbstractJavaSamplerClient implements Serializable
      * @param context
      *            the context which contains the initialization parameters.
      */
-    private void listParameters(JavaSamplerContext context) {
+    private static void listParameters(JavaSamplerContext context) {
         Iterator<String> argsIt = context.getParameterNamesIterator();
         while (argsIt.hasNext()) {
             String lName = argsIt.next();

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -315,7 +315,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
         }
     }
 
-    private void putIntoVar(final JMeterVariables jmvars, final String name,
+    private static void putIntoVar(final JMeterVariables jmvars, final String name,
             final Clob clob) throws SQLException {
         try {
             if (clob.length() > MAX_RETAIN_SIZE) {
@@ -418,7 +418,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
         return outputs;
     }
 
-    private void setArgument(PreparedStatement pstmt, String argument, int targetSqlType, int index) throws SQLException {
+    private static void setArgument(PreparedStatement pstmt, String argument, int targetSqlType, int index) throws SQLException {
         switch (targetSqlType) {
         case Types.INTEGER:
             pstmt.setInt(index, Integer.parseInt(argument));
@@ -582,7 +582,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
         return sb.toString();
     }
 
-    private int processRow(ResultSet rs, ResultSetMetaData meta, StringBuilder sb, int numColumns,
+    private static int processRow(ResultSet rs, ResultSetMetaData meta, StringBuilder sb, int numColumns,
             JMeterVariables jmvars, String[] varNames, List<Map<String, Object>> results, int currentIterationIndex)
             throws SQLException, UnsupportedEncodingException {
         Map<String, Object> row = null;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
@@ -150,7 +150,7 @@ public class DataSourceElementBeanInfo extends BeanInfoSupport {
      * Get the list of JDBC driver classname for the main databases
      * @return a String[] with the list of JDBC driver classname
      */
-    private String[] getListJDBCDriverClass() {
+    private static String[] getListJDBCDriverClass() {
         return JOrphanUtils.split(JMeterUtils.getPropDefault("jdbc.config.jdbc.driver.class", ""), "|"); //$NON-NLS-1$
     }
 
@@ -159,7 +159,7 @@ public class DataSourceElementBeanInfo extends BeanInfoSupport {
      * Based in https://stackoverflow.com/questions/10684244/dbcp-validationquery-for-different-databases
      * @return a String[] with the list of check queries
      */
-    private String[] getListCheckQuery() {
+    private static String[] getListCheckQuery() {
         return JOrphanUtils.split(JMeterUtils.getPropDefault("jdbc.config.check.query", ""), "|"); //$NON-NLS-1$
     }
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ReceiveSubscriber.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ReceiveSubscriber.java
@@ -269,7 +269,7 @@ public class ReceiveSubscriber implements Closeable, MessageListener {
      * @return the message consumer
      * @throws JMSException
      */
-    private MessageConsumer createSubscriber(Session session,
+    private static MessageConsumer createSubscriber(Session session,
             Destination destination, String durableSubscriptionId,
             String jmsSelector) throws JMSException {
         if (isEmpty(durableSubscriptionId)) {
@@ -377,7 +377,7 @@ public class ReceiveSubscriber implements Closeable, MessageListener {
      * @param s1
      * @return True if input is null, an empty string, or a white space-only string
      */
-    private boolean isEmpty(String s1) {
+    private static boolean isEmpty(String s1) {
         return s1 == null || s1.trim().isEmpty();
     }
 }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSPropertiesPanel.java
@@ -60,7 +60,7 @@ public class JMSPropertiesPanel extends JPanel implements ActionListener {
     private static final int COL_VALUE = 1;
     private static final int COL_TYPE = 2;
 
-    private InnerTableModel tableModel;
+    private final InnerTableModel tableModel;
 
     private JTable jmsPropertiesTable;
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/control/gui/JMSSamplerGui.java
@@ -51,29 +51,29 @@ public class JMSSamplerGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 240L;
 
-    private JLabeledTextField queueConnectionFactory = new JLabeledTextField(
+    private final JLabeledTextField queueConnectionFactory = new JLabeledTextField(
             JMeterUtils.getResString("jms_queue_connection_factory")); //$NON-NLS-1$
 
-    private JLabeledTextField sendQueue = new JLabeledTextField(JMeterUtils.getResString("jms_send_queue")); //$NON-NLS-1$
+    private final JLabeledTextField sendQueue = new JLabeledTextField(JMeterUtils.getResString("jms_send_queue")); //$NON-NLS-1$
 
-    private JLabeledTextField receiveQueue = new JLabeledTextField(JMeterUtils.getResString("jms_receive_queue")); //$NON-NLS-1$
+    private final JLabeledTextField receiveQueue = new JLabeledTextField(JMeterUtils.getResString("jms_receive_queue")); //$NON-NLS-1$
 
-    private JLabeledTextField timeout = new JLabeledTextField(JMeterUtils.getResString("jms_timeout"), 10); //$NON-NLS-1$
+    private final JLabeledTextField timeout = new JLabeledTextField(JMeterUtils.getResString("jms_timeout"), 10); //$NON-NLS-1$
 
-    private JLabeledTextField expiration = new JLabeledTextField(JMeterUtils.getResString("jms_expiration"), 10); //$NON-NLS-1$
+    private final JLabeledTextField expiration = new JLabeledTextField(JMeterUtils.getResString("jms_expiration"), 10); //$NON-NLS-1$
 
-    private JLabeledTextField priority = new JLabeledTextField(JMeterUtils.getResString("jms_priority"), 1); //$NON-NLS-1$
+    private final JLabeledTextField priority = new JLabeledTextField(JMeterUtils.getResString("jms_priority"), 1); //$NON-NLS-1$
 
-    private JLabeledTextField jmsSelector = new JLabeledTextField(JMeterUtils.getResString("jms_selector")); //$NON-NLS-1$
+    private final JLabeledTextField jmsSelector = new JLabeledTextField(JMeterUtils.getResString("jms_selector")); //$NON-NLS-1$
 
-    private JLabeledTextField numberOfSamplesToAggregate = new JLabeledTextField("Number of samples to aggregate"); //$NON-NLS-1$
+    private final JLabeledTextField numberOfSamplesToAggregate = new JLabeledTextField("Number of samples to aggregate"); //$NON-NLS-1$
 
-    private JSyntaxTextArea messageContent = JSyntaxTextArea.getInstance(10, 50); // $NON-NLS-1$
+    private final JSyntaxTextArea messageContent = JSyntaxTextArea.getInstance(10, 50); // $NON-NLS-1$
 
-    private JLabeledTextField initialContextFactory = new JLabeledTextField(
+    private final JLabeledTextField initialContextFactory = new JLabeledTextField(
             JMeterUtils.getResString("jms_initial_context_factory")); //$NON-NLS-1$
 
-    private JLabeledTextField providerUrl = new JLabeledTextField(JMeterUtils.getResString("jms_provider_url")); //$NON-NLS-1$
+    private final JLabeledTextField providerUrl = new JLabeledTextField(JMeterUtils.getResString("jms_provider_url")); //$NON-NLS-1$
 
     private static final String[] JMS_COMMUNICATION_STYLE_LABELS = new String[] {
             "request_only", // $NON-NLS-1$
@@ -83,7 +83,7 @@ public class JMSSamplerGui extends AbstractSamplerGui {
             "clear" // $NON-NLS-1$
     };
 
-    private JLabeledChoice jmsCommunicationStyle = new JLabeledChoice(
+    private final JLabeledChoice jmsCommunicationStyle = new JLabeledChoice(
             JMeterUtils.getResString("jms_communication_style"), // $NON-NLS-1$
             JMS_COMMUNICATION_STYLE_LABELS);
 

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -355,7 +355,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
     }
 
     @SuppressWarnings("JdkObsolete")
-    private void extractContent(StringBuilder buffer, StringBuilder propBuffer, Message msg) {
+    private static void extractContent(StringBuilder buffer, StringBuilder propBuffer, Message msg) {
         if (msg != null) {
             try {
                 if (msg instanceof TextMessage) {
@@ -733,7 +733,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
     }
 
     @SuppressWarnings("JdkObsolete")
-    private void printEnvironment(Context context) throws NamingException {
+    private static void printEnvironment(Context context) throws NamingException {
         try {
             Hashtable<?, ?> env = context.getEnvironment();
             if (env != null) {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/SubscriberSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/SubscriberSampler.java
@@ -266,7 +266,7 @@ public class SubscriberSampler extends BaseJMSSampler implements Interruptible, 
      * @param now current time
      * @return wait time
      */
-    private long calculateWait(long until, long now) {
+    private static long calculateWait(long until, long now) {
         if (until == 0) {
             return DEFAULT_WAIT; // Timeouts not active
         }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/TemporaryQueueExecutor.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/TemporaryQueueExecutor.java
@@ -35,7 +35,7 @@ public class TemporaryQueueExecutor implements QueueExecutor {
     private static final Logger LOGGER = LoggerFactory.getLogger(TemporaryQueueExecutor.class);
     /** The sender and receiver. */
     private final TimeoutEnabledQueueRequestor requestor;
-    private int timeout;
+    private final int timeout;
 
     /**
      * Constructor.

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/TimeoutEnabledQueueRequestor.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/TimeoutEnabledQueueRequestor.java
@@ -44,9 +44,9 @@ import org.slf4j.LoggerFactory;
  */
 public class TimeoutEnabledQueueRequestor {
     private static final Logger logger = LoggerFactory.getLogger(TimeoutEnabledQueueRequestor.class);
-    private TemporaryQueue tempQueue;
-    private MessageProducer sender;
-    private MessageConsumer receiver;
+    private final TemporaryQueue tempQueue;
+    private final MessageProducer sender;
+    private final MessageConsumer receiver;
 
     /**
      * Constructor for the <code>TimeoutEnabledQueueRequestor</code> class.

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/BinaryMessageRenderer.java
@@ -30,7 +30,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 
 class BinaryMessageRenderer implements MessageRenderer<byte[]> {
 
-    private TextMessageRenderer delegate;
+    private final TextMessageRenderer delegate;
 
     public BinaryMessageRenderer(TextMessageRenderer delegate) {
         this.delegate = delegate;

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/MapMessageRenderer.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/render/MapMessageRenderer.java
@@ -26,7 +26,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 
 public class MapMessageRenderer implements MessageRenderer<Map<String,Object>> {
 
-    private TextMessageRenderer delegate;
+    private final TextMessageRenderer delegate;
 
     public MapMessageRenderer(TextMessageRenderer delegate) {
         this.delegate = delegate;

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/JUnitTestSamplerGui.java
@@ -93,36 +93,36 @@ implements ChangeListener, ActionListener, ItemListener
         SPATHS = paths;
     }
 
-    private JTextField constructorLabel =
+    private final JTextField constructorLabel =
         new JTextField();
 
-    private JTextField successMsg =
+    private final JTextField successMsg =
         new JTextField();
 
-    private JTextField failureMsg =
+    private final JTextField failureMsg =
         new JTextField();
 
-    private JTextField errorMsg =
+    private final JTextField errorMsg =
         new JTextField();
 
-    private JTextField successCode =
+    private final JTextField successCode =
         new JTextField();
 
-    private JTextField failureCode =
+    private final JTextField failureCode =
         new JTextField();
 
-    private JTextField errorCode =
+    private final JTextField errorCode =
         new JTextField();
 
-    private JLabeledTextField filterpkg =
+    private final JLabeledTextField filterpkg =
         new JLabeledTextField(
             JMeterUtils.getResString("junit_pkg_filter"), 50); //$NON-NLS-1$
 
-    private JCheckBox doSetup = new JCheckBox(JMeterUtils.getResString("junit_do_setup_teardown")); //$NON-NLS-1$
-    private JCheckBox appendError = new JCheckBox(JMeterUtils.getResString("junit_append_error")); //$NON-NLS-1$
-    private JCheckBox appendExc = new JCheckBox(JMeterUtils.getResString("junit_append_exception")); //$NON-NLS-1$
-    private JCheckBox junit4 = new JCheckBox(JMeterUtils.getResString("junit_junit4")); //$NON-NLS-1$
-    private JCheckBox createInstancePerSample = new JCheckBox(JMeterUtils.getResString("junit_create_instance_per_sample")); //$NON-NLS-1$
+    private final JCheckBox doSetup = new JCheckBox(JMeterUtils.getResString("junit_do_setup_teardown")); //$NON-NLS-1$
+    private final JCheckBox appendError = new JCheckBox(JMeterUtils.getResString("junit_append_error")); //$NON-NLS-1$
+    private final JCheckBox appendExc = new JCheckBox(JMeterUtils.getResString("junit_append_exception")); //$NON-NLS-1$
+    private final JCheckBox junit4 = new JCheckBox(JMeterUtils.getResString("junit_junit4")); //$NON-NLS-1$
+    private final JCheckBox createInstancePerSample = new JCheckBox(JMeterUtils.getResString("junit_create_instance_per_sample")); //$NON-NLS-1$
 
     /** A combo box allowing the user to choose a test class. */
     private JComboBox<String> classnameCombo;

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
@@ -552,7 +552,7 @@ public class JUnitSampler extends AbstractSampler implements ThreadListener {
      * @return the method or null if an error occurred
      * (or either parameter is null)
      */
-    private Method getMethod(Object clazz, String method){
+    private static Method getMethod(Object clazz, String method){
         if (clazz != null && method != null){
             try {
                 return clazz.getClass().getMethod(method,new Class[0]);
@@ -563,7 +563,7 @@ public class JUnitSampler extends AbstractSampler implements ThreadListener {
         return null;
     }
 
-    private Method getMethodWithAnnotation(Object clazz, Class<? extends Annotation> annotation) {
+    private static Method getMethodWithAnnotation(Object clazz, Class<? extends Annotation> annotation) {
         if(null != clazz && null != annotation) {
             for(Method m : clazz.getClass().getMethods()) {
                 if(m.isAnnotationPresent(annotation)) {

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
@@ -55,7 +55,7 @@ public class LDAPArgumentsPanel extends AbstractConfigGui implements ActionListe
     private static final long serialVersionUID = 240L;
 
     /** The title label for this component. */
-    private JLabel tableLabel;
+    private final JLabel tableLabel;
 
     /** The table containing the list of arguments. */
     private transient JTable table;

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LDAPArgumentsPanel.java
@@ -258,7 +258,7 @@ public class LDAPArgumentsPanel extends AbstractConfigGui implements ActionListe
      *
      * @return a new LDAPArgument object
      */
-    private LDAPArgument makeNewLDAPArgument() {
+    private static LDAPArgument makeNewLDAPArgument() {
         return new LDAPArgument("", "", "");
     }
 

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
@@ -54,39 +54,39 @@ public class LdapConfigGui extends AbstractConfigGui implements ItemListener {
 
     private static final long serialVersionUID = 241L;
 
-    private JTextField rootdn = new JTextField(20);
+    private final JTextField rootdn = new JTextField(20);
 
-    private JTextField searchbase = new JTextField(20);
+    private final JTextField searchbase = new JTextField(20);
 
-    private JTextField searchfilter = new JTextField(20);
+    private final JTextField searchfilter = new JTextField(20);
 
-    private JTextField delete = new JTextField(20);
+    private final JTextField delete = new JTextField(20);
 
-    private JTextField add = new JTextField(20);
+    private final JTextField add = new JTextField(20);
 
-    private JTextField modify = new JTextField(20);
+    private final JTextField modify = new JTextField(20);
 
-    private JTextField servername = new JTextField(20);
+    private final JTextField servername = new JTextField(20);
 
-    private JTextField port = new JTextField(20);
+    private final JTextField port = new JTextField(20);
 
-    private JCheckBox userDefined = new JCheckBox(JMeterUtils.getResString("user_defined_test")); // $NON-NLS-1$
+    private final JCheckBox userDefined = new JCheckBox(JMeterUtils.getResString("user_defined_test")); // $NON-NLS-1$
 
-    private JRadioButton addTest = new JRadioButton(JMeterUtils.getResString("add_test")); // $NON-NLS-1$
+    private final JRadioButton addTest = new JRadioButton(JMeterUtils.getResString("add_test")); // $NON-NLS-1$
 
-    private JRadioButton modifyTest = new JRadioButton(JMeterUtils.getResString("modify_test")); // $NON-NLS-1$
+    private final JRadioButton modifyTest = new JRadioButton(JMeterUtils.getResString("modify_test")); // $NON-NLS-1$
 
-    private JRadioButton deleteTest = new JRadioButton(JMeterUtils.getResString("delete_test")); // $NON-NLS-1$
+    private final JRadioButton deleteTest = new JRadioButton(JMeterUtils.getResString("delete_test")); // $NON-NLS-1$
 
-    private JRadioButton searchTest = new JRadioButton(JMeterUtils.getResString("search_test")); // $NON-NLS-1$
+    private final JRadioButton searchTest = new JRadioButton(JMeterUtils.getResString("search_test")); // $NON-NLS-1$
 
-    private ButtonGroup bGroup = new ButtonGroup();
+    private final ButtonGroup bGroup = new ButtonGroup();
 
     private boolean displayName = true;
 
-    private ArgumentsPanel tableAddPanel = new ArgumentsPanel(JMeterUtils.getResString("add_test")); // $NON-NLS-1$
+    private final ArgumentsPanel tableAddPanel = new ArgumentsPanel(JMeterUtils.getResString("add_test")); // $NON-NLS-1$
 
-    private ArgumentsPanel tableModifyPanel = new ArgumentsPanel(JMeterUtils.getResString("modify_test")); // $NON-NLS-1$
+    private final ArgumentsPanel tableModifyPanel = new ArgumentsPanel(JMeterUtils.getResString("modify_test")); // $NON-NLS-1$
 
     private JPanel cards;
 

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapConfigGui.java
@@ -342,7 +342,7 @@ public class LdapConfigGui extends AbstractConfigGui implements ItemListener {
      *            text field to display
      * @return newly created panel
      */
-    private JPanel createLabelPanel(String key, JTextField field) {
+    private static JPanel createLabelPanel(String key, JTextField field) {
         JPanel addInnerPanel = new JPanel(new BorderLayout(5, 0));
         JLabel label = new JLabel(JMeterUtils.getResString(key)); // $NON-NLS-1$
         label.setLabelFor(field);

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
@@ -58,21 +58,21 @@ public class LdapExtConfigGui extends AbstractConfigGui implements ItemListener 
 
     private static final long serialVersionUID = 240L;
 
-    private JTextField rootdn = new JTextField(20);
+    private final JTextField rootdn = new JTextField(20);
 
-    private JTextField searchbase = new JTextField(20);
+    private final JTextField searchbase = new JTextField(20);
 
-    private JTextField searchfilter = new JTextField(20);
+    private final JTextField searchfilter = new JTextField(20);
 
-    private JTextField delete = new JTextField(20);
+    private final JTextField delete = new JTextField(20);
 
-    private JTextField add = new JTextField(20);
+    private final JTextField add = new JTextField(20);
 
-    private JTextField modify = new JTextField(20);
+    private final JTextField modify = new JTextField(20);
 
-    private JTextField servername = new JTextField(20);
+    private final JTextField servername = new JTextField(20);
 
-    private JTextField port = new JTextField(20);
+    private final JTextField port = new JTextField(20);
 
     /*
      * N.B. These entry indexes MUST agree with the SearchControls SCOPE_LEVELS, i.e.
@@ -102,65 +102,65 @@ public class LdapExtConfigGui extends AbstractConfigGui implements ItemListener 
     private static final String CARDS_SEARCH = "Search"; // $NON-NLS-1$
     private static final String CARDS_MODIFY = "Modify"; // $NON-NLS-1$
 
-    private JLabeledChoice scope =
+    private final JLabeledChoice scope =
         new JLabeledChoice(JMeterUtils.getResString("scope"), // $NON-NLS-1$
         SCOPE_STRINGS);
 
-    private JTextField countlim = new JTextField(20);
+    private final JTextField countlim = new JTextField(20);
 
-    private JTextField timelim = new JTextField(20);
+    private final JTextField timelim = new JTextField(20);
 
-    private JTextField attribs = new JTextField(20);
+    private final JTextField attribs = new JTextField(20);
 
-    private JCheckBox retobj = new JCheckBox(JMeterUtils.getResString("retobj")); // $NON-NLS-1$
+    private final JCheckBox retobj = new JCheckBox(JMeterUtils.getResString("retobj")); // $NON-NLS-1$
 
-    private JCheckBox deref = new JCheckBox(JMeterUtils.getResString("deref")); // $NON-NLS-1$
+    private final JCheckBox deref = new JCheckBox(JMeterUtils.getResString("deref")); // $NON-NLS-1$
 
-    private JTextField userdn = new JTextField(20);
+    private final JTextField userdn = new JTextField(20);
 
-    private JTextField userpw = new JPasswordField(20);
+    private final JTextField userpw = new JPasswordField(20);
 
-    private JTextField comparedn = new JTextField(20);
+    private final JTextField comparedn = new JTextField(20);
 
-    private JTextField comparefilt = new JTextField(20);
+    private final JTextField comparefilt = new JTextField(20);
 
-    private JTextField modddn = new JTextField(20);
+    private final JTextField modddn = new JTextField(20);
 
-    private JTextField newdn = new JTextField(20);
+    private final JTextField newdn = new JTextField(20);
 
-    private JTextField connto = new JTextField(20);
+    private final JTextField connto = new JTextField(20);
 
-    private JCheckBox parseflag = new JCheckBox(JMeterUtils.getResString("ldap_parse_results")); // $NON-NLS-1$
+    private final JCheckBox parseflag = new JCheckBox(JMeterUtils.getResString("ldap_parse_results")); // $NON-NLS-1$
 
-    private JCheckBox secure = new JCheckBox(JMeterUtils.getResString("ldap_secure")); // $NON-NLS-1$
+    private final JCheckBox secure = new JCheckBox(JMeterUtils.getResString("ldap_secure")); // $NON-NLS-1$
 
-    private JCheckBox trustAll = new JCheckBox(JMeterUtils.getResString("ldap_trust_all")); // $NON-NLS-1$
+    private final JCheckBox trustAll = new JCheckBox(JMeterUtils.getResString("ldap_trust_all")); // $NON-NLS-1$
 
-    private JRadioButton addTest = new JRadioButton(JMeterUtils.getResString("addtest")); // $NON-NLS-1$
+    private final JRadioButton addTest = new JRadioButton(JMeterUtils.getResString("addtest")); // $NON-NLS-1$
 
-    private JRadioButton modifyTest = new JRadioButton(JMeterUtils.getResString("modtest")); // $NON-NLS-1$
+    private final JRadioButton modifyTest = new JRadioButton(JMeterUtils.getResString("modtest")); // $NON-NLS-1$
 
-    private JRadioButton deleteTest = new JRadioButton(JMeterUtils.getResString("deltest")); // $NON-NLS-1$
+    private final JRadioButton deleteTest = new JRadioButton(JMeterUtils.getResString("deltest")); // $NON-NLS-1$
 
-    private JRadioButton searchTest = new JRadioButton(JMeterUtils.getResString("searchtest")); // $NON-NLS-1$
+    private final JRadioButton searchTest = new JRadioButton(JMeterUtils.getResString("searchtest")); // $NON-NLS-1$
 
-    private JRadioButton bind = new JRadioButton(JMeterUtils.getResString("bind")); // $NON-NLS-1$
+    private final JRadioButton bind = new JRadioButton(JMeterUtils.getResString("bind")); // $NON-NLS-1$
 
-    private JRadioButton rename = new JRadioButton(JMeterUtils.getResString("rename")); // $NON-NLS-1$
+    private final JRadioButton rename = new JRadioButton(JMeterUtils.getResString("rename")); // $NON-NLS-1$
 
-    private JRadioButton unbind = new JRadioButton(JMeterUtils.getResString("unbind")); // $NON-NLS-1$
+    private final JRadioButton unbind = new JRadioButton(JMeterUtils.getResString("unbind")); // $NON-NLS-1$
 
-    private JRadioButton sbind = new JRadioButton(JMeterUtils.getResString("sbind")); // $NON-NLS-1$
+    private final JRadioButton sbind = new JRadioButton(JMeterUtils.getResString("sbind")); // $NON-NLS-1$
 
-    private JRadioButton compare = new JRadioButton(JMeterUtils.getResString("compare")); // $NON-NLS-1$
+    private final JRadioButton compare = new JRadioButton(JMeterUtils.getResString("compare")); // $NON-NLS-1$
 
-    private ButtonGroup bGroup = new ButtonGroup();
+    private final ButtonGroup bGroup = new ButtonGroup();
 
     private boolean displayName = true;
 
-    private ArgumentsPanel tableAddPanel = new ArgumentsPanel(JMeterUtils.getResString("addtest")); // $NON-NLS-1$
+    private final ArgumentsPanel tableAddPanel = new ArgumentsPanel(JMeterUtils.getResString("addtest")); // $NON-NLS-1$
 
-    private LDAPArgumentsPanel tableModifyPanel = new LDAPArgumentsPanel(JMeterUtils.getResString("modtest")); // $NON-NLS-1$
+    private final LDAPArgumentsPanel tableModifyPanel = new LDAPArgumentsPanel(JMeterUtils.getResString("modtest")); // $NON-NLS-1$
 
     private JPanel cards;
 

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/config/gui/LdapExtConfigGui.java
@@ -487,7 +487,7 @@ public class LdapExtConfigGui extends AbstractConfigGui implements ItemListener 
      *            field to show and attach the label
      * @return newly constructed panel
      */
-    private JPanel createLabelPanel(String key, JTextField field) {
+    private static JPanel createLabelPanel(String key, JTextField field) {
         JPanel panel = new JPanel(new BorderLayout(5, 0));
         JLabel label = new JLabel(JMeterUtils.getResString(key)); // $NON-NLS-1$
         label.setLabelFor(field);

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPExtSampler.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPExtSampler.java
@@ -564,7 +564,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
      *
      * @return The BasicAttributes (null means all)
      **/
-    private String[] getRequestAttributes(String reqAttr) {
+    private static String[] getRequestAttributes(String reqAttr) {
         int index;
         String[] mods;
         int count = 0;
@@ -602,7 +602,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
      *
      * @return The BasicAttribute
      **************************************************************************/
-    private BasicAttribute getBasicAttribute(String name, String value) {
+    private static BasicAttribute getBasicAttribute(String name, String value) {
         return new BasicAttribute(name, value);
     }
 
@@ -915,7 +915,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
         }
     }
 
-    private void writeSearchResult(final SearchResult sr, final XMLBuffer xmlb)
+    private static void writeSearchResult(final SearchResult sr, final XMLBuffer xmlb)
             throws NamingException
     {
         final Attributes attrs = sr.getAttributes();
@@ -955,7 +955,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
         }
     }
 
-    private void sortAttributes(final List<Attribute> sortedAttrs) {
+    private static void sortAttributes(final List<Attribute> sortedAttrs) {
         sortedAttrs.sort((o1, o2) -> {
             String nm1 = o1.getID();
             String nm2 = o2.getID();
@@ -964,7 +964,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
         });
     }
 
-    private void sortResults(final List<SearchResult> sortedResults) {
+    private static void sortResults(final List<SearchResult> sortedResults) {
         sortedResults.sort(new Comparator<SearchResult>() {
             private int compareToReverse(final String s1, final String s2) {
                 int len1 = s1.length();
@@ -999,7 +999,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
         });
     }
 
-    private String normaliseSearchDN(final SearchResult sr, final String searchBase, final String rootDn)
+    private static String normaliseSearchDN(final SearchResult sr, final String searchBase, final String rootDn)
     {
         String srName = sr.getName();
 
@@ -1019,7 +1019,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
         return srName;
     }
 
-    private String getWriteValue(final Object value) {
+    private static String getWriteValue(final Object value) {
         if (value instanceof String) {
             // assume it's sensitive data
             return StringEscapeUtils.escapeXml10((String)value);

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPSampler.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPSampler.java
@@ -299,7 +299,7 @@ public class LDAPSampler extends AbstractSampler {
      *
      * @return the BasicAttributes
      */
-    private ModificationItem[] getModificationItem() {
+    private static ModificationItem[] getModificationItem() {
         ModificationItem[] mods = new ModificationItem[2];
         // replace (update) attribute
         Attribute mod0 = new BasicAttribute("userpassword", "secret"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -345,7 +345,7 @@ public class LDAPSampler extends AbstractSampler {
      *
      * @return the BasicAttribute
      */
-    private BasicAttribute getBasicAttribute(String name, String value) {
+    private static BasicAttribute getBasicAttribute(String name, String value) {
         BasicAttribute attr = new BasicAttribute(name, value);
         return attr;
     }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPSampler.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPSampler.java
@@ -87,7 +87,7 @@ public class LDAPSampler extends AbstractSampler {
 
     // For In build test case using this counter
     // create the new entry in the server
-    private static AtomicInteger COUNTER = new AtomicInteger(0);
+    private static final AtomicInteger COUNTER = new AtomicInteger(0);
 
     private boolean searchFoundEntries;// TODO turn into parameter?
 

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/MailReaderSampler.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/MailReaderSampler.java
@@ -320,7 +320,7 @@ public class MailReaderSampler extends AbstractSampler implements Interruptible 
         }
     }
 
-    private void appendMessageData(SampleResult child, Message message)
+    private static void appendMessageData(SampleResult child, Message message)
             throws MessagingException, IOException {
         StringBuilder cdata = new StringBuilder();
         cdata.append("Date: "); // $NON-NLS-1$
@@ -363,7 +363,7 @@ public class MailReaderSampler extends AbstractSampler implements Interruptible 
         }
     }
 
-    private void appendMultiPart(SampleResult child, StringBuilder cdata,
+    private static void appendMultiPart(SampleResult child, StringBuilder cdata,
             MimeMultipart mmp) throws MessagingException, IOException {
         String preamble = mmp.getPreamble();
         if (preamble != null ){
@@ -613,7 +613,7 @@ public class MailReaderSampler extends AbstractSampler implements Interruptible 
      * @param propname the property name suffix, i.e. "starttls.require" in the example
      * @return the constructed name
      */
-    private String mailProp(String protocol, String propname) {
+    private static String mailProp(String protocol, String propname) {
         return "mail." + protocol + "." + propname;
     }
 }

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/mail/sampler/gui/MailReaderSamplerGui.java
@@ -253,7 +253,7 @@ public class MailReaderSamplerGui extends AbstractSamplerGui implements ActionLi
         add(settings, BorderLayout.CENTER);
     }
 
-    private void addField(JPanel panel, JLabel label, JComponent field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, JLabel label, JComponent field, GridBagConstraints gbc) {
         gbc.fill=GridBagConstraints.NONE;
         gbc.anchor = GridBagConstraints.LINE_END;
         panel.add(label, gbc);
@@ -265,17 +265,17 @@ public class MailReaderSamplerGui extends AbstractSamplerGui implements ActionLi
         nextLine(gbc);
     }
 
-    private void addField(JPanel panel, String text, JComponent field, GridBagConstraints gbc) {
+    private static void addField(JPanel panel, String text, JComponent field, GridBagConstraints gbc) {
         addField(panel, new JLabel(text), field, gbc);
     }
 
-    private void nextLine(GridBagConstraints gbc) {
+    private static void nextLine(GridBagConstraints gbc) {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.weightx = 0;
     }
 
-    private GridBagConstraints getConstraints() {
+    private static GridBagConstraints getConstraints() {
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridheight = 1;
         gbc.gridwidth = 1;

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/SmtpSampler.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/SmtpSampler.java
@@ -166,7 +166,7 @@ public class SmtpSampler extends AbstractSampler {
         return result;
     }
 
-    private boolean executeMessage(SampleResult result, SendMailCommand sendMailCmd, Message message) {
+    private static boolean executeMessage(SampleResult result, SendMailCommand sendMailCmd, Message message) {
         boolean didSampleSucceed = false;
         try {
             sendMailCmd.execute(message);
@@ -199,7 +199,7 @@ public class SmtpSampler extends AbstractSampler {
         }
     }
 
-    private byte[] processSampler(Message message) throws IOException, MessagingException {
+    private static byte[] processSampler(Message message) throws IOException, MessagingException {
         // process the sampler result
         try (InputStream is = message.getInputStream()) {
             return IOUtils.toByteArray(is);
@@ -210,11 +210,11 @@ public class SmtpSampler extends AbstractSampler {
         final String[] attachments = getPropertyAsString(ATTACH_FILE).split(FILENAME_SEPARATOR);
         return Arrays.stream(attachments) // NOSONAR No need to close
                 .filter(s -> !s.isEmpty())
-                .map(this::attachmentToFile)
+                .map(SmtpSampler::attachmentToFile)
                 .collect(Collectors.toList());
     }
 
-    private File attachmentToFile(String attachment) { // NOSONAR False positive saying not used
+    private static File attachmentToFile(String attachment) { // NOSONAR False positive saying not used
         File file = new File(attachment);
         if (!file.isAbsolute() && !file.exists()) {
             if(log.isDebugEnabled()) {
@@ -293,7 +293,7 @@ public class SmtpSampler extends AbstractSampler {
         return sendMailCmd;
     }
 
-    private String getRequestHeaders(Message message) throws MessagingException {
+    private static String getRequestHeaders(Message message) throws MessagingException {
         StringBuilder sb = new StringBuilder();
         @SuppressWarnings("unchecked") // getAllHeaders() is not yet genericised
         Enumeration<Header> headers = message.getAllHeaders(); // throws ME
@@ -301,7 +301,7 @@ public class SmtpSampler extends AbstractSampler {
         return sb.toString();
     }
 
-    private String getSamplerData(Message message) throws MessagingException, IOException {
+    private static String getSamplerData(Message message) throws MessagingException, IOException {
         StringBuilder sb = new StringBuilder();
         Object content = message.getContent(); // throws ME
         if (content instanceof Multipart) {
@@ -333,7 +333,7 @@ public class SmtpSampler extends AbstractSampler {
     }
 
     @SuppressWarnings("JdkObsolete")
-    private void writeHeaders(Enumeration<Header> headers, StringBuilder sb) {
+    private static void writeHeaders(Enumeration<Header> headers, StringBuilder sb) {
         while (headers.hasMoreElements()) {
             Header header = headers.nextElement();
             sb.append(header.getName());
@@ -343,7 +343,7 @@ public class SmtpSampler extends AbstractSampler {
         }
     }
 
-    private void writeBodyPart(StringBuilder sb, BodyPart bodyPart)
+    private static void writeBodyPart(StringBuilder sb, BodyPart bodyPart)
             throws MessagingException, IOException {
         @SuppressWarnings("unchecked") // API not yet generic
         Enumeration<Header> allHeaders = bodyPart.getAllHeaders(); // throws ME
@@ -379,7 +379,7 @@ public class SmtpSampler extends AbstractSampler {
         }
     }
 
-    private String encodeAddress(String address) {
+    private static String encodeAddress(String address) {
         String trimmedAddress = address.trim();
         if (!StringUtils.isAsciiPrintable(trimmedAddress)) {
             try {

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SecuritySettingsPanel.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SecuritySettingsPanel.java
@@ -208,6 +208,7 @@ public class SecuritySettingsPanel extends JPanel{
      * @param evt
      *            ActionEvent to be handled
      */
+    @SuppressWarnings("MethodCanBeStatic")
     private void cbEnforceStartTLSActionPerformed(ActionEvent evt) { // NOSONAR This method is used through lambda
         // NOOP
     }

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/gui/SmtpPanel.java
@@ -86,8 +86,8 @@ public class SmtpPanel extends JPanel {
     private JButton addHeaderFieldButton;
     private JLabel headerFieldName;
     private JLabel headerFieldValue;
-    private Map<JTextField, JTextField> headerFields = new HashMap<>();
-    private Map<JButton,JTextField> removeButtons = new HashMap<>();
+    private final Map<JTextField, JTextField> headerFields = new HashMap<>();
+    private final Map<JButton,JTextField> removeButtons = new HashMap<>();
     private int headerGridY = 0;
 
     private SecuritySettingsPanel securitySettingsPanel;

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
@@ -134,7 +134,7 @@ public class TCPClientImpl extends AbstractTCPClient {
         }
     }
 
-    private String showEOL(final String input) {
+    private static String showEOL(final String input) {
         StringBuilder sb = new StringBuilder(input.length()*2);
         for(int i=0; i < input.length(); i++) {
             char ch = input.charAt(i);

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
@@ -141,7 +141,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
         log.debug("Created {}", this); //$NON-NLS-1$
     }
 
-    private String getError() {
+    private static String getError() {
         Map<String, Object> cp = tp.get();
         return (String) cp.get(ERRKEY);
     }
@@ -311,7 +311,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
         return "tcp://" + this.getServer() + ":" + this.getPort();//$NON-NLS-1$ $NON-NLS-2$
     }
 
-    private Class<?> getClass(String className) {
+    private static Class<?> getClass(String className) {
         Class<?> c = null;
         try {
             c = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
@@ -429,7 +429,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
      * @param protocolHandler {@link TCPClient}
      * @return boolean if sample is considered as successful
      */
-    private boolean setupSampleResult(SampleResult sampleResult,
+    private static boolean setupSampleResult(SampleResult sampleResult,
             String readResponse,
             Exception exception,
             TCPClient protocolHandler) {
@@ -470,7 +470,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
      * @param rc response code
      * @return whether this represents success or not
      */
-    private boolean checkResponseCode(String rc) {
+    private static boolean checkResponseCode(String rc) {
         int responseCode = Integer.parseInt(rc);
         return responseCode >= 400 && responseCode <= 599;
     }
@@ -524,7 +524,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
     /**
      * Closes all connections, clears Map and remove thread local Map
      */
-    private void tearDown() {
+    private static void tearDown() {
         Map<String, Object> cp = tp.get();
         cp.forEach((k, v) -> {
             if(k.startsWith(TCPKEY)) {

--- a/src/testkit-wiremock/src/main/java/org/apache/jmeter/wiremock/WireMockExtension.java
+++ b/src/testkit-wiremock/src/main/java/org/apache/jmeter/wiremock/WireMockExtension.java
@@ -50,11 +50,11 @@ public class WireMockExtension implements BeforeEachCallback, BeforeAllCallback,
         return getServer(extensionContext);
     }
 
-    private ExtensionContext.Store getStore(ExtensionContext context) {
+    private static ExtensionContext.Store getStore(ExtensionContext context) {
         return context.getStore(NAMESPACE);
     }
 
-    private WireMockServer getServer(ExtensionContext context) {
+    private static WireMockServer getServer(ExtensionContext context) {
         return getStore(context).get("server", WireMockServer.class);
     }
 


### PR DESCRIPTION
The code changes are performed using two approaches:
1) IDEA's "run inspection by name". "field may be static", "field may be final", "method may be static", "replace iterator with foreach"
2) Manual edits driven by Errorprone failures: remove default cases in enum switch, and some of "method may be static"

In other words, there are no changes that were made "just in case", and the code changes are accompanied with the corresponding Errorprone verifications, so we won't accidentally re-introduce the same issues.