### PR TITLE
Trim variable names in Argument objects

### DIFF
--- a/src/components/src/test/java/org/apache/jmeter/config/gui/TestArgumentsPanel.java
+++ b/src/components/src/test/java/org/apache/jmeter/config/gui/TestArgumentsPanel.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * A GUI panel allowing the user to enter name-value argument pairs. These
@@ -44,5 +46,21 @@ public class TestArgumentsPanel {
 
         assertEquals("=", ((Argument) ((Arguments) gui.createTestElement()).getArguments().get(0).getObjectValue())
                 .getMetaData());
+    }
+
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "WITHOUT_SPACE,WITHOUT_SPACE",
+            " WITH_OUTER_SPACE ,WITH_OUTER_SPACE",
+            "WITH_SUFFIX_SPACE ,WITH_SUFFIX_SPACE",
+            " WITH_PREFIX_SPACE,WITH_PREFIX_SPACE"
+    }, ignoreLeadingAndTrailingWhitespace = false)
+    public void testArgumentNames(String name, String expectedName) throws Exception {
+        ArgumentsPanel gui = new ArgumentsPanel();
+        gui.tableModel.addRow(new Argument());
+        gui.tableModel.setValueAt(name, 0, 0);
+
+        assertEquals(expectedName, ((Argument) ((Arguments) gui.createTestElement()).getArguments().get(0).getObjectValue()).getName());
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/config/Argument.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/Argument.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.config;
 
 import java.io.Serializable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jorphan.util.JOrphanUtils;
@@ -92,7 +93,7 @@ public class Argument extends AbstractTestElement implements Serializable {
      */
     public Argument(String name, String value, String metadata, String description) {
         if(name != null) {
-            setProperty(new StringProperty(ARG_NAME, name));
+            setProperty(new StringProperty(ARG_NAME, StringUtils.strip(name)));
         }
         if(value != null) {
             setProperty(new StringProperty(VALUE, value));
@@ -113,7 +114,7 @@ public class Argument extends AbstractTestElement implements Serializable {
      */
     @Override
     public void setName(String newName) {
-        setProperty(new StringProperty(ARG_NAME, newName));
+        setProperty(new StringProperty(ARG_NAME, StringUtils.strip(newName)));
     }
 
     /**

--- a/src/core/src/test/java/org/apache/jmeter/config/ArgumentTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/config/ArgumentTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ArgumentTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "simple_name,simple_name",
+            " with_spaces ,with_spaces",
+            "\twith_tabs\t,with_tabs"
+    },ignoreLeadingAndTrailingWhitespace = false)
+    void setName(String name, String expectedName) {
+        Argument arg = new Argument();
+        arg.setName(name);
+        assertEquals(expectedName, arg.getName());
+    }
+}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -176,6 +176,7 @@ Summary
 <h3>General</h3>
 <ul>
   <li><bug>66157</bug><pr>719</pr>Correct theme for darklaf on rsyntaxtextarea</li>
+  <li><issue>5872</issue><pr>5874</pr>Trim name in Argument objects.</li>
 </ul>
 
  <!--  =================== Thanks =================== -->


### PR DESCRIPTION
## Description

Trim names in Argument objects.

## Motivation and Context

Should fix #5872

I think, we never intended to allow whitespace at the start or ending of a variable name.

## How Has This Been Tested?

Added a JUnit test case for `Argumet#setName(String)`

## Screenshots (if appropriate):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
