### PR TITLE
Use JMeterProperty#intValue for loop count directly

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/control/LoopController.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/LoopController.java
@@ -87,7 +87,7 @@ public class LoopController extends GenericController implements Serializable, I
                 ) {
             try {
                 JMeterProperty prop = getProperty(LOOPS);
-                nbLoops = Integer.valueOf(prop.getStringValue());
+                nbLoops = prop.getIntValue();
             } catch (NumberFormatException e) {
                 nbLoops = 0;
             }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -597,7 +597,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
 
     public int getCommunicationstyle() {
         JMeterProperty prop = getProperty(JMS_COMMUNICATION_STYLE);
-        return Integer.parseInt(prop.getStringValue());
+        return prop.getIntValue();
     }
 
     public String getCommunicationstyleString() {


### PR DESCRIPTION
## Description

This will get rid of the roundtrip over a String in case, the prop is already an IntegerProperty.

## Motivation and Context

Came up in the discussion about #5875 and looks like an easy first fix.
 
## How Has This Been Tested?

Should be covered by the unit tests already


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
