### PR TITLE
Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
 
 import java.util.*
 
@@ -24,7 +25,8 @@ pluginManagement {
 }
 
 plugins {
-    `gradle-enterprise`
+    id("com.gradle.enterprise") version "3.13.1"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.10"
 }
 
 dependencyResolutionManagement {
@@ -105,12 +107,18 @@ if (property("localReleasePlugins").toBool(nullAs = false, blankAs = true, defau
 
 val isCiServer = System.getenv().containsKey("CI")
 
-if (isCiServer) {
-    gradleEnterprise {
-        buildScan {
-            termsOfServiceUrl = "https://gradle.com/terms-of-service"
-            termsOfServiceAgree = "yes"
-            tag("CI")
+gradleEnterprise {
+    server = "https://ge.apache.org"
+    allowUntrustedServer = false
+
+    buildScan {
+        capture { isTaskInputFiles = true }
+        isUploadInBackground = !isCiServer
+        publishAlways()
+        this as BuildScanExtensionWithHiddenFeatures
+        publishIfAuthenticated()
+        obfuscation {
+            ipAddresses { addresses -> addresses.map { "0.0.0.0" } }
         }
     }
 }
@@ -159,8 +167,6 @@ val expectedSha512 = mapOf(
         to "gradle-enterprise-gradle-plugin-3.8.1.jar",
     "B795B889E3E2EC6D3E3DEB7429345A62B3FCCB4E51B88014AA77FBC3F61D3BC4307E023C83B08FEDA49BF2EAC6B99A48D2995CB9425E5C3E76BBE25D4170BDC8"
         to "gradle-enterprise-gradle-plugin-3.11.4.jar",
-    "AFC0F3E5B78359131E2BF6C24A128F1CE76F2D128F38DFA8C01F7CF74D1695527C8E953E4B6E7C3ACD925CC03A50845A53B84359AC2B0F5C1F233355E45186D1"
-        to "gradle-enterprise-gradle-plugin-3.12.6.jar",
     "4E240B7811EF90C090E83A181DACE41DA487555E4136221861B0060F9AF6D8B316F2DD0472F747ADB98CA5372F46055456EF04BDC0C3992188AB13302922FCE9"
         to "bcpg-jdk15on-1.70.jar",
     "7DCCFC636EE4DF1487615818CFA99C69941081DF95E8EF1EAF4BCA165594DFF9547E3774FD70DE3418ABACE77D2C45889F70BCD2E6823F8539F359E68EAF36D1"
@@ -205,4 +211,13 @@ property("localAutostyle")?.ifBlank { "../autostyle" }?.let {
 property("localDarklaf")?.ifBlank { "../darklaf" }?.let {
     println("Importing project '$it'")
     includeBuild(it)
+}
+
+buildCache {
+    local {
+        isEnabled = !isCiServer
+    }
+    remote(gradleEnterprise.buildCache) {
+        isEnabled = false
+    }
 }


### PR DESCRIPTION
## Description
This PR publishes a build scan for every CI build on Jenkins and GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache JMeter project are published to the Gradle Enterprise instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by the Apache JMeter project and all other Apache projects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, the Apache JMeter build is configured to publish build scans to the publicly available [scans.gradle.com](https://scans.gradle.com/). This pull request enhances that functionality by instead publishing build scans to [ge.apache.org](https://ge.apache.org/). On this Gradle Enterprise instance, Apache JMeter will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

If interested in exploring a fully populated Gradle Enterprise instance, please explore the Maven builds already connected to [ge.apache.org](https://ge.apache.org/), the [Spring project’s instance](https://ge.spring.io/scans?search.relativeStartTime=P28D&search.timeZoneId=Europe/Zurich), or any number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Gradle Enterprise.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This change has been verified by publishing build scans to a Gradle Enterprise instance, rather than to scans.gradle.com.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Build improvements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
