### PR TITLE
Speed up CPU-bound tests by skipping recoverRunningVersion for elements that are shared between threads (the ones that implement NoThreadClone)

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.jmeter.engine.util.NoThreadClone;
 import org.apache.jmeter.gui.Searchable;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.CollectionProperty;
@@ -502,6 +503,11 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
      */
     @Override
     public void recoverRunningVersion() {
+        if (this instanceof NoThreadClone) {
+            // The element is shared between threads, so there's nothing to recover
+            // See https://github.com/apache/jmeter/issues/5875
+            return;
+        }
         Iterator<Map.Entry<String, JMeterProperty>>  iter = propMap.entrySet().iterator();
         while (iter.hasNext()) {
             Map.Entry<String, JMeterProperty> entry = iter.next();

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -99,6 +99,7 @@ Summary
 <h3>General</h3>
 <ul>
   <li><pr>5792</pr>Add KeyStroke for start_no_timers (Start no pauses: CRTL+SHIFT+n)</li>
+  <li><pr>5899</pr>Speed up CPU-bound tests by skipping <code>recoverRunningVersion</code> for elements that are shared between threads (the ones that implement <code>NoThreadClone</code>)</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
## Motivation and Context

See https://github.com/apache/jmeter/issues/5875

I think we would like to completely remove `recoverRunningVersion`, however, it looks like skipping `recoverRunningVersion` for the shared components is a low-hanging fruit.
