### PR TITLE
Add NoThreadClone#isShareable method so the elements can dynamically decide if they need cloning or not

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/engine/TreeCloner.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/TreeCloner.java
@@ -71,7 +71,7 @@ public class TreeCloner implements HashTreeTraverser {
     protected Object addNodeToTree(Object node) {
         if ( (node instanceof TestElement) // Check can cast for clone
            // Don't clone NoThreadClone unless honourNoThreadClone == false
-          && !(honourNoThreadClone && node instanceof NoThreadClone)
+          && !(honourNoThreadClone && node instanceof NoThreadClone && ((NoThreadClone) node).isShareable())
         ) {
             Object newNode = ((TestElement) node).clone();
             newTree.add(objects, newNode);

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/NoThreadClone.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/NoThreadClone.java
@@ -24,4 +24,13 @@ package org.apache.jmeter.engine.util;
  *
  */
 public interface NoThreadClone {
+    /**
+     * Allows element to indicate whether it can be shared between threads.
+     * By default, elements that implement {@code NoThreadClone} are shareable.
+     *
+     * @return true if the element is shareable between threads, so it won't be cloned
+     */
+    default boolean isShareable() {
+        return true;
+    }
 }

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -503,7 +503,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
      */
     @Override
     public void recoverRunningVersion() {
-        if (this instanceof NoThreadClone) {
+        if (this instanceof NoThreadClone && ((NoThreadClone) this).isShareable()) {
             // The element is shared between threads, so there's nothing to recover
             // See https://github.com/apache/jmeter/issues/5875
             return;

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -108,6 +108,7 @@ Summary
     Previously it cached the values based on iteration number only which triggered wrong results on concurrent executions.
     The previous behavior can be temporary restored with <code>function.cache.per.iteration</code> property.
   </li>
+  <li><pr></pr> Add <code>NoThreadClone#isShareable</code> method so the elements can dynamically decide if they need cloning or not</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
## Motivation and Context

Previously, components could `implements NoThreadClone` to prevent cloning in each thread, however, there was no way to "unimplement" the interface.
    
By default, `isShareable` returns true, so existing components work as before.

This improvement is needed for:
* https://github.com/apache/jmeter/pull/727
* Timers often have features like "global timer" vs "thread-local timer". Typically, timers have `Map<ThreadGroup, ...>`, however, making timer clonable or non-clonable depending on "local vs global" property might be a nicer way to code timers.
