### PR TITLE
Deprecate getHeaderManager and setHeaderManager in HTTPSamplerBase

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -282,7 +282,9 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
     private HTTPSamplerProxy createHttpRequest(Request request, HashTree parentHT, String commentText) throws MalformedURLException {
         HTTPSamplerProxy httpSampler = createSampler(request,commentText);
         HashTree samplerHT = parentHT.add(httpSampler);
-        samplerHT.add(httpSampler.getHeaderManager());
+        @SuppressWarnings("deprecation")
+        HeaderManager headerManager = httpSampler.getHeaderManager();
+        samplerHT.add(headerManager);
         if (CERT.equals(request.getCaCert())) {
             samplerHT.add(httpSampler.getKeystoreConfig());
         }
@@ -763,6 +765,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
                         createCookieManager(cookieManager, request);
                     }
                 }
+                @SuppressWarnings("deprecation")
                 HeaderManager headerManager = sampler.getHeaderManager();
                 KeystoreConfig keystoreConfig = sampler.getKeystoreConfig();
                 final JMeterTreeNode newNode = treeModel.addComponent(sampler, currentNode);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
@@ -241,7 +241,7 @@ public class Proxy extends Thread {
              * captured and sent to the server
              */
             headers = request.getHeaderManager();
-            sampler.setHeaderManager(headers);
+            setHeaderManager(headers, sampler);
 
             sampler.threadStarted(); // Needed for HTTPSampler2
             if (isDebug) {
@@ -315,6 +315,11 @@ public class Proxy extends Thread {
             }
             JMeterContextService.getContext().setRecording(false);
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void setHeaderManager(HeaderManager headers, HTTPSamplerBase sampler) {
+        sampler.setHeaderManager(headers);
     }
 
     /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AjpSampler.java
@@ -201,6 +201,7 @@ public class AjpSampler extends HTTPSamplerBase implements Interruptible {
     }
 
     private int getHeaderSize(String method, URL url) {
+        @SuppressWarnings("deprecation")
         HeaderManager headers = getHeaderManager();
         CookieManager cookies = getCookieManager();
         AuthManager auth = getAuthManager();
@@ -231,6 +232,7 @@ public class AjpSampler extends HTTPSamplerBase implements Interruptible {
 
     private String setConnectionHeaders(URL url, String host, String method)
     throws IOException {
+        @SuppressWarnings("deprecation")
         HeaderManager headers = getHeaderManager();
         AuthManager auth = getAuthManager();
         StringBuilder hbuf = new StringBuilder();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
@@ -193,7 +193,9 @@ public abstract class HTTPAbstractImpl implements Interruptible, HTTPConstantsIn
      * Invokes {@link HTTPSamplerBase#getHeaderManager()}
      *
      * @return the {@link HeaderManager} of the associated test element
+     * @deprecated since 5.6 as it prevents sharing a common Header Manager across samplers
      */
+    @Deprecated
     protected HeaderManager getHeaderManager() {
         return testElement.getHeaderManager();
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -1304,7 +1304,9 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
             httpRequest.setHeader(HTTPConstants.HEADER_CONNECTION, HTTPConstants.CONNECTION_CLOSE);
         }
 
-        setConnectionHeaders(httpRequest, url, getHeaderManager(), getCacheManager());
+        @SuppressWarnings("deprecation")
+        HeaderManager headerManager = getHeaderManager();
+        setConnectionHeaders(httpRequest, url, headerManager, getCacheManager());
 
         String cookies = setConnectionCookie(httpRequest, url, getCookieManager());
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
@@ -191,7 +191,9 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
         }
 
         conn.setRequestMethod(method);
-        setConnectionHeaders(conn, u, getHeaderManager(), getCacheManager());
+        @SuppressWarnings("deprecation")
+        HeaderManager headerManager = getHeaderManager();
+        setConnectionHeaders(conn, u, headerManager, getCacheManager());
         String cookies = setConnectionCookie(conn, u, getCookieManager());
 
         Map<String, String> securityHeaders = setConnectionAuthorization(conn, u, getAuthManager());
@@ -518,7 +520,9 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
         // Check cache for an entry with an Expires header in the future
         final CacheManager cacheManager = getCacheManager();
         if (cacheManager != null && HTTPConstants.GET.equalsIgnoreCase(method)) {
-           if (cacheManager.inCache(url, getHeaders(getHeaderManager()))) {
+            @SuppressWarnings("deprecation")
+            HeaderManager headerManager = getHeaderManager();
+            if (cacheManager.inCache(url, getHeaders(headerManager))) {
                return updateSampleResultForResourceInCache(res);
            }
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -928,7 +928,14 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         return (AuthManager) getProperty(AUTH_MANAGER).getObjectValue();
     }
 
+    /**
+     * Sets HTTP Header Manager for this sampler.
+     * @deprecated since 5.6 as it prevents sharing a common Header Manager across samplers
+     * @param value header manager
+     */
+    @Deprecated
     public void setHeaderManager(final HeaderManager value) {
+        @SuppressWarnings("deprecation")
         HeaderManager mgr = getHeaderManager();
         HeaderManager lValue = value;
         if (mgr != null) {
@@ -943,6 +950,11 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         setProperty(new TestElementProperty(HEADER_MANAGER, lValue));
     }
 
+    /**
+     * Retrieves HTTP Header Manager for this sampler.
+     * @deprecated since 5.6 as it prevents sharing a common Header Manager across samplers
+     */
+    @Deprecated
     public HeaderManager getHeaderManager() {
         return (HeaderManager) getProperty(HEADER_MANAGER).getObjectValue();
     }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/gui/action/ParseCurlCommandActionTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/gui/action/ParseCurlCommandActionTest.java
@@ -251,8 +251,10 @@ public class ParseCurlCommandActionTest {
         assertEquals("www.example.com", httpSampler.getDomain());
         assertEquals("/12345?param1=value1&param2=value2", httpSampler.getPath());
         assertEquals("PUT", httpSampler.getMethod());
-        assertEquals(new Header("accept", "*/*"), httpSampler.getHeaderManager().getHeader(0));
-        assertEquals(new Header("X-XSRF-TOKEN", "1234"), httpSampler.getHeaderManager().getHeader(1));
+        @SuppressWarnings("deprecation")
+        HeaderManager headerManager = httpSampler.getHeaderManager();
+        assertEquals(new Header("accept", "*/*"), headerManager.getHeader(0));
+        assertEquals(new Header("X-XSRF-TOKEN", "1234"), headerManager.getHeader(1));
     }
 
     @Test

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
@@ -74,7 +74,7 @@ public class TestDecompression {
                 hm.add(new Header("Accept-Encoding", "gzip"));
             }
             hm.add(new Header("Content-Encoding", "utf-8"));
-            http.setHeaderManager(hm);
+            setHeaderManager(http, hm);
             MappingBuilder mappingBuilder = WireMock.get("/gzip");
             if (clientGzip == ClientGzip.REQUESTED) {
                 mappingBuilder = mappingBuilder.withHeader("Accept-Encoding", WireMock.equalTo("gzip"));
@@ -106,6 +106,11 @@ public class TestDecompression {
         } finally {
             server.stop();
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void setHeaderManager(HTTPSamplerBase http, HeaderManager hm) {
+        http.setHeaderManager(hm);
     }
 
     private WireMockServer createServer(Consumer<WireMockConfiguration> config) {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -75,6 +75,7 @@ Summary
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
   <li><pr>5911</pr> Use Caffeine for caching HTTP headers instead of commons-collections4 LRUMap</li>
+  <li><pr>5917</pr><pr>727</pr> Deprecate <code>HTTPSamplerBase#getHeaderManager</code> and <code>HTTPSamplerBase#setHeaderManager</code> so HTTP Header Managers could be shared in the future</li>
 </ul>
 
 <h3>Other samplers</h3>


### PR DESCRIPTION
## Motivation and Context

See https://github.com/apache/jmeter/pull/727
`getHeaderManager` and `setHeaderManager` allow too broad API, and they effectively prevent sharing header managers between threads.

HTTP Header Manager is a non-trivial object, and it might consume a lot of memory (e.g. if each HTTP Sampler has a Header Manager), so it would be nice to reuse HTTP Headers somehow.

At least, the mechanics of `setHeaderManager` automatically clones and merges the elements look suspicious.