### PR TITLE
Fix resource not closed issue

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
+++ b/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
@@ -457,18 +457,21 @@ public class FileServer {
     }
 
     private static BufferedWriter createBufferedWriter(FileEntry fileEntry) throws IOException {
-        OutputStream fos = Files.newOutputStream(fileEntry.file.toPath());
-        OutputStreamWriter osw;
-        // If file encoding is specified, write using that encoding, otherwise use default platform encoding
-        String charsetName = fileEntry.charSetEncoding;
-        if(!JOrphanUtils.isBlank(charsetName)) {
-            osw = new OutputStreamWriter(fos, charsetName);
-        } else {
-            @SuppressWarnings("DefaultCharset")
-            final OutputStreamWriter withPlatformEncoding = new OutputStreamWriter(fos);
-            osw = withPlatformEncoding;
+        try (OutputStream fos = Files.newOutputStream(fileEntry.file.toPath())) {
+            OutputStreamWriter osw;
+            // If file encoding is specified, write using that encoding, otherwise use default platform encoding
+            String charsetName = fileEntry.charSetEncoding;
+            if (!JOrphanUtils.isBlank(charsetName)) {
+                osw = new OutputStreamWriter(fos, charsetName);
+            } else {
+                @SuppressWarnings("DefaultCharset") final OutputStreamWriter withPlatformEncoding = new OutputStreamWriter(fos);
+                osw = withPlatformEncoding;
+            }
+
+            return new BufferedWriter(osw);
+        } catch (Exception e) {
+            return null;
         }
-        return new BufferedWriter(osw);
     }
 
     public synchronized void closeFiles() throws IOException {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->
The OutputStream fos should be closed to prevent resource leak. 
Use try catch can automatic close resources
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
