### PR TITLE
feat: Enable usage of ${...} expressions for checkbox controls

### DIFF
--- a/src/components/src/test/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroupConfigElementTest.kt
+++ b/src/components/src/test/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroupConfigElementTest.kt
@@ -23,12 +23,9 @@ import org.apache.jmeter.junit.JMeterTestCase
 import org.apache.jmeter.modifiers.CounterConfig
 import org.apache.jmeter.sampler.DebugSampler
 import org.apache.jmeter.testelement.TestPlan
-import org.apache.jmeter.testelement.property.TestElementProperty
-import org.apache.jmeter.threads.AbstractThreadGroup
 import org.apache.jorphan.collections.ListedHashTree
 import org.apache.jorphan.test.JMeterSerialTest
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Test
 import java.time.Duration
 
@@ -37,7 +34,8 @@ class OpenModelThreadGroupConfigElementTest : JMeterTestCase(), JMeterSerialTest
      * Create Test Plan with Open Model Thread Group and Counter Config.
      */
     @Test
-    @Ignore("Sometimes the listener gets no results for unknown reason")
+    // Un-comment if you want try running the test multiple times locally:
+    // @RepeatedTest(value = 10)
     fun `ensure thread group initializes counter only once for each thread`() {
         val listener = TestTransactionController.TestSampleListener()
 
@@ -45,12 +43,9 @@ class OpenModelThreadGroupConfigElementTest : JMeterTestCase(), JMeterSerialTest
             add(TestPlan()).apply {
                 val threadGroup = OpenModelThreadGroup().apply {
                     name = "Thread Group"
-                    scheduleString = "rate(5 / sec) random_arrivals(1 sec)"
-                    setProperty(
-                        TestElementProperty(
-                            AbstractThreadGroup.MAIN_CONTROLLER, OpenModelThreadGroupController()
-                        )
-                    )
+                    // 5 samples within 100ms
+                    // Then 2 sec pause to let all the threads to finish, especially the ones that start at 99ms
+                    scheduleString = "rate(50 / sec) random_arrivals(100 ms) pause(2 s)"
                 }
                 add(threadGroup).apply {
                     add(listener)
@@ -78,7 +73,7 @@ class OpenModelThreadGroupConfigElementTest : JMeterTestCase(), JMeterSerialTest
             awaitTermination(Duration.ofSeconds(10))
         }
 
-        // There's no guarantee that thread execute exactly in order, so we sort
+        // There's no guarantee that threads execute exactly in order, so we sort
         // the labels to avoid test failure in case the thread execute out of order.
         val actual = listener.events.map { it.result.sampleLabel }.sorted()
 

--- a/src/core/src/jmh/java/org/apache/jmeter/testelement/property/PropertyGetBooleanBenchmarkJava.java
+++ b/src/core/src/jmh/java/org/apache/jmeter/testelement/property/PropertyGetBooleanBenchmarkJava.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.property;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.jmeter.testelement.TestElementSchema;
+import org.apache.jmeter.testelement.TestPlan;
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Fork(value = 1, jvmArgsPrepend = {"-Xmx128m"})
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class PropertyGetBooleanBenchmarkJava {
+    TestPlan testPlan;
+    BooleanPropertyDescriptor<TestElementSchema> enabled;
+
+    @Setup
+    public void setup() {
+        testPlan = new TestPlan();
+        testPlan.setName("test plan name");
+        testPlan.setComment("test plan comment");
+        testPlan.setSerialized(true);
+        enabled = TestElementSchema.INSTANCE.getEnabled();
+    }
+
+    @Benchmark
+    public TestPlan configure_and_getBoolean() {
+        // Does not allocate heap
+        testPlan.getProps().invoke(
+                (plan, klass) -> {
+                    // Note: set.. would allocate BooleanProperty, so we test get here
+                    if (!plan.get(klass.getEnabled())) {
+                        throw new IllegalStateException("enabled must be true");
+                    }
+                }
+        );
+        return testPlan;
+    }
+
+    @Benchmark
+    public boolean props_klass_prop_getBoolean() {
+        return testPlan.getProps().getSchema().getEnabled().get(testPlan);
+    }
+
+    @Benchmark
+    public boolean booleanDescriptor_getBoolean() {
+        return enabled.get(testPlan);
+    }
+
+    @Benchmark
+    public boolean props_getBoolean() {
+        return testPlan.getProps().get(enabled);
+    }
+
+    @Benchmark
+    public boolean props_selector_getBoolean() {
+        return testPlan.getProps().get(TestElementSchema::getEnabled);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(PropertyGetBooleanBenchmarkJava.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .detectJvmArgs()
+                .build();
+        new Runner(opt).run();
+    }
+}

--- a/src/core/src/jmh/kotlin/org/apache/jmeter/testelement/property/PropertyGetBooleanBenchmarkKotlin.kt
+++ b/src/core/src/jmh/kotlin/org/apache/jmeter/testelement/property/PropertyGetBooleanBenchmarkKotlin.kt
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.property
+
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.TestPlan
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.profile.GCProfiler
+import org.openjdk.jmh.runner.Runner
+import org.openjdk.jmh.runner.options.Options
+import org.openjdk.jmh.runner.options.OptionsBuilder
+import java.util.concurrent.TimeUnit
+
+@Fork(value = 1, jvmArgsPrepend = ["-Xmx129m"])
+@Measurement(iterations = 500, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+open class PropertyGetBooleanBenchmarkKotlin {
+    lateinit var testPlan: TestPlan
+    lateinit var enabled: BooleanPropertyDescriptor<TestElementSchema>
+
+    @Setup
+    fun setup() {
+        testPlan = TestPlan().apply {
+            name = "test plan name"
+            comment = "test plan comment"
+            isSerialized = true
+        }
+        enabled = TestElementSchema.enabled
+    }
+
+    @Benchmark
+    fun getBoolean(): Boolean =
+        testPlan.isSerialized
+
+    @Benchmark
+    fun configure_and_getBoolean(): TestPlan {
+        // Does not allocate heap
+        testPlan.props {
+            // Note: set.. would allocate BooleanProperty, so we test get here
+            if (!it[enabled]) {
+                throw IllegalStateException("enabled must be true")
+            }
+        }
+        return testPlan
+    }
+
+    @Benchmark
+    open fun props_klass_prop_getBoolean(): Boolean =
+        testPlan.props.schema.enabled[testPlan]
+
+    @Benchmark
+    fun booleanDescriptor_getBoolean(): Boolean =
+        enabled[testPlan]
+
+    @Benchmark
+    fun props_getBoolean(): Boolean =
+        testPlan.props[enabled]
+
+    @Benchmark
+    fun props_selector_getBoolean(): Boolean =
+        testPlan.props[ { enabled }]
+}
+
+fun main() {
+    println(PropertyGetBooleanBenchmarkKotlin::class.java.simpleName)
+    val opt: Options = OptionsBuilder()
+        .include(PropertyGetBooleanBenchmarkKotlin::class.java.simpleName)
+        .addProfiler(GCProfiler::class.java)
+        .detectJvmArgs()
+        .build()
+    Runner(opt).run()
+}

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -84,6 +84,7 @@ import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.save.SaveService;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.testelement.TestElementSchema;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.RemoteThreadsListenerTestElement;
 import org.apache.jmeter.util.BeanShellInterpreter;
@@ -425,6 +426,29 @@ public class JMeter implements JMeterPlugin {
             JMeterUtils.setProperty("START.MS",Long.toString(now.toEpochMilli()));// $NON-NLS-1$
             JMeterUtils.setProperty("START.YMD", getFormatter("yyyyMMdd").format(now));// $NON-NLS-1$ $NON-NLS-2$
             JMeterUtils.setProperty("START.HMS", getFormatter("HHmmss").format(now));// $NON-NLS-1$ $NON-NLS-2$
+
+            // For unknown reason, TestElementSchema might fail to initialize in remote execution mode
+            // It reproduces with Java 11.0.13, and the error is StackOverflowError with the following stacktrace
+            // The workaround is to initialize Kotlin reflection before deserializing the test plan.
+            //  at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174) ~[?:?]
+            //  at java.net.URLClassLoader.defineClass(URLClassLoader.java:555) ~[?:?]
+            //  at java.net.URLClassLoader$1.run(URLClassLoader.java:458) ~[?:?]
+            //  at java.net.URLClassLoader$1.run(URLClassLoader.java:452) ~[?:?]
+            //  at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
+            //  at java.net.URLClassLoader.findClass(URLClassLoader.java:451) ~[?:?]
+            //  at java.lang.ClassLoader.loadClass(ClassLoader.java:589) ~[?:?]
+            //  at org.apache.jmeter.DynamicClassLoader.loadClass(DynamicClassLoader.java:81) ~[ApacheJMeter.jar:5.5.1-SNAPSHOT]
+            //  at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
+            //  at kotlin.jvm.internal.ClassReference.<clinit>(ClassReference.kt:156) ~[kotlin-stdlib-1.8.21.jar:1.8.21-release-380(1.8.21)]
+            //  at kotlin.jvm.internal.ReflectionFactory.getOrCreateKotlinClass(ReflectionFactory.java:30) ~[kotlin-stdlib-1.8.21.jar)]
+            //  at kotlin.jvm.internal.Reflection.getOrCreateKotlinClass(Reflection.java:60) ~[kotlin-stdlib-1.8.21.jar:1.8.21-release-380(1.8.21)]
+            //  at org.apache.jmeter.testelement.TestElementSchema.<init>(TestElementSchema.kt:33) ~[ApacheJMeter_core.jar:5.5.1-SNAPSHOT]
+            //  at org.apache.jmeter.testelement.TestElementSchema$INSTANCE.<init>(TestElementSchema.kt:26) ~[ApacheJMeter_core.jar:5.5.1-SNAPSHOT]
+            //  at org.apache.jmeter.testelement.TestElementSchema$INSTANCE.<init>(TestElementSchema.kt) ~[ApacheJMeter_core.jar:5.5.1-SNAPSHOT]
+            //  at org.apache.jmeter.testelement.TestElementSchema.<clinit>(TestElementSchema.kt) ~[ApacheJMeter_core.jar:5.5.1-SNAPSHOT]
+            //  at org.apache.jmeter.protocol.java.sampler.BeanShellSampler.<clinit>(BeanShellSampler.java:53) ~[ApacheJMeter_java.jar:5.5.1-SNAPSHOT]
+            //  at jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method) ~[?:?]
+            TestElementSchema.INSTANCE.getGuiClass();
 
             if (parser.getArgumentById(VERSION_OPT) != null) {
                 displayAsciiArt();

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceStringWithFunctions.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceStringWithFunctions.java
@@ -27,6 +27,8 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
  * Replaces a String containing functions with their Function properties equivalent, example:
  * ${__time()}_${__threadNum()}_${__machineName()} will become a FunctionProperty of
  * a CompoundVariable containing  3 functions
+ * @see TransformStringsIntoFunctions
+ * @see TestElementPropertyTransformer#USE_FUNCTIONS
  */
 public class ReplaceStringWithFunctions extends AbstractTransformer {
     public ReplaceStringWithFunctions(CompoundVariable masterFunction, Map<String, String> variables) {

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ValueReplacer.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ValueReplacer.java
@@ -151,11 +151,10 @@ public class ValueReplacer {
      * {@link org.apache.jmeter.testelement.property.FunctionProperty} of
      * a {@link CompoundVariable} containing three functions
      * @param iter the {@link PropertyIterator} over all properties, in which the values should be replaced
-     * @param transform the {@link ValueTransformer}, that should do transformation
+     * @param transform the {@link PropertyTransformer}, that should do transformation
      * @return a new {@link Collection} with all the transformed {@link JMeterProperty}s
-     * @throws InvalidVariableException when <code>transform</code> throws an {@link InvalidVariableException} while transforming a value
      */
-    private static Collection<JMeterProperty> replaceValues(PropertyIterator iter, ValueTransformer transform) throws InvalidVariableException {
+    private static Collection<JMeterProperty> replaceValues(PropertyIterator iter, PropertyTransformer transform) {
         List<JMeterProperty> props = new ArrayList<>();
         while (iter.hasNext()) {
             JMeterProperty val = iter.next();
@@ -166,11 +165,11 @@ public class ValueReplacer {
                 // Must not convert TestElement.gui_class etc
                 if (!val.getName().equals(TestElement.GUI_CLASS) &&
                         !val.getName().equals(TestElement.TEST_CLASS)) {
-                    val = transform.transformValue(val);
+                    val = transform.transform(val);
                     log.debug("Replacement result: {}", val);
                 }
             } else if (val instanceof NumberProperty) {
-                val = transform.transformValue(val);
+                val = transform.transform(val);
                 log.debug("Replacement result: {}", val);
             } else if (val instanceof MultiProperty) {
                 MultiProperty multiVal = (MultiProperty) val;

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ValueTransformer.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ValueTransformer.java
@@ -21,8 +21,23 @@ import java.util.Map;
 
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apiguardian.api.API;
 
-interface ValueTransformer {
+/**
+ * @deprecated use {@link PropertyTransformer} instead
+ */
+@Deprecated
+@API(status = API.Status.DEPRECATED, since = "5.6")
+interface ValueTransformer extends PropertyTransformer {
+    @Override
+    default JMeterProperty transform(JMeterProperty input) {
+        try {
+            return transformValue(input);
+        } catch (InvalidVariableException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Transform the given property and return the new version.
      *

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -27,9 +27,8 @@ import java.util.Map;
 import org.apache.jmeter.NewDriver;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.services.FileServer;
-import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
-import org.apache.jmeter.testelement.property.TestElementProperty;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
@@ -39,19 +38,6 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     private static final long serialVersionUID = 234L;
 
     private static final Logger log = LoggerFactory.getLogger(TestPlan.class);
-
-    //+ JMX field names - do not change values
-    private static final String FUNCTIONAL_MODE = "TestPlan.functional_mode"; //$NON-NLS-1$
-
-    private static final String USER_DEFINED_VARIABLES = "TestPlan.user_defined_variables"; //$NON-NLS-1$
-
-    private static final String SERIALIZE_THREADGROUPS = "TestPlan.serialize_threadgroups"; //$NON-NLS-1$
-
-    private static final String CLASSPATHS = "TestPlan.user_define_classpath"; //$NON-NLS-1$
-
-    private static final String TEARDOWN_ON_SHUTDOWN = "TestPlan.tearDown_on_shutdown"; //$NON-NLS-1$
-
-    //- JMX field names
 
     private static final String CLASSPATH_SEPARATOR = ","; //$NON-NLS-1$
 
@@ -68,6 +54,16 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
 
     public TestPlan(String name) {
         setName(name);
+    }
+
+    @Override
+    public TestPlanSchema getSchema() {
+        return TestPlanSchema.INSTANCE;
+    }
+
+    @Override
+    public PropertiesAccessor<? extends TestPlan, ? extends TestPlanSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
     }
 
     // create transient item
@@ -87,15 +83,15 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
      * @return functional mode
      */
     public boolean isFunctionalMode() {
-        return getPropertyAsBoolean(FUNCTIONAL_MODE);
+        return get(getSchema().getFunctionalMode());
     }
 
     public void setUserDefinedVariables(Arguments vars) {
-        setProperty(new TestElementProperty(USER_DEFINED_VARIABLES, vars));
+        set(getSchema().getUserDefinedVariables(), vars);
     }
 
     public JMeterProperty getUserDefinedVariablesAsProperty() {
-        return getProperty(USER_DEFINED_VARIABLES);
+        return getProperty(getSchema().getUserDefinedVariables().getName());
     }
 
     public String getBasedir() {
@@ -117,16 +113,11 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     }
 
     private Arguments getVariables() {
-        Arguments args = (Arguments) getProperty(USER_DEFINED_VARIABLES).getObjectValue();
-        if (args == null) {
-            args = new Arguments();
-            setUserDefinedVariables(args);
-        }
-        return args;
+        return getSchema().getUserDefinedVariables().getOrCreate(this, Arguments::new);
     }
 
     public void setFunctionalMode(boolean funcMode) {
-        setProperty(new BooleanProperty(FUNCTIONAL_MODE, funcMode));
+        set(getSchema().getFunctionalMode(), funcMode);
         setGlobalFunctionalMode(funcMode);
     }
 
@@ -148,15 +139,15 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
     }
 
     public void setSerialized(boolean serializeTGs) {
-        setProperty(new BooleanProperty(SERIALIZE_THREADGROUPS, serializeTGs));
+        set(getSchema().getSerializeThreadgroups(), serializeTGs);
     }
 
     public void setTearDownOnShutdown(boolean tearDown) {
-        setProperty(TEARDOWN_ON_SHUTDOWN, tearDown, false);
+        set(getSchema().getTearDownOnShutdown(), tearDown);
     }
 
     public boolean isTearDownOnShutdown() {
-        return getPropertyAsBoolean(TEARDOWN_ON_SHUTDOWN, false);
+        return get(getSchema().getTearDownOnShutdown());
     }
 
     /**
@@ -168,7 +159,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
      *            the classpath to be set
      */
     public void setTestPlanClasspath(String text) {
-        setProperty(CLASSPATHS,text);
+        set(getSchema().getTestPlanClasspath(), text);
     }
 
     public void setTestPlanClasspathArray(String[] text) {
@@ -191,7 +182,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
      * @return classpath
      */
     public String getTestPlanClasspath() {
-        return getPropertyAsString(CLASSPATHS);
+        return get(getSchema().getTestPlanClasspath());
     }
 
     /**
@@ -200,7 +191,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
      * @return serialized setting
      */
     public boolean isSerialized() {
-        return getPropertyAsBoolean(SERIALIZE_THREADGROUPS);
+        return get(getSchema().getSerializeThreadgroups());
     }
 
     public void addParameter(String name, String value) {

--- a/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -31,13 +31,12 @@ import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jmeter.testelement.property.BooleanProperty;
-import org.apache.jmeter.testelement.property.IntegerProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
-import org.apache.jmeter.testelement.property.TestElementProperty;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
 import org.apiguardian.api.API;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * ThreadGroup holds the settings for a JMeter thread group.
@@ -77,15 +76,31 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
     public static final String ON_SAMPLE_ERROR_STOPTEST_NOW = "stoptestnow";
 
     /** Number of threads in the thread group */
-    public static final String NUM_THREADS = "ThreadGroup.num_threads";
+    @Deprecated
+    public static final String NUM_THREADS =
+            AbstractThreadGroupSchema.INSTANCE.getNumThreads().getName();
 
-    public static final String MAIN_CONTROLLER = "ThreadGroup.main_controller";
+    public static final String MAIN_CONTROLLER =
+            AbstractThreadGroupSchema.INSTANCE.getMainController().getName();
 
     /** The same user or different users */
-    public static final String IS_SAME_USER_ON_NEXT_ITERATION = "ThreadGroup.same_user_on_next_iteration";
+    @Deprecated
+    public static final String IS_SAME_USER_ON_NEXT_ITERATION =
+            AbstractThreadGroupSchema.INSTANCE.getSameUserOnNextIteration().getName();
 
 
     private final AtomicInteger numberOfThreads = new AtomicInteger(0); // Number of active threads in this group
+
+    @Override
+    public AbstractThreadGroupSchema getSchema() {
+        return AbstractThreadGroupSchema.INSTANCE;
+    }
+
+    @NotNull
+    @Override
+    public PropertiesAccessor<? extends AbstractThreadGroup, ? extends AbstractThreadGroupSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -105,7 +120,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      * @return the sampler controller.
      */
     public Controller getSamplerController() {
-        return (Controller) getProperty(MAIN_CONTROLLER).getObjectValue();
+        return get(getSchema().getMainController());
     }
 
     /**
@@ -116,7 +131,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      */
     public void setSamplerController(LoopController c) {
         c.setContinueForever(false);
-        setProperty(new TestElementProperty(MAIN_CONTROLLER, c));
+        set(getSchema().getMainController(), c);
     }
 
     /**
@@ -188,7 +203,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      *            the number of threads.
      */
     public void setNumThreads(int numThreads) {
-        setProperty(new IntegerProperty(NUM_THREADS, numThreads));
+        set(getSchema().getNumThreads(), numThreads);
     }
 
     /**
@@ -220,7 +235,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      * @return the number of threads.
      */
     public int getNumThreads() {
-        return this.getPropertyAsInt(AbstractThreadGroup.NUM_THREADS);
+        return get(getSchema().getNumThreads());
     }
 
     /**
@@ -322,7 +337,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      *            false is a different user on next iteration of loop
      */
     public void setIsSameUserOnNextIteration(boolean isSameUserOnNextIteration) {
-        setProperty(new BooleanProperty(IS_SAME_USER_ON_NEXT_ITERATION, isSameUserOnNextIteration));
+        set(getSchema().getSameUserOnNextIteration(), isSameUserOnNextIteration);
     }
 
     /**
@@ -334,7 +349,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      * @return the kind of user.
      */
     public boolean isSameUserOnNextIteration() {
-        return getPropertyAsBoolean(ThreadGroup.IS_SAME_USER_ON_NEXT_ITERATION, true);
+        return get(getSchema().getSameUserOnNextIteration());
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
@@ -28,9 +28,11 @@ import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.IntegerProperty;
 import org.apache.jmeter.testelement.property.LongProperty;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.ListedHashTree;
 import org.apache.jorphan.util.JMeterStopTestException;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,19 +57,20 @@ public class ThreadGroup extends AbstractThreadGroup {
     //+ JMX entries - do not change the string values
 
     /** Ramp-up time */
-    public static final String RAMP_TIME = "ThreadGroup.ramp_time";
+    public static final String RAMP_TIME = ThreadGroupSchema.INSTANCE.getRampTime().getName();
 
     /** Whether thread startup is delayed until required */
-    public static final String DELAYED_START = "ThreadGroup.delayedStart";
+    @Deprecated
+    public static final String DELAYED_START = ThreadGroupSchema.INSTANCE.getDelayedStart().getName();
 
     /** Whether scheduler is being used */
-    public static final String SCHEDULER = "ThreadGroup.scheduler";
+    public static final String SCHEDULER = ThreadGroupSchema.INSTANCE.getUseScheduler().getName();
 
     /** Scheduler duration, overrides end time */
-    public static final String DURATION = "ThreadGroup.duration";
+    public static final String DURATION = ThreadGroupSchema.INSTANCE.getDuration().getName();
 
     /** Scheduler start delay, overrides start time */
-    public static final String DELAY = "ThreadGroup.delay";
+    public static final String DELAY = ThreadGroupSchema.INSTANCE.getDelay().getName();
     //- JMX entries
 
     private transient Thread threadStarter;
@@ -97,6 +100,16 @@ public class ThreadGroup extends AbstractThreadGroup {
      */
     public ThreadGroup() {
         super();
+    }
+
+    @Override
+    public ThreadGroupSchema getSchema() {
+        return ThreadGroupSchema.INSTANCE;
+    }
+
+    @Override
+    public @NotNull PropertiesAccessor<? extends ThreadGroup, ? extends ThreadGroupSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
     }
 
     /**
@@ -175,7 +188,7 @@ public class ThreadGroup extends AbstractThreadGroup {
     }
 
     private boolean isDelayedStartup() {
-        return getPropertyAsBoolean(DELAYED_START);
+        return get(getSchema().getDelayedStart());
     }
 
     /**

--- a/src/core/src/main/kotlin/org/apache/jmeter/engine/util/DeepPropertyTransformer.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/engine/util/DeepPropertyTransformer.kt
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.engine.util
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apache.jmeter.testelement.property.MultiProperty
+import org.apiguardian.api.API
+import org.slf4j.LoggerFactory
+
+/**
+ * Transforms [JMeterProperty] and including the contents of [MultiProperty].
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class DeepPropertyTransformer(
+    private val simpleTransformer: PropertyTransformer
+) : PropertyTransformer {
+    private companion object {
+        private val log = LoggerFactory.getLogger(DeepPropertyTransformer::class.java)
+    }
+
+    override fun transform(input: JMeterProperty): JMeterProperty {
+        log.debug("Processing property {}", input)
+
+        return when (input) {
+            is MultiProperty ->
+                processMultiProperty(input) ?: input
+
+            else ->
+                simpleTransformer.transform(input)
+        }
+    }
+
+    /**
+     * Transforms a [MultiProperty]. Currently, there's no way to "clone MultiProperty with new values",
+     * so we use old approach of "clear and add all values again".
+     * @return the modified property or null if no modifications were made
+     */
+    private fun processMultiProperty(input: MultiProperty): MultiProperty? {
+        // TODO move this to JMeterProperty.accept(visitor) returns JMeter Property
+        // so we can avoid mutating the properties in-place
+        // Modifying input property makes it harder to understand if it was modified or not
+        return getNewPropsOrNull(input)?.let { props ->
+            log.debug("About to replace values in MultiProperty {} with new ones: {}", input, props)
+            input.clear()
+            for (prop in props) {
+                input.addProperty(prop)
+            }
+            input
+        }
+    }
+
+    /**
+     * Return the new list of transformed properties, or null if no transformations were made.
+     */
+    private fun getNewPropsOrNull(
+        input: MultiProperty,
+    ): MutableList<JMeterProperty>? {
+        // We don't know if there will be transformations, so we need to store
+        // all the properties.
+        val props = mutableListOf<JMeterProperty>()
+        var hasTransformations = false
+        val it = input.iterator()
+        while (it.hasNext()) {
+            val property = it.next()
+
+            // MultiProperty is replaced in-place, so we ask the function to set hasModifications flag on changes
+            val newValue = when (property) {
+                is MultiProperty -> {
+                    val res = processMultiProperty(property)
+                    res?.also { hasTransformations = true } ?: property
+                }
+
+                else ->
+                    when (property.name) {
+                        // Avoid replacing vital properties
+                        TestElement.GUI_CLASS, TestElement.TEST_CLASS -> property
+                        else -> transform(property)
+                    }
+            }
+            if (property !== newValue) {
+                // If the value is different, it was transformed
+                hasTransformations = true
+            }
+            props.add(newValue)
+        }
+        return props.takeIf { hasTransformations }
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/engine/util/PropertyTransformer.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/engine/util/PropertyTransformer.kt
@@ -15,32 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.jmeter.engine.util;
+package org.apache.jmeter.engine.util
 
-import java.util.Map;
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apiguardian.api.API
 
-@SuppressWarnings("deprecation")
-abstract class AbstractTransformer implements ValueTransformer {
-
-    private CompoundVariable masterFunction;
-
-    private Map<String, String> variables;
-
-    @Override
-    public void setMasterFunction(CompoundVariable variable) {
-        masterFunction = variable;
-    }
-
-    protected CompoundVariable getMasterFunction() {
-        return masterFunction;
-    }
-
-    public Map<String, String> getVariables() {
-        return variables;
-    }
-
-    @Override
-    public void setVariables(Map<String, String> map) {
-        variables = map;
-    }
+/**
+ * Transform [JMeterProperty] into a different [JMeterProperty].
+ * The transformer should not modify the source property.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public fun interface PropertyTransformer {
+    public fun transform(input: JMeterProperty): JMeterProperty
 }

--- a/src/core/src/main/kotlin/org/apache/jmeter/engine/util/TestElementPropertyTransformer.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/engine/util/TestElementPropertyTransformer.kt
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.engine.util
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.property.TestElementProperty
+import org.apiguardian.api.API
+
+/**
+ * Transforms properties of the input [TestElement] with given [PropertyTransformer].
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class TestElementPropertyTransformer(
+    propertyTransformer: PropertyTransformer
+) {
+    public companion object {
+        @JvmField
+        public val USE_FUNCTIONS: TestElementPropertyTransformer =
+            TestElementPropertyTransformer(TransformStringsIntoFunctions)
+    }
+
+    private val transformer = DeepPropertyTransformer(propertyTransformer)
+
+    public fun visit(testElement: TestElement) {
+        // For now, DeepPropertyTransformer mutates MultiProperties inplace, so
+        transformer.transform(TestElementProperty("temp", testElement))
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/engine/util/TransformStringsIntoFunctions.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/engine/util/TransformStringsIntoFunctions.kt
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.engine.util
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.property.FunctionProperty
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apache.jmeter.testelement.property.StringProperty
+import org.apiguardian.api.API
+
+/**
+ * Converts a [StringProperty] containing functions to the corresponding [FunctionProperty] equivalent, example:
+ * ${__time()}_${__threadNum()}_${__machineName()} will become a FunctionProperty of
+ * a [CompoundVariable] containing  3 functions.
+ *
+ * Note: this implementation does not convert nested properties, use [TestElementPropertyTransformer.USE_FUNCTIONS]
+ * if you need process all properties of a [TestElement].
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public object TransformStringsIntoFunctions : PropertyTransformer {
+    private val parser = CompoundVariable()
+
+    override fun transform(input: JMeterProperty): JMeterProperty {
+        if (input !is StringProperty) {
+            return input
+        }
+        synchronized(parser) {
+            // TODO: move parsing logic out of CompoundVariable
+            parser.clear()
+            parser.setParameters(input.stringValue)
+            if (parser.hasFunction()) {
+                return FunctionProperty(input.getName(), parser.function)
+            }
+        }
+        return input
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/JBooleanPropertyEditor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/JBooleanPropertyEditor.kt
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.property.BooleanProperty
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.util.JMeterUtils
+import org.apache.jorphan.gui.JEditableCheckBox
+import org.apiguardian.api.API
+
+/**
+ * Provides editor component for boolean properties that accommodate both true/false and expression string.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class JBooleanPropertyEditor(
+    private val propertyDescriptor: BooleanPropertyDescriptor<*>,
+    label: String,
+) : JEditableCheckBox(label, DEFAULT_CONFIGURATION) {
+    private companion object {
+        @JvmField
+        val DEFAULT_CONFIGURATION: Configuration = Configuration(
+            startEditing = JMeterUtils.getResString("editable_checkbox.use_expression"),
+            trueValue = "true",
+            falseValue = "false",
+            extraValues = listOf(
+                "\${__P(property_name)}",
+                "\${variable_name}",
+            )
+        )
+    }
+
+    public fun reset() {
+        value = Value.of(propertyDescriptor.defaultValue ?: false)
+    }
+
+    /**
+     * Update [TestElement] based on the state of the UI.
+     * TODO: we might better use PropertiesAccessor<TestElement, ElementSchema>
+     *     However, it would require callers to pass element.getProps() which might allocate.
+     * @param testElement element to update
+     */
+    public fun updateElement(testElement: TestElement) {
+        when (val value = value) {
+            is Value.Boolean -> testElement[propertyDescriptor] = value.value
+            is Value.Text -> testElement[propertyDescriptor] = value.value
+        }
+    }
+
+    /**
+     * Update UI based on the state of the given [TestElement].
+     * TODO: we might better use PropertiesAccessor<TestElement, ElementSchema>
+     *     However, it would require callers to pass element.getProps() which might allocate.
+     * @param testElement element to get the state from
+     */
+    public fun updateUi(testElement: TestElement) {
+        value = when (val value = testElement.getPropertyOrNull(propertyDescriptor)) {
+            is BooleanProperty, null -> Value.of(value?.booleanValue ?: propertyDescriptor.defaultValue ?: false)
+            // TODO: should we rather fail in case we detect an unknown property?
+            else -> Value.Text(value.stringValue)
+        }
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/JMeterPropertySchemaUnchecked.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/JMeterPropertySchemaUnchecked.kt
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement
+
+/**
+ * Annotation that marks methods which access [TestElement] properties without verifying
+ * if the property belongs to the test element or not.
+ * Prefer using
+ *    testElement.props[ElementClass.property] = ...
+ *    testElement.props { it[property] = ... }
+ * instead of
+ *    testElement[ElementClass.property]
+ *
+ * As the latter does not verify if testElement and ElementClass are related.
+ */
+@DslMarker
+@Retention(AnnotationRetention.BINARY)
+public annotation class JMeterPropertySchemaUnchecked()

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
@@ -17,9 +17,28 @@
 
 package org.apache.jmeter.testelement
 
+import org.apache.jmeter.testelement.property.BooleanProperty
+import org.apache.jmeter.testelement.property.CollectionProperty
+import org.apache.jmeter.testelement.property.DoubleProperty
+import org.apache.jmeter.testelement.property.FloatProperty
+import org.apache.jmeter.testelement.property.IntegerProperty
 import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apache.jmeter.testelement.property.LongProperty
 import org.apache.jmeter.testelement.property.NullProperty
 import org.apache.jmeter.testelement.property.PropertyIterator
+import org.apache.jmeter.testelement.property.StringProperty
+import org.apache.jmeter.testelement.property.TestElementProperty
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.ClassPropertyDescriptor
+import org.apache.jmeter.testelement.schema.CollectionPropertyDescriptor
+import org.apache.jmeter.testelement.schema.DoublePropertyDescriptor
+import org.apache.jmeter.testelement.schema.FloatPropertyDescriptor
+import org.apache.jmeter.testelement.schema.IntegerPropertyDescriptor
+import org.apache.jmeter.testelement.schema.LongPropertyDescriptor
+import org.apache.jmeter.testelement.schema.PropertiesAccessor
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
+import org.apache.jmeter.testelement.schema.TestElementPropertyDescriptor
 import org.apache.jmeter.threads.JMeterContext
 import org.apiguardian.api.API
 
@@ -34,6 +53,17 @@ public interface TestElement : Cloneable {
         // Also TestElementConverter and TestElementPropertyConverter for handling empty comments
         public const val COMMENTS: String = "TestPlan.comments" // $NON-NLS-1$
     }
+
+    public val schema: TestElementSchema
+        get() = TestElementSchema
+
+    /**
+     * Allows type-safe accessors to the properties of the current element.
+     * Note: when overriding the method, ensure you emit wildcards.
+     * For instance: [JMeterElementInstance<? extends TestPlanClass> getProps() { return ... }]
+     */
+    public val props: PropertiesAccessor<@JvmWildcard TestElement, @JvmWildcard TestElementSchema>
+        get() = PropertiesAccessor(this, schema)
 
     public fun addTestElement(child: TestElement)
 
@@ -206,6 +236,278 @@ public interface TestElement : Cloneable {
      * @return [JMeterProperty] stored under the name, or [NullProperty] if no property can be found
      */
     public fun getProperty(propName: String): JMeterProperty
+
+    /**
+     * Retrieve property or return `null` if the property is unset.
+     *
+     * Note: the result of the method does not account the default value,
+     * so consider using `get(PropertyDescriptor)` methods if you need
+     * to account for default values.
+     *
+     * @param propName the name of the property to get
+     * @return [JMeterProperty] or `null` if the property is unset
+     * @since 5.6
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public fun getPropertyOrNull(propName: String): JMeterProperty? =
+        getProperty(propName).takeIf { it !is NullProperty }
+
+    /**
+     * Retrieve property or return `null` if the property is unset.
+     *
+     * Note: the result of the method does not account the default value,
+     * so consider using `get(PropertyDescriptor)` methods if you need
+     * to account for default values.
+     *
+     * @param property descriptor of the property to retrieve
+     * @return [JMeterProperty] or `null` if the property is unset
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public fun getPropertyOrNull(property: PropertyDescriptor<*, *>): JMeterProperty? =
+        getPropertyOrNull(property.name)
+
+    /**
+     * Retrieve property name as string.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: StringPropertyDescriptor<*>): String =
+        getPropertyOrNull(property)?.stringValue ?: property.defaultValue ?: ""
+
+    /**
+     * Read property value as string, and return default value if the property is unset.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public fun getString(property: PropertyDescriptor<*, *>): String =
+        getPropertyOrNull(property)?.stringValue ?: property.defaultValueAsString ?: ""
+
+    /**
+     * Set property as string, or remove it if the given value matches the default one for the property.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: PropertyDescriptor<*, *>, value: String) {
+        removeOrSet(property.defaultValueAsString == value, property.name) {
+            StringProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve boolean property value.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: BooleanPropertyDescriptor<*>): Boolean =
+        getPropertyOrNull(property)?.booleanValue ?: property.defaultValue ?: false
+
+    /**
+     * Set property as boolean, or remove it if the given value matches the default one for the property.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: BooleanPropertyDescriptor<*>, value: Boolean) {
+        removeOrSet(property.defaultValue == value, property.name) {
+            BooleanProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve integer property value.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: IntegerPropertyDescriptor<*>): Int =
+        getPropertyOrNull(property)?.intValue ?: property.defaultValue ?: 0
+
+    /**
+     * Set property as integer, or remove it if the given value matches the default one for the property.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: IntegerPropertyDescriptor<*>, value: Int) {
+        removeOrSet(property.defaultValue == value, property.name) {
+            IntegerProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve long property value.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: LongPropertyDescriptor<*>): Long =
+        getPropertyOrNull(property)?.longValue ?: property.defaultValue ?: 0
+
+    /**
+     * Set property as long, or remove it if the given value matches the default one for the property.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: LongPropertyDescriptor<*>, value: Long) {
+        removeOrSet(property.defaultValue != value, property.name) {
+            LongProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve float property value.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: FloatPropertyDescriptor<*>): Float =
+        getPropertyOrNull(property)?.floatValue ?: property.defaultValue ?: 0.0f
+
+    /**
+     * Set property as float, or remove it if the given value matches the default one for the property.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: FloatPropertyDescriptor<*>, value: Float) {
+        removeOrSet(property.defaultValue != value, property.name) {
+            FloatProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve double property value.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: DoublePropertyDescriptor<*>): Double =
+        getPropertyOrNull(property)?.doubleValue ?: property.defaultValue ?: 0.0
+
+    /**
+     * Set property as double, or remove it if the given value matches the default one for the property.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: DoublePropertyDescriptor<*>, value: Double) {
+        removeOrSet(property.defaultValue != value, property.name) {
+            DoubleProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve [Class] property value, or throw [NoSuchElementException] in case the property is unset.
+     * @throws NoSuchElementException if the property is unset
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun <ValueClass : Any> get(property: ClassPropertyDescriptor<*, ValueClass>): Class<out ValueClass> =
+        getPropertyOrNull(property)?.objectValue?.let {
+            Class.forName(getString(property), false, Thread.currentThread().contextClassLoader)
+                .asSubclass(property.klass)
+        } ?: property.defaultValue
+            ?: throw NoSuchElementException("Property ${property.name} is unset for element $this")
+
+    /**
+     * Set property as [Class], or remove it if the given value matches the default one for the property.
+     * The value is set as [StringProperty] with the name of the given class.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun <ValueClass : Any> set(property: ClassPropertyDescriptor<*, ValueClass>, value: Class<out ValueClass>?) {
+        removeOrSet(value == null || property.defaultValue != value, property.name) {
+            StringProperty(it, value!!.name)
+        }
+    }
+
+    /**
+     * Retrieve [TestElement] property value, or throw [NoSuchElementException] in case the property is unset.
+     * @throws NoSuchElementException if the property is unset
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun <TestElementClass : TestElement> get(
+        property: TestElementPropertyDescriptor<*, TestElementClass>
+    ): TestElementClass =
+        getPropertyOrNull(property)?.objectValue?.let { property.klass.cast(it) }
+            ?: throw NoSuchElementException("Property ${property.name} is unset for element $this")
+
+    /**
+     * Retrieve [TestElement] property value, or create one and set it the property is unset.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public fun <TestElementClass : TestElement> getOrCreate(
+        property: TestElementPropertyDescriptor<*, TestElementClass>,
+        ifMissing: () -> TestElementClass
+    ): TestElementClass =
+        getPropertyOrNull(property)?.objectValue?.let { property.klass.cast(it) }
+            ?: ifMissing().also { set(property, it) }
+
+    /**
+     * Set property as [TestElement], or remove it if the given [TestElement] is `null`.
+     * The values of collection will be converted to [JMeterProperty] as in [CollectionProperty.addItem].
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun <TestElementClass : TestElement> set(property: TestElementPropertyDescriptor<*, TestElementClass>, value: TestElementClass?) {
+        removeOrSet(value == null, property.name) {
+            TestElementProperty(it, value)
+        }
+    }
+
+    /**
+     * Retrieve [Collection] property value, or throw [NoSuchElementException] in case the property is unset.
+     * @throws NoSuchElementException if the property is unset
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun get(property: CollectionPropertyDescriptor<*>): Collection<JMeterProperty> =
+        getPropertyOrNull(property)?.let {
+            @Suppress("UNCHECKED_CAST")
+            (it as CollectionProperty).objectValue as Collection<JMeterProperty>
+        } ?: throw NoSuchElementException("Property ${property.name} is unset for element $this")
+
+    /**
+     * Retrieve [Collection] property value, or create one and set it the property is unset.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public fun getOrCreate(
+        property: CollectionPropertyDescriptor<*>,
+        ifMissing: () -> Collection<JMeterProperty>
+    ): Collection<JMeterProperty> =
+        getPropertyOrNull(property)?.let {
+            @Suppress("UNCHECKED_CAST")
+            (it as CollectionProperty).objectValue as Collection<JMeterProperty>
+        } ?: ifMissing().also { set(property, it) }
+
+    /**
+     * Set property as [Collection], or remove it if the given [Collection] is `null`.
+     * @since 5.6
+     */
+    @JMeterPropertySchemaUnchecked
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6")
+    public operator fun set(property: CollectionPropertyDescriptor<*>, value: Collection<*>?) {
+        removeOrSet(value == null, property.name) {
+            CollectionProperty(it, value)
+        }
+    }
 
     /**
      * Get a Property Iterator for the TestElements properties.

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElementSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElementSchema.kt
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement
+
+import org.apache.jmeter.gui.JMeterGUIComponent
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.ClassPropertyDescriptor
+import org.apache.jmeter.testelement.schema.EmptyTestElementSchema
+import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [TestElement].
+ * @see TestElement
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class TestElementSchema protected constructor() : EmptyTestElementSchema() {
+    public companion object INSTANCE : TestElementSchema()
+
+    public val name: StringPropertyDescriptor<TestElementSchema> =
+        string("TestElement.name")
+    public val comments: StringPropertyDescriptor<TestElementSchema> =
+        string("TestElement.comments")
+    public open val guiClass: ClassPropertyDescriptor<TestElementSchema, JMeterGUIComponent> =
+        classProperty(JMeterGUIComponent::class, "TestElement.gui_class")
+    public val testClass: ClassPropertyDescriptor<TestElementSchema, Any> =
+        classProperty(Any::class, "TestElement.testClass")
+    public val enabled: BooleanPropertyDescriptor<TestElementSchema> =
+        boolean("TestElement.enabled", default = true)
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestPlanSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestPlanSchema.kt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement
+
+import org.apache.jmeter.config.Arguments
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
+import org.apache.jmeter.testelement.schema.TestElementPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [TestPlan].
+ * @see TestPlan
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class TestPlanSchema protected constructor() : TestElementSchema() {
+    public companion object INSTANCE : TestPlanSchema()
+
+    public val functionalMode: BooleanPropertyDescriptor<TestPlanSchema> =
+        boolean("TestPlan.functional_mode")
+
+    public val serializeThreadgroups: BooleanPropertyDescriptor<TestPlanSchema> =
+        boolean("TestPlan.serialize_threadgroups")
+
+    public val tearDownOnShutdown: BooleanPropertyDescriptor<TestPlanSchema> =
+        boolean("TestPlan.tearDown_on_shutdown", false)
+
+    public val userDefinedVariables: TestElementPropertyDescriptor<TestPlanSchema, Arguments> =
+        testElement("TestPlan.user_defined_variables")
+
+    public val testPlanClasspath: StringPropertyDescriptor<TestPlanSchema> =
+        string("TestPlan.user_define_classpath")
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/removeOrSet.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/removeOrSet.kt
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement
+
+import org.apache.jmeter.testelement.property.JMeterProperty
+
+internal inline fun TestElement.removeOrSet(remove: Boolean, name: String, factory: (String) -> JMeterProperty) {
+    if (remove) {
+        removeProperty(name)
+    } else {
+        setProperty(factory(name))
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/BooleanPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/BooleanPropertyDescriptor.kt
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.BooleanProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [BooleanProperty]: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.boolean] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class BooleanPropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: Boolean?
+) : PropertyDescriptor<Schema, Boolean> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override fun toString(): String = "BooleanPropertyDescriptor(name='$name', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): Boolean =
+        target[this]
+
+    public operator fun set(target: TestElement, value: Boolean) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Boolean {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Boolean) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/ClassPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/ClassPropertyDescriptor.kt
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [JMeterProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.classProperty] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class ClassPropertyDescriptor<in Schema : TestElementSchema, ValueClass : Any>(
+    public val klass: Class<ValueClass>,
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: Class<ValueClass>? = null
+) : PropertyDescriptor<Schema, Class<ValueClass>> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override val defaultValueAsString: String?
+        get() = defaultValue?.name
+
+    override fun toString(): String = "ClassPropertyDescriptor(name='$name', klass='$klass', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): Class<out ValueClass> =
+        target[this]
+
+    public operator fun set(target: TestElement, klass: Class<out ValueClass>?) {
+        target[this] = klass
+    }
+
+    public operator fun set(target: TestElement, klass: KClass<out ValueClass>?) {
+        set(target, klass?.java)
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Class<out ValueClass> {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Class<out ValueClass>?) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/CollectionPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/CollectionPropertyDescriptor.kt
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.CollectionProperty
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [CollectionProperty]: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.collection] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class CollectionPropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+) : PropertyDescriptor<Schema, Collection<JMeterProperty>> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    public override val defaultValue: Collection<JMeterProperty>? = null
+
+    override fun toString(): String = "CollectionPropertyDescriptor(name='$name')"
+
+    /**
+     * Retrieve [Collection] property value, or throw [NoSuchElementException] in case the property is unset.
+     * @throws NoSuchElementException if the property is unset
+     */
+    public operator fun get(target: TestElement): Collection<JMeterProperty> =
+        target[this]
+
+    /**
+     * Retrieve [Collection] property value, or create one and set it the property is unset.
+     */
+    public fun getOrCreate(target: TestElement, ifMissing: () -> Collection<JMeterProperty>): Collection<JMeterProperty> =
+        target.getOrCreate(this, ifMissing)
+
+    public operator fun set(target: TestElement, value: Collection<*>?) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Collection<JMeterProperty> {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Collection<JMeterProperty>) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/DoublePropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/DoublePropertyDescriptor.kt
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.DoubleProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [DoubleProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.double] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class DoublePropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: Double?
+) : PropertyDescriptor<Schema, Double> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override fun toString(): String = "DoublePropertyDescriptor(name='$name', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): Double =
+        target[this]
+
+    public operator fun set(target: TestElement, value: Double) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Double {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Double) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/EmptyTestElementSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/EmptyTestElementSchema.kt
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apiguardian.api.API
+import kotlin.reflect.KClass
+
+/**
+ * Describes properties available for configuration of well-known [TestElement].
+ * Style guide:
+ * * avoid using "is" prefixes. The properties are declare [PropertyDescriptor] rather than property itself,
+ *   so "is" is not needed
+ * * declare default value when declaring a property. It would help users.
+ *
+ * TODO: decide if boolean, int, long, etc values must always have a default
+ *
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public abstract class EmptyTestElementSchema {
+    private val propertyDescriptors: MutableMap<String, PropertyDescriptor<*, *>> = mutableMapOf()
+
+    public val properties: Map<String, PropertyDescriptor<*, *>> = propertyDescriptors
+
+    @JvmOverloads
+    protected fun <Schema : TestElementSchema> string(
+        name: String,
+        default: String? = null
+    ): StringPropertyDescriptor<Schema> =
+        StringPropertyDescriptor<Schema>(name, default).also {
+            propertyDescriptors[name] = it
+        }
+
+    protected fun <Schema : TestElementSchema, ValueClass : Any> classProperty(
+        klass: KClass<ValueClass>,
+        name: String
+    ): ClassPropertyDescriptor<Schema, ValueClass> =
+        classProperty(klass.java, name)
+
+    protected fun <Schema : TestElementSchema, ValueClass : Any> classProperty(
+        klass: Class<ValueClass>,
+        name: String
+    ): ClassPropertyDescriptor<Schema, ValueClass> =
+        ClassPropertyDescriptor<Schema, ValueClass>(klass, name).also {
+            propertyDescriptors[name] = it
+        }
+
+    protected inline fun <Schema : TestElementSchema, reified TestElementClass : TestElement> testElement(
+        name: String
+    ): TestElementPropertyDescriptor<Schema, TestElementClass> =
+        testElement(TestElementClass::class.java, name)
+
+    protected fun <Schema : TestElementSchema, TestElementClass : TestElement> testElement(
+        klass: Class<TestElementClass>,
+        name: String
+    ): TestElementPropertyDescriptor<Schema, TestElementClass> =
+        TestElementPropertyDescriptor<Schema, TestElementClass>(klass, name).also {
+            propertyDescriptors[name] = it
+        }
+
+    protected fun <Schema : TestElementSchema, ValueClass : Any> collection(
+        klass: Class<ValueClass>,
+        name: String
+    ): ClassPropertyDescriptor<Schema, ValueClass> =
+        ClassPropertyDescriptor<Schema, ValueClass>(klass, name).also {
+            propertyDescriptors[name] = it
+        }
+
+    @JvmOverloads
+    protected fun <Schema : TestElementSchema> boolean(
+        name: String,
+        default: Boolean? = null
+    ): BooleanPropertyDescriptor<Schema> =
+        BooleanPropertyDescriptor<Schema>(name, default).also {
+            propertyDescriptors[name] = it
+        }
+
+    @JvmOverloads
+    protected fun <Schema : TestElementSchema> integer(
+        name: String,
+        default: Int? = null
+    ): IntegerPropertyDescriptor<Schema> =
+        IntegerPropertyDescriptor<Schema>(name, default).also {
+            propertyDescriptors[name] = it
+        }
+
+    @JvmOverloads
+    protected fun <Schema : TestElementSchema> long(
+        name: String,
+        default: Long? = null
+    ): LongPropertyDescriptor<Schema> =
+        LongPropertyDescriptor<Schema>(name, default).also {
+            propertyDescriptors[name] = it
+        }
+
+    @JvmOverloads
+    protected fun <Schema : TestElementSchema> float(
+        name: String,
+        default: Float? = null
+    ): FloatPropertyDescriptor<Schema> =
+        FloatPropertyDescriptor<Schema>(name, default).also {
+            propertyDescriptors[name] = it
+        }
+
+    @JvmOverloads
+    protected fun <Schema : TestElementSchema> double(
+        name: String,
+        default: Double? = null
+    ): DoublePropertyDescriptor<Schema> =
+        DoublePropertyDescriptor<Schema>(name, default).also {
+            propertyDescriptors[name] = it
+        }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/FloatPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/FloatPropertyDescriptor.kt
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.FloatProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [FloatProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.float] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class FloatPropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: Float?
+) : PropertyDescriptor<Schema, Float> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override fun toString(): String = "FloatPropertyDescriptor(name='$name', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): Float =
+        target[this]
+
+    public operator fun set(target: TestElement, value: Float) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Float {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Float) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/IntegerPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/IntegerPropertyDescriptor.kt
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.IntegerProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [IntegerProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.integer] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class IntegerPropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: Int?
+) : PropertyDescriptor<Schema, Int> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override fun toString(): String = "IntegerPropertyDescriptor(name='$name', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): Int =
+        target[this]
+
+    public operator fun set(target: TestElement, value: Int) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Int {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Int) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/LongPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/LongPropertyDescriptor.kt
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.LongProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [LongProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.long] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class LongPropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: Long?
+) : PropertyDescriptor<Schema, Long> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override fun toString(): String = "LongPropertyDescriptor(name='$name', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): Long =
+        target[this]
+
+    public operator fun set(target: TestElement, value: Long) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Long {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: Long) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertiesAccessor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertiesAccessor.kt
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.apiguardian.api.API
+import kotlin.experimental.ExperimentalTypeInference
+import kotlin.reflect.KClass
+
+/**
+ * Enables type-safe access to [TestElement] properties.
+ * For instance:
+ *     testPlan.props[TestPlanClass.serializeThreadGroups] // succeeds
+ *     testPlan.props[{ serializeThreadGroups }] // succeeds
+ *     httpSampler.props[TestPlanClass.serializeThreadGroups] // fails as HTTP Sampler is not related to TestPlanClass
+ *     httpSampler.props[{ enabled }] // succeeds since "enabled" property exists in the superclass of HTTP Sampler
+ *
+ * If you need configuring several properties, you might use `element.props { ... }` syntax:
+ *
+ *     testPlan.props {
+ *         it[serializeThreadGroups] = true
+ *         it[enabled] = false
+ *     }
+ *
+ * The same in Java would be
+ *    testPlan.getProps().invoke((it, schema) -> {
+ *      it.set(schema.getSerializeThreadGroups(), true);
+ *      it.set(schema.getEnabled(), false);
+ *    });
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class PropertiesAccessor<out TestElementClass : TestElement, out Schema : TestElementSchema>(
+    public val target: TestElementClass,
+    public val schema: Schema
+) {
+    /**
+     * This interface makes `invoke` function easier to use from Java.
+     * ` -> Unit` functions require to return `Unit.INSTANCE` from Java,
+     * so we add an interface
+     */
+    public fun interface InstanceConfigurator<in TestElementClass : TestElement, in Schema : TestElementSchema> {
+        public fun configure(testElement: PropertiesAccessor<TestElementClass, Schema>, klass: Schema)
+    }
+
+    /**
+     * Function types are idiomatic in Kotlin, however they require `return Unit.INSTANCE` in Java,
+     * so we hide the method from Java.
+     */
+    @JvmSynthetic
+    public inline operator fun invoke(body: Schema.(PropertiesAccessor<TestElementClass, Schema>) -> Unit) {
+        body(schema, this)
+    }
+
+    /**
+     * Function types are idiomatic in Kotlin, however they require `return Unit.INSTANCE` in Java,
+     * so we hide the method from Java.
+     * This is not intended to be used from Kotlin, however, there's no way to easily prevent it.
+     * @see [KT-36439](https://youtrack.jetbrains.com/issue/KT-36439/PlatformOnly-annotation-to-hide-symbols-from-Kotlin)
+     */
+    public fun invoke(body: InstanceConfigurator<TestElementClass, Schema>) {
+        body.configure(this, schema)
+    }
+
+    // All properties can be removed
+    public fun remove(property: PropertyDescriptor<Schema, *>) {
+        target.removeProperty(property.name)
+    }
+
+    // All properties can be set as strings
+    public operator fun set(property: PropertyDescriptor<Schema, *>, value: String) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> PropertyDescriptor<Schema, *>,
+        value: String
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    public fun getString(property: PropertyDescriptor<Schema, *>): String =
+        property.getString(target)
+
+    public inline fun getString(propertySelector: Schema.() -> PropertyDescriptor<Schema, *>): String =
+        propertySelector(schema).getString(target)
+
+    /**
+     * Returns a property or null if it is not set.
+     */
+    public fun getPropertyOrNull(property: PropertyDescriptor<Schema, *>): JMeterProperty? =
+        target.getPropertyOrNull(property)
+
+    // Boolean properties
+    public operator fun get(property: BooleanPropertyDescriptor<Schema>): Boolean =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> BooleanPropertyDescriptor<Schema>): Boolean =
+        target[propertySelector(schema)]
+
+    public operator fun set(property: BooleanPropertyDescriptor<Schema>, value: Boolean) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> BooleanPropertyDescriptor<Schema>,
+        value: Boolean
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // String properties
+    public operator fun get(property: StringPropertyDescriptor<Schema>): String =
+        property.getString(target)
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> StringPropertyDescriptor<Schema>): String =
+        propertySelector(schema).getString(target)
+
+    // Class properties
+    public operator fun <ValueClass : Any> get(property: ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass>? =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public operator fun <ValueClass : Any> get(propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass>? =
+        get(propertySelector(schema))
+
+    public operator fun <ValueClass : Any> set(
+        property: ClassPropertyDescriptor<Schema, ValueClass>,
+        value: KClass<out ValueClass>
+    ) {
+        target[property] = value.java
+    }
+
+    public inline operator fun <ValueClass : Any> set(
+        propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>,
+        value: KClass<ValueClass>
+    ) {
+        set(propertySelector, value.java)
+    }
+
+    public operator fun <ValueClass : Any> set(
+        property: ClassPropertyDescriptor<Schema, ValueClass>,
+        value: Class<out ValueClass>
+    ) {
+        target[property] = value
+    }
+
+    public inline operator fun <ValueClass : Any> set(
+        propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>,
+        value: Class<ValueClass>
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // Integer properties
+    public operator fun get(property: IntegerPropertyDescriptor<Schema>): Int =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> IntegerPropertyDescriptor<Schema>): Int =
+        target[propertySelector(schema)]
+
+    public operator fun set(property: IntegerPropertyDescriptor<Schema>, value: Int) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> IntegerPropertyDescriptor<Schema>,
+        value: Int
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // Long properties
+    public operator fun get(property: LongPropertyDescriptor<Schema>): Long =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> LongPropertyDescriptor<Schema>): Long =
+        target[propertySelector(schema)]
+
+    public operator fun set(property: LongPropertyDescriptor<Schema>, value: Long) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> LongPropertyDescriptor<Schema>,
+        value: Long
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // Float properties
+    public operator fun get(property: FloatPropertyDescriptor<Schema>): Float =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> FloatPropertyDescriptor<Schema>): Float =
+        target[propertySelector(schema)]
+
+    public operator fun set(property: FloatPropertyDescriptor<Schema>, value: Float) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> FloatPropertyDescriptor<Schema>,
+        value: Float
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // Double properties
+    public operator fun get(property: DoublePropertyDescriptor<Schema>): Double =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> DoublePropertyDescriptor<Schema>): Double =
+        target[propertySelector(schema)]
+
+    public operator fun set(property: DoublePropertyDescriptor<Schema>, value: Double) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> DoublePropertyDescriptor<Schema>,
+        value: Double
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // TestElement properties
+    public operator fun <ValueClass : TestElement> get(property: TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass? =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun <ValueClass : TestElement> get(propertySelector: Schema.() -> TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass? =
+        target[propertySelector(schema)]
+
+    public operator fun <ValueClass : TestElement> set(
+        property: TestElementPropertyDescriptor<Schema, ValueClass>,
+        value: ValueClass
+    ) {
+        target[property] = value
+    }
+
+    public inline operator fun <ValueClass : TestElement> set(
+        propertySelector: Schema.() -> TestElementPropertyDescriptor<Schema, ValueClass>,
+        value: ValueClass
+    ) {
+        target[propertySelector(schema)] = value
+    }
+
+    // Collection properties
+    public operator fun get(property: CollectionPropertyDescriptor<Schema>): Collection<JMeterProperty> =
+        target[property]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline operator fun get(propertySelector: Schema.() -> CollectionPropertyDescriptor<Schema>): Collection<JMeterProperty> =
+        target[propertySelector(schema)]
+
+    public operator fun set(property: CollectionPropertyDescriptor<Schema>, value: Collection<*>) {
+        target[property] = value
+    }
+
+    public inline operator fun set(
+        propertySelector: Schema.() -> CollectionPropertyDescriptor<Schema>,
+        value: Collection<*>
+    ) {
+        target[propertySelector(schema)] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertyDescriptor.kt
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.JMeterPropertySchemaUnchecked
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apiguardian.api.API
+import java.io.Serializable
+
+/**
+ * Describes a [JMeterProperty]: name, default value, and provides accessors for properties.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public interface PropertyDescriptor<in Schema : TestElementSchema, Value> : Serializable {
+    public val name: String
+    public val defaultValue: Value?
+
+    public val defaultValueAsString: String?
+        get() = defaultValue?.toString()
+
+    @JMeterPropertySchemaUnchecked
+    public fun remove(target: TestElement) {
+        target.removeProperty(name)
+    }
+
+    public operator fun set(target: TestElement, value: String) {
+        target[this] = value
+    }
+
+    public fun getString(target: TestElement): String =
+        target.getString(this)
+
+    public val asString: StringPropertyDescriptor<Schema>
+        get() = if (this is StringPropertyDescriptor) this else StringPropertyDescriptor(name, defaultValueAsString)
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/StringPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/StringPropertyDescriptor.kt
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.StringProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [StringProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.string] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class StringPropertyDescriptor<in Schema : TestElementSchema>(
+    public override val name: String,
+    /** Default value, null means there's no default */
+    public override val defaultValue: String?
+) : PropertyDescriptor<Schema, String> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    override fun toString(): String = "StringPropertyDescriptor(name='$name', defaultValue='$defaultValue')"
+
+    public operator fun get(target: TestElement): String =
+        target[this]
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): String {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: String) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/TestElementPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/TestElementPropertyDescriptor.kt
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.schema
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.property.TestElementProperty
+import org.apiguardian.api.API
+import kotlin.reflect.KProperty
+
+/**
+ * Describes a [TestElementProperty] that contains class reference: name, default value, and provides accessors for properties.
+ * Use [EmptyTestElementSchema.testElement] for building the property descriptors.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class TestElementPropertyDescriptor<in Schema : TestElementSchema, TestElementClass : TestElement>(
+    public val klass: Class<TestElementClass>,
+    public override val name: String,
+) : PropertyDescriptor<Schema, Class<TestElementClass>> {
+    private companion object {
+        private const val serialVersionUID: Long = 1
+    }
+
+    /** Test Elements have no default values */
+    public override val defaultValue: Class<TestElementClass>? = null
+
+    override fun toString(): String = "TestElementPropertyDescriptor(name='$name', klass='$klass')"
+
+    /**
+     * Retrieve [TestElement] property value, or throw [NoSuchElementException] in case the property is unset.
+     * @throws NoSuchElementException if the property is unset
+     */
+    public operator fun get(target: TestElement): TestElementClass =
+        target[this]
+
+    /**
+     * Retrieve [TestElement] property value, or create one and set it the property is unset.
+     * @since 5.6
+     */
+    public fun getOrCreate(target: TestElement, ifMissing: () -> TestElementClass): TestElementClass =
+        target.getOrCreate(this, ifMissing)
+
+    public operator fun set(target: TestElement, value: TestElementClass?) {
+        target[this] = value
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): TestElementClass {
+        return testElement[this]
+    }
+
+    @JvmSynthetic
+    @Suppress("NOTHING_TO_INLINE")
+    public inline operator fun setValue(testElement: TestElement, property: KProperty<*>, value: TestElementClass?) {
+        testElement[this] = value
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/AbstractThreadGroupSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/AbstractThreadGroupSchema.kt
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.threads
+
+import org.apache.jmeter.control.Controller
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.IntegerPropertyDescriptor
+import org.apache.jmeter.testelement.schema.TestElementPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [AbstractThreadGroup].
+ * @see AbstractThreadGroup
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class AbstractThreadGroupSchema protected constructor() : TestElementSchema() {
+    public companion object INSTANCE : AbstractThreadGroupSchema()
+
+    public val numThreads: IntegerPropertyDescriptor<AbstractThreadGroupSchema> =
+        integer("ThreadGroup.num_threads")
+
+    public val mainController: TestElementPropertyDescriptor<AbstractThreadGroupSchema, Controller> =
+        testElement("ThreadGroup.main_controller")
+
+    public val sameUserOnNextIteration: BooleanPropertyDescriptor<AbstractThreadGroupSchema> =
+        boolean("ThreadGroup.same_user_on_next_iteration", default = true)
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/ThreadGroupSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/ThreadGroupSchema.kt
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.threads
+
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.IntegerPropertyDescriptor
+import org.apache.jmeter.testelement.schema.LongPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [ThreadGroup].
+ * @see ThreadGroup
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class ThreadGroupSchema : AbstractThreadGroupSchema() {
+    public companion object INSTANCE : ThreadGroupSchema()
+
+    /** Whether thread startup is delayed until required */
+    public val delayedStart: BooleanPropertyDescriptor<ThreadGroupSchema> =
+        boolean("ThreadGroup.delayedStart", default = false)
+
+    /** Ramp-up time */
+    public val rampTime: IntegerPropertyDescriptor<ThreadGroupSchema> =
+        integer("ThreadGroup.ramp_time")
+
+    /** Whether scheduler is being used */
+    public val useScheduler: BooleanPropertyDescriptor<ThreadGroupSchema> =
+        boolean("ThreadGroup.scheduler")
+
+    /** Scheduler start delay, overrides start time */
+    public val delay: LongPropertyDescriptor<ThreadGroupSchema> =
+        long("ThreadGroup.delay")
+
+    /** Scheduler duration, overrides end time */
+    public val duration: LongPropertyDescriptor<ThreadGroupSchema> =
+        long("ThreadGroup.duration")
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroupSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroupSchema.kt
@@ -17,32 +17,23 @@
 
 package org.apache.jmeter.threads.openmodel
 
-import org.apache.jmeter.control.GenericController
-import org.apache.jmeter.control.IteratingController
-import org.apache.jmeter.engine.event.LoopIterationEvent
-import org.apache.jmeter.samplers.Sampler
+import org.apache.jmeter.testelement.schema.LongPropertyDescriptor
+import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
+import org.apache.jmeter.threads.AbstractThreadGroupSchema
 import org.apiguardian.api.API
 
-@API(status = API.Status.EXPERIMENTAL, since = "5.5")
-public class OpenModelThreadGroupController : GenericController(), IteratingController {
-    private companion object {
-        private const val serialVersionUID: Long = 1L
-    }
+/**
+ * Lists properties of a [OpenModelThreadGroup].
+ * @see OpenModelThreadGroup
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class OpenModelThreadGroupSchema protected constructor() : AbstractThreadGroupSchema() {
+    public companion object INSTANCE : OpenModelThreadGroupSchema()
 
-    override fun next(): Sampler? =
-        super.next().also {
-            if (iterCount >= 1) {
-                // For now, every thread performs just one iteration
-                isDone = true
-            }
-        }
+    public val schedule: StringPropertyDescriptor<OpenModelThreadGroupSchema> =
+        string("OpenModelThreadGroup.schedule")
 
-    override fun iterationStart(iterEvent: LoopIterationEvent?) {
-    }
-
-    override fun startNextLoop() {
-    }
-
-    override fun breakLoop() {
-    }
+    public val randomSeed: LongPropertyDescriptor<OpenModelThreadGroupSchema> =
+        long("OpenModelThreadGroup.random_seed")
 }

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/gui/OpenModelThreadGroupGui.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/gui/OpenModelThreadGroupGui.kt
@@ -21,12 +21,9 @@ import net.miginfocom.swing.MigLayout
 import org.apache.jmeter.engine.util.CompoundVariable
 import org.apache.jmeter.gui.TestElementMetadata
 import org.apache.jmeter.testelement.TestElement
-import org.apache.jmeter.testelement.property.TestElementProperty
-import org.apache.jmeter.threads.AbstractThreadGroup
 import org.apache.jmeter.threads.gui.AbstractThreadGroupGui
 import org.apache.jmeter.threads.openmodel.DefaultThreadSchedule
 import org.apache.jmeter.threads.openmodel.OpenModelThreadGroup
-import org.apache.jmeter.threads.openmodel.OpenModelThreadGroupController
 import org.apache.jmeter.threads.openmodel.ThreadSchedule
 import org.apache.jmeter.threads.openmodel.ThreadScheduleStep
 import org.apache.jmeter.threads.openmodel.asSeconds
@@ -136,7 +133,6 @@ public class OpenModelThreadGroupGui : AbstractThreadGroupGui() {
 
     override fun createTestElement(): TestElement =
         OpenModelThreadGroup().also {
-            it.setProperty(TestElementProperty(AbstractThreadGroup.MAIN_CONTROLLER, OpenModelThreadGroupController()))
             modifyTestElement(it)
         }
 

--- a/src/core/src/main/resources/org/apache/jmeter/resources/messages.properties
+++ b/src/core/src/main/resources/org/apache/jmeter/resources/messages.properties
@@ -314,6 +314,7 @@ duration_assertion_label=Duration in milliseconds\:
 duration_assertion_title=Duration Assertion
 duration_tooltip=Elapsed time of current running Test
 edit=Edit
+editable_checkbox.use_expression=Use Expression
 email_results_title=Email Results
 en=English
 enable=Enable

--- a/src/core/src/main/resources/org/apache/jmeter/resources/messages_fr.properties
+++ b/src/core/src/main/resources/org/apache/jmeter/resources/messages_fr.properties
@@ -309,6 +309,7 @@ duration_assertion_label=Durée en millisecondes \:
 duration_assertion_title=Assertion Durée
 duration_tooltip=Temps passé depuis le début du test en cours
 edit=Editer
+editable_checkbox.use_expression=Utiliser l'expression
 email_results_title=Résultat d'email
 en=Anglais
 enable=Activer

--- a/src/core/src/test/kotlin/org/apache/jmeter/engine/util/AssertionsKt.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/engine/util/AssertionsKt.kt
@@ -15,32 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.jmeter.engine.util;
+package org.apache.jmeter.engine.util
 
-import java.util.Map;
+import org.apache.jmeter.testelement.property.FunctionProperty
+import org.apache.jmeter.testelement.property.JMeterProperty
+import org.junit.jupiter.api.Assertions
 
-@SuppressWarnings("deprecation")
-abstract class AbstractTransformer implements ValueTransformer {
-
-    private CompoundVariable masterFunction;
-
-    private Map<String, String> variables;
-
-    @Override
-    public void setMasterFunction(CompoundVariable variable) {
-        masterFunction = variable;
+fun assertFunctionProperty(expected: String, property: JMeterProperty?, message: () -> String) {
+    Assertions.assertInstanceOf(FunctionProperty::class.java, property) {
+        message() + ", got $property"
     }
-
-    protected CompoundVariable getMasterFunction() {
-        return masterFunction;
-    }
-
-    public Map<String, String> getVariables() {
-        return variables;
-    }
-
-    @Override
-    public void setVariables(Map<String, String> map) {
-        variables = map;
-    }
+    Assertions.assertEquals(expected, property?.stringValue)
 }

--- a/src/core/src/test/kotlin/org/apache/jmeter/engine/util/DeepPropertyTransformerTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/engine/util/DeepPropertyTransformerTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.engine.util
+
+import org.apache.jmeter.testelement.property.CollectionProperty
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class DeepPropertyTransformerTest {
+    @Test
+    fun collection() {
+        val input = CollectionProperty(
+            "collection_prop",
+            mutableListOf("test", "\${variable}", "test")
+        )
+
+        val output = DeepPropertyTransformer(TransformStringsIntoFunctions).transform(input)
+        Assertions.assertInstanceOf(CollectionProperty::class.java, output) {
+            "DeepPropertyTransformer(TransformStringsIntoFunctions).transform($input)"
+        }
+        output as CollectionProperty
+        assertFunctionProperty("\${variable}", output[1]) {
+            "DeepPropertyTransformer(TransformStringsIntoFunctions).transform($input)[1]"
+        }
+    }
+}

--- a/src/core/src/test/kotlin/org/apache/jmeter/engine/util/TransformStringsIntoFunctionsTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/engine/util/TransformStringsIntoFunctionsTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.engine.util
+
+import org.apache.jmeter.testelement.property.StringProperty
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+class TransformStringsIntoFunctionsTest {
+    @Test
+    fun `no modifications`() {
+        val input = StringProperty("not_modified_property", "original value")
+        val output = TransformStringsIntoFunctions.transform(input)
+        assertAll(
+            {
+                assertSame(input, output) {
+                    "TransformStringsIntoFunctions should return input value when no modifications happen"
+                }
+            },
+            {
+                assertEquals("original value", input.stringValue) {
+                    "TransformStringsIntoFunctions should not modify the input value"
+                }
+            },
+        )
+    }
+
+    @Test
+    fun `with functions`() {
+        val input = StringProperty("modified_property", "\${variable}")
+        val output = TransformStringsIntoFunctions.transform(input)
+        assertFunctionProperty("\${variable}", output) {
+            "TransformStringsIntoFunctions.transform($input)"
+        }
+    }
+}

--- a/src/core/src/test/kotlin/org/apache/jmeter/engine/util/UseFunctionsTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/engine/util/UseFunctionsTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.engine.util
+
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.TestPlan
+import org.apache.jmeter.testelement.property.CollectionProperty
+import org.apache.jmeter.testelement.schema.CollectionPropertyDescriptor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies [TestElementPropertyTransformer.USE_FUNCTIONS].
+ */
+class UseFunctionsTest {
+
+    @Test
+    fun `property replaces with function`() {
+        val input = TestPlan().apply {
+            props {
+                it[enabled] = "\${test}"
+            }
+        }
+
+        TestElementPropertyTransformer.USE_FUNCTIONS.visit(input)
+
+        val output = input.props.getPropertyOrNull(input.schema.enabled)
+        assertFunctionProperty("\${test}", output) {
+            "TestElementPropertyTransformer.USE_FUNCTIONS($input)"
+        }
+    }
+
+    @Test
+    fun `nested collection property replaces with function`() {
+        val sampleProp = CollectionPropertyDescriptor<TestElementSchema>("test.prop")
+
+        val input = TestPlan().apply {
+            props {
+                it[sampleProp] = mutableListOf(mutableListOf("\${test}"))
+            }
+        }
+
+        TestElementPropertyTransformer.USE_FUNCTIONS.visit(input)
+
+        val output = input.props[ { sampleProp }]
+
+        // These assertions verify CollectionProperty behavior rather than USE_FUNCTIONS behavior
+        // However, we can't extract deeply-nested item right away
+        assertEquals(1, output.size) {
+            "size of first level collection should be 1, actual: $output"
+        }
+        val nested = output.first()
+        assertInstanceOf(CollectionProperty::class.java, nested) {
+            "element of the top-level collection should be CollectionProperty as well, got $nested"
+        }
+        nested as CollectionProperty
+        assertEquals(1, nested.size()) {
+            "size of the nested collection should be 1, actual: $nested"
+        }
+
+        // Now is the real test:
+        assertFunctionProperty("\${test}", nested.get(0)) {
+            "the first element of collection $nested"
+        }
+    }
+}

--- a/src/core/src/test/kotlin/org/apache/jmeter/testelement/property/JMeterElementSchemaTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/testelement/property/JMeterElementSchemaTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.property
+
+import org.apache.jmeter.control.gui.TestPlanGui
+import org.apache.jmeter.testelement.AbstractTestElement
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.schema.PropertiesAccessor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class JMeterElementSchemaTest {
+    open class WarpDriveElementSchema : TestElementSchema() {
+        companion object INSTANCE : WarpDriveElementSchema()
+
+        val warpFactor = integer<WarpDriveElementSchema>("WarpDriveElement.warpFactor", default = 7)
+    }
+
+    open class WarpDriveElement : AbstractTestElement() {
+        override val schema: WarpDriveElementSchema
+            get() = WarpDriveElementSchema
+        override val props: PropertiesAccessor<WarpDriveElement, WarpDriveElementSchema>
+            get() = PropertiesAccessor(this, schema)
+    }
+
+    @Test
+    fun `getPropertyOrNull returns null for unset props`() {
+        val warpDrive = WarpDriveElement()
+        assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.warpFactor)) {
+            "${WarpDriveElementSchema.warpFactor} should be null for newly created element, getPropertyOrNull(PropertyDescriptor)"
+        }
+        assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.warpFactor.name)) {
+            "${WarpDriveElementSchema.warpFactor} should be null for newly created element, getPropertyOrNull(String)"
+        }
+    }
+
+    @Test
+    fun `get returns default value`() {
+        val warpDrive = WarpDriveElement()
+        assertGetWarpFactor(7, warpDrive, "element is empty, so default value expected")
+    }
+
+    @Test
+    fun `set modifies value`() {
+        val warpDrive = WarpDriveElement()
+        warpDrive[warpDrive.schema.warpFactor] = 8
+
+        assertGetWarpFactor(8, warpDrive, "value was modified with [warpFactor] = 8")
+    }
+
+    @Test
+    fun `props set modifies value`() {
+        val warpDrive = WarpDriveElement()
+        warpDrive.props {
+            it[warpFactor] = 8
+        }
+
+        assertGetWarpFactor(8, warpDrive, "value was modified with props { it[warpFactor] = 8 }")
+    }
+
+    @Test
+    fun `test string setter`() {
+        val warpDrive = WarpDriveElement()
+        warpDrive.props {
+            it[warpFactor] = "\${hello}"
+        }
+        assertEquals("\${hello}", warpDrive.getString(warpDrive.schema.warpFactor)) {
+            "Int property should support get and set with String value for expressions purposes"
+        }
+    }
+
+    private fun assertGetWarpFactor(expected: Int, warpDrive: WarpDriveElement, message: String) {
+        assertEquals(expected, warpDrive[warpDrive.schema.warpFactor]) {
+            "get(warpFactor): ${WarpDriveElementSchema.warpFactor}, $message"
+        }
+        assertEquals(expected, warpDrive.props[ { warpDrive.schema.warpFactor }]) {
+            "props.get[{warpFactor}]: ${WarpDriveElementSchema.warpFactor}, $message"
+        }
+        assertEquals(expected.toString(), warpDrive.getString(warpDrive.schema.warpFactor)) {
+            "getString(warpFactor): ${WarpDriveElementSchema.warpFactor}, $message"
+        }
+    }
+
+    @Suppress("UNUSED_VARIABLE", "ReplaceGetOrSet")
+    fun `compilation succeeds`() {
+        // Below code does not make much sense, and it tests different styles of using the properties
+        lateinit var base: TestElement
+        lateinit var warpDrive: WarpDriveElement
+
+        base.props {
+            it[name] = "test"
+            // Does not compile
+            // it[WarpDriveElementSchema.warpFactor] = ""
+        }
+        warpDrive.props[WarpDriveElementSchema.warpFactor] = 8
+        warpDrive.props[WarpDriveElementSchema.name] = "true"
+        warpDrive.props[ { name }] = "true"
+        warpDrive.props.set({ warpFactor }, "true")
+
+        warpDrive.props {
+            it[warpFactor] = 5
+            it[name] = "test"
+        }
+
+        warpDrive.props[WarpDriveElementSchema.guiClass] = TestPlanGui::class
+        warpDrive.props[WarpDriveElementSchema.guiClass] = TestPlanGui::class.java
+        val gc = warpDrive.props[WarpDriveElementSchema.guiClass]
+        // ok: can't pass non-GUI class to guiClass property
+        // warpDrive.props[WarpDriveElementSchema.guiClass] = WarpDriveElement::class
+        val x: Int = warpDrive.props[WarpDriveElementSchema.warpFactor]
+        val y: Int = warpDrive.props[ { warpFactor }]
+        val z: String = warpDrive.props[WarpDriveElementSchema.name]
+
+        WarpDriveElementSchema.guiClass.getString(warpDrive)
+        val guiClassAsString1 = warpDrive.props.getString { guiClass }
+        val guiClassAsString2 = warpDrive.props.getString(WarpDriveElementSchema.guiClass)
+
+        // ok: Fails to compile since TestElement does not have WarpDriveElement::warpFactor property
+        // base.props[WarpDriveElement.warpFactor] = "true"
+        base.props[WarpDriveElementSchema.name] = "true"
+    }
+}

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/JFactory.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/JFactory.java
@@ -107,6 +107,12 @@ public class JFactory {
         return STYLE.withFont(component, JMeterUIDefaults.CHECKBOX_SMALL_FONT);
     }
 
+    @API(since = "5.6", status = API.Status.EXPERIMENTAL)
+    public static JEditableCheckBox small(JEditableCheckBox component) {
+        component.makeSmall();
+        return component;
+    }
+
     @API(since = "5.3", status = API.Status.EXPERIMENTAL)
     public static JLabel big(JLabel component) {
         return STYLE.withFont(component, JMeterUIDefaults.LABEL_BIG_FONT);

--- a/src/jorphan/src/main/kotlin/org/apache/jorphan/gui/CardLayoutWithSizeOfCurrentVisibleElement.kt
+++ b/src/jorphan/src/main/kotlin/org/apache/jorphan/gui/CardLayoutWithSizeOfCurrentVisibleElement.kt
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui
+
+import org.apiguardian.api.API
+import java.awt.CardLayout
+import java.awt.Container
+import java.awt.Dimension
+import java.awt.Insets
+
+/**
+ * An alternative [CardLayout] that computes the size based on the currently visible component only.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class CardLayoutWithSizeOfCurrentVisibleElement : CardLayout() {
+    override fun preferredLayoutSize(parent: Container): Dimension {
+        synchronized(parent.treeLock) {
+            val current = parent.components.firstOrNull { it.isVisible } ?: return super.preferredLayoutSize(parent)
+            return addInsets(current.preferredSize, parent.insets)
+        }
+    }
+
+    override fun minimumLayoutSize(parent: Container): Dimension {
+        synchronized(parent.treeLock) {
+            val current = parent.components.firstOrNull { it.isVisible } ?: return super.minimumLayoutSize(parent)
+            return addInsets(current.minimumSize, parent.insets)
+        }
+    }
+
+    private fun addInsets(size: Dimension, insets: Insets) = Dimension(
+        size.width + insets.left + insets.right + hgap * 2,
+        size.height + insets.top + insets.bottom + vgap * 2
+    )
+}

--- a/src/jorphan/src/main/kotlin/org/apache/jorphan/gui/JEditableCheckBox.kt
+++ b/src/jorphan/src/main/kotlin/org/apache/jorphan/gui/JEditableCheckBox.kt
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.gui
+
+import org.apiguardian.api.API
+import java.awt.Container
+import java.awt.FlowLayout
+import javax.swing.Box
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JPopupMenu
+import javax.swing.SwingUtilities
+import javax.swing.event.ChangeEvent
+
+/**
+ * A Checkbox that can be converted to an editable field and back.
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class JEditableCheckBox(
+    label: String,
+    private val configuration: Configuration
+) : JPanel() {
+    public companion object {
+        public const val CHECKBOX_CARD: String = "checkbox"
+        public const val EDITABLE_CARD: String = "editable"
+    }
+
+    /**
+     * The representation of the state.
+     */
+    public sealed interface Value {
+        public companion object {
+            @JvmStatic
+            public fun of(value: kotlin.Boolean): Boolean =
+                if (value) Boolean.TRUE else Boolean.FALSE
+        }
+
+        /**
+         * The value is a checkbox.
+         */
+        public sealed interface Boolean : Value {
+            public val value: kotlin.Boolean
+
+            public object TRUE : Boolean {
+                override val value: kotlin.Boolean
+                    get() = true
+            }
+
+            public object FALSE : Boolean {
+                override val value: kotlin.Boolean
+                    get() = false
+            }
+        }
+
+        /**
+         * The value is a free text.
+         */
+        public data class Text(val value: String) : Value
+    }
+
+    /**
+     * Supplies the parameters to [JEditableCheckBox].
+     */
+    public data class Configuration(
+        /** Menu item title to "start editing" the checkbox value. */
+        val startEditing: String = "Use Expression",
+        /** The title to be used for "true" value in the checkbox. */
+        val trueValue: String = "true",
+        /** The title to be used for "false" value in the checkbox. */
+        val falseValue: String = "false",
+        /** Extra values to be added for the combobox. */
+        val extraValues: List<String> = listOf(),
+    )
+
+    private val cards = CardLayoutWithSizeOfCurrentVisibleElement()
+
+    private val checkbox: JCheckBox = JCheckBox(label).apply {
+        componentPopupMenu = JPopupMenu().apply {
+            add(configuration.startEditing).apply {
+                addActionListener {
+                    cards.next(this@JEditableCheckBox)
+                    comboBox.requestFocusInWindow()
+                }
+            }
+        }
+    }
+
+    private val comboBox: JComboBox<String> = JComboBox<String>().apply {
+        isEditable = true
+        configuration.extraValues.forEach {
+            addItem(it)
+        }
+        addItem(configuration.trueValue)
+        addItem(configuration.falseValue)
+        addActionListener {
+            val jComboBox = it.source as JComboBox<*>
+            SwingUtilities.invokeLater {
+                if (jComboBox.isPopupVisible) {
+                    return@invokeLater
+                }
+                when (val value = jComboBox.selectedItem as String) {
+                    configuration.trueValue, configuration.falseValue -> {
+                        checkbox.isSelected = value == configuration.trueValue
+                        cards.show(this@JEditableCheckBox, CHECKBOX_CARD)
+                        checkbox.requestFocusInWindow()
+                    }
+                }
+            }
+        }
+    }
+
+    private val textFieldLabel = JLabel(label).apply {
+        labelFor = comboBox
+    }
+
+    @Transient
+    private var changeEvent: ChangeEvent? = null
+
+    init {
+        layout = cards
+        add(
+            // A dummy container ensures popup menu appears on top of the checkbox
+            Container().apply {
+                layout = FlowLayout(FlowLayout.LEADING, 0, 0)
+                add(checkbox)
+            },
+            CHECKBOX_CARD
+        )
+        add(
+            Container().apply {
+                // FlowLayout adds horizontal gap before the first element, so we set zero gaps
+                // and add the gap between the components manually.
+                layout = FlowLayout(FlowLayout.LEADING, 0, 0)
+                add(comboBox)
+                add(Box.createHorizontalStrut(5))
+                add(textFieldLabel)
+            },
+            EDITABLE_CARD
+        )
+    }
+
+    public var value: Value
+        get() = when (components.indexOfFirst { it.isVisible }) {
+            0 -> if (checkbox.isSelected) Value.Boolean.TRUE else Value.Boolean.FALSE
+            else -> Value.Text(comboBox.selectedItem as String)
+        }
+        set(value) {
+            when (value) {
+                is Value.Boolean -> {
+                    comboBox.selectedItem = ""
+                    checkbox.isSelected = value.value
+                    cards.show(this, CHECKBOX_CARD)
+                }
+
+                is Value.Text -> {
+                    checkbox.isSelected = false
+                    comboBox.selectedItem = value.value
+                    cards.show(this, EDITABLE_CARD)
+                }
+            }
+        }
+
+    @get:JvmSynthetic
+    public var booleanValue: Boolean
+        @Deprecated(message = "write-only property", level = DeprecationLevel.HIDDEN)
+        get() = TODO()
+        set(value) {
+            this.value = Value.of(value)
+        }
+
+    @get:JvmSynthetic
+    public var stringValue: String
+        @Deprecated(message = "write-only property", level = DeprecationLevel.HIDDEN)
+        get() = TODO()
+        set(value) {
+            this.value = Value.Text(value)
+        }
+
+    public fun makeSmall() {
+        JFactory.small(checkbox)
+        // We do not make combobox small as the expression migh be hard to read
+    }
+}

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
@@ -32,12 +32,14 @@ import javax.swing.event.ChangeListener;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.ConfigTestElement;
+import org.apache.jmeter.gui.JBooleanPropertyEditor;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.protocol.http.gui.HTTPArgumentsPanel;
 import org.apache.jmeter.protocol.http.gui.HTTPFileArgsPanel;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBaseSchema;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
@@ -90,11 +92,11 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
 
     private JCheckBox autoRedirects;
 
-    private JCheckBox useKeepAlive;
+    private JBooleanPropertyEditor useKeepAlive;
 
-    private JCheckBox useMultipart;
+    private JBooleanPropertyEditor useMultipart;
 
-    private JCheckBox useBrowserCompatibleMultipartMode;
+    private JBooleanPropertyEditor useBrowserCompatibleMultipartMode;
 
     private JLabeledChoice method;
 
@@ -158,9 +160,8 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
             followRedirects.setSelected(getUrlConfigDefaults().isFollowRedirects());
             autoRedirects.setSelected(getUrlConfigDefaults().isAutoRedirects());
             method.setText(getUrlConfigDefaults().getDefaultMethod());
-            useKeepAlive.setSelected(getUrlConfigDefaults().isUseKeepAlive());
-            useMultipart.setSelected(getUrlConfigDefaults().isUseMultipart());
-            useBrowserCompatibleMultipartMode.setSelected(getUrlConfigDefaults().isUseBrowserCompatibleMultipartMode());
+            useKeepAlive.setBooleanValue(getUrlConfigDefaults().isUseKeepAlive());
+            useBrowserCompatibleMultipartMode.setBooleanValue(getUrlConfigDefaults().isUseBrowserCompatibleMultipartMode());
         }
         path.setText(""); // $NON-NLS-1$
         port.setText(""); // $NON-NLS-1$
@@ -225,11 +226,9 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
             element.setProperty(HTTPSamplerBase.METHOD, method.getText());
             element.setProperty(new BooleanProperty(HTTPSamplerBase.FOLLOW_REDIRECTS, followRedirects.isSelected()));
             element.setProperty(new BooleanProperty(HTTPSamplerBase.AUTO_REDIRECTS, autoRedirects.isSelected()));
-            element.setProperty(new BooleanProperty(HTTPSamplerBase.USE_KEEPALIVE, useKeepAlive.isSelected()));
-            element.setProperty(new BooleanProperty(HTTPSamplerBase.DO_MULTIPART_POST, useMultipart.isSelected()));
-            element.setProperty(HTTPSamplerBase.BROWSER_COMPATIBLE_MULTIPART,
-                    useBrowserCompatibleMultipartMode.isSelected(),
-                    HTTPSamplerBase.BROWSER_COMPATIBLE_MULTIPART_MODE_DEFAULT);
+            useKeepAlive.updateElement(element);
+            useMultipart.updateElement(element);
+            useBrowserCompatibleMultipartMode.updateElement(element);
         }
     }
 
@@ -308,10 +307,9 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
             method.setText(el.getPropertyAsString(HTTPSamplerBase.METHOD));
             followRedirects.setSelected(el.getPropertyAsBoolean(HTTPSamplerBase.FOLLOW_REDIRECTS));
             autoRedirects.setSelected(el.getPropertyAsBoolean(HTTPSamplerBase.AUTO_REDIRECTS));
-            useKeepAlive.setSelected(el.getPropertyAsBoolean(HTTPSamplerBase.USE_KEEPALIVE));
-            useMultipart.setSelected(el.getPropertyAsBoolean(HTTPSamplerBase.DO_MULTIPART_POST));
-            useBrowserCompatibleMultipartMode.setSelected(el.getPropertyAsBoolean(
-                    HTTPSamplerBase.BROWSER_COMPATIBLE_MULTIPART, HTTPSamplerBase.BROWSER_COMPATIBLE_MULTIPART_MODE_DEFAULT));
+            useKeepAlive.updateUi(el);
+            useMultipart.updateUi(el);
+            useBrowserCompatibleMultipartMode.updateUi(el);
         }
     }
 
@@ -391,19 +389,25 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
             autoRedirects.setSelected(getUrlConfigDefaults().isAutoRedirects());// Default changed in 2.3 and again in 2.4
             autoRedirects.setVisible(getUrlConfigDefaults().isAutoRedirectsVisible());
 
-            useKeepAlive = new JCheckBox(JMeterUtils.getResString("use_keepalive")); // $NON-NLS-1$
+            useKeepAlive = new JBooleanPropertyEditor(
+                    HTTPSamplerBaseSchema.INSTANCE.getUseKeepalive(),
+                    JMeterUtils.getResString("use_keepalive"));
             JFactory.small(useKeepAlive);
-            useKeepAlive.setSelected(getUrlConfigDefaults().isUseKeepAlive());
+            useKeepAlive.setBooleanValue(getUrlConfigDefaults().isUseKeepAlive());
             useKeepAlive.setVisible(getUrlConfigDefaults().isUseKeepAliveVisible());
 
-            useMultipart = new JCheckBox(JMeterUtils.getResString("use_multipart_for_http_post")); // $NON-NLS-1$
+            useMultipart = new JBooleanPropertyEditor(
+                    HTTPSamplerBaseSchema.INSTANCE.getUseMultipartPost(),
+                    JMeterUtils.getResString("use_multipart_for_http_post")); // $NON-NLS-1$
             JFactory.small(useMultipart);
-            useMultipart.setSelected(getUrlConfigDefaults().isUseMultipart());
+            useMultipart.setBooleanValue(getUrlConfigDefaults().isUseMultipart());
             useMultipart.setVisible(getUrlConfigDefaults().isUseMultipartVisible());
 
-            useBrowserCompatibleMultipartMode = new JCheckBox(JMeterUtils.getResString("use_multipart_mode_browser")); // $NON-NLS-1$
+            useBrowserCompatibleMultipartMode = new JBooleanPropertyEditor(
+                    HTTPSamplerBaseSchema.INSTANCE.getUseBrowserCompatibleMultipart(),
+                    JMeterUtils.getResString("use_multipart_mode_browser")); // $NON-NLS-1$
             JFactory.small(useBrowserCompatibleMultipartMode);
-            useBrowserCompatibleMultipartMode.setSelected(getUrlConfigDefaults().isUseBrowserCompatibleMultipartMode());
+            useBrowserCompatibleMultipartMode.setBooleanValue(getUrlConfigDefaults().isUseBrowserCompatibleMultipartMode());
             useBrowserCompatibleMultipartMode.setVisible(getUrlConfigDefaults().isUseBrowserCompatibleMultipartModeVisible());
         }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -97,6 +97,7 @@ import org.apache.jmeter.testbeans.gui.TestBeanGUI;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestPlan;
 import org.apache.jmeter.threads.AbstractThreadGroup;
+import org.apache.jmeter.threads.AbstractThreadGroupSchema;
 import org.apache.jmeter.threads.ThreadGroup;
 import org.apache.jmeter.threads.gui.ThreadGroupGui;
 import org.apache.jmeter.util.JMeterUtils;
@@ -225,7 +226,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         ThreadGroup threadGroup = new ThreadGroup();
         threadGroup.setProperty(TestElement.GUI_CLASS, ThreadGroupGui.class.getName());
         threadGroup.setProperty(TestElement.NAME, "Thread Group");
-        threadGroup.setProperty(AbstractThreadGroup.NUM_THREADS, "${__P(threads,10)}");
+        threadGroup.set(AbstractThreadGroupSchema.INSTANCE.getNumThreads(), "${__P(threads,10)}");
         threadGroup.setProperty(ThreadGroup.RAMP_TIME,"${__P(rampup,30)}");
         threadGroup.setScheduler(true);
         threadGroup.setProperty(ThreadGroup.DURATION,"${__P(duration,3600)}");

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -85,6 +85,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.testelement.property.TestElementProperty;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
@@ -165,7 +166,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     public static final String PATH = "HTTPSampler.path"; // $NON-NLS-1$
 
-    public static final String FOLLOW_REDIRECTS = "HTTPSampler.follow_redirects"; // $NON-NLS-1$
+    public static final String FOLLOW_REDIRECTS = HTTPSamplerBaseSchema.INSTANCE.getFollowRedirects().getName();
 
     public static final String AUTO_REDIRECTS = "HTTPSampler.auto_redirects"; // $NON-NLS-1$
 
@@ -184,11 +185,12 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     public static final String IP_SOURCE_TYPE = "HTTPSampler.ipSourceType"; // $NON-NLS-1$
 
-    public static final String USE_KEEPALIVE = "HTTPSampler.use_keepalive"; // $NON-NLS-1$
+    public static final String USE_KEEPALIVE = HTTPSamplerBaseSchema.INSTANCE.getUseKeepalive().getName();
 
-    public static final String DO_MULTIPART_POST = "HTTPSampler.DO_MULTIPART_POST"; // $NON-NLS-1$
+    public static final String DO_MULTIPART_POST = HTTPSamplerBaseSchema.INSTANCE.getUseMultipartPost().getName();
 
-    public static final String BROWSER_COMPATIBLE_MULTIPART  = "HTTPSampler.BROWSER_COMPATIBLE_MULTIPART"; // $NON-NLS-1$
+    public static final String BROWSER_COMPATIBLE_MULTIPART =
+            HTTPSamplerBaseSchema.INSTANCE.getUseBrowserCompatibleMultipart().getName();
 
     public static final String CONCURRENT_DWN = "HTTPSampler.concurrentDwn"; // $NON-NLS-1$
 
@@ -353,6 +355,16 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         setArguments(new Arguments());
     }
 
+    @Override
+    public HTTPSamplerBaseSchema getSchema() {
+        return HTTPSamplerBaseSchema.INSTANCE;
+    }
+
+    @Override
+    public PropertiesAccessor<? extends HTTPSamplerBase, ? extends HTTPSamplerBaseSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
+    }
+
     public enum SourceType {
         HOSTNAME("web_testing_source_ip_hostname"), //$NON-NLS-1$
         DEVICE("web_testing_source_ip_device"), //$NON-NLS-1$
@@ -515,11 +527,11 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     }
 
     public void setFollowRedirects(boolean value) {
-        setProperty(new BooleanProperty(FOLLOW_REDIRECTS, value));
+        set(getSchema().getFollowRedirects(), value);
     }
 
     public boolean getFollowRedirects() {
-        return getPropertyAsBoolean(FOLLOW_REDIRECTS);
+        return get(getSchema().getFollowRedirects());
     }
 
     public void setAutoRedirects(boolean value) {
@@ -556,11 +568,11 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     }
 
     public void setUseKeepAlive(boolean value) {
-        setProperty(new BooleanProperty(USE_KEEPALIVE, value));
+        set(getSchema().getUseKeepalive(), value);
     }
 
     public boolean getUseKeepAlive() {
-        return getPropertyAsBoolean(USE_KEEPALIVE);
+        return get(getSchema().getUseKeepalive());
     }
 
     /**
@@ -582,19 +594,19 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     }
 
     public void setDoMultipart(boolean value) {
-        setProperty(new BooleanProperty(DO_MULTIPART_POST, value));
+        set(getSchema().getUseMultipartPost(), value);
     }
 
     public boolean getDoMultipart() {
-        return getPropertyAsBoolean(DO_MULTIPART_POST, false);
+        return get(getSchema().getUseMultipartPost());
     }
 
     public void setDoBrowserCompatibleMultipart(boolean value) {
-        setProperty(BROWSER_COMPATIBLE_MULTIPART, value, BROWSER_COMPATIBLE_MULTIPART_MODE_DEFAULT);
+        set(getSchema().getUseBrowserCompatibleMultipart(), value);
     }
 
     public boolean getDoBrowserCompatibleMultipart() {
-        return getPropertyAsBoolean(BROWSER_COMPATIBLE_MULTIPART, BROWSER_COMPATIBLE_MULTIPART_MODE_DEFAULT);
+        return get(getSchema().getUseBrowserCompatibleMultipart());
     }
 
     public void setMonitor(String value) {

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http.sampler
+
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [HTTPSamplerBase].
+ * @see HTTPSamplerBase
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class HTTPSamplerBaseSchema : TestElementSchema() {
+    public companion object INSTANCE : HTTPSamplerBaseSchema()
+
+    public val followRedirects: BooleanPropertyDescriptor<HTTPSamplerBaseSchema> =
+        boolean("HTTPSampler.follow_redirects")
+
+    public val useKeepalive: BooleanPropertyDescriptor<HTTPSamplerBaseSchema> =
+        boolean("HTTPSampler.use_keepalive")
+
+    public val useMultipartPost: BooleanPropertyDescriptor<HTTPSamplerBaseSchema> =
+        boolean("HTTPSampler.DO_MULTIPART_POST")
+
+    public val useBrowserCompatibleMultipart: BooleanPropertyDescriptor<HTTPSamplerBaseSchema> =
+        boolean("HTTPSampler.BROWSER_COMPATIBLE_MULTIPART", default = false)
+}

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
@@ -20,20 +20,20 @@ package org.apache.jmeter.protocol.java.control.gui;
 import java.awt.BorderLayout;
 
 import javax.swing.Box;
-import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
+import org.apache.jmeter.gui.JBooleanPropertyEditor;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanelEntry;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.protocol.java.sampler.BeanShellSampler;
+import org.apache.jmeter.protocol.java.sampler.BeanShellSamplerSchema;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.util.JMeterUtils;
 
 @TestElementMetadata(labelResource = "bsh_sampler_title")
@@ -41,7 +41,11 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
 
     private static final long serialVersionUID = 240L;
 
-    private JCheckBox resetInterpreter;// reset the bsh.Interpreter before each execution
+    // reset the bsh.Interpreter before each execution
+    private final JBooleanPropertyEditor resetInterpreter =
+            new JBooleanPropertyEditor(
+                    BeanShellSamplerSchema.INSTANCE.getResetInterpreter(),
+                    JMeterUtils.getResString("bsh_script_reset_interpreter"));
 
     private final FilePanelEntry filename = new FilePanelEntry(JMeterUtils.getResString("bsh_script_file"),".bsh"); // script file name (if present)
 
@@ -55,11 +59,11 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
 
     @Override
     public void configure(TestElement element) {
-        scriptField.setInitialText(element.getPropertyAsString(BeanShellSampler.SCRIPT));
+        scriptField.setInitialText(element.get(BeanShellSamplerSchema.INSTANCE.getScript()));
         scriptField.setCaretPosition(0);
-        filename.setFilename(element.getPropertyAsString(BeanShellSampler.FILENAME));
-        parameters.setText(element.getPropertyAsString(BeanShellSampler.PARAMETERS));
-        resetInterpreter.setSelected(element.getPropertyAsBoolean(BeanShellSampler.RESET_INTERPRETER));
+        filename.setFilename(element.get(BeanShellSamplerSchema.INSTANCE.getFilename()));
+        parameters.setText(element.get(BeanShellSamplerSchema.INSTANCE.getParameters()));
+        resetInterpreter.updateUi(element);
         super.configure(element);
     }
 
@@ -79,10 +83,10 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
     public void modifyTestElement(TestElement te) {
         te.clear();
         super.configureTestElement(te);
-        te.setProperty(BeanShellSampler.SCRIPT, scriptField.getText());
-        te.setProperty(BeanShellSampler.FILENAME, filename.getFilename());
-        te.setProperty(BeanShellSampler.PARAMETERS, parameters.getText());
-        te.setProperty(new BooleanProperty(BeanShellSampler.RESET_INTERPRETER, resetInterpreter.isSelected()));
+        te.set(BeanShellSamplerSchema.INSTANCE.getScript(), scriptField.getText());
+        te.set(BeanShellSamplerSchema.INSTANCE.getFilename(), filename.getFilename());
+        te.set(BeanShellSamplerSchema.INSTANCE.getParameters(), parameters.getText());
+        resetInterpreter.updateElement(te);
     }
 
     /**
@@ -95,7 +99,7 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
         filename.setFilename(""); //$NON-NLS-1$
         parameters.setText(""); //$NON-NLS-1$
         scriptField.setInitialText(""); //$NON-NLS-1$
-        resetInterpreter.setSelected(false);
+        resetInterpreter.reset();
     }
 
     @Override
@@ -115,7 +119,7 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
         JLabel label = new JLabel(JMeterUtils.getResString("bsh_script_parameters")); // $NON-NLS-1$
 
         parameters = new JTextField(10);
-        parameters.setName(BeanShellSampler.PARAMETERS);
+        parameters.setName(BeanShellSamplerSchema.INSTANCE.getParameters().getName());
         label.setLabelFor(parameters);
 
         JPanel parameterPanel = new JPanel(new BorderLayout(5, 0));
@@ -125,9 +129,6 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
     }
 
     private JPanel createResetPanel() {
-        resetInterpreter = new JCheckBox(JMeterUtils.getResString("bsh_script_reset_interpreter")); // $NON-NLS-1$
-        resetInterpreter.setName(BeanShellSampler.PARAMETERS);
-
         JPanel resetInterpreterPanel = new JPanel(new BorderLayout());
         resetInterpreterPanel.add(resetInterpreter, BorderLayout.WEST);
         return resetInterpreterPanel;

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.samplers.Interruptible;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.util.BeanShellInterpreter;
 import org.apache.jmeter.util.BeanShellTestElement;
 import org.apache.jorphan.util.JMeterException;
@@ -49,41 +50,71 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
 
     private static final long serialVersionUID = 4;
 
-    public static final String FILENAME = "BeanShellSampler.filename"; //$NON-NLS-1$
+    /**
+     * @deprecated use {@link BeanShellSamplerSchema#getFilename()} instead
+     */
+    @Deprecated
+    public static final String FILENAME = BeanShellSamplerSchema.INSTANCE.getFilename().getName();
 
-    public static final String SCRIPT = "BeanShellSampler.query"; //$NON-NLS-1$
+    /**
+     * @deprecated use {@link BeanShellSamplerSchema#getFilename()} instead
+     */
+    @Deprecated
+    public static final String SCRIPT = BeanShellSamplerSchema.INSTANCE.getScript().getName();
 
-    public static final String PARAMETERS = "BeanShellSampler.parameters"; //$NON-NLS-1$
+    /**
+     * @deprecated use {@link BeanShellSamplerSchema#getParameters()} instead
+     */
+    @Deprecated
+    public static final String PARAMETERS = BeanShellSamplerSchema.INSTANCE.getParameters().getName();
 
-    public static final String INIT_FILE = "beanshell.sampler.init"; //$NON-NLS-1$
+    /**
+     * @deprecated use {@link BeanShellSamplerSchema#getInitFile()} instead
+     */
+    @Deprecated
+    public static final String INIT_FILE = BeanShellSamplerSchema.INSTANCE.getInitFile().getName();
 
-    public static final String RESET_INTERPRETER = "BeanShellSampler.resetInterpreter"; //$NON-NLS-1$
+    /**
+     * @deprecated use {@link BeanShellSamplerSchema#getResetInterpreter()} instead
+     */
+    @Deprecated
+    public static final String RESET_INTERPRETER = BeanShellSamplerSchema.INSTANCE.getResetInterpreter().getName();
 
     private transient volatile BeanShellInterpreter savedBsh = null;
 
     @Override
+    public BeanShellSamplerSchema getSchema() {
+        return BeanShellSamplerSchema.INSTANCE;
+    }
+
+    @Override
+    public PropertiesAccessor<? extends BeanShellSampler, ? extends BeanShellSamplerSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
+    }
+
+    @Override
     protected String getInitFileProperty() {
-        return INIT_FILE;
+        return BeanShellSamplerSchema.INSTANCE.getInitFile().getName();
     }
 
     @Override
     public String getScript() {
-        return this.getPropertyAsString(SCRIPT);
+        return get(getSchema().getScript());
     }
 
     @Override
     public String getFilename() {
-        return getPropertyAsString(FILENAME);
+        return get(getSchema().getFilename());
     }
 
     @Override
     public String getParameters() {
-        return getPropertyAsString(PARAMETERS);
+        return get(getSchema().getParameters());
     }
 
     @Override
     public boolean isResetInterpreter() {
-        return getPropertyAsBoolean(RESET_INTERPRETER);
+        return get(getSchema().getResetInterpreter());
     }
 
     @Override

--- a/src/protocol/java/src/main/kotlin/org/apache/jmeter/protocol/java/sampler/BeanShellSamplerSchema.kt
+++ b/src/protocol/java/src/main/kotlin/org/apache/jmeter/protocol/java/sampler/BeanShellSamplerSchema.kt
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.java.sampler
+
+import org.apache.jmeter.testelement.TestElementSchema
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [BeanShellSampler].
+ * @see BeanShellSampler
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public open class BeanShellSamplerSchema : TestElementSchema() {
+    public companion object INSTANCE : BeanShellSamplerSchema()
+
+    public val resetInterpreter: BooleanPropertyDescriptor<BeanShellSamplerSchema> =
+        boolean("BeanShellSampler.resetInterpreter", default = false)
+
+    public val script: StringPropertyDescriptor<BeanShellSamplerSchema> =
+        string("BeanShellSampler.query")
+
+    public val parameters: StringPropertyDescriptor<BeanShellSamplerSchema> =
+        string("BeanShellSampler.parameters")
+
+    public val initFile: StringPropertyDescriptor<BeanShellSamplerSchema> =
+        string("beanshell.sampler.init")
+
+    public val filename: StringPropertyDescriptor<BeanShellSamplerSchema> =
+        string("BeanShellSampler.filename")
+}

--- a/src/protocol/java/src/test/kotlin/org/apache/jmeter/protocol/java/sampler/BeanShellSamplerTest.kt
+++ b/src/protocol/java/src/test/kotlin/org/apache/jmeter/protocol/java/sampler/BeanShellSamplerTest.kt
@@ -17,33 +17,21 @@
 
 package org.apache.jmeter.protocol.java.sampler
 
-import org.apache.jmeter.engine.util.CompoundVariable
-import org.apache.jmeter.testelement.TestElement
-import org.apache.jmeter.testelement.property.FunctionProperty
+import org.apache.jmeter.engine.util.TestElementPropertyTransformer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class BeanShellSamplerTest {
-    // TODO: move to TestElement itself?
-    private fun TestElement.setFunctionProperty(name: String, expression: String) {
-        setProperty(
-            FunctionProperty(
-                name,
-                CompoundVariable(expression).function
-            )
-        )
-    }
-
     @Test
     fun `getScript executes only once`() {
         val sampler = BeanShellSampler().apply {
             name = "BeanShell Sampler"
-            setFunctionProperty(
-                BeanShellSampler.SCRIPT,
-                """ResponseMessage="COUNTER=${"$"}{__counter(FALSE)}""""
-            )
-            setProperty(BeanShellSampler.FILENAME, "")
-            setProperty(BeanShellSampler.PARAMETERS, "")
+            props {
+                it[script] = """ResponseMessage="COUNTER=${"$"}{__counter(FALSE)}""""
+                it[filename] = ""
+                it[parameters] = ""
+            }
+            TestElementPropertyTransformer.USE_FUNCTIONS.visit(this)
             isRunningVersion = true
         }
         val result = sampler.sample(null)

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -119,6 +119,7 @@ Summary
   <li><pr>5934</pr>Added caching for date formatters for <code>__time</code> function</li>
   <li><pr>710</pr><issue>5666</issue>Added Shortcut key event for Reset search: <code>ctrl + alt + F</code>, <code>cmd + alt + F</code></li>
   <li><pr>5959</pr><code>TestElement</code> has been migrated to Kotlin, so nullable types are annotated better</li>
+  <li><pr>5944</pr>Add PI for declaring <code>TestElement</code> schemas so element properties are easier to access in code (see <code>TestElementSchema</code>, <code>TestElement#getSchema()</code>, <code>TestElement#getProps()</code>)</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -120,6 +120,7 @@ Summary
   <li><pr>710</pr><issue>5666</issue>Added Shortcut key event for Reset search: <code>ctrl + alt + F</code>, <code>cmd + alt + F</code></li>
   <li><pr>5959</pr><code>TestElement</code> has been migrated to Kotlin, so nullable types are annotated better</li>
   <li><pr>5944</pr>Add PI for declaring <code>TestElement</code> schemas so element properties are easier to access in code (see <code>TestElementSchema</code>, <code>TestElement#getSchema()</code>, <code>TestElement#getProps()</code>)</li>
+  <li><pr>5944</pr>Enable usage of <code>${...}</code> expressions for checkbox controls (see context menus for checkboxes, however, the individual components should be adapted individually)</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
## Description

The checkbox can be converted to an editable field by calling a context menu:
* right-click on the checkbox
* or press shift+F10

The editable box converts back to a checkbox if you select "true" or "false"

Fixes https://github.com/apache/jmeter/issues/1252
See https://github.com/apache/jmeter/pull/5761

## Motivation and Context

Previously, JMeter did not allow users to use `${...}` expressions for checkbox elements, however, there are cases when the checkbox should be customizable.
For instance, users might want to test different values `enable keepalive` setting, and currently it is not possible to configure it from a property file.

## How Has This Been Tested?

Only manual testing for now :-/

## Screenshots (if appropriate):

The second `Run Thread Groups consecutively` element is the new checkbox. It behaves like a usual checkbox.

<img width="388" alt="sample use of the new checkbox element" src="https://github.com/apache/jmeter/assets/213894/0ce02ac2-2c0f-4784-bb85-cafddfc3a4bc">

However, it has a popup menu (right-click or shift+F10) so the users can convert it to an expression:

<img width="388" alt="popup menu for the new checkbox" src="https://github.com/apache/jmeter/assets/213894/6990e798-dc40-46b1-a751-abee094a109f">

The editable element looks like an editable combobox:

<img width="456" alt="editable combo box instead of checkbox" src="https://github.com/apache/jmeter/assets/213894/bb32ad07-3256-4f1b-a293-9c67910af1b6">

Users can type `up`, `down` to select a predefined value, or they can select `true` or `false` in which case the element would collapse to a checkbox again:

<img width="455" alt="combo box with available items" src="https://github.com/apache/jmeter/assets/213894/8295ef70-4d6b-4dbf-972c-ccaa1397be82">

## Open questions

It is unclear what we do with methods like `org.apache.jmeter.testelement.TestPlan#setSerialized(boolean)` and `boolean org.apache.jmeter.testelement.TestPlan#isSerialized()`.

We might add a second pair of getter and setter for exposing the property as `String`, so the UI element can propagate the free-form text expression to the test plan configuration.

I remember I had the same issue with `OpenModelThreadGroup` where I created two properties `randomSeed: Long` and `randomSeedString: String`: https://github.com/apache/jmeter/blob/4d9d99a364d0533782e14209a399b60672fa7032/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroup.kt#L91-L100
Duplicating properties does not look nice :-(

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
