### PR TITLE
Update HTML parser to pick up `preload` attribute for `rel`

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParser.java
@@ -63,6 +63,7 @@ public abstract class HTMLParser extends BaseParser {
 
     protected static final String SHORTCUT_ICON     = "shortcut icon";
     protected static final String ICON              = "icon";
+    protected static final String PRELOAD           = "preload";
 
     protected static final String IE_UA             = "MSIE ([0-9]+.[0-9]+)";// $NON-NLS-1$
     protected static final Pattern IE_UA_PATTERN    = Pattern.compile(IE_UA);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
@@ -148,7 +148,8 @@ class JTidyHTMLParser extends HTMLParser {
             if (TAG_LINK.equalsIgnoreCase(name) &&
                     (STYLESHEET.equalsIgnoreCase(getValue(attrs, ATT_REL))
                             || SHORTCUT_ICON.equalsIgnoreCase(getValue(attrs, ATT_REL))
-                            || ICON.equalsIgnoreCase(getValue(attrs, ATT_REL)))) {
+                            || ICON.equalsIgnoreCase(getValue(attrs, ATT_REL))
+                            || PRELOAD.equalsIgnoreCase(getValue(attrs, ATT_REL)))) {
                 urls.addURL(getValue(attrs, ATT_HREF), baseUrl);
                 break;
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
@@ -127,8 +127,10 @@ public class JsoupBasedHtmlParser extends HTMLParser {
             } else if (tagName.equals(TAG_LINK)) {
                 String relAttr = tag.attr(ATT_REL);
                 // Putting the string first means it works even if the attribute is null
-                if (STYLESHEET.equalsIgnoreCase(relAttr) || ICON.equalsIgnoreCase(relAttr)
-                        || SHORTCUT_ICON.equalsIgnoreCase(relAttr)) {
+                if (STYLESHEET.equalsIgnoreCase(relAttr)
+                        || ICON.equalsIgnoreCase(relAttr)
+                        || SHORTCUT_ICON.equalsIgnoreCase(relAttr)
+                        || PRELOAD.equalsIgnoreCase(relAttr)) {
                     extractAttribute(tag, ATT_HREF);
                 }
             } else {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
@@ -167,7 +167,8 @@ public class LagartoBasedHtmlParser extends HTMLParser {
                     if (relAttribute != null &&
                             (CharSequenceUtil.equalsIgnoreCase(STYLESHEET,relAttribute)
                                     || CharSequenceUtil.equalsIgnoreCase(ICON, relAttribute)
-                                    || CharSequenceUtil.equalsIgnoreCase(SHORTCUT_ICON, relAttribute))) {
+                                    || CharSequenceUtil.equalsIgnoreCase(SHORTCUT_ICON, relAttribute)
+                                    || CharSequenceUtil.equalsIgnoreCase(PRELOAD, relAttribute))) {
                         extractAttribute(tag, ATT_HREF);
                     }
                 } else {


### PR DESCRIPTION
## Description
Updated JMeter HTML parsers to pick up on the `preload` value for the `rel` attribute in `<link>` tags.

A constant has been added to `HTMLParser.java` for the preload value. The parser implementation classes have been updated to use this constant.

## Motivation and Context
During a project we found some embedded resource files that were not being downloaded by default. To address this in the meantime we have used the parallel sampler extension. We found that the problem was the `preload` value wasn't being picked up as a valid value in the JMeter HTML parsers, so I am proposing that this becomes part of the HTML parsers.

I am unaware of any open issue for this.

## How Has This Been Tested?
`./gradlew runGui` has been run, and a simple test hitting an HTML page with `rel=preload` attributes was run. 

`./gradlew check` has been run and passes.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
