### PR TITLE
perf: remove excessive BufferedInputStream from HTTP sampler

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.protocol.http.sampler;
 
-import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -228,7 +227,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
      *                if an I/O exception occurs
      */
     protected byte[] readResponse(HttpURLConnection conn, SampleResult res) throws IOException {
-        BufferedInputStream in;
+        InputStream in;
 
         final long contentLength = conn.getContentLength();
         if ((contentLength == 0)
@@ -245,9 +244,9 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
         try {
             instream = new CountingInputStream(conn.getInputStream());
             if (gzipped) {
-                in = new BufferedInputStream(new GZIPInputStream(instream));
+                in = new GZIPInputStream(instream);
             } else {
-                in = new BufferedInputStream(instream);
+                in = instream;
             }
         } catch (IOException e) {
             if (! (e.getCause() instanceof FileNotFoundException))
@@ -277,9 +276,9 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
             }
 
             if (gzipped) {
-                in = new BufferedInputStream(new GZIPInputStream(errorStream));
+                in = new GZIPInputStream(errorStream);
             } else {
-                in = new BufferedInputStream(errorStream);
+                in = errorStream;
             }
         } catch (Exception e) {
             log.error("readResponse: {}", e.toString());
@@ -290,7 +289,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
                     throw (Error)cause;
                 }
             }
-            in = new BufferedInputStream(conn.getErrorStream());
+            in = conn.getErrorStream();
         }
         // N.B. this closes 'in'
         byte[] responseData = readResponse(res, in, contentLength);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
@@ -17,16 +17,16 @@
 
 package org.apache.jmeter.protocol.http.sampler;
 
-import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -412,7 +412,7 @@ public class PostWriter {
         // uploads were being done. Could be fixed by increasing the evacuation
         // ratio in bin/jmeter[.bat], but this is better.
         int read;
-        try (InputStream in = new BufferedInputStream(new FileInputStream(filename))) {
+        try (InputStream in = Files.newInputStream(Paths.get(filename))) {
             while ((read = in.read(buf)) > 0) {
                 out.write(buf, 0, read);
             }


### PR DESCRIPTION
HTTPSamplerBase.readResponse uses byte[8192] array anyway, so creating BufferedInputStream is not useful there.

