### PR TITLE
perf: avoid String.replaceAll in HTTPJavaImpl

### DIFF
--- a/src/jorphan/src/main/java/org/apache/jorphan/util/StringUtilities.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/StringUtilities.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.util;
+
+import org.apiguardian.api.API;
+
+/**
+ * Functions that are missing in other libraries.
+ *
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public class StringUtilities {
+    private StringUtilities() {
+    }
+
+    /**
+     * Counts the number of times a given char is present in the string.
+     *
+     * @param input input string
+     * @param ch    char to search
+     * @return number of times the character is present in the string, or 0 if no char found
+     */
+    public static int count(String input, char ch) {
+        if (input.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        int idx = 0;
+        while ((idx = input.indexOf(ch, idx)) != -1) {
+            count++;
+            idx++;
+        }
+        return count;
+    }
+}

--- a/src/jorphan/src/test/kotlin/org/apache/jorphan/util/StringUtilitiesTest.kt
+++ b/src/jorphan/src/test/kotlin/org/apache/jorphan/util/StringUtilitiesTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.util
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class StringUtilitiesTest {
+    @ParameterizedTest
+    @CsvSource(
+        "2,t,test",
+        "0,w,test",
+        "1,e,test",
+        "0,e,\"\"",
+    )
+    fun count(expected: Int, char: Char, input: String) {
+        Assertions.assertEquals(expected, StringUtilities.count(input, char)) {
+            "StringUtilities.count($input, $char)"
+        }
+    }
+}

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
@@ -46,6 +46,7 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.SSLManager;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -616,8 +617,13 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
             }
 
             // record headers size to allow HTTPSampleResult.getBytes() with different options
-            res.setHeadersSize(responseHeaders.replaceAll("\n", "\r\n") // $NON-NLS-1$ $NON-NLS-2$
-                    .length() + 2); // add 2 for a '\r\n' at end of headers (before data)
+            // It used to be responseHeaders.replaceAll("\n", "\r\n").length(),
+            // however we don't need the resulting string, just the length
+            // So we add the number of \n in the string to account for \n
+            res.setHeadersSize(
+                    responseHeaders.length()
+                            + StringUtilities.count(responseHeaders, '\n')
+                            + 2); // add 2 for a '\r\n' at end of headers (before data)
             if (log.isDebugEnabled()) {
                 log.debug("Response headersSize={}, bodySize={}, Total={}",
                         res.getHeadersSize(),  res.getBodySizeAsLong(),


### PR DESCRIPTION
HTTP Java sampler used `replaceAll("\n", "\r\n").length()`, and we could count the number of `\n` instead to avoid building the string.