### PR TITLE
fix: PropertyIterator.remove should remove properties from both collections in TestElement

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -587,7 +587,7 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
     public PropertyIterator propertyIterator() {
         Map<String, JMeterProperty> propMapConcurrent = this.propMapConcurrent;
         if (propMapConcurrent != null) {
-            return new PropertyIteratorImpl(propMapConcurrent.values());
+            return new PropertyIteratorImpl(this, propMapConcurrent.values());
         }
 
         // TODO: copy the contents of the iterator to avoid ConcurrentModificationException?

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/PropertyIteratorImpl.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/PropertyIteratorImpl.java
@@ -20,12 +20,21 @@ package org.apache.jmeter.testelement.property;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.apache.jmeter.testelement.TestElement;
+
 public class PropertyIteratorImpl implements PropertyIterator {
 
-    private final Iterator<JMeterProperty> iter;
+    private final TestElement owner;
+    private final Iterator<? extends JMeterProperty> iter;
+    private String lastPropertyName;
 
     public PropertyIteratorImpl(Collection<JMeterProperty> value) {
-        iter = value.iterator();
+        this(null, value);
+    }
+
+    public PropertyIteratorImpl(TestElement owner, Iterable<? extends JMeterProperty> properties) {
+        this.owner = owner;
+        this.iter = properties.iterator();
     }
 
     /** {@inheritDoc} */
@@ -37,13 +46,21 @@ public class PropertyIteratorImpl implements PropertyIterator {
     /** {@inheritDoc} */
     @Override
     public JMeterProperty next() {
-        return iter.next();
+        JMeterProperty last = iter.next();
+        if (owner != null) {
+            lastPropertyName = last.getName();
+        }
+        return last;
     }
 
     /** {@inheritDoc} */
     @Override
     public void remove() {
         iter.remove();
+        if (lastPropertyName != null) {
+            owner.removeProperty(lastPropertyName);
+            lastPropertyName = null;
+        }
     }
 
 }

--- a/src/core/src/test/kotlin/org/apache/jmeter/testelement/property/TestElementPropertyIteratorTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/testelement/property/TestElementPropertyIteratorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement.property
+
+import org.apache.jmeter.engine.util.NoThreadClone
+import org.apache.jmeter.testelement.AbstractTestElement
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TestElementPropertyIteratorTest {
+    class TempConfig : AbstractTestElement(), NoThreadClone
+
+    @Test
+    fun `iterator remove from nocloneelement`() {
+        val a = TempConfig().apply {
+            setProperty("present", "1")
+        }
+        val b = TempConfig().apply {
+            setProperty("present", "1")
+            setProperty("to_remove", "to be removed")
+        }
+        val it = b.propertyIterator()
+        while (it.hasNext()) {
+            val prop = it.next()
+            if (prop.name == "to_remove") {
+                it.remove()
+            }
+        }
+        assertTrue(a == b) {
+            "Elements should be equal after removal of property <<to_remove>> with iterator.remove(). " +
+                "If properties look the same, it might mean propMap and propMapConcurrent diverged. " +
+                "Properties of a default element: ${a.propertyIterator().asSequence().joinToString { "${it.name}=${it.stringValue}" }}, " +
+                "Properties of element after removal: ${b.propertyIterator().asSequence().joinToString { "${it.name}=${it.stringValue}" }}"
+        }
+    }
+}


### PR DESCRIPTION
This is a fixup to https://github.com/apache/jmeter/commit/a8317d0fdb563ea7580317b9bd123f0e2797bb48
