### PR TITLE
chore: reduce verbosity of the build logs

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
@@ -108,12 +108,14 @@ tasks.configureEach<Javadoc> {
         windowTitle = "Apache JMeter ${project.name} API"
         header = "<b>Apache JMeter</b>"
         addStringOption("source", "8")
+        addStringOption("Xmaxwarns", "10")
+        addBooleanOption("Xdoclint:all,-missing", true)
         val lastEditYear: String by rootProject.extra
         bottom =
             "Copyright &copy; 1998-$lastEditYear Apache Software Foundation. All Rights Reserved."
         if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
             addBooleanOption("html5", true)
-            links("https://docs.oracle.com/javase/11/docs/api/")
+            links("https://docs.oracle.com/en/java/javase/11/docs/api/")
         } else {
             links("https://docs.oracle.com/javase/8/docs/api/")
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,3 +40,7 @@ com.github.vlsi.checksum-dependency.version=1.88
 kotlin.api.version=1.5
 # See https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
 kotlin.explicitApi=true
+
+# com.github.vlsi.gradle-extensions prints only failing or slow test results
+slowTestLogThreshold=1000
+slowSuiteLogThreshold=2000

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanHelper.java
@@ -122,7 +122,6 @@ public class TestBeanHelper {
     /**
      * Prepare the bean for work by populating the bean's properties from the
      * property value map.
-     * <p>
      *
      * @param el the TestElement to be prepared
      */

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/HeapDumper.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/HeapDumper.java
@@ -108,7 +108,7 @@ public class HeapDumper {
 
     /**
      * Dumps live objects from the heap to the outputFile file in the same format as the hprof heap dump.
-     * <p>
+     *
      * @see #dumpHeap(String, boolean)
      * @param fileName name of the heap dump file. Must be creatable, i.e. must not exist.
      * @throws Exception if the MXBean cannot be found, or if there is a problem during invocation
@@ -122,7 +122,7 @@ public class HeapDumper {
      * <p>
      * Creates the dump using the file name: dump_yyyyMMdd_hhmmss_SSS.hprof
      * The dump is created in the current directory.
-     * <p>
+     * </p>
      * @see #dumpHeap(boolean)
      * @return the name of the dump file that was created
      * @throws Exception if the MXBean cannot be found, or if there is a problem during invocation
@@ -136,7 +136,7 @@ public class HeapDumper {
      * <p>
      * Creates the dump using the file name: dump_yyyyMMdd_hhmmss_SSS.hprof
      * The dump is created in the current directory.
-     * <p>
+     * </p>
      * @see #dumpHeap(String, boolean)
      * @param live true id only live objects are to be dumped.
      *
@@ -152,7 +152,7 @@ public class HeapDumper {
      * The dump is created in the specified directory.
      * <p>
      * Creates the dump using the file name: dump_yyyyMMdd_hhmmss_SSS.hprof
-     * <p>
+     * </p>
      * @see #dumpHeap(String, boolean)
      * @param basedir File object for the target base directory.
      * @param live true id only live objects are to be dumped.


### PR DESCRIPTION
Ignore "missing javadoc" warnings
