### PR TITLE
fix: AbstractTestElement#clone might produce non-identical clones if element constructor adds a non-default property value

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -121,6 +121,15 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
         try {
             TestElement clonedElement = this.getClass().getDeclaredConstructor().newInstance();
 
+            // Default constructor might be configuring non-default properties, and we want
+            // the clone to be identical to the source, so we remove properties before copying.
+            // For example, LoopController in JMeter 5.5
+            // Note: clonedElement.clear(); might set unwanted options as well.
+            PropertyIterator clonedProps = clonedElement.propertyIterator();
+            while (clonedProps.hasNext()) {
+                clonedProps.next();
+                clonedProps.remove();
+            }
             PropertyIterator iter = propertyIterator();
             while (iter.hasNext()) {
                 clonedElement.setProperty(iter.next().clone());

--- a/src/core/src/test/kotlin/org/apache/jmeter/testelement/AbstractTestElementTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/testelement/AbstractTestElementTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AbstractTestElementTest {
+    @Test
+    fun `clone can remove properties`() {
+        class ElementWithDefaultComment : AbstractTestElement() {
+            init {
+                set(TestElementSchema.comments, "initialized in constructor")
+            }
+        }
+
+        val source = ElementWithDefaultComment().apply {
+            removeProperty(TestElementSchema.comments.name)
+        }
+
+        val cloned = source.clone() as ElementWithDefaultComment
+
+        cloned.propertyIterator().asSequence().toList()
+
+        assertEquals(
+            source.propertyIterator().asSequence().toList().joinToString("\n") { it.name + " = " + it.stringValue },
+            cloned.propertyIterator().asSequence().toList().joinToString("\n") { it.name + " = " + it.stringValue },
+        ) {
+            "The properties after cloning the element should match the original properites. " +
+                "Note that comments is added in constructor, however, we remove <<comments>> property before cloning"
+        }
+
+        assertEquals(source, cloned) {
+            "The cloned element should be be equal the original element. " +
+                "Note that comments is added in constructor, however, we remove <<comments>> property before cloning"
+        }
+    }
+}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -230,6 +230,7 @@ Summary
   <li><issue>5872</issue><pr>5874</pr>Trim name in Argument objects.</li>
   <li><pr>693</pr>Avoid wrong results when <code>Object.hashCode()</code> happen to collide. Use <code>IdentityHashMap</code> instead of <code>HashMap</code> when key is <code>TestElement</code></li>
   <li>Refresh UI when dragging JMeter window from one monitor to another, so rich syntax text areas are properly editable after window movement</li>
+  <li><pr>5984</pr><code>AbstractTestElement#clone</code> might produce non-identical clones if element constructor adds a non-default property value</li>
 </ul>
 
  <!--  =================== Thanks =================== -->


### PR DESCRIPTION
Historically AbstractTestElement calls default constructor in order to create a clone. It might be that a constructor would add properties (e.g. LoopController, HeaderManager), so we might get invalid clones if the clone source _removes_ a property which was added in the constructor.

An alternative approach would be using `super.clone()`, however, it would be a significant change, so for now I suggest just removing "extra" properties that might be accidentally added in constructor.

The visible effect was that `LoopController` was unequal after cloning if user removes `continueForever` property from the `LoopController`.