### PR TITLE
fix: encode unicode characters in filenames when sending files in HTTP Sampler

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/config/Arguments.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/Arguments.java
@@ -62,7 +62,7 @@ public class Arguments extends ConfigTestElement implements Serializable, Iterab
      * @return the arguments
      */
     public CollectionProperty getArguments() {
-        return (CollectionProperty) getPropertyOrNull(getSchema().getArguments());
+        return getOrNull(getSchema().getArguments());
     }
 
     /**

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
@@ -488,29 +488,28 @@ public interface TestElement : Cloneable {
     }
 
     /**
-     * Retrieve [Collection] property value, or throw [NoSuchElementException] in case the property is unset.
+     * Retrieve [CollectionProperty] property value, or throw [NoSuchElementException] in case the property is unset.
      * @throws NoSuchElementException if the property is unset
      * @since 5.6
      */
     @JMeterPropertySchemaUnchecked
     @API(status = API.Status.EXPERIMENTAL, since = "5.6")
-    public operator fun get(property: CollectionPropertyDescriptor<*>): Collection<JMeterProperty> =
+    public operator fun get(property: CollectionPropertyDescriptor<*>): CollectionProperty =
         getOrNull(property) ?: throw NoSuchElementException("Property ${property.name} is unset for element $this")
 
     /**
-     * Retrieve [Collection] property value, or return `null` in case the property is unset.
+     * Retrieve [CollectionProperty] property value, or return `null` in case the property is unset.
      * @since 5.6
      */
     @JMeterPropertySchemaUnchecked
     @API(status = API.Status.EXPERIMENTAL, since = "5.6")
-    public fun getOrNull(property: CollectionPropertyDescriptor<*>): Collection<JMeterProperty>? =
+    public fun getOrNull(property: CollectionPropertyDescriptor<*>): CollectionProperty? =
         getPropertyOrNull(property)?.let {
-            @Suppress("UNCHECKED_CAST")
-            (it as CollectionProperty).objectValue as Collection<JMeterProperty>
+            it as CollectionProperty
         }
 
     /**
-     * Retrieve [Collection] property value, or create one and set it the property is unset.
+     * Retrieve [CollectionProperty] property value, or create one and set it the property is unset.
      * @since 5.6
      */
     @JMeterPropertySchemaUnchecked
@@ -518,8 +517,8 @@ public interface TestElement : Cloneable {
     public fun getOrCreate(
         property: CollectionPropertyDescriptor<*>,
         ifMissing: () -> Collection<JMeterProperty>
-    ): Collection<JMeterProperty> =
-        getOrNull(property) ?: ifMissing().also { set(property, it) }
+    ): CollectionProperty =
+        getOrNull(property) ?: CollectionProperty(property.name, ifMissing()).also { setProperty(it) }
 
     /**
      * Set property as [Collection], or remove it if the given [Collection] is `null`.

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/CollectionPropertyDescriptor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/CollectionPropertyDescriptor.kt
@@ -40,22 +40,22 @@ public data class CollectionPropertyDescriptor<in Schema : BaseTestElementSchema
     override val defaultValue: Collection<JMeterProperty>? = null
 
     /**
-     * Retrieve [Collection] property value, or throw [NoSuchElementException] in case the property is unset.
+     * Retrieve [CollectionProperty] property value, or throw [NoSuchElementException] in case the property is unset.
      * @throws NoSuchElementException if the property is unset
      */
-    public operator fun get(target: TestElement): Collection<JMeterProperty> =
+    public operator fun get(target: TestElement): CollectionProperty =
         target[this]
 
     /**
-     * Retrieve [Collection] property value, or return `null` in case the property is unset.
+     * Retrieve [CollectionProperty] property value, or return `null` in case the property is unset.
      */
-    public fun getOrNull(target: TestElement): Collection<JMeterProperty>? =
+    public fun getOrNull(target: TestElement): CollectionProperty? =
         target.getOrNull(this)
 
     /**
-     * Retrieve [Collection] property value, or create one and set it the property is unset.
+     * Retrieve [CollectionProperty] property value, or create one and set it the property is unset.
      */
-    public fun getOrCreate(target: TestElement, ifMissing: () -> Collection<JMeterProperty>): Collection<JMeterProperty> =
+    public fun getOrCreate(target: TestElement, ifMissing: () -> Collection<JMeterProperty>): CollectionProperty =
         target.getOrCreate(this, ifMissing)
 
     public operator fun set(target: TestElement, value: Collection<*>?) {
@@ -64,7 +64,7 @@ public data class CollectionPropertyDescriptor<in Schema : BaseTestElementSchema
 
     @JvmSynthetic
     @Suppress("NOTHING_TO_INLINE")
-    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): Collection<JMeterProperty> {
+    public inline operator fun getValue(testElement: TestElement, property: KProperty<*>): CollectionProperty {
         return testElement[this]
     }
 

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertiesAccessor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertiesAccessor.kt
@@ -18,6 +18,7 @@
 package org.apache.jmeter.testelement.schema
 
 import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.property.CollectionProperty
 import org.apache.jmeter.testelement.property.JMeterProperty
 import org.apiguardian.api.API
 import kotlin.experimental.ExperimentalTypeInference
@@ -136,13 +137,21 @@ public class PropertiesAccessor<out TestElementClass : TestElement, out Schema :
         propertySelector(schema).getString(target)
 
     // Class properties
-    public operator fun <ValueClass : Any> get(property: ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass>? =
+    public operator fun <ValueClass : Any> get(property: ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass> =
         target[property]
+
+    public fun <ValueClass : Any> getOrNull(property: ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass>? =
+        target.getOrNull(property)
 
     @OptIn(ExperimentalTypeInference::class)
     @OverloadResolutionByLambdaReturnType
-    public operator fun <ValueClass : Any> get(propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass>? =
+    public operator fun <ValueClass : Any> get(propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass> =
         get(propertySelector(schema))
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public fun <ValueClass : Any> getOrNull(propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>): Class<out ValueClass>? =
+        getOrNull(propertySelector(schema))
 
     public operator fun <ValueClass : Any> set(
         property: ClassPropertyDescriptor<Schema, ValueClass>,
@@ -153,21 +162,21 @@ public class PropertiesAccessor<out TestElementClass : TestElement, out Schema :
 
     public inline operator fun <ValueClass : Any> set(
         propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>,
-        value: KClass<ValueClass>
+        value: KClass<ValueClass>?
     ) {
-        set(propertySelector, value.java)
+        set(propertySelector, value?.java)
     }
 
     public operator fun <ValueClass : Any> set(
         property: ClassPropertyDescriptor<Schema, ValueClass>,
-        value: Class<out ValueClass>
+        value: Class<out ValueClass>?
     ) {
         target[property] = value
     }
 
     public inline operator fun <ValueClass : Any> set(
         propertySelector: Schema.() -> ClassPropertyDescriptor<Schema, ValueClass>,
-        value: Class<ValueClass>
+        value: Class<ValueClass>?
     ) {
         target[propertySelector(schema)] = value
     }
@@ -253,44 +262,60 @@ public class PropertiesAccessor<out TestElementClass : TestElement, out Schema :
     }
 
     // TestElement properties
-    public operator fun <ValueClass : TestElement> get(property: TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass? =
+    public operator fun <ValueClass : TestElement> get(property: TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass =
         target[property]
+
+    public fun <ValueClass : TestElement> getOrNull(property: TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass? =
+        target.getOrNull(property)
 
     @OptIn(ExperimentalTypeInference::class)
     @OverloadResolutionByLambdaReturnType
-    public inline operator fun <ValueClass : TestElement> get(propertySelector: Schema.() -> TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass? =
+    public inline operator fun <ValueClass : TestElement> get(propertySelector: Schema.() -> TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass =
         target[propertySelector(schema)]
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline fun <ValueClass : TestElement> getOrNull(propertySelector: Schema.() -> TestElementPropertyDescriptor<Schema, ValueClass>): ValueClass? =
+        target.getOrNull(propertySelector(schema))
 
     public operator fun <ValueClass : TestElement> set(
         property: TestElementPropertyDescriptor<Schema, ValueClass>,
-        value: ValueClass
+        value: ValueClass?
     ) {
         target[property] = value
     }
 
     public inline operator fun <ValueClass : TestElement> set(
         propertySelector: Schema.() -> TestElementPropertyDescriptor<Schema, ValueClass>,
-        value: ValueClass
+        value: ValueClass?
     ) {
         target[propertySelector(schema)] = value
     }
 
     // Collection properties
-    public operator fun get(property: CollectionPropertyDescriptor<Schema>): Collection<JMeterProperty> =
+    public operator fun get(property: CollectionPropertyDescriptor<Schema>): CollectionProperty =
         target[property]
+
+    public fun getOrNull(property: CollectionPropertyDescriptor<Schema>): CollectionProperty? =
+        target.getOrNull(property)
 
     @OptIn(ExperimentalTypeInference::class)
     @OverloadResolutionByLambdaReturnType
-    public inline operator fun get(propertySelector: Schema.() -> CollectionPropertyDescriptor<Schema>): Collection<JMeterProperty> =
+    public inline operator fun get(propertySelector: Schema.() -> CollectionPropertyDescriptor<Schema>): CollectionProperty =
         target[propertySelector(schema)]
 
-    public operator fun set(property: CollectionPropertyDescriptor<Schema>, value: Collection<*>) {
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    public inline fun getOrNull(propertySelector: Schema.() -> CollectionPropertyDescriptor<Schema>): CollectionProperty? =
+        target.getOrNull(propertySelector(schema))
+
+    public operator fun set(property: CollectionPropertyDescriptor<Schema>, value: Collection<*>?) {
         target[property] = value
     }
 
     public inline operator fun set(
         propertySelector: Schema.() -> CollectionPropertyDescriptor<Schema>,
-        value: Collection<*>
+        value: Collection<*>?
     ) {
         target[propertySelector(schema)] = value
     }

--- a/src/core/src/test/kotlin/org/apache/jmeter/engine/util/UseFunctionsTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/engine/util/UseFunctionsTest.kt
@@ -61,7 +61,7 @@ class UseFunctionsTest {
 
         // These assertions verify CollectionProperty behavior rather than USE_FUNCTIONS behavior
         // However, we can't extract deeply-nested item right away
-        assertEquals(1, output.size) {
+        assertEquals(1, output.size()) {
             "size of first level collection should be 1, actual: $output"
         }
         val nested = output.first()

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HeaderManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HeaderManager.java
@@ -86,7 +86,7 @@ public class HeaderManager extends ConfigTestElement implements Serializable, Re
      * @return the header collection property
      */
     public CollectionProperty getHeaders() {
-        return (CollectionProperty) getPropertyOrNull(getSchema().getHeaders());
+        return getOrNull(getSchema().getHeaders());
     }
 
     public int getColumnCount() {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -150,6 +150,7 @@ import org.apache.jmeter.protocol.http.control.HeaderManager;
 import org.apache.jmeter.protocol.http.sampler.hc.LaxDeflateInputStream;
 import org.apache.jmeter.protocol.http.sampler.hc.LaxGZIPInputStream;
 import org.apache.jmeter.protocol.http.sampler.hc.LazyLayeredConnectionSocketFactory;
+import org.apache.jmeter.protocol.http.util.ConversionUtils;
 import org.apache.jmeter.protocol.http.util.EncoderCache;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -1508,7 +1509,9 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
         private boolean hideFileData;
 
         public ViewableFileBody(File file, ContentType contentType) {
-            super(file, contentType);
+            // Note: HttpClient4 does not support encoding the file name, so we explicitly encode it here
+            // See https://issues.apache.org/jira/browse/HTTPCLIENT-293
+            super(file, contentType, ConversionUtils.percentEncode(file.getName()));
             hideFileData = false;
         }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -82,7 +82,6 @@ import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
-import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.testelement.schema.PropertyDescriptor;
 import org.apache.jmeter.threads.JMeterContext;
@@ -92,6 +91,7 @@ import org.apache.jorphan.util.JOrphanUtils;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Matcher;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -248,7 +248,6 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     // @see mergeFileProperties
     // Must be private, as the file list needs special handling
-    private static final String FILE_ARGS = "HTTPsampler.Files"; // $NON-NLS-1$
     // MIMETYPE is kept for backward compatibility with old test plans
     private static final String MIMETYPE = "HTTPSampler.mimetype"; // $NON-NLS-1$
     // FILE_NAME is kept for backward compatibility with old test plans
@@ -1829,18 +1828,14 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      *   HTTPFileArgs object that stores file list to be uploaded.
      */
     private void setHTTPFileArgs(HTTPFileArgs value) {
-        if (value.getHTTPFileArgCount() > 0) {
-            setProperty(new TestElementProperty(FILE_ARGS, value));
-        } else {
-            removeProperty(FILE_ARGS); // no point saving an empty list
-        }
+        set(getSchema().getFileArguments(), value.getHTTPFileArgCount() == 0 ? null : value);
     }
 
     /*
      * Method to get files list to be uploaded.
      */
-    private HTTPFileArgs getHTTPFileArgs() {
-        return (HTTPFileArgs) getProperty(FILE_ARGS).getObjectValue();
+    private @Nullable HTTPFileArgs getHTTPFileArgs() {
+        return getOrNull(getSchema().getFileArguments());
     }
 
     /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import org.apache.jmeter.protocol.http.util.ConversionUtils;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
@@ -391,7 +392,7 @@ public class PostWriter {
         write(out, "Content-Disposition: form-data; name=\""); // $NON-NLS-1$
         write(out, nameField);
         write(out, "\"; filename=\"");// $NON-NLS-1$
-        write(out, new File(filename).getName());
+        write(out, ConversionUtils.percentEncode(new File(filename).getName()));
         writeln(out, "\""); // $NON-NLS-1$
         writeln(out, "Content-Type: " + mimetype); // $NON-NLS-1$
         writeln(out, "Content-Transfer-Encoding: binary"); // $NON-NLS-1$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apiguardian.api.API;
 
 // @see TestHTTPUtils for unit tests
 
@@ -93,6 +94,23 @@ public class ConversionUtils {
             }
         }
         return charSet;
+    }
+
+    /**
+     * Encodes the string according to RFC7578 and RFC3986.
+     * The string is UTF-8 encoded, and non-ASCII bytes are represented as {@code %XX}.
+     * It is close to UrlEncode, however, {@code percentEncode} does not replace space with +.
+     * @param value input value to convert
+     * @return converted value
+     * @since 5.6
+     */
+    @API(status = API.Status.MAINTAINED, since = "5.6")
+    public static String percentEncode(String value) {
+        try {
+            return new URI(null, null, value, null).toASCIIString();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Can't encode value " + value, e);
+        }
     }
 
     /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
@@ -24,7 +24,8 @@ import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
-import org.apache.jmeter.testelement.property.StringProperty;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
+import org.apache.jmeter.testelement.schema.PropertyDescriptor;
 import org.apache.tika.Tika;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
@@ -40,15 +41,6 @@ import org.xml.sax.SAXException;
 public class HTTPFileArg extends AbstractTestElement implements Serializable {
 
     private static final long serialVersionUID = 240L;
-
-    /** Name used to store the file's path. */
-    private static final String FILEPATH = "File.path";
-
-    /** Name used to store the file's paramname. */
-    private static final String PARAMNAME = "File.paramname";
-
-    /** Name used to store the file's mimetype. */
-    private static final String MIMETYPE = "File.mimetype";
 
     /** temporary storage area for the body header. */
     private String header;
@@ -139,14 +131,24 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
         if (path == null || paramname == null || mimetype == null){
             throw new IllegalArgumentException("Parameters must not be null");
         }
-        setProperty(FILEPATH, path);
-        setProperty(MIMETYPE, mimetype);
-        setProperty(PARAMNAME, paramname);
+        setProperty(getSchema().getPath(), path);
+        setProperty(getSchema().getMimeType(), mimetype);
+        setProperty(getSchema().getParameterName(), paramname);
     }
 
-    private void setProperty(String name, JMeterProperty prop) {
+    @Override
+    public HTTPFileArgSchema getSchema() {
+        return HTTPFileArgSchema.INSTANCE;
+    }
+
+    @Override
+    public PropertiesAccessor<? extends HTTPFileArg, ? extends HTTPFileArgSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
+    }
+
+    private void setProperty(PropertyDescriptor<?, ?> descriptor, JMeterProperty prop) {
         JMeterProperty jmp = prop.clone();
-        jmp.setName(name);
+        jmp.setName(descriptor.getName());
         setProperty(jmp);
     }
 
@@ -170,7 +172,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
      * the new http parameter name
      */
     public void setParamName(String newParamName) {
-        setProperty(new StringProperty(PARAMNAME, newParamName));
+        set(getSchema().getParameterName(), newParamName);
     }
 
     /**
@@ -179,7 +181,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
      * @return the http parameter name
      */
     public String getParamName() {
-        return getPropertyAsString(PARAMNAME);
+        return get(getSchema().getParameterName());
     }
 
     /**
@@ -189,7 +191,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
      * the new mimetype
      */
     public void setMimeType(String newMimeType) {
-        setProperty(new StringProperty(MIMETYPE, newMimeType));
+        set(getSchema().getMimeType(), newMimeType);
     }
 
     /**
@@ -198,7 +200,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
      * @return the http parameter mimetype
      */
     public String getMimeType() {
-        return getPropertyAsString(MIMETYPE);
+        return get(getSchema().getMimeType());
     }
 
     /**
@@ -209,7 +211,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
      */
     public void setPath(String newPath) {
         setMimeType(detectMimeType(newPath, getMimeType()));
-        setProperty(new StringProperty(FILEPATH, newPath));
+        set(getSchema().getPath(), newPath);
     }
 
     /**
@@ -218,7 +220,7 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
      * @return the file's path
      */
     public String getPath() {
-        return getPropertyAsString(FILEPATH);
+        return get(getSchema().getPath());
     }
 
    /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArgs.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArgs.java
@@ -25,6 +25,7 @@ import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 import org.apache.jmeter.testelement.property.TestElementProperty;
+import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 
 /**
  * A set of HTTPFileArg objects.
@@ -34,14 +35,21 @@ public class HTTPFileArgs extends ConfigTestElement implements Serializable {
 
     private static final long serialVersionUID = 240L;
 
-    /** The name of the property used to store the files. */
-    private static final String HTTP_FILE_ARGS = "HTTPFileArgs.files"; //$NON-NLS-1$
-
     /**
      * Create a new HTTPFileArgs object with no files.
      */
     public HTTPFileArgs() {
-        setProperty(new CollectionProperty(HTTP_FILE_ARGS, new ArrayList<HTTPFileArg>()));
+        setHTTPFileArgs(new ArrayList<>());
+    }
+
+    @Override
+    public HTTPFileArgsSchema getSchema() {
+        return HTTPFileArgsSchema.INSTANCE;
+    }
+
+    @Override
+    public PropertiesAccessor<? extends HTTPFileArgs, ? extends HTTPFileArgsSchema> getProps() {
+        return new PropertiesAccessor<>(this, getSchema());
     }
 
     /**
@@ -50,7 +58,7 @@ public class HTTPFileArgs extends ConfigTestElement implements Serializable {
      * @return the files
      */
     public CollectionProperty getHTTPFileArgsCollection() {
-        return (CollectionProperty) getProperty(HTTP_FILE_ARGS);
+        return getOrNull(getSchema().getFileArguments());
     }
 
     /**
@@ -59,7 +67,7 @@ public class HTTPFileArgs extends ConfigTestElement implements Serializable {
     @Override
     public void clear() {
         super.clear();
-        setProperty(new CollectionProperty(HTTP_FILE_ARGS, new ArrayList<HTTPFileArg>()));
+        setHTTPFileArgs(new ArrayList<>());
     }
 
     /**
@@ -68,7 +76,7 @@ public class HTTPFileArgs extends ConfigTestElement implements Serializable {
      * @param files the new files
      */
     public void setHTTPFileArgs(List<HTTPFileArg> files) {
-        setProperty(new CollectionProperty(HTTP_FILE_ARGS, files));
+        set(getSchema().getFileArguments(), files);
     }
 
     /**

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
@@ -25,6 +25,7 @@ import org.apache.jmeter.protocol.http.control.CookieManager
 import org.apache.jmeter.protocol.http.control.DNSCacheManager
 import org.apache.jmeter.protocol.http.control.HeaderManager
 import org.apache.jmeter.protocol.http.util.HTTPConstants
+import org.apache.jmeter.protocol.http.util.HTTPFileArgs
 import org.apache.jmeter.testelement.TestElementSchema
 import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
 import org.apache.jmeter.testelement.schema.IntegerPropertyDescriptor
@@ -132,4 +133,7 @@ public abstract class HTTPSamplerBaseSchema : TestElementSchema() {
 
     public val ipSourceType: IntegerPropertyDescriptor<HTTPSamplerBaseSchema>
         by int("HTTPSampler.ipSourceType", default = HTTPSamplerBase.SourceType.HOSTNAME.ordinal)
+
+    public val fileArguments: TestElementPropertyDescriptor<HTTPSamplerBaseSchema, HTTPFileArgs>
+        by testElement("HTTPsampler.Files")
 }

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/util/HTTPFileArgSchema.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/util/HTTPFileArgSchema.kt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http.util
+
+import org.apache.jmeter.config.ConfigTestElementSchema
+import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [HTTPFileArg].
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public abstract class HTTPFileArgSchema : ConfigTestElementSchema() {
+    public companion object INSTANCE : HTTPFileArgSchema()
+
+    /** File's path */
+    public val path: StringPropertyDescriptor<HTTPFileArgSchema>
+        by string("File.path")
+
+    /** Name of the parameter that stores the file */
+    public val parameterName: StringPropertyDescriptor<HTTPFileArgSchema>
+        by string("File.paramname")
+
+    /** File's mimetype */
+    public val mimeType: StringPropertyDescriptor<HTTPFileArgSchema>
+        by string("File.mimetype")
+}

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/util/HTTPFileArgsSchema.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/util/HTTPFileArgsSchema.kt
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http.util
+
+import org.apache.jmeter.config.ConfigTestElementSchema
+import org.apache.jmeter.testelement.schema.CollectionPropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Lists properties of a [HTTPFileArgs].
+ * @since 5.6
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6")
+public abstract class HTTPFileArgsSchema : ConfigTestElementSchema() {
+    public companion object INSTANCE : HTTPFileArgsSchema()
+
+    public val fileArguments: CollectionPropertyDescriptor<HTTPFileArgsSchema>
+        by collection("HTTPFileArgs.files")
+}

--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http.sampler
+
+import com.github.tomakehurst.wiremock.client.WireMock.aMultipart
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import org.apache.jmeter.control.LoopController
+import org.apache.jmeter.junit.JMeterTestCase
+import org.apache.jmeter.protocol.http.util.HTTPFileArg
+import org.apache.jmeter.test.assertions.executePlanAndCollectEvents
+import org.apache.jmeter.threads.ThreadGroup
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.writeText
+import kotlin.time.Duration.Companion.seconds
+
+@WireMockTest
+class HttpSamplerTest : JMeterTestCase() {
+    @TempDir
+    lateinit var dir: Path
+
+    @ParameterizedTest
+    @ValueSource(strings = ["Java", "HttpClient4"])
+    fun `upload file uses percent encoding for filename`(httpImplementation: String, server: WireMockRuntimeInfo) {
+        server.wireMock.register(
+            post("/upload")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                )
+        )
+
+        // Quote is invalid character for a filename in Windows, so we do not test it here
+        // See ConversionUtilsTest for escaping quotes.
+        val testFile = dir.resolve("testfile привет %.txt")
+        testFile.writeText("hello, привет")
+
+        executePlanAndCollectEvents(10.seconds) {
+            ThreadGroup::class {
+                numThreads = 1
+                rampUp = 0
+                setSamplerController(
+                    LoopController().apply {
+                        loops = 1
+                    }
+                )
+                org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy::class {
+                    name = "Upload file"
+                    implementation = httpImplementation
+                    method = "POST"
+                    domain = "localhost"
+                    port = server.httpPort
+                    path = "/upload"
+                    httpFiles = arrayOf(
+                        HTTPFileArg(testFile.absolutePathString(), "file_parameter", "application/octet-stream")
+                    )
+                }
+            }
+        }
+
+        server.wireMock.verifyThat(
+            1,
+            postRequestedFor(urlEqualTo("/upload"))
+                .withAnyRequestBodyPart(
+                    aMultipart("file_parameter")
+                        .withHeader(
+                            "Content-Disposition",
+                            containing("filename=\"testfile%20%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82%20%25.txt\"")
+                        )
+                        .withBody(equalTo("hello, привет"))
+                )
+        )
+    }
+}

--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/util/ConversionUtilsTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/util/ConversionUtilsTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class ConversionUtilsTest {
+    @ParameterizedTest
+    @CsvSource(
+        ignoreLeadingAndTrailingWhitespace = false,
+        value = [
+            "hello,hello",
+            "%,%25",
+            "\",%22",
+            " ,%20",
+            "😃,%F0%9F%98%83",
+            "comment ça va?,comment%20%C3%A7a%20va%3F",
+        ]
+    )
+    fun percentEncode(input: String, output: String) {
+        assertEquals(output, ConversionUtils.percentEncode(input)) {
+            "ConversionUtils.percentEncode($input)"
+        }
+    }
+}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -179,6 +179,7 @@ Summary
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
   <li><pr>5901</pr>Fix NumberFormatException when counter is empty or not a digit on Proxy Settings panel</li>
+  <li><pr>5987</pr><issue>4546</issue>Encode unicode characters in filenames when sending files in HTTP Sampler</li>
 </ul>
 
 <h3>Other Samplers</h3>


### PR DESCRIPTION
## Description

Use RFC 7578 for encoding filenames when uploading files in HTTP Sampler.
HttpClient4 does not support filename encoding, so we encode it at JMeter side

## Motivation and Context

See https://github.com/apache/jmeter/issues/4546

## How Has This Been Tested?

See `ConversionUtilsTest`, `HttpSamplerTest`
