### PR TITLE
fix: restore public static final String references to literals for backward compatibility

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/config/Argument.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/Argument.java
@@ -33,16 +33,16 @@ public class Argument extends AbstractTestElement implements Serializable {
     private static final long serialVersionUID = 240L;
 
     /** Name used to store the argument's name. */
-    public static final String ARG_NAME = ArgumentSchema.INSTANCE.getArgumentName().getName();
+    public static final String ARG_NAME = "Argument.name"; // $NON-NLS-1$
 
     /** Name used to store the argument's value. */
-    public static final String VALUE = ArgumentSchema.INSTANCE.getValue().getName();
+    public static final String VALUE = "Argument.value"; // $NON-NLS-1$
 
     /** Name used to store the argument's description. */
-    public static final String DESCRIPTION = ArgumentSchema.INSTANCE.getDescription().getName();
+    public static final String DESCRIPTION = "Argument.desc"; // $NON-NLS-1$
 
     /** Name used to store the argument's metadata. */
-    public static final String METADATA = ArgumentSchema.INSTANCE.getMetadata().getName();
+    public static final String METADATA = "Argument.metadata"; // $NON-NLS-1$
 
     /**
      * Create a new Argument without a name, value, or metadata.

--- a/src/core/src/main/java/org/apache/jmeter/config/Arguments.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/Arguments.java
@@ -37,7 +37,7 @@ public class Arguments extends ConfigTestElement implements Serializable, Iterab
     private static final long serialVersionUID = 240L;
 
     /** The name of the property used to store the arguments. */
-    public static final String ARGUMENTS = ArgumentsSchema.INSTANCE.getArguments().getName();
+    public static final String ARGUMENTS = "Arguments.arguments"; //$NON-NLS-1$
 
     /**
      * Create a new Arguments object with no arguments.

--- a/src/core/src/main/java/org/apache/jmeter/control/LoopController.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/LoopController.java
@@ -33,7 +33,7 @@ public class LoopController extends GenericController implements Serializable, I
 
     public static final int INFINITE_LOOP_COUNT = -1; // $NON-NLS-1$
 
-    public static final String LOOPS = LoopControllerSchema.INSTANCE.getLoops().getName();
+    public static final String LOOPS = "LoopController.loops"; // $NON-NLS-1$
 
     private static final long serialVersionUID = 7833960784370272300L;
     private static final Logger LOGGER = LoggerFactory.getLogger(LoopController.class);

--- a/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -58,7 +58,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
                     JMeterUtils.getPropDefault("jmeterengine.threadstop.wait", 5 * 1000L));
 
     /** Action to be taken when a Sampler error occurs */
-    public static final String ON_SAMPLE_ERROR = AbstractThreadGroupSchema.INSTANCE.getOnSampleError().getName();
+    public static final String ON_SAMPLE_ERROR = "ThreadGroup.on_sample_error"; // int
 
     /** Continue, i.e. ignore sampler errors */
     public static final String ON_SAMPLE_ERROR_CONTINUE = "continue";
@@ -76,17 +76,12 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
     public static final String ON_SAMPLE_ERROR_STOPTEST_NOW = "stoptestnow";
 
     /** Number of threads in the thread group */
-    @Deprecated
-    public static final String NUM_THREADS =
-            AbstractThreadGroupSchema.INSTANCE.getNumThreads().getName();
+    public static final String NUM_THREADS = "ThreadGroup.num_threads";
 
-    public static final String MAIN_CONTROLLER =
-            AbstractThreadGroupSchema.INSTANCE.getMainController().getName();
+    public static final String MAIN_CONTROLLER = "ThreadGroup.main_controller";
 
     /** The same user or different users */
-    @Deprecated
-    public static final String IS_SAME_USER_ON_NEXT_ITERATION =
-            AbstractThreadGroupSchema.INSTANCE.getSameUserOnNextIteration().getName();
+    public static final String IS_SAME_USER_ON_NEXT_ITERATION = "ThreadGroup.same_user_on_next_iteration";
 
 
     private final AtomicInteger numberOfThreads = new AtomicInteger(0); // Number of active threads in this group

--- a/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
@@ -57,20 +57,19 @@ public class ThreadGroup extends AbstractThreadGroup {
     //+ JMX entries - do not change the string values
 
     /** Ramp-up time */
-    public static final String RAMP_TIME = ThreadGroupSchema.INSTANCE.getRampTime().getName();
+    public static final String RAMP_TIME = "ThreadGroup.ramp_time";
 
     /** Whether thread startup is delayed until required */
-    @Deprecated
-    public static final String DELAYED_START = ThreadGroupSchema.INSTANCE.getDelayedStart().getName();
+    public static final String DELAYED_START = "ThreadGroup.delayedStart";
 
     /** Whether scheduler is being used */
-    public static final String SCHEDULER = ThreadGroupSchema.INSTANCE.getUseScheduler().getName();
+    public static final String SCHEDULER = "ThreadGroup.scheduler";
 
     /** Scheduler duration, overrides end time */
-    public static final String DURATION = ThreadGroupSchema.INSTANCE.getDuration().getName();
+    public static final String DURATION = "ThreadGroup.duration";
 
     /** Scheduler start delay, overrides start time */
-    public static final String DELAY = ThreadGroupSchema.INSTANCE.getDelay().getName();
+    public static final String DELAY = "ThreadGroup.delay";
     //- JMX entries
 
     private transient Thread threadStarter;

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
@@ -44,19 +44,14 @@ import org.apiguardian.api.API
 
 public interface TestElement : Cloneable {
     public companion object {
-        @JvmField
-        public val NAME: String = TestElementSchema.name.name
-        @JvmField
-        public val GUI_CLASS: String = TestElementSchema.guiClass.name
-        @JvmField
-        public val ENABLED: String = TestElementSchema.enabled.name
-        @JvmField
-        public val TEST_CLASS: String = TestElementSchema.testClass.name
+        public const val NAME: String = "TestElement.name" // $NON-NLS-1$
+        public const val GUI_CLASS: String = "TestElement.gui_class" // $NON-NLS-1$
+        public const val ENABLED: String = "TestElement.enabled" // $NON-NLS-1$
+        public const val TEST_CLASS: String = "TestElement.test_class" // $NON-NLS-1$
 
         // Needed by AbstractTestElement.
         // Also TestElementConverter and TestElementPropertyConverter for handling empty comments
-        @JvmField
-        public val COMMENTS: String = TestElementSchema.comments.name
+        public const val COMMENTS: String = "TestPlan.comments" // $NON-NLS-1$
     }
 
     public val schema: TestElementSchema

--- a/src/core/src/test/java/org/apache/jmeter/testelement/TestElementTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/testelement/TestElementTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.testelement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestElementTest {
+    /**
+     * Verifies that {@code TestElement.NAME} is workable in annotations.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {TestElement.NAME})
+    public void fieldBackwardCompatibility(String name) {
+        assertEquals("TestElement.name", name);
+    }
+}

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HeaderManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HeaderManager.java
@@ -45,7 +45,7 @@ public class HeaderManager extends ConfigTestElement implements Serializable, Re
 
     private static final long serialVersionUID = 240L;
 
-    public static final String HEADERS = HeaderManagerSchema.INSTANCE.getHeaders().getName();
+    public static final String HEADERS = "HeaderManager.headers";// $NON-NLS-1$
 
     private static final String[] COLUMN_RESOURCE_NAMES = {
           "name",             // $NON-NLS-1$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -121,57 +121,55 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                     "org.apache.jmeter.testbeans.gui.TestBeanGUI"
             ));
 
-    private static final HTTPSamplerBaseSchema SCHEMA = HTTPSamplerBaseSchema.INSTANCE;
-
     //+ JMX names - do not change
-    public static final String ARGUMENTS = SCHEMA.getArguments().getName();
+    public static final String ARGUMENTS = "HTTPsampler.Arguments"; // $NON-NLS-1$
 
-    public static final String AUTH_MANAGER = SCHEMA.getAuthManager().getName();
+    public static final String AUTH_MANAGER = "HTTPSampler.auth_manager"; // $NON-NLS-1$
 
-    public static final String COOKIE_MANAGER = SCHEMA.getCookieManager().getName();
+    public static final String COOKIE_MANAGER = "HTTPSampler.cookie_manager"; // $NON-NLS-1$
 
-    public static final String KEYSTORE_CONFIG = SCHEMA.getCookieManager().getName();
+    public static final String KEYSTORE_CONFIG = "HTTPSampler.keystore_configuration"; // $NON-NLS-1$
 
     public static final String SAMPLE_TIMEOUT = "HTTPSampler.sample_timeout"; // $NON-NLS-1$
 
-    public static final String CACHE_MANAGER = SCHEMA.getCacheManager().getName();
+    public static final String CACHE_MANAGER = "HTTPSampler.cache_manager"; // $NON-NLS-1$
 
-    public static final String HEADER_MANAGER = SCHEMA.getHeaderManager().getName();
+    public static final String HEADER_MANAGER = "HTTPSampler.header_manager"; // $NON-NLS-1$
 
-    public static final String DNS_CACHE_MANAGER = SCHEMA.getDnsCacheManager().getName();
+    public static final String DNS_CACHE_MANAGER = "HTTPSampler.dns_cache_manager"; // $NON-NLS-1$
 
-    public static final String DOMAIN = SCHEMA.getDomain().getName();
+    public static final String DOMAIN = "HTTPSampler.domain"; // $NON-NLS-1$
 
-    public static final String PORT = SCHEMA.getPort().getName();
+    public static final String PORT = "HTTPSampler.port"; // $NON-NLS-1$
 
-    public static final String PROXYSCHEME = SCHEMA.getProxy().getScheme().getName();
+    public static final String PROXYSCHEME = "HTTPSampler.proxyScheme"; // $NON-NLS-1$
 
-    public static final String PROXYHOST = SCHEMA.getProxy().getHost().getName();
+    public static final String PROXYHOST = "HTTPSampler.proxyHost"; // $NON-NLS-1$
 
-    public static final String PROXYPORT = SCHEMA.getProxy().getPort().getName();
+    public static final String PROXYPORT = "HTTPSampler.proxyPort"; // $NON-NLS-1$
 
-    public static final String PROXYUSER = SCHEMA.getProxy().getUsername().getName();
+    public static final String PROXYUSER = "HTTPSampler.proxyUser"; // $NON-NLS-1$
 
-    public static final String PROXYPASS = SCHEMA.getProxy().getPassword().getName();
+    public static final String PROXYPASS = "HTTPSampler.proxyPass"; // $NON-NLS-1$
 
-    public static final String CONNECT_TIMEOUT = SCHEMA.getConnectTimeout().getName();
+    public static final String CONNECT_TIMEOUT = "HTTPSampler.connect_timeout"; // $NON-NLS-1$
 
-    public static final String RESPONSE_TIMEOUT = SCHEMA.getResponseTimeout().getName();
+    public static final String RESPONSE_TIMEOUT = "HTTPSampler.response_timeout"; // $NON-NLS-1$
 
-    public static final String METHOD = SCHEMA.getMethod().getName();
+    public static final String METHOD = "HTTPSampler.method"; // $NON-NLS-1$
 
     /** This is the encoding used for the content, i.e. the charset name, not the header "Content-Encoding" */
-    public static final String CONTENT_ENCODING = SCHEMA.getContentEncoding().getName();
+    public static final String CONTENT_ENCODING = "HTTPSampler.contentEncoding"; // $NON-NLS-1$
 
-    public static final String IMPLEMENTATION = SCHEMA.getImplementation().getName();
+    public static final String IMPLEMENTATION = "HTTPSampler.implementation"; // $NON-NLS-1$
 
-    public static final String PATH = SCHEMA.getPath().getName();
+    public static final String PATH = "HTTPSampler.path"; // $NON-NLS-1$
 
-    public static final String FOLLOW_REDIRECTS = SCHEMA.getFollowRedirects().getName();
+    public static final String FOLLOW_REDIRECTS = HTTPSamplerBaseSchema.INSTANCE.getFollowRedirects().getName();
 
-    public static final String AUTO_REDIRECTS = SCHEMA.getAutoRedirects().getName();
+    public static final String AUTO_REDIRECTS = "HTTPSampler.auto_redirects"; // $NON-NLS-1$
 
-    public static final String PROTOCOL = SCHEMA.getProtocol().getName();
+    public static final String PROTOCOL = "HTTPSampler.protocol"; // $NON-NLS-1$
 
     static final String PROTOCOL_FILE = "file"; // $NON-NLS-1$
 
@@ -180,24 +178,21 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     /**
      * IP source to use - does not apply to Java HTTP implementation currently
      */
-    public static final String IP_SOURCE = SCHEMA.getIpSource().getName();
+    public static final String IP_SOURCE = "HTTPSampler.ipSource"; // $NON-NLS-1$
 
-    public static final String IP_SOURCE_TYPE = SCHEMA.getIpSourceType().getName();
+    public static final String IP_SOURCE_TYPE = "HTTPSampler.ipSourceType"; // $NON-NLS-1$
 
-    public static final String USE_KEEPALIVE = SCHEMA.getUseKeepalive().getName();
+    public static final String USE_KEEPALIVE = "HTTPSampler.use_keepalive"; // $NON-NLS-1$
 
-    public static final String DO_MULTIPART_POST = SCHEMA.getUseMultipartPost().getName();
+    public static final String DO_MULTIPART_POST = "HTTPSampler.DO_MULTIPART_POST"; // $NON-NLS-1$
 
-    public static final String BROWSER_COMPATIBLE_MULTIPART =
-            SCHEMA.getUseBrowserCompatibleMultipart().getName();
+    public static final String BROWSER_COMPATIBLE_MULTIPART  = "HTTPSampler.BROWSER_COMPATIBLE_MULTIPART"; // $NON-NLS-1$
 
-    public static final String CONCURRENT_DWN = SCHEMA.getConcurrentDownload().getName();
+    public static final String CONCURRENT_DWN = "HTTPSampler.concurrentDwn"; // $NON-NLS-1$
 
-    public static final String CONCURRENT_POOL = SCHEMA.getConcurrentDownloadPoolSize().getName();
+    public static final String CONCURRENT_POOL = "HTTPSampler.concurrentPool"; // $NON-NLS-1$
 
-    // Default concurrent pool size for download embedded resources
-    @SuppressWarnings("DataFlowIssue")
-    public static final int CONCURRENT_POOL_SIZE = SCHEMA.getConcurrentDownloadPoolSize().getDefaultValue();
+    public static final int CONCURRENT_POOL_SIZE = 6; // Default concurrent pool size for download embedded resources
 
     private static final String USER_AGENT = "User-Agent"; // $NON-NLS-1$
 
@@ -265,18 +260,18 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     public static final String CONTENT_TYPE = "HTTPSampler.CONTENT_TYPE"; // $NON-NLS-1$
 
     // IMAGE_PARSER now really means EMBEDDED_PARSER
-    public static final String IMAGE_PARSER = SCHEMA.getRetrieveEmbeddedResources().getName();
+    public static final String IMAGE_PARSER = "HTTPSampler.image_parser"; // $NON-NLS-1$
 
     // Embedded URLs must match this RE (if provided)
-    public static final String EMBEDDED_URL_RE = SCHEMA.getEmbeddedUrlAllowRegex().getName();
+    public static final String EMBEDDED_URL_RE = "HTTPSampler.embedded_url_re"; // $NON-NLS-1$
 
     // Embedded URLs must not match this RE (if provided)
-    public static final String EMBEDDED_URL_EXCLUDE_RE = SCHEMA.getEmbeddedUrlExcludeRegex().getName();
+    public static final String EMBEDDED_URL_EXCLUDE_RE = "HTTPSampler.embedded_url_exclude_re"; // $NON-NLS-1$
 
     public static final String MONITOR = "HTTPSampler.monitor"; // $NON-NLS-1$
 
     // Store MD5 hash instead of storing response
-    public static final String MD5 = SCHEMA.getStoreAsMD5().getName();
+    public static final String MD5 = "HTTPSampler.md5"; // $NON-NLS-1$
 
     /** A number to indicate that the port has not been set. */
     public static final int UNSPECIFIED_PORT = 0;
@@ -290,10 +285,9 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     protected static final String NON_HTTP_RESPONSE_MESSAGE = "Non HTTP response message";
 
-    public static final String POST_BODY_RAW = SCHEMA.getPostBodyRaw().getName();
+    public static final String POST_BODY_RAW = "HTTPSampler.postBodyRaw";
 
-    @SuppressWarnings("DataFlowIssue")
-    public static final boolean POST_BODY_RAW_DEFAULT = SCHEMA.getPostBodyRaw().getDefaultValue();
+    public static final boolean POST_BODY_RAW_DEFAULT = false;
 
     private static final String ARG_VAL_SEP = "="; // $NON-NLS-1$
 

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
@@ -50,35 +50,15 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
 
     private static final long serialVersionUID = 4;
 
-    /**
-     * @deprecated use {@link BeanShellSamplerSchema#getFilename()} instead
-     */
-    @Deprecated
-    public static final String FILENAME = BeanShellSamplerSchema.INSTANCE.getFilename().getName();
+    public static final String FILENAME = "BeanShellSampler.filename"; //$NON-NLS-1$
 
-    /**
-     * @deprecated use {@link BeanShellSamplerSchema#getFilename()} instead
-     */
-    @Deprecated
-    public static final String SCRIPT = BeanShellSamplerSchema.INSTANCE.getScript().getName();
+    public static final String SCRIPT = "BeanShellSampler.query"; //$NON-NLS-1$
 
-    /**
-     * @deprecated use {@link BeanShellSamplerSchema#getParameters()} instead
-     */
-    @Deprecated
-    public static final String PARAMETERS = BeanShellSamplerSchema.INSTANCE.getParameters().getName();
+    public static final String PARAMETERS = "BeanShellSampler.parameters"; //$NON-NLS-1$
 
-    /**
-     * @deprecated use {@link BeanShellSamplerSchema#getInitFile()} instead
-     */
-    @Deprecated
-    public static final String INIT_FILE = BeanShellSamplerSchema.INSTANCE.getInitFile().getName();
+    public static final String INIT_FILE = "beanshell.sampler.init"; //$NON-NLS-1$
 
-    /**
-     * @deprecated use {@link BeanShellSamplerSchema#getResetInterpreter()} instead
-     */
-    @Deprecated
-    public static final String RESET_INTERPRETER = BeanShellSamplerSchema.INSTANCE.getResetInterpreter().getName();
+    public static final String RESET_INTERPRETER = "BeanShellSampler.resetInterpreter"; //$NON-NLS-1$
 
     private transient volatile BeanShellInterpreter savedBsh = null;
 


### PR DESCRIPTION
## Motivation and Context

Previously, TestElement.NAME and similar constants were coded as literals, and it was possible to use those references in annotation values.

If the replace literals with method calls, then it would be impossible to use the fields in annotation values.

So the static fields are reverted to literals.

This partially reverts commits like https://github.com/apache/jmeter/pull/678,
