### PR TITLE
docs: add release-drafter for populating GitHub releases info based on the PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,75 @@
+# See https://github.com/release-drafter/release-drafter#configuration-options
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+# Filter previous releases to consider only those with the target matching the current branch
+filter-by-commitish: true
+tag-prefix: REL
+exclude-labels:
+  - 'skip-changelog'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'defect'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '⬆️ Dependencies'
+    collapse-after: 8
+    labels:
+      - 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES
+# See https://github.com/release-drafter/release-drafter#autolabeler
+# This is more like a reference, since auto-labelling PRs seems to require too much privileges
+autolabeler:
+  - label: 'dependencies'
+    files:
+      - 'gradle-wrapper.properties'
+    title:
+      - '/^fix\(deps\)/i'
+      - '/^chore:\s*bump/i'
+  - label: 'chore'
+    files:
+      - '*gradle*'
+    branch:
+      - '/docs{0,1}\/.+/'
+    title:
+      - '/^chore/i'
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/^fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+    title:
+      - '/^feat/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+      - 'release/**'
+  # pull_request_target allows PR from forks to access secrets, so please NEVER add pull_request_target
+
+jobs:
+  update_release_draft:
+    # Skip release drafts in forks
+    if: github.repository_owner == 'apache'
+    name: Update Release Draft
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - name: Update release body draft
+        uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
+        id: prepare_release
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        with:
+        #   config-name: my-config.yml
+           disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -101,6 +101,7 @@ Summary
 
 <ch_section>Non-functional changes</ch_section>
 <ul>
+  <li><pr>6000</pr>Add release-drafter for populating GitHub releases info based on the merged PRs</li>
 </ul>
 
  <!-- =================== Bug fixes =================== -->


### PR DESCRIPTION
## Description

This will populate https://github.com/apache/jmeter/releases based on the merged PRs.

## Motivation and Context

GitHub Releases are convenient for the following use-cases:
1) User is already browsing GitHub sources, so they might quickly peek for the changes
2) Dependabot and Renovatebot can infer links to GitHub Releases, so the users will have a non-empty changelog when reviewing PRs from the bots

## How Has This Been Tested?

The similar configuration works for pgjdbc/pgjdbc, see https://github.com/pgjdbc/pgjdbc/releases
