### PR TITLE
fix: use UTF-8 as a default encoding in HTTP sampler

### DIFF
--- a/bin/testfiles/HTMLParserTestFile_2.xml
+++ b/bin/testfiles/HTMLParserTestFile_2.xml
@@ -10,7 +10,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2.html</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-1" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="1321" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-1" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="1321" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>
@@ -29,7 +29,7 @@
       <queryString class="java.lang.String"></queryString>
       <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/halfbanner.htm</java.net.URL>
     </httpSample>
-    <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2_files/halfbanner.htm-1" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="5421" sc="1" ec="0" ng="0" na="0">
+    <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2_files/halfbanner.htm-1" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="5421" sc="1" ec="0" ng="0" na="0">
       <responseHeader class="java.lang.String"></responseHeader>
       <requestHeader class="java.lang.String"></requestHeader>
       <responseFile class="java.lang.String"></responseFile>
@@ -46,7 +46,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/halfbanner.htm</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-3" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="8584" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-3" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="8584" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>
@@ -55,7 +55,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/jakarta-logo.gif</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-4" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="8886" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-4" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="8886" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>
@@ -64,7 +64,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/logo.jpg</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-5" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="3064" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-5" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="3064" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>
@@ -73,7 +73,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/http-config-example.png</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-6" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="2395" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-6" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="2395" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>
@@ -82,7 +82,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/scoping1.png</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-7" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="2641" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-7" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="2641" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>
@@ -91,7 +91,7 @@
     <queryString class="java.lang.String"></queryString>
     <java.net.URL>file:testfiles/HTMLParserTestFile_2_files/scoping2.png</java.net.URL>
   </httpSample>
-  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-8" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="" by="3260" sc="1" ec="0" ng="1" na="1">
+  <httpSample s="true" lb="file:testfiles/HTMLParserTestFile_2.html-8" rc="200" rm="OK" tn="Thread Group 1-1" dt="text" de="UTF-8" by="3260" sc="1" ec="0" ng="1" na="1">
     <responseHeader class="java.lang.String"></responseHeader>
     <requestHeader class="java.lang.String"></requestHeader>
     <responseFile class="java.lang.String"></responseFile>

--- a/bin/testfiles/TEST_HTTP.jmx
+++ b/bin/testfiles/TEST_HTTP.jmx
@@ -932,7 +932,7 @@ mirrorServer.start();</stringProp>
             <stringProp name="cacheKey">true</stringProp>
             <stringProp name="filename"></stringProp>
             <stringProp name="parameters"></stringProp>
-            <stringProp name="script">String textToCheck =  &apos;Content-Disposition: form-data; name=&quot;?_param&quot;&apos;;
+            <stringProp name="script">String textToCheck =  &apos;Content-Disposition: form-data; name=&quot;安_param&quot;&apos;;
 if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
 	AssertionResult.setFailure(true);
 	AssertionResult.setFailureMessage(&quot;Request does not contains &apos;&quot;+textToCheck+&quot;&apos;&quot;);
@@ -1005,7 +1005,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="-1049865380">nv_contentType</stringProp>
-              <stringProp name="817335912">text/plain</stringProp>
+              <stringProp name="1947100436">text/plain; charset=UTF-8</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
@@ -56,7 +56,7 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
      * The default encoding to be used if not overridden.
      * The value is ISO-8859-1.
      */
-    public static final String DEFAULT_HTTP_ENCODING = StandardCharsets.ISO_8859_1.name();
+    public static final String DEFAULT_HTTP_ENCODING = StandardCharsets.UTF_8.name();
 
     private static final String OK_CODE = Integer.toString(HttpURLConnection.HTTP_OK);
     private static final String OK_MSG = "OK"; // $NON-NLS-1$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -43,7 +43,6 @@ import org.apache.jmeter.protocol.http.control.gui.GraphQLHTTPSamplerGui;
 import org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerFactory;
-import org.apache.jmeter.protocol.http.sampler.PostWriter;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
 import org.apache.jmeter.protocol.http.util.GraphQLRequestParamUtils;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
@@ -218,24 +217,10 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
             final String contentType = request.getContentType();
             MultipartUrlConfig urlConfig = request.getMultipartConfig(contentType);
             String contentEncoding = sampler.getContentEncoding();
+            log.debug("Using encoding {} for request body", contentEncoding);
+
             // Get the post data using the content encoding of the request
-            String postData = null;
-            if (log.isDebugEnabled()) {
-                if(!StringUtils.isEmpty(contentEncoding)) {
-                    log.debug("Using encoding {} for request body", contentEncoding);
-                }
-                else {
-                    log.debug("No encoding found, using JRE default encoding for request body");
-                }
-            }
-
-
-            if (!StringUtils.isEmpty(contentEncoding)) {
-                postData = new String(request.getRawPostData(), contentEncoding);
-            } else {
-                // Use default encoding
-                postData = new String(request.getRawPostData(), PostWriter.ENCODING);
-            }
+            String postData = new String(request.getRawPostData(), contentEncoding);
 
             if (urlConfig != null) {
                 urlConfig.parseArguments(postData);
@@ -436,16 +421,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
      * @param request {@link HttpRequestHdr}
      */
     protected void computePath(HTTPSamplerBase sampler, HttpRequestHdr request) {
-        if(sampler.getContentEncoding() != null) {
-            sampler.setPath(request.getPath(), sampler.getContentEncoding());
-        }
-        else {
-            // Although the spec says UTF-8 should be used for encoding URL parameters,
-            // most browser use ISO-8859-1 for default if encoding is not known.
-            // We use null for contentEncoding, then the url parameters will be added
-            // with the value in the URL, and the "encode?" flag set to false
-            sampler.setPath(request.getPath(), null);
-        }
+        sampler.setPath(request.getPath(), sampler.getContentEncoding());
         if (log.isDebugEnabled()) {
             log.debug("Proxy: finished setting path: {}", sampler.getPath());
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
@@ -165,7 +165,7 @@ public class HttpRequestHdr {
                     inHeaders = false;
                     firstLine = false; // cannot be first line either
                 }
-                final String reqLine = line.toString(StandardCharsets.ISO_8859_1.name());
+                final String reqLine = line.toString(StandardCharsets.UTF_8.name());
                 if (firstLine) {
                     parseFirstLine(reqLine);
                     firstLine = false;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -558,7 +558,11 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @return the encoding of the content, i.e. its charset name
      */
     public String getContentEncoding() {
-        return get(getSchema().getContentEncoding());
+        String encoding = get(getSchema().getContentEncoding());
+        if (encoding.isEmpty()) {
+            return getSchema().getContentEncoding().getDefaultValue();
+        }
+        return encoding;
     }
 
     public void setUseKeepAlive(boolean value) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
@@ -22,8 +22,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -32,7 +34,6 @@ import org.apache.jmeter.protocol.http.util.ConversionUtils;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
-import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 
 /**
@@ -49,7 +50,9 @@ public class PostWriter {
 
     private static final byte[] CRLF = { 0x0d, 0x0A };
 
-    public static final String ENCODING = StandardCharsets.ISO_8859_1.name();
+    private static final String CRLF_STRING = "\r\n";
+
+    public static final String ENCODING = StandardCharsets.UTF_8.name();
 
     /** The form data that is going to be sent as url encoded */
     protected byte[] formDataUrlEncoded;
@@ -57,6 +60,9 @@ public class PostWriter {
     protected byte[] formDataPostBody;
     /** The boundary string for multipart */
     private final String boundary;
+
+    private final String multipartDivider;
+    private final byte[] multipartDividerBytes;
 
     /**
      * Constructor for PostWriter.
@@ -74,6 +80,8 @@ public class PostWriter {
      */
     public PostWriter(String boundary) {
         this.boundary = boundary;
+        this.multipartDivider = DASH_DASH + boundary;
+        this.multipartDividerBytes = multipartDivider.getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -94,9 +102,6 @@ public class PostWriter {
         HTTPFileArg[] files = sampler.getHTTPFiles();
 
         String contentEncoding = sampler.getContentEncoding();
-        if(contentEncoding == null || contentEncoding.length() == 0) {
-            contentEncoding = ENCODING;
-        }
 
         // Check if we should do a multipart/form-data or an
         // application/x-www-form-urlencoded post request
@@ -111,11 +116,16 @@ public class PostWriter {
             postedBody.append(new String(formDataPostBody, contentEncoding));
 
             // Add any files
-            for (int i=0; i < files.length; i++) {
-                HTTPFileArg file = files[i];
+            for (HTTPFileArg file : files) {
+                out.write(multipartDividerBytes);
+                out.write(CRLF);
+                postedBody.append(multipartDivider);
+                postedBody.append("\r\n");
+
                 // First write the start multipart file
                 final String headerValue = file.getHeader();
-                byte[] header = headerValue.getBytes(ENCODING);
+                // TODO: reuse the bytes prepared in org.apache.jmeter.protocol.http.sampler.PostWriter.setHeaders
+                byte[] header = headerValue.getBytes(contentEncoding);
                 out.write(header);
                 // Retrieve the formatted data using the same encoding used to create it
                 postedBody.append(headerValue);
@@ -123,22 +133,15 @@ public class PostWriter {
                 writeFileToStream(file.getPath(), out);
                 // We just add placeholder text for file content
                 postedBody.append("<actual file content, not shown here>"); // $NON-NLS-1$
-                // Write the end of multipart file
-                byte[] fileMultipartEndDivider = getFileMultipartEndDivider();
-                out.write(fileMultipartEndDivider);
-                // Retrieve the formatted data using the same encoding used to create it
-                postedBody.append(new String(fileMultipartEndDivider, ENCODING));
-                if(i + 1 < files.length) {
-                    out.write(CRLF);
-                    postedBody.append(new String(CRLF, SampleResult.DEFAULT_HTTP_ENCODING));
-                }
+                out.write(CRLF);
+                postedBody.append(CRLF_STRING);
             }
-            // Write end of multipart
-            byte[] multipartEndDivider = getMultipartEndDivider();
-            out.write(multipartEndDivider);
-            postedBody.append(new String(multipartEndDivider, ENCODING));
-
-            out.flush();
+            // Write end of multipart: --, boundary, --, CRLF
+            out.write(multipartDividerBytes);
+            out.write(DASH_DASH_BYTES);
+            out.write(CRLF);
+            postedBody.append(multipartDivider);
+            postedBody.append("--\r\n");
             out.close();
         }
         else {
@@ -172,9 +175,6 @@ public class PostWriter {
     public void setHeaders(URLConnection connection, HTTPSamplerBase sampler) throws IOException {
         // Get the encoding to use for the request
         String contentEncoding = sampler.getContentEncoding();
-        if(contentEncoding == null || contentEncoding.length() == 0) {
-            contentEncoding = ENCODING;
-        }
         long contentLength = 0L;
         HTTPFileArg[] files = sampler.getHTTPFiles();
 
@@ -188,9 +188,7 @@ public class PostWriter {
 
             // Write the form section
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
-
-            // First the multipart start divider
-            bos.write(getMultipartDivider());
+            OutputStreamWriter osw = new OutputStreamWriter(bos, contentEncoding);
             // Add any parameters
             for (JMeterProperty jMeterProperty : sampler.getArguments()) {
                 HTTPArgument arg = (HTTPArgument) jMeterProperty.getObjectValue();
@@ -198,49 +196,40 @@ public class PostWriter {
                 if (arg.isSkippable(parameterName)) {
                     continue;
                 }
-                // End the previous multipart
-                bos.write(CRLF);
                 // Write multipart for parameter
-                writeFormMultipart(bos, parameterName, arg.getValue(), contentEncoding, sampler.getDoBrowserCompatibleMultipart());
+                writeFormMultipart(osw, contentEncoding, parameterName, arg.getValue(), sampler.getDoBrowserCompatibleMultipart());
             }
-            // If there are any files, we need to end the previous multipart
-            if(files.length > 0) {
-                // End the previous multipart
-                bos.write(CRLF);
-            }
-            bos.flush();
+            osw.flush();
             // Keep the content, will be sent later
             formDataPostBody = bos.toByteArray();
-            bos.close();
             contentLength = formDataPostBody.length;
 
             // Now we just construct any multipart for the files
             // We only construct the file multipart start, we do not write
             // the actual file content
-            for (int i=0; i < files.length; i++) {
+            for (int i = 0; i < files.length; i++) {
+                bos.reset();
+                contentLength += multipartDividerBytes.length + CRLF.length;
                 HTTPFileArg file = files[i];
                 // Write multipart for file
-                bos = new ByteArrayOutputStream();
-                writeStartFileMultipart(bos, file.getPath(), file.getParamName(), file.getMimeType());
-                bos.flush();
-                String header = bos.toString(contentEncoding);// TODO is this correct?
+                writeStartFileMultipart(osw, contentEncoding, file.getPath(), file.getParamName(), file.getMimeType());
+                osw.flush();
+                // Technically speaking, we should refrain from decoding the header to string
+                // since we will have to encode it again when sending the request
+                // However, HTTPFileArg#setHeaer(byte[]) does not exist yet
+                String header = bos.toString(contentEncoding);
                 // If this is not the first file we can't write its header now
                 // for simplicity we always save it, even if there is only one file
                 file.setHeader(header);
-                bos.close();
-                contentLength += header.length();
+                contentLength += bos.size();
                 // Add also the length of the file content
                 File uploadFile = new File(file.getPath());
                 contentLength += uploadFile.length();
-                // And the end of the file multipart
-                contentLength += getFileMultipartEndDivider().length;
-                if(i+1 < files.length) {
-                    contentLength += CRLF.length;
-                }
+                contentLength += CRLF.length;
             }
 
             // Add the end of multipart
-            contentLength += getMultipartEndDivider().length;
+            contentLength += multipartDividerBytes.length + DASH_DASH_BYTES.length + CRLF.length;
 
             // Set the content length
             connection.setRequestProperty(HTTPConstants.HEADER_CONTENT_LENGTH, Long.toString(contentLength));
@@ -344,59 +333,32 @@ public class PostWriter {
     }
 
     /**
-     * Get the bytes used to separate multiparts
-     * Encoded using ENCODING
-     *
-     * @return the bytes used to separate multiparts
-     * @throws IOException
-     */
-    private byte[] getMultipartDivider() throws IOException {
-        return (DASH_DASH + getBoundary()).getBytes(ENCODING);
-    }
-
-    /**
-     * Get the bytes used to end a file multipart
-     * Encoded using ENCODING
-     *
-     * @return the bytes used to end a file multipart
-     * @throws IOException
-     */
-    private byte[] getFileMultipartEndDivider() throws IOException{
-        byte[] ending = getMultipartDivider();
-        byte[] completeEnding = new byte[ending.length + CRLF.length];
-        System.arraycopy(CRLF, 0, completeEnding, 0, CRLF.length);
-        System.arraycopy(ending, 0, completeEnding, CRLF.length, ending.length);
-        return completeEnding;
-    }
-
-    /**
-     * Get the bytes used to end the multipart request
-     *
-     * @return the bytes used to end the multipart request
-     */
-    private static byte[] getMultipartEndDivider(){
-        byte[] ending = DASH_DASH_BYTES;
-        byte[] completeEnding = new byte[ending.length + CRLF.length];
-        System.arraycopy(ending, 0, completeEnding, 0, ending.length);
-        System.arraycopy(CRLF, 0, completeEnding, ending.length, CRLF.length);
-        return completeEnding;
-    }
-
-    /**
      * Write the start of a file multipart, up to the point where the
      * actual file content should be written
      */
-    private static void writeStartFileMultipart(OutputStream out, String filename,
+    private static void writeStartFileMultipart(
+            Writer out,
+            String contentEncoding,
+            String filePath,
             String nameField, String mimetype)
             throws IOException {
         write(out, "Content-Disposition: form-data; name=\""); // $NON-NLS-1$
-        write(out, nameField);
+        // See quoting in (line is wrapped to avoid checkstyle warnings)
+        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/network/form_data_encoder.cc
+        // ;l=142;drc=4cd749d0d82138ff31ed3a2bc5d925bb6d83fe16
+        write(out, ConversionUtils.percentEncode(nameField));
         write(out, "\"; filename=\"");// $NON-NLS-1$
-        write(out, ConversionUtils.percentEncode(new File(filename).getName()));
+        String filename = new File(filePath).getName();
+        // See quoting in
+        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/network/form_data_encoder.cc
+        // ;l=190;drc=4cd749d0d82138ff31ed3a2bc5d925bb6d83fe16
+        Charset charset = Charset.forName(contentEncoding);
+        write(out, ConversionUtils.percentEncode(ConversionUtils.encodeWithEntities(filename, charset)));
         writeln(out, "\""); // $NON-NLS-1$
-        writeln(out, "Content-Type: " + mimetype); // $NON-NLS-1$
+        write(out, "Content-Type: "); // $NON-NLS-1$
+        writeln(out, mimetype);
         writeln(out, "Content-Transfer-Encoding: binary"); // $NON-NLS-1$
-        out.write(CRLF);
+        out.write(CRLF_STRING);
     }
 
     /**
@@ -423,32 +385,33 @@ public class PostWriter {
     /**
      * Writes form data in multipart format.
      */
-    private void writeFormMultipart(OutputStream out, String name, String value, String charSet,
+    private void writeFormMultipart(
+            Writer out,
+            String contentEncoding,
+            String name, String value,
             boolean browserCompatibleMultipart)
         throws IOException {
-        writeln(out, "Content-Disposition: form-data; name=\"" + name + "\""); // $NON-NLS-1$ // $NON-NLS-2$
+        writeln(out, multipartDivider);
+        write(out, "Content-Disposition: form-data; name=\"");
+        write(out, ConversionUtils.percentEncode(name));
+        writeln(out, "\""); // $NON-NLS-1$ // $NON-NLS-2$
         if (!browserCompatibleMultipart){
-            writeln(out, "Content-Type: text/plain; charset=" + charSet); // $NON-NLS-1$
+            write(out, "Content-Type: text/plain; charset="); // $NON-NLS-1$
+            writeln(out, contentEncoding);
             writeln(out, "Content-Transfer-Encoding: 8bit"); // $NON-NLS-1$
         }
-        out.write(CRLF);
-        out.write(value.getBytes(charSet));
-        out.write(CRLF);
-        // Write boundary end marker
-        out.write(getMultipartDivider());
+        out.write(CRLF_STRING);
+        out.write(value);
+        out.write(CRLF_STRING);
     }
 
-    private static void write(OutputStream out, String value)
-    throws UnsupportedEncodingException, IOException
-    {
-        out.write(value.getBytes(ENCODING));
+    private static void write(Writer out, String value) throws IOException {
+        out.write(value);
     }
 
 
-    private static void writeln(OutputStream out, String value)
-    throws UnsupportedEncodingException, IOException
-    {
-        out.write(value.getBytes(ENCODING));
-        out.write(CRLF);
+    private static void writeln(Writer out, String value) throws IOException {
+        out.write(value);
+        out.write(CRLF_STRING);
     }
 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PutWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PutWriter.java
@@ -44,9 +44,6 @@ public class PutWriter extends PostWriter {
     public void setHeaders(URLConnection connection, HTTPSamplerBase sampler) throws IOException {
         // Get the encoding to use for the request
         String contentEncoding = sampler.getContentEncoding();
-        if(contentEncoding == null || contentEncoding.length() == 0) {
-            contentEncoding = ENCODING;
-        }
         long contentLength = 0L;
         boolean hasPutBody = false;
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
@@ -22,7 +22,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -97,20 +102,85 @@ public class ConversionUtils {
     }
 
     /**
-     * Encodes the string according to RFC7578 and RFC3986.
-     * The string is UTF-8 encoded, and non-ASCII bytes are represented as {@code %XX}.
-     * It is close to UrlEncode, however, {@code percentEncode} does not replace space with +.
+     * Encodes strings for {@code multipart/form-data} names and values.
+     * The encoding is {@code "} as {@code %22}, {@code CR} as {@code %0D}, and {@code LF} as {@code %0A}.
+     * Note: {@code %} is not encoded, so it creates ambiguity which might be resolved in a later specification version.
+     * @see <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart-form-data">Multipart form data specification</a>
+     * @see <a href="https://github.com/whatwg/html/issues/7575">Escaping % in multipart/form-data</a>
      * @param value input value to convert
      * @return converted value
      * @since 5.6
      */
     @API(status = API.Status.MAINTAINED, since = "5.6")
     public static String percentEncode(String value) {
-        try {
-            return new URI(null, null, value, null).toASCIIString();
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Can't encode value " + value, e);
+        if (value.indexOf('"') == -1 && value.indexOf('\r') == -1 && value.indexOf('\n') == -1) {
+            return value;
         }
+        StringBuilder sb = new StringBuilder(value.length() + 2);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("%22");
+                    break;
+                case 0x0A:
+                    sb.append("%0A");
+                    break;
+                case 0x0D:
+                    sb.append("%0D");
+                    break;
+                default:
+                    sb.append(c);
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Encodes non-encodable characters as HTML entities like e.g. &amp;#128514; for 😂.
+     * @param value value to encode
+     * @param charset charset that will be used for encoding, defaults to UTF-8 if null
+     * @return input value with non-encodable characters replaced with HTML entities
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "5.6.1")
+    public static String encodeWithEntities(String value, Charset charset) {
+        // See the reason at
+        // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/network/form_data_encoder.cc;
+        // l=162-191;drc=4cd749d0d82138ff31ed3a2bc5d925bb6d83fe16
+
+        if (charset == null) {
+            charset = StandardCharsets.UTF_8;
+        }
+        CharsetEncoder encoder = charset.newEncoder();
+        if (encoder.canEncode(value)) {
+            // When the strinc can be encoded, leave it intact
+            return value;
+        }
+        // Some of the characters can't be encoded, so replace them with HTML entities
+        StringBuilder sb = new StringBuilder(value.length() + 10);
+        encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+        CharBuffer input = CharBuffer.wrap(value);
+        ByteBuffer output = ByteBuffer.allocate(Math.min(1000, (int) (encoder.maxBytesPerChar() * value.length())));
+        int lastPos = 0;
+        while (input.position() < input.limit()) {
+            output.clear();
+            CoderResult cr = encoder.encode(input, output, true);
+
+            // Append successfully encoded chars
+            if (input.position() > lastPos) {
+                sb.append(value, lastPos, input.position());
+                lastPos = input.position();
+            }
+
+            if (cr.isUnmappable()) {
+                int codePoint = value.codePointAt(input.position());
+                sb.append("&#").append(codePoint);
+                input.position(input.position() + Character.charCount(codePoint));
+                lastPos = input.position();
+            }
+        }
+        return sb.toString();
     }
 
     /**

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
@@ -32,6 +32,7 @@ import org.apache.jmeter.testelement.schema.IntegerPropertyDescriptor
 import org.apache.jmeter.testelement.schema.StringPropertyDescriptor
 import org.apache.jmeter.testelement.schema.TestElementPropertyDescriptor
 import org.apiguardian.api.API
+import java.nio.charset.StandardCharsets
 
 /**
  * Lists properties of a [HTTPSamplerBase].
@@ -81,7 +82,7 @@ public abstract class HTTPSamplerBaseSchema : TestElementSchema() {
     public val proxy: HTTPSamplerProxyParamsSchema<HTTPSamplerBaseSchema> by HTTPSamplerProxyParamsSchema()
 
     public val contentEncoding: StringPropertyDescriptor<HTTPSamplerBaseSchema>
-        by string("HTTPSampler.contentEncoding")
+        by string("HTTPSampler.contentEncoding", default = StandardCharsets.UTF_8.name())
 
     public val implementation: StringPropertyDescriptor<HTTPSamplerBaseSchema>
         by string("HTTPSampler.implementation")

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/PostWriterTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/PostWriterTest.java
@@ -114,8 +114,8 @@ public class PostWriterTest {
 
         checkContentTypeMultipart(connection, PostWriter.BOUNDARY);
         byte[] expectedFormBody = createExpectedOutput(PostWriter.BOUNDARY, null, titleValue, descriptionValue, TEST_FILE_CONTENT);
-        checkContentLength(connection, expectedFormBody.length);
         checkArraysHaveSameContent(expectedFormBody, connection.getOutputStreamContent());
+        checkContentLength(connection, expectedFormBody.length);
         connection.disconnect();
 
         // Test sending data as ISO-8859-1
@@ -545,14 +545,14 @@ public class PostWriterTest {
 
         checkNoContentType(connection);
         StringBuilder sb = new StringBuilder();
-        expectedUrl = sb.append("title=").append(titleValue.replaceAll("%20", "+").replaceAll("%C3%85", "%C5"))
-                .append("&description=").append(descriptionValue.replaceAll("%C3%85", "%C5")).toString().getBytes("US-ASCII");
-        checkContentLength(connection, expectedUrl.length);
+        expectedUrl = sb.append("title=").append(titleValue.replaceAll("%20", "+"))
+                .append("&description=").append(descriptionValue).toString().getBytes(StandardCharsets.UTF_8);
         checkArraysHaveSameContent(expectedUrl, connection.getOutputStreamContent());
+        checkContentLength(connection, expectedUrl.length);
         assertEquals(
-                // HTTPSampler uses ISO-8859-1 as default encoding
-                URLDecoder.decode(new String(expectedUrl, "US-ASCII"), "ISO-8859-1"),
-                URLDecoder.decode(new String(connection.getOutputStreamContent(), "US-ASCII"), "ISO-8859-1"));
+                // HTTPSampler uses UTF-8 as default encoding
+                URLDecoder.decode(new String(expectedUrl, StandardCharsets.UTF_8), "UTF-8"),
+                URLDecoder.decode(new String(connection.getOutputStreamContent(), StandardCharsets.UTF_8), "UTF-8"));
         connection.disconnect();
 
         // Test sending data as ISO-8859-1

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -70,6 +70,8 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     private static final String ISO_8859_1 = "ISO-8859-1"; // $NON-NLS-1$
     private static final String US_ASCII = "US-ASCII"; // $NON-NLS-1$
 
+    private static final String DEFAULT_HTTP_CONTENT_ENCODING = StandardCharsets.UTF_8.name();
+
     private static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain";
 
     private static final byte[] CRLF = {0x0d, 0x0A};
@@ -151,21 +153,21 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     }
 
     public void testPostRequest_FormMultipart_0() throws Exception {
-        testPostRequest_FormMultipart(HTTP_SAMPLER, ISO_8859_1);
+        testPostRequest_FormMultipart(HTTP_SAMPLER);
     }
 
     public void testPostRequest_FormMultipart3() throws Exception {
         // see https://issues.apache.org/jira/browse/HTTPCLIENT-1665
-        testPostRequest_FormMultipart(HTTP_SAMPLER3, US_ASCII);
+        testPostRequest_FormMultipart(HTTP_SAMPLER3);
     }
 
     public void testPostRequest_FileUpload() throws Exception {
-        testPostRequest_FileUpload(HTTP_SAMPLER, ISO_8859_1);
+        testPostRequest_FileUpload(HTTP_SAMPLER);
     }
 
     public void testPostRequest_FileUpload3() throws Exception {
         // see https://issues.apache.org/jira/browse/HTTPCLIENT-1665
-        testPostRequest_FileUpload(HTTP_SAMPLER3, US_ASCII);
+        testPostRequest_FileUpload(HTTP_SAMPLER3);
     }
 
     public void testPostRequest_BodyFromParameterValues() throws Exception {
@@ -352,7 +354,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         }
     }
 
-    private void testPostRequest_FormMultipart(int samplerType, String samplerDefaultEncoding) throws Exception {
+    private void testPostRequest_FormMultipart(int samplerType) throws Exception {
         String titleField = "title";
         String titleValue = "mytitle";
         String descriptionField = "description";
@@ -365,7 +367,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         setupFormData(sampler, false, titleField, titleValue, descriptionField, descriptionValue);
         sampler.setDoMultipart(true);
         HTTPSampleResult res = executeSampler(sampler);
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue);
 
@@ -376,7 +378,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         setupFormData(sampler, false, titleField, titleValue, descriptionField, descriptionValue);
         sampler.setDoMultipart(true);
         res = executeSampler(sampler);
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue);
 
@@ -389,7 +391,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         setupFormData(sampler, false, titleField, titleValue, descriptionField, descriptionValue);
         sampler.setDoMultipart(true);
         res = executeSampler(sampler);
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue);
 
@@ -403,7 +405,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         setupFormData(sampler, false, titleField, titleValue, descriptionField, descriptionValue);
         sampler.setDoMultipart(true);
         res = executeSampler(sampler);
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue);
 
@@ -418,7 +420,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         res = executeSampler(sampler);
         String expectedTitleValue = "mytitle/=";
         String expectedDescriptionValue = "mydescription   /\\";
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, expectedTitleValue,
                 descriptionField, expectedDescriptionValue);
 
@@ -431,7 +433,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         setupFormData(sampler, false, titleField, titleValue, descriptionField, descriptionValue);
         sampler.setDoMultipart(true);
         res = executeSampler(sampler);
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue);
 
@@ -459,12 +461,12 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
         res = executeSampler(sampler);
         expectedTitleValue = "a test\u00c5mytitle\u0153\u20a1\u0115\u00c5";
         expectedDescriptionValue = "mydescription\u0153\u20a1\u0115\u00c5the_end";
-        checkPostRequestFormMultipart(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFormMultipart(sampler, res,
                 contentEncoding, titleField, expectedTitleValue,
                 descriptionField, expectedDescriptionValue);
     }
 
-    private void testPostRequest_FileUpload(int samplerType, String samplerDefaultEncoding) throws Exception {
+    private void testPostRequest_FileUpload(int samplerType) throws Exception {
         String titleField = "title";
         String titleValue = "mytitle";
         String descriptionField = "description";
@@ -480,7 +482,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
                 descriptionField, descriptionValue, fileField, temporaryFile,
                 fileMimeType);
         HTTPSampleResult res = executeSampler(sampler);
-        checkPostRequestFileUpload(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFileUpload(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue, fileField, temporaryFile, fileMimeType,
                 TEST_FILE_CONTENT);
@@ -493,7 +495,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
                 descriptionField, descriptionValue, fileField, temporaryFile,
                 fileMimeType);
         res = executeSampler(sampler);
-        checkPostRequestFileUpload(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFileUpload(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue, fileField, temporaryFile, fileMimeType,
                 TEST_FILE_CONTENT);
@@ -508,7 +510,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
                 descriptionField, descriptionValue, fileField, temporaryFile,
                 fileMimeType);
         res = executeSampler(sampler);
-        checkPostRequestFileUpload(sampler, res, samplerDefaultEncoding,
+        checkPostRequestFileUpload(sampler, res,
                 contentEncoding, titleField, titleValue, descriptionField,
                 descriptionValue, fileField, temporaryFile, fileMimeType,
                 TEST_FILE_CONTENT);
@@ -868,14 +870,13 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     private void checkPostRequestFormMultipart(
             HTTPSamplerBase sampler,
             HTTPSampleResult res,
-            String samplerDefaultEncoding,
             String contentEncoding,
             String titleField,
             String titleValue,
             String descriptionField,
             String descriptionValue) throws IOException {
         if (contentEncoding == null || contentEncoding.isEmpty()) {
-            contentEncoding = samplerDefaultEncoding;
+            contentEncoding = DEFAULT_HTTP_CONTENT_ENCODING;
         }
         // Check URL
         assertEquals(sampler.getUrl(), res.getURL());
@@ -913,7 +914,6 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
     private void checkPostRequestFileUpload(
             HTTPSamplerBase sampler,
             HTTPSampleResult res,
-            String samplerDefaultEncoding,
             String contentEncoding,
             String titleField,
             String titleValue,
@@ -924,7 +924,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCaseJUnit
             String fileMimeType,
             byte[] fileContent) throws IOException {
         if (contentEncoding == null || contentEncoding.isEmpty()) {
-            contentEncoding = samplerDefaultEncoding;
+            contentEncoding = DEFAULT_HTTP_CONTENT_ENCODING;
         }
         // Check URL
         assertEquals(sampler.getUrl(), res.getURL());

--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/util/ConversionUtilsTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/util/ConversionUtilsTest.kt
@@ -19,24 +19,49 @@ package org.apache.jmeter.protocol.http.util
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 class ConversionUtilsTest {
+    companion object {
+        @JvmStatic
+        fun percentEncodeValues() =
+            listOf(
+                arguments("hello", "hello"),
+                arguments("%", "%"),
+                arguments("\"", "%22"),
+                arguments(" ", " "),
+                arguments("\r", "%0D"),
+                arguments("\n", "%0A"),
+                arguments("\r\r\n\n", "%0D%0D%0A%0A"),
+                arguments("😃", "😃"),
+                arguments("comment ça va?", "comment ça va?"),
+                arguments("quoted \"content\"", "quoted %22content%22"),
+            )
+
+        @JvmStatic
+        fun htmlEntityValues() =
+            listOf(
+                arguments("Hello, 😃, world", "Hello, 😃, world", StandardCharsets.UTF_8),
+                arguments("Hello, 😃, world", "Hello, &#128515, world", StandardCharsets.ISO_8859_1),
+                arguments("丈, 😃, and नि", "丈, 😃, and नि", StandardCharsets.UTF_8),
+                arguments("丈, 😃, and नि", "&#19976, &#128515, and &#2344&#2367", StandardCharsets.ISO_8859_1),
+            )
+    }
+
     @ParameterizedTest
-    @CsvSource(
-        ignoreLeadingAndTrailingWhitespace = false,
-        value = [
-            "hello,hello",
-            "%,%25",
-            "\",%22",
-            " ,%20",
-            "😃,%F0%9F%98%83",
-            "comment ça va?,comment%20%C3%A7a%20va%3F",
-        ]
-    )
+    @MethodSource("percentEncodeValues")
     fun percentEncode(input: String, output: String) {
         assertEquals(output, ConversionUtils.percentEncode(input)) {
             "ConversionUtils.percentEncode($input)"
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("htmlEntityValues")
+    fun htmlEntities(input: String, output: String, charset: Charset) {
+        assertEquals(output, ConversionUtils.encodeWithEntities(input, charset))
     }
 }

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -73,6 +73,7 @@ Summary
 
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
+  <li><pr>6010</pr>Use UTF-8 as a default encoding in HTTP sampler. It enables sending parameter names, and filenames with unicode characters</li>
 </ul>
 
 <h3>Other samplers</h3>


### PR DESCRIPTION
In PR 5987 HTTP sampler encoded filenames with percent encoding, however, it should not encode all the characters.

Fixes https://github.com/apache/jmeter/issues/6005

This is a fixup to https://github.com/apache/jmeter/pull/5987

## Motivation and Context

HTTP sampler should send requests like browsers do: UTF-8 encoded filenames.
