### PR TITLE
fix: use default value for LoopController.continue_forever rather than initializing it in the constructor

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/control/LoopController.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/LoopController.java
@@ -48,10 +48,6 @@ public class LoopController extends GenericController implements Serializable, I
 
     private boolean breakLoop;
 
-    public LoopController() {
-        set(getSchema().getContinueForever(), true);
-    }
-
     @Override
     public LoopControllerSchema getSchema() {
         return LoopControllerSchema.INSTANCE;

--- a/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/AbstractTestElement.java
@@ -482,10 +482,16 @@ public abstract class AbstractTestElement implements TestElement, Serializable, 
         } else {
             writeLock();
             try {
-                propMap.put(property.getName(), property);
-                Map<String, JMeterProperty> propMapConcurrent = this.propMapConcurrent;
-                if (propMapConcurrent != null) {
-                    propMapConcurrent.put(property.getName(), property);
+                if (property instanceof StringProperty && property.getStringValue() == null) {
+                    // Avoid storing properties with null values since they will be skipped anyway when saving
+                    // the test plan
+                    removeProperty(property.getName());
+                } else {
+                    propMap.put(property.getName(), property);
+                    Map<String, JMeterProperty> propMapConcurrent = this.propMapConcurrent;
+                    if (propMapConcurrent != null) {
+                        propMapConcurrent.put(property.getName(), property);
+                    }
                 }
             } finally {
                 writeUnlock();

--- a/src/core/src/main/kotlin/org/apache/jmeter/control/LoopControllerSchema.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/control/LoopControllerSchema.kt
@@ -45,5 +45,5 @@ public abstract class LoopControllerSchema : GenericControllerSchema() {
      * However, it's not clear that a Thread Group could ever be repeated.
      */
     public val continueForever: BooleanPropertyDescriptor<LoopControllerSchema>
-        by boolean("LoopController.continue_forever")
+        by boolean("LoopController.continue_forever", default = true /* previous releases initialized value in constructor */)
 }

--- a/src/core/src/main/kotlin/org/apache/jmeter/dsl/DslPrinterTraverser.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/dsl/DslPrinterTraverser.kt
@@ -173,7 +173,7 @@ public class DslPrinterTraverser(
             is DoubleProperty -> append(property.stringValue)
             is FloatProperty -> append(property.stringValue).append('f')
             is LongProperty -> append(property.stringValue).append('d')
-            is StringProperty -> appendLiteral(property.stringValue)
+            is StringProperty -> property.stringValue?.let { appendLiteral(it) } ?: run { append("null") }
 
             is TestElementProperty -> {
                 val element = property.element

--- a/src/dist-check/src/test/java/org/apache/jmeter/save/TestSaveService.java
+++ b/src/dist-check/src/test/java/org/apache/jmeter/save/TestSaveService.java
@@ -117,7 +117,7 @@ public class TestSaveService extends JMeterTestCase {
         final FileStats origStats = getFileStats(testFile);
         final FileStats savedStats = getFileStats(savedFile);
 
-        ByteArrayOutputStream out = new ByteArrayOutputStream(1000000);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(Math.toIntExact(testFile.length()));
         try {
             HashTree tree = SaveService.loadTree(testFile);
             SaveService.saveTree(tree, out);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.prefs.Preferences;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -398,11 +399,19 @@ public class ProxyControl extends GenericController implements NonTestElement {
     }
 
     public void setIncludeList(Collection<String> list) {
-        setProperty(new CollectionProperty(INCLUDE_LIST, new HashSet<>(list)));
+        if (list.size() >= 2) {
+            // Deduplicate if there is more than one element in the list
+            list = list.stream().distinct().collect(Collectors.toList());
+        }
+        setProperty(new CollectionProperty(INCLUDE_LIST, list));
     }
 
     public void setExcludeList(Collection<String> list) {
-        setProperty(new CollectionProperty(EXCLUDE_LIST, new HashSet<>(list)));
+        if (list.size() >= 2) {
+            // Deduplicate if there is more than one element in the list
+            list = list.stream().distinct().collect(Collectors.toList());
+        }
+        setProperty(new CollectionProperty(EXCLUDE_LIST, list));
     }
 
     public void setRegexMatch(boolean b) {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -109,6 +109,12 @@ Summary
 
 <ch_section>Bug fixes</ch_section>
 
+<h3>Thread Groups</h3>
+<ul>
+  <li><pr>6011</pr>Regression since 5.6: ThreadGroups are running endlessly in non-gui mode: use default value
+    for LoopController.continue_forever rather than initializing it in the constructor</li>
+</ul>
+
 <h3>HTTP Samplers and Test Script Recorder</h3>
 <ul>
 </ul>

--- a/xdocs/changes_history.xml
+++ b/xdocs/changes_history.xml
@@ -236,6 +236,8 @@ Apologies if we have omitted anyone else.
 
 <ch_section>Known problems and workarounds</ch_section>
 <ul>
+  <li><issue>6008</issue> ThreadGroups are running endlessly in non-gui mode (fixed in 5.6.1, see <pr>6011</pr>)</li>
+
   <li><pr>5987</pr>HTTP sampler sends filenames with percent-encoded UTF-8, however it is not aligned with the browsers. The workaround is to refrain non-ASCII filenames</li>
 
   <li><issue>6004</issue>Java Request sampler cannot be enabled again after disabling in UI (fixed in 5.6.1, <pr>6012</pr>)</li>


### PR DESCRIPTION
Previously LoopController initialized continue_forever=true in the constructor, however, and ThreadGroup.setMainController flipped the value to false.

It caused inconsistency since non-GUI launch does not call ThreadGroup.setMainController.

Using default=true enables to treat "false" as non-standard, so =false is saved t the jmx, and it gets loaded in non-GUI as well.

Fixes https://github.com/apache/jmeter/issues/6008
