### PR TITLE
fix: after disabling the Java Request sampler, it cannot be enabled again

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -69,7 +69,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     /** Logging */
     private static final Logger log = LoggerFactory.getLogger(AbstractJMeterGuiComponent.class);
 
-    /** Flag indicating whether or not this component is enabled. */
+    /** Flag indicating whether this component is enabled. */
     private boolean enabled = true;
 
     /**

--- a/src/core/src/test/kotlin/org/apache/jmeter/gui/AbstractJMeterGuiComponentTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/gui/AbstractJMeterGuiComponentTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import javax.swing.JPopupMenu
+
+class AbstractJMeterGuiComponentTest {
+    @Test
+    fun isEnabled() {
+        val element = object : AbstractJMeterGuiComponent() {
+            override fun getLabelResource(): String = "dummy_element_for_tests"
+
+            override fun createTestElement(): TestElement = TODO()
+
+            override fun modifyTestElement(element: TestElement?) = TODO()
+
+            override fun createPopupMenu(): JPopupMenu = TODO()
+
+            override fun getMenuCategories(): MutableCollection<String> = TODO()
+        }
+
+        assertEquals(true, element.isEnabled, "element.isEnabled after creation of the element")
+
+        element.clearGui()
+        assertEquals(true, element.isEnabled, "element.isEnabled after element.clearGui()")
+    }
+}

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/JavaTestSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/JavaTestSamplerGui.java
@@ -78,8 +78,10 @@ public class JavaTestSamplerGui extends AbstractSamplerGui {
     public void modifyTestElement(TestElement sampler) {
         sampler.clear();
         JavaConfig config = (JavaConfig) javaPanel.createTestElement();
-        configureTestElement(sampler);
         sampler.addTestElement(config);
+        // Set base parameters (name, description, enabled) from the main control
+        // to avoid merging them from the config element above
+        configureTestElement(sampler);
     }
 
     /* Overrides AbstractJMeterGuiComponent.configure(TestElement) */


### PR DESCRIPTION
Java sampler was inheriting "enabled" status from its config element as internally, Java Sampler UI always creates a config element and merges it to the java sampler.

The solution is to move "configureTestElement(sampler);" to the very end of modifyTestElement so all the base properties are populated based on the element properties rather than "config element" properties.

Ideally, we should somehow limit "mergeIn", and we should refrain from merging unexpected properties.

Fixes https://github.com/apache/jmeter/issues/6004
