### PR TITLE
doc: update documentation for sampleresult.default.encoding default value

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1101,8 +1101,8 @@ csvdataset.file.encoding_list=UTF-8|UTF-16|ISO-8859-15|US-ASCII
 # List of extra HTTP methods that should be available in select box
 #httpsampler.user_defined_methods=VERSION-CONTROL,REPORT,CHECKOUT,CHECKIN,UNCHECKOUT,MKWORKSPACE,UPDATE,LABEL,MERGE,BASELINE-CONTROL,MKACTIVITY
 
-# The encoding to be used if none is provided (default ISO-8859-1)
-#sampleresult.default.encoding=ISO-8859-1
+# The encoding to be used if none is provided (default UTF-8 since JMeter 5.6.1)
+#sampleresult.default.encoding=UTF-8
 
 # CookieManager behaviour - should cookies with null/empty values be deleted?
 # Default is true. Use false to revert to original behaviour

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
@@ -63,15 +63,10 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
     private static final String INVALID_CALL_SEQUENCE_MSG = "Invalid call sequence"; // $NON-NLS-1$
 
 
-    // Bug 33196 - encoding ISO-8859-1 is only suitable for Western countries
-    // However the suggested System.getProperty("file.encoding") is Cp1252 on
-    // Windows
-    // So use a new property with the original value as default
-    // needs to be accessible from test code
     /**
      * The default encoding to be used to decode the responseData byte array.
      * The value is defined by the property "sampleresult.default.encoding"
-     * with a default of DEFAULT_HTTP_ENCODING if that is not defined.
+     * with a default of {@link #DEFAULT_HTTP_ENCODING} if that is not defined.
      */
     protected static final String DEFAULT_ENCODING
             = JMeterUtils.getPropDefault("sampleresult.default.encoding", // $NON-NLS-1$

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -84,6 +84,11 @@ Summary
   <li><pr>6023</pr>Update checker-qual to 3.35.0 (from 3.34.0)</li>
 </ul>
 
+<h3>Other Samplers</h3>
+<ul>
+  <li><pr>6028</pr> Change default value for <code>sampleresult.default.encoding</code> to UTF-8 (it inherits default HTTP encoding which was modified in <pr>6010</pr>)</li>
+</ul>
+
  <!-- =================== Bug fixes =================== -->
 
 <ch_section>Bug fixes</ch_section>

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1399,7 +1399,7 @@ JMETER-SERVER</source>
 </property>
 <property name="sampleresult.default.encoding">
     The encoding to be used if none is provided.<br/>
-    Defaults to: <code>ISO-8859-1</code>
+    Defaults to: <code>UTF-8</code> (since 5.6.1)
 </property>
 <property name="CookieManager.delete_null_cookies">
     CookieManager behaviour - should cookies with null/empty values be deleted?<br/>


### PR DESCRIPTION
`sampleresult.default.encoding` defaults to `DEFAULT_HTTP_ENCODING` which moved to UTF-8, so updating the documentation accordingly.

See https://github.com/apache/jmeter/issues/6005#issuecomment-1617473097
