### PR TITLE
Add space before stopping_test_host

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -409,7 +409,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
         stoppingMessage = new EscapeDialog(this, JMeterUtils.getResString("stopping_test_title"), true); //$NON-NLS-1$
         String label = JMeterUtils.getResString("stopping_test"); //$NON-NLS-1
         if (!StringUtils.isEmpty(host)) {
-            label = label + JMeterUtils.getResString("stopping_test_host")+ ": " + host;
+            label = label + " " + JMeterUtils.getResString("stopping_test_host") + ": " + host;
         }
         JLabel stopLabel = new JLabel(label); //$NON-NLS-1$$NON-NLS-2$
         stopLabel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));


### PR DESCRIPTION
## Description
Edited MainFrame.java in order to add a space before stopping_test_host message string in showStoppingMessage(String host) to separate this message string from the stopping_test one

## Motivation and Context
It's aesthetically ugly to have these strings attached to each other (see screenshot below).

## Screenshots (if appropriate):
![Immagine](https://github.com/apache/jmeter/assets/50794441/92865250-0819-43bb-99eb-a0799c4b34dc)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)