### PR TITLE
Restore references to boms in the generated pom.xml files

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.autoservice.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.autoservice.gradle.kts
@@ -23,9 +23,7 @@ plugins {
 
 dependencies {
     annotationProcessor("com.google.auto.service:auto-service")
-    // Technically speaking, the version is already declared with bom-thirdparty,
-    // however we have to duplicate it here to workaround https://github.com/gradle/gradle/issues/25712
-    compileOnlyApi("com.google.auto.service:auto-service-annotations:1.1.1")
+    compileOnlyApi("com.google.auto.service:auto-service-annotations")
 }
 
 plugins.withId("org.jetbrains.kotlin.jvm") {

--- a/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
@@ -37,7 +37,7 @@ java {
         configureToolchain(buildParameters.buildJdk)
     }
     consistentResolution {
-        useCompileClasspathVersions()
+        useRuntimeClasspathVersions()
     }
 }
 

--- a/build-logic/jvm/src/main/kotlin/build-logic.jmh.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.jmh.gradle.kts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import net.ltgt.gradle.errorprone.ErrorProneOptions
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {

--- a/build-logic/publishing/src/main/kotlin/build-logic.publish-to-central.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/build-logic.publish-to-central.gradle.kts
@@ -44,17 +44,13 @@ publishing {
         plugins.withId("java") {
             versionMapping {
                 usage(Usage.JAVA_API) {
-                    fromResolutionOf("runtimeClasspath")
+                    fromResolutionResult()
                 }
             }
         }
         pom {
             withXml {
                 val pom = asNode()
-                // Maven does not support dependencyManagement, so remove it anyway
-                for (dependencyManagement in (pom["dependencyManagement"] as NodeList)) {
-                    pom.remove(dependencyManagement as Node)
-                }
                 // Gradle maps test fixtures to optional=true, so we remove those elements form the POM to avoid
                 // confusion
                 // See https://github.com/gradle/gradle/issues/14936
@@ -70,7 +66,9 @@ publishing {
                             continue
                         }
                         if ((dependency["version"] as NodeList).isEmpty()) {
-                            throw IllegalStateException("Generated pom.xml contains a dependency without <version> for dependency ${dependency}. It will cause issues with Maven resolution, see https://github.com/apache/jmeter/issues/6041")
+                            throw IllegalStateException(
+                                "Generated pom.xml contains a dependency without <version> for dependency ${dependency}. " +
+                                "Technically speaking, the version is not mandatory, however, having explicit versions would make it easier to review the dependencies in pom")
                         }
                     }
                 }


### PR DESCRIPTION
## Description

Technically speaking, Maven could use `dependencyManagement / scope=import` for resolution, so we would rather have it for the documentation purposes.

At the same time, we put "resolved" versions in the published poms (e.g. to help human consumers, and avoid discrepancies between Maven resolution and Gradle resolution). However, previously we used "runtimeClasspath" for resolving versions for `scope=compile`, and it does not work for dependencies which are "compile-only".

So the important change here is `fromResolutionOf("runtimeClasspath")` -> `fromResolutionResult()` which would default to use `compileClasspath` for `compile` dependencies.

