### PR TITLE
Change the FileServer class to enhance the ability to process multiple test plan execution files #6053

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -221,11 +221,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
      */
     @Override
     public void testEnded() {
-        try {
-            FileServer.getFileServer().closeFiles();
-        } catch (IOException e) {
-            log.error("Problem closing files at end of test", e);
-        }
+
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.samplers.SampleListener;
 import org.apache.jmeter.samplers.SampleMonitor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
+import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.testelement.AbstractScopedAssertion;
 import org.apache.jmeter.testelement.AbstractTestElement;
@@ -340,6 +341,7 @@ public class JMeterThread implements Runnable, Interruptible {
                 threadFinished(iterationListener);
                 monitor.threadFinished(this); // Tell the monitor we are done
                 JMeterContextService.removeContext(); // Remove the ThreadLocal entry
+                FileServer.getFileServer().closeFiles(threadName); // Close files
             } finally {
                 interruptLock.unlock(); // Allow any pending interrupt to complete (OK because currentSampler == null)
             }
@@ -363,7 +365,7 @@ public class JMeterThread implements Runnable, Interruptible {
         if (realSampler == null) {
             throw new IllegalStateException(
                     "Got null subSampler calling findRealSampler for:" +
-                    (sampler != null ? sampler.getName() : "null") + ", sampler:" + sampler);
+                            (sampler != null ? sampler.getName() : "null") + ", sampler:" + sampler);
         }
         // Find parent controllers of current sampler
         FindTestElementsUpToRootTraverser pathToRootTraverser = new FindTestElementsUpToRootTraverser(realSampler);


### PR DESCRIPTION
## Description

File processing through thread isolation solves the problem of file loss when multiple test plans are executed at the same time

## How Has This Been Tested?

Enhanced file processing capabilities, support multiple TestPlan simultaneous execution lead to file loss
## Screenshots (if appropriate):

