### PR TITLE
Resolve checkstyle cache miss

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.checkstyle.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.checkstyle.gradle.kts
@@ -24,9 +24,12 @@ plugins {
 }
 
 checkstyle {
+    // TOOD: move to /config
+    val configDir = File(rootDir, "config/checkstyle")
+
     toolVersion = "10.12.1"
     configProperties = mapOf(
-        "cache_file" to buildDir.resolve("checkstyle/cacheFile")
+        "cache_file" to buildDir.resolve("checkstyle/cacheFile").relativeTo(configDir)
     )
 
     providers.gradleProperty("checkstyle.version")
@@ -34,8 +37,7 @@ checkstyle {
         ?.let { toolVersion = it.get() }
 
     isShowViolations = true
-    // TOOD: move to /config
-    val configDir = File(rootDir, "config/checkstyle")
+
     configDirectory.set(configDir)
     configFile = configDir.resolve("checkstyle.xml")
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,7 +22,7 @@
 
 <module name="Checker">
 
-  <property name="cacheFile" value="${cache_file}"/>
+  <property name="cacheFile" value="${config_loc}/${cache_file}"/>
 
   <property name="localeLanguage" value="en"/>
   <property name="charset" value="UTF-8"/>


### PR DESCRIPTION
## Description

Resolves a cache miss caused by an absolute path present in Checkstyle's `configProperties` extension property. The `cache_file` entry in `configProperties` was previously being set to the absolute path of the cache file.

The value of the `cache_file` entry has been updated to the relative path to the cache file from Checkstyle's `configDir`. The value of `configDir` is available in `checkstyle.xml` as `config_loc`, per the Gradle documentation [here](https://docs.gradle.org/current/userguide/checkstyle_plugin.html#sec:checkstyle_built_in_variables). In `checkstyle.xml`, the `cache_file` relative path is then appended to `config_loc` to construct the full path to the cache file. 

Updating `configProperties` to only contain relative paths avoids cache misses that may occur based on the absolute path of the repository.

[Task input comparison showing `configProperties` differences causing a cache miss](https://ge.solutions-team.gradle.com/c/yu4dqq4vajkfw/enu64pu3chb7e/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)
[Task input comparison showing no differences in inputs with this fix applied](https://ge.solutions-team.gradle.com/c/o76h3xk77gcpy/jsxrvevjg3zcc/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure)

## Motivation and Context

Avoiding absolute paths in input properties ensures that the project can take full advantage of both the local and remote build caches from either local or CI builds independent of the absolute path of the repository.

## How Has This Been Tested?

Running a clean build shows that the Checkstyle cache file is still written at the correct path - `build/checkstyle/cacheFile`.

Gradle's [build validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md) show [`configProperties` input differences](https://ge.solutions-team.gradle.com/c/yu4dqq4vajkfw/enu64pu3chb7e/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) before this fix was applied, and [no input differences](https://ge.solutions-team.gradle.com/c/o76h3xk77gcpy/jsxrvevjg3zcc/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure) with the fix applied.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
