### PR TITLE
Add Java 22 version (ignored) to the build matrix

### DIFF
--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -18,7 +18,7 @@ matrix.addAxis({
   ]
 });
 
-const eaJava = '21';
+const eaJava = '22';
 
 matrix.addAxis({
   name: 'java_version',
@@ -27,6 +27,7 @@ matrix.addAxis({
     '8',
     '11',
     '17',
+    '21',
     eaJava,
   ]
 });
@@ -83,7 +84,9 @@ matrix.exclude({java_distribution: {value: 'semeru'}, java_version: '8'});
 matrix.exclude({java_distribution: {value: 'microsoft'}, java_version: '8'});
 // Oracle JDK is only supported for JDK 17 and later
 matrix.exclude({java_distribution: {value: 'oracle'}, java_version: ['8', '11']});
-// matrix.imply({java_version: eaJava}, {java_distribution: {value: 'oracle'}})
+// Ignore builds with JAVA EA for now, see https://github.com/apache/jmeter/issues/6114
+matrix.exclude({java_version: eaJava})
+matrix.imply({java_version: eaJava}, {java_distribution: {value: 'oracle'}})
 // TODO: Semeru does not ship Java 21 builds yet
 matrix.exclude({java_distribution: {value: 'semeru'}, java_version: '21'})
 // Ensure at least one job with "same" hashcode exists
@@ -98,8 +101,10 @@ matrix.generateRow({java_version: "8"});
 matrix.generateRow({java_version: "11"});
 // Ensure there will be at least one job with Java 17
 matrix.generateRow({java_version: "17"});
+// Ensure there will be at least one job with Java 21
+matrix.generateRow({java_version: "21"});
 // Ensure there will be at least one job with Java EA
-matrix.generateRow({java_version: eaJava});
+// matrix.generateRow({java_version: eaJava});
 const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
 if (include.length === 0) {
   throw new Error('Matrix list is empty');


### PR DESCRIPTION
## Motivation and Context

We need testing with more Java versions. Let's prepare the CI for Java 22, and unlock it later