### PR TITLE
chore: use toolchains for kotlin-dsl for Gradle 9 compatibility

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -16,8 +16,6 @@
  */
 
 import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     `kotlin-dsl`
@@ -34,20 +32,13 @@ dependencies {
 }
 
 // We need to figure out a version that is supported by the current JVM, and by the Kotlin Gradle plugin
-val currentJava = JavaVersion.current()
-if (currentJava > JavaVersion.VERSION_1_8) {
-    // We want an LTS Java release for build script compilation
-    val latestSupportedLts = listOf("17", "11")
-        .intersect(JvmTarget.values().mapTo(mutableSetOf()) { it.target })
-        .first { JavaVersion.toVersion(it) <= currentJava }
-
-    tasks.withType<JavaCompile>().configureEach {
-        options.release.set(JavaVersion.toVersion(latestSupportedLts).majorVersion.toInt())
-    }
-
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = latestSupportedLts
+// So we settle on 17 or 11 if the current JVM supports it
+listOf(17, 11)
+    .firstOrNull { JavaVersion.toVersion(it) <= JavaVersion.current() }
+    ?.let { buildScriptJvmTarget ->
+        java {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(buildScriptJvmTarget))
+            }
         }
     }
-}

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -25,8 +25,14 @@ tasks.validatePlugins {
     enableStricterValidation.set(true)
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+// We need to figure out a version that is supported by the current JVM, and by the Kotlin Gradle plugin
+// So we settle on 17 or 11 if the current JVM supports it
+listOf(17, 11)
+    .firstOrNull { JavaVersion.toVersion(it) <= JavaVersion.current() }
+    ?.let { buildScriptJvmTarget ->
+        java {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(buildScriptJvmTarget))
+            }
+        }
     }
-}


### PR DESCRIPTION
## Motivation and Context

`jvmTarget` will be deprecated in Gradle 9, so we should better use toolchains

See https://docs.gradle.org/current/userguide/upgrading_version_7.html#kotlin_dsl_plugin_toolchains