### PR TITLE
chore: Use Java 21 for building JMeter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,13 @@ jobs:
       with:
         website: ${{ matrix.oracle_java_website }}
         release: ${{ matrix.java_version }}
-    - name: Set up Java 17 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}
+    - name: Set up Java 21 and ${{ matrix.non_ea_java_version }}, ${{ matrix.java_distribution }}
       uses: actions/setup-java@v3
       with:
-        # The latest one will be the default, so we use Java 17 for launching Gradle
+        # The latest one will be the default, so we use Java 21 for launching Gradle
         java-version: |
           ${{ matrix.non_ea_java_version }}
-          17
+          21
         distribution: ${{ matrix.java_distribution }}
         architecture: x64
     - name: Steps to reproduce
@@ -77,7 +77,7 @@ jobs:
         properties: |
           testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
           testDisableCaching=${{ matrix.testDisableCaching }}
-          jdkBuildVersion=17
+          jdkBuildVersion=21
           jdkTestVersion=${{ matrix.java_version }}
           jdkTestVendor=${{ matrix.java_vendor }}
           # We provision JDKs with GitHub Actions for caching purposes, so Gradle should rather fail in case JDK is not found
@@ -87,14 +87,14 @@ jobs:
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
 
   errorprone:
-    name: 'Error Prone (JDK 11)'
+    name: 'Error Prone (JDK 17)'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: 'Set up JDK 11'
+    - name: 'Set up JDK 17'
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'zulu'
     - uses: burrunan/gradle-cache-action@v1
       name: Test

--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -43,7 +43,7 @@ buildParameters {
         description.set("Java version for source and target compatibility")
     }
     integer("jdkBuildVersion") {
-        defaultValue.set(17)
+        defaultValue.set(21)
         mandatory.set(true)
         description.set("JDK version to use for building JMeter. If the value is 0, then the current Java is used. (see https://docs.gradle.org/8.0/userguide/toolchains.html#sec:consuming)")
     }

--- a/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.java.gradle.kts
@@ -92,7 +92,8 @@ tasks.configureEach<JavaCompile> {
     inputs.property("java.vm.version", System.getProperty("java.vm.version"))
     options.apply {
         encoding = "UTF-8"
-        compilerArgs.add("-Xlint:deprecation")
+        // Suppress "Java 8 is obsolete and will be removed in a future release"
+        compilerArgs.add("-Xlint:deprecation,-options")
         if (buildParameters.werror) {
             compilerArgs.add("-Werror")
         }


### PR DESCRIPTION
## Description

Java 21 has been released some time ago, so we can use it as the default build JDK.

## Motivation and Context

We want to use the recent `javac` to avoid bugs in the old compilers.
Java 21 supports `--release 8`, so we would still support running with Java 8.

## TODO

* Wait for Gradle 8.5 release. It would enable us to target Java 21 in the build scripts. Otherwise, we would need both Java 17 (for the build scripts) and Java 21 for the main build
* Deal with "Java 21 not being released by Semeru". Currently, we expect that "default build Java" is to be available in all the distributions (see https://github.com/apache/jmeter/blob/3c6cacb507cddfe4c337213f364f2b5730d6b5d1/.github/workflows/main.yml#L58-L62 ), however, it is failing for Semeru