### PR TITLE
fix: log errors happening while JMeter starts the test

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/timers/ConstantTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/ConstantTimer.java
@@ -19,8 +19,6 @@ package org.apache.jmeter.timers;
 
 import java.io.Serializable;
 
-import org.apache.jmeter.engine.event.LoopIterationEvent;
-import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.util.JMeterUtils;
 

--- a/src/components/src/test/groovy/org/apache/jmeter/timers/UniformRandomTimerSpec.groovy
+++ b/src/components/src/test/groovy/org/apache/jmeter/timers/UniformRandomTimerSpec.groovy
@@ -25,8 +25,6 @@ class UniformRandomTimerSpec extends Specification {
     def sut = new UniformRandomTimer()
 
     def "default delay is 0"() {
-        given:
-            sut.iterationStart(null)
         when:
             def computedDelay = sut.delay()
         then:
@@ -34,8 +32,6 @@ class UniformRandomTimerSpec extends Specification {
     }
 
     def "default range is 0"() {
-        given:
-            sut.iterationStart(null)
         when:
             def actualRange = sut.range
         then:
@@ -45,7 +41,6 @@ class UniformRandomTimerSpec extends Specification {
     def "delay can be set via a String"() {
         given:
             sut.setDelay("1")
-            sut.iterationStart(null)
         when:
             def computedDelay = sut.delay()
         then:
@@ -57,7 +52,6 @@ class UniformRandomTimerSpec extends Specification {
         given:
             sut.setDelay(delay)
             sut.setRange(range)
-            sut.iterationStart(null)
         when:
             def computedDelay = sut.delay()
         then:

--- a/src/components/src/test/java/org/apache/jmeter/timers/ConstantThroughputTimerTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/timers/ConstantThroughputTimerTest.java
@@ -127,7 +127,6 @@ class ConstantThroughputTimerTest {
         UniformRandomTimer timer = new UniformRandomTimer();
         timer.setDelay("1000");
         timer.setRange(100d);
-        timer.iterationStart(null);
         long delay = timer.delay();
         assertBetween(1000, 1100, delay);
     }
@@ -142,7 +141,6 @@ class ConstantThroughputTimerTest {
     void testConstantTimer() throws Exception {
         ConstantTimer timer = new ConstantTimer();
         timer.setDelay("1000");
-        timer.iterationStart(null);
         Assertions.assertEquals(1000, timer.delay());
     }
 
@@ -151,7 +149,6 @@ class ConstantThroughputTimerTest {
         PoissonRandomTimer timer = new PoissonRandomTimer();
         timer.setDelay("300");
         timer.setRange(100d);
-        timer.iterationStart(null);
         long delay = timer.delay();
         assertBetween(356, 457, delay);
     }
@@ -161,7 +158,6 @@ class ConstantThroughputTimerTest {
         PoissonRandomTimer timer = new PoissonRandomTimer();
         timer.setDelay("300");
         timer.setRange(30d);
-        timer.iterationStart(null);
         long delay = timer.delay();
         assertBetween(305, 362, delay);
     }

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -239,13 +239,21 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
 
     private void notifyTestListenersOfStart(SearchByClass<? extends TestStateListener> testListeners) {
         for (TestStateListener tl : testListeners.getSearchResults()) {
-            if (tl instanceof TestBean) {
-                TestBeanHelper.prepare((TestElement) tl);
-            }
-            if (host == null) {
-                tl.testStarted();
-            } else {
-                tl.testStarted(host);
+            try {
+                if (tl instanceof TestBean) {
+                    TestBeanHelper.prepare((TestElement) tl);
+                }
+                if (host == null) {
+                    tl.testStarted();
+                } else {
+                    tl.testStarted(host);
+                }
+            } catch (Throwable e) {
+                // TODO: we should not be logging the exceptions multiple times, however, currently GUI does not
+                //   monitor if the running test fails, so we log the exception for the users to see in the logs
+                log.error("Unable to execute testStarted({}) for test element {}", host, tl, e);
+                throw new IllegalStateException(
+                        "Unable to execute testStarted(" + host + ") for test element " + tl, e);
             }
         }
     }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/TestBeanHelper.java
@@ -134,9 +134,25 @@ public class TestBeanHelper {
         try {
             for (CachedPropertyDescriptor desc : GOOD_PROPS.get(el.getClass())) {
                 // Obtain a value of the appropriate type for this property.
-                JMeterProperty jprop = el.getProperty(desc.descriptor.getName());
                 Class<?> type = desc.propertyType;
-                Object value = unwrapProperty(desc.descriptor, jprop, type);
+
+                JMeterProperty jprop;
+                Object value;
+                try {
+                    jprop = el.getProperty(desc.descriptor.getName());
+                    value = unwrapProperty(desc.descriptor, jprop, type);
+                } catch (OutOfMemoryError | StackOverflowError e) {
+                    throw e;
+                } catch (Throwable e) {
+                    String elementName;
+                    try {
+                        elementName = el.getName();
+                    } catch(Throwable ignore) {
+                        elementName = el.getClass().getName();
+                    }
+                    throw new IllegalStateException(
+                            "Can't retrieve property '" + desc.descriptor.getName() + "' of element " + elementName, e);
+                }
 
                 if (log.isDebugEnabled()) {
                     log.debug("Setting {}={}", jprop.getName(), value);

--- a/src/functions/src/main/java/org/apache/jmeter/functions/TimeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/TimeFunction.java
@@ -71,9 +71,14 @@ public class TimeFunction extends AbstractFunction implements TestStateListener 
                             long div = Long.parseLong(fmt.substring(1)); // should never case NFE
                             return () -> Long.toString(System.currentTimeMillis() / div);
                         }
-                        DateTimeFormatter df = DateTimeFormatter
-                                .ofPattern(fmt)
-                                .withZone(ZoneId.systemDefault());
+                        DateTimeFormatter df;
+                        try {
+                            df = DateTimeFormatter
+                                    .ofPattern(fmt)
+                                    .withZone(ZoneId.systemDefault());
+                        } catch (IllegalArgumentException e) {
+                            throw new IllegalArgumentException("Unable to parse date format " + fmt, e);
+                        }
                         if (isPossibleUsageOfUInFormat(df, fmt)) {
                             log.warn(
                                     MessageFormat.format(

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -47,7 +47,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.testelement.AbstractTestElement;
-import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
@@ -57,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * A base class for all JDBC test elements handling the basics of a SQL request.
  *
  */
-public abstract class AbstractJDBCTestElement extends AbstractTestElement implements TestStateListener{
+public abstract class AbstractJDBCTestElement extends AbstractTestElement {
     private static final long serialVersionUID = 235L;
 
     private static final Logger log = LoggerFactory.getLogger(AbstractJDBCTestElement.class);
@@ -819,40 +818,4 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement implem
     public void setResultVariable(String resultVariable) {
         this.resultVariable = resultVariable;
     }
-
-
-    /**
-     * {@inheritDoc}
-     * @see org.apache.jmeter.testelement.TestStateListener#testStarted()
-     */
-    @Override
-    public void testStarted() {
-        testStarted("");
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see org.apache.jmeter.testelement.TestStateListener#testStarted(java.lang.String)
-     */
-    @Override
-    public void testStarted(String host) {
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see org.apache.jmeter.testelement.TestStateListener#testEnded()
-     */
-    @Override
-    public void testEnded() {
-        testEnded("");
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see org.apache.jmeter.testelement.TestStateListener#testEnded(java.lang.String)
-     */
-    @Override
-    public void testEnded(String host) {
-    }
-
 }


### PR DESCRIPTION
Previously, the exceptions from `TestStateListener.testStarted` might be unnoticed since the UI did not display them.
    
This change is a workaround to surface errors in common cases.
We should make UI to monitor the running test, however, I would defer that to JMeter 6.0
    
See https://github.com/apache/jmeter/issues/6174