### PR TITLE
Streamline binding of UI elements to TestElement properties

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/control/gui/TransactionControllerGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/control/gui/TransactionControllerGui.java
@@ -17,12 +17,11 @@
 
 package org.apache.jmeter.control.gui;
 
-import javax.swing.JCheckBox;
-
 import org.apache.jmeter.control.TransactionController;
+import org.apache.jmeter.control.TransactionControllerSchema;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.JBooleanPropertyEditor;
 import org.apache.jmeter.gui.TestElementMetadata;
-import org.apache.jmeter.gui.util.CheckBoxPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.layout.VerticalLayout;
@@ -37,40 +36,36 @@ public class TransactionControllerGui extends AbstractControllerGui {
     private static final long serialVersionUID = 240L;
 
     /** If selected, then generate parent sample, otherwise as per original controller */
-    private JCheckBox generateParentSample;
+    private final JBooleanPropertyEditor generateParentSample =
+            new JBooleanPropertyEditor(
+                    TransactionControllerSchema.INSTANCE.getGenearteParentSample(),
+                    JMeterUtils.getResString("transaction_controller_parent"));
 
     /** if selected, add duration of timers to total runtime */
-    private JCheckBox includeTimers;
+    private final JBooleanPropertyEditor includeTimers =
+            new JBooleanPropertyEditor(
+                    TransactionControllerSchema.INSTANCE.getIncludeTimers(),
+                    JMeterUtils.getResString("transaction_controller_include_timers"));
 
     /**
      * Create a new TransactionControllerGui instance.
      */
     public TransactionControllerGui() {
         init();
+        bindingGroup.add(generateParentSample);
+        bindingGroup.add(includeTimers);
     }
 
     @Override
-    public TestElement createTestElement() {
-        TransactionController lc = new TransactionController();
-        lc.setIncludeTimers(false); // change default for new test elements
-        configureTestElement(lc);
-        return lc;
+    public TestElement makeTestElement() {
+        return new TransactionController();
     }
 
     @Override
-    public void configure(TestElement el) {
-        super.configure(el);
-        generateParentSample.setSelected(((TransactionController) el).isGenerateParentSample());
-        includeTimers.setSelected(((TransactionController) el).isIncludeTimers());
-    }
-
-    @Override
-    public void modifyTestElement(TestElement el) {
-        configureTestElement(el);
-        ((TransactionController) el).setGenerateParentSample(generateParentSample.isSelected());
-        TransactionController tc = (TransactionController) el;
-        tc.setGenerateParentSample(generateParentSample.isSelected());
-        tc.setIncludeTimers(includeTimers.isSelected());
+    public void assignDefaultValues(TestElement element) {
+        super.assignDefaultValues(element);
+        // See https://github.com/apache/jmeter/issues/3282
+        ((TransactionController) element).setIncludeTimers(false);
     }
 
     @Override
@@ -85,9 +80,7 @@ public class TransactionControllerGui extends AbstractControllerGui {
         setLayout(new VerticalLayout(5, VerticalLayout.BOTH, VerticalLayout.TOP));
         setBorder(makeBorder());
         add(makeTitlePanel());
-        generateParentSample = new JCheckBox(JMeterUtils.getResString("transaction_controller_parent")); // $NON-NLS-1$
-        add(CheckBoxPanel.wrap(generateParentSample));
-        includeTimers = new JCheckBox(JMeterUtils.getResString("transaction_controller_include_timers"), true); // $NON-NLS-1$
-        add(CheckBoxPanel.wrap(includeTimers));
+        add(generateParentSample);
+        add(includeTimers);
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -35,9 +35,10 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.border.Border;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jmeter.testelement.property.StringProperty;
+import org.apache.jmeter.testelement.TestElementSchema;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Printable;
 import org.apache.jorphan.gui.JFactory;
@@ -82,6 +83,13 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     protected NamePanel namePanel;
 
     private final JTextArea commentField = JFactory.tabMovesFocus(new JTextArea());
+
+    /**
+     * Stores a collection of property editors, so GuiCompoenent can have default implementations that
+     * update the UI fields based on {@link TestElement} properties and vice versa.
+     */
+    @API(status = EXPERIMENTAL, since = "5.6.3")
+    protected final BindingGroup bindingGroup = new BindingGroup();
 
     /**
      * When constructing a new component, this takes care of basic tasks like
@@ -205,6 +213,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
         setName(element.getName());
         enabled = element.isEnabled();
         commentField.setText(element.getComment());
+        bindingGroup.updateUi(element);
     }
 
     /**
@@ -228,6 +237,14 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
         initGui();
     }
 
+    @Override
+    @API(status = EXPERIMENTAL, since = "5.6.3")
+    public void modifyTestElement(TestElement element) {
+        JMeterGUIComponent.super.modifyTestElement(element);
+        modifyTestElementEnabledAndComment(element);
+        bindingGroup.updateElement(element);
+    }
+
     /**
      * This provides a convenience for extenders when they implement the
      * {@link JMeterGUIComponent#modifyTestElement(TestElement)} method. This
@@ -235,21 +252,37 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
      * Element. It should be called by every extending class when
      * creating/modifying Test Elements, as that will best assure consistent
      * behavior.
+     * <p>Deprecation notice: most likely you do not need the method, and you should
+     * override {@link #modifyTestElement(TestElement)} instead</p>
      *
      * @param mc
      *            the TestElement being created.
      */
+    @API(status = DEPRECATED, since = "5.6.3")
     protected void configureTestElement(TestElement mc) {
-        mc.setName(getName());
+        mc.setName(StringUtils.defaultIfEmpty(getName(), null));
+        TestElementSchema schema = TestElementSchema.INSTANCE;
+        mc.set(schema.getGuiClass(), getClass());
+        mc.set(schema.getTestClass(), mc.getClass());
+        modifyTestElementEnabledAndComment(mc);
+    }
 
-        mc.setProperty(new StringProperty(TestElement.GUI_CLASS, this.getClass().getName()));
-
-        mc.setProperty(new StringProperty(TestElement.TEST_CLASS, mc.getClass().getName()));
-
+    /**
+     * Assigns basic fields from UI to the test element: name, comments, gui class, and the registered editors.
+     *
+     * @param mc test element
+     */
+    private void modifyTestElementEnabledAndComment(TestElement mc) {
         // This stores the state of the TestElement
         log.debug("setting element to enabled: {}", enabled);
-        mc.setEnabled(enabled);
-        mc.setComment(getComment());
+        // We can skip storing "enabled" state if it's true, as it's default value.
+        // JMeter removes disabled elements early from the tree, so configuration elements
+        // with enabled=false (~HTTP Request Defaults) can't unexpectedly override the regular ones
+        // like HTTP Request.
+        mc.set(TestElementSchema.INSTANCE.getEnabled(), enabled ? null : Boolean.FALSE);
+        // Note: we can't use editors for "comments" as getComments() is not a final method, so plugins might
+        // override it and provide a different implementation.
+        mc.setComment(StringUtils.defaultIfEmpty(getComment(), null));
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/PostThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/PostThreadGroupGui.java
@@ -38,9 +38,7 @@ public class PostThreadGroupGui extends ThreadGroupGui implements ItemListener {
     }
 
     @Override
-    public TestElement createTestElement() {
-        PostThreadGroup tg = new PostThreadGroup();
-        modifyTestElement(tg);
-        return tg;
+    public TestElement makeTestElement() {
+        return new PostThreadGroup();
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/SetupThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/SetupThreadGroupGui.java
@@ -38,9 +38,7 @@ public class SetupThreadGroupGui extends ThreadGroupGui implements ItemListener 
     }
 
     @Override
-    public TestElement createTestElement() {
-        SetupThreadGroup tg = new SetupThreadGroup();
-        modifyTestElement(tg);
-        return tg;
+    public TestElement makeTestElement() {
+        return new SetupThreadGroup();
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/gui/ThreadGroupGui.java
@@ -22,9 +22,9 @@ import static org.apache.jmeter.util.JMeterUtils.labelFor;
 import java.awt.BorderLayout;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.Arrays;
 
 import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -32,14 +32,15 @@ import javax.swing.JTextField;
 import org.apache.jmeter.control.LoopController;
 import org.apache.jmeter.control.gui.LoopControlPanel;
 import org.apache.jmeter.gui.JBooleanPropertyEditor;
+import org.apache.jmeter.gui.JTextComponentBinding;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jmeter.threads.AbstractThreadGroupSchema;
 import org.apache.jmeter.threads.ThreadGroup;
 import org.apache.jmeter.threads.ThreadGroupSchema;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.gui.JEditableCheckBox;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -61,7 +62,10 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
 
     private JBooleanPropertyEditor delayedStart;
 
-    private final JCheckBox scheduler = new JCheckBox(JMeterUtils.getResString("scheduler"));
+    private final JBooleanPropertyEditor scheduler =
+            new JBooleanPropertyEditor(
+                    ThreadGroupSchema.INSTANCE.getUseScheduler(),
+                    JMeterUtils.getResString("scheduler"));
 
     private final JTextField duration = new JTextField();
     private final JLabel durationLabel = labelFor(duration, "duration");
@@ -83,13 +87,40 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
         this.showDelayedStart = showDelayedStart;
         init();
         initGui();
+        if (showDelayedStart) {
+            bindingGroup.add(delayedStart);
+        }
+        bindingGroup.addAll(
+                Arrays.asList(
+                        new JTextComponentBinding(threadInput, AbstractThreadGroupSchema.INSTANCE.getNumThreads()),
+                        new JTextComponentBinding(rampInput, ThreadGroupSchema.INSTANCE.getRampTime()),
+                        new JTextComponentBinding(duration, ThreadGroupSchema.INSTANCE.getDuration()),
+                        new JTextComponentBinding(delay, ThreadGroupSchema.INSTANCE.getDelay()),
+                        sameUserBox,
+                        scheduler
+                )
+        );
+    }
+
+    @Override
+    public TestElement makeTestElement() {
+        return new ThreadGroup();
     }
 
     @Override
     public TestElement createTestElement() {
-        ThreadGroup tg = new ThreadGroup();
+        TestElement tg = makeTestElement();
+        // modifyTestElement is here for backward compatibility
         modifyTestElement(tg);
+        assignDefaultValues(tg);
         return tg;
+    }
+
+    @Override
+    public void assignDefaultValues(TestElement element) {
+        super.assignDefaultValues(element);
+        element.set(ThreadGroupSchema.INSTANCE.getNumThreads(), 1);
+        element.set(ThreadGroupSchema.INSTANCE.getRampTime(), 1);
     }
 
     /**
@@ -103,46 +134,22 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
         if (tg instanceof AbstractThreadGroup) {
             ((AbstractThreadGroup) tg).setSamplerController((LoopController) loopPanel.createTestElement());
         }
-        tg.set(AbstractThreadGroupSchema.INSTANCE.getNumThreads(), threadInput.getText());
-        tg.setProperty(ThreadGroup.RAMP_TIME, rampInput.getText());
-        if (showDelayedStart) {
-            delayedStart.updateElement(tg);
-        }
-        tg.setProperty(new BooleanProperty(ThreadGroup.SCHEDULER, scheduler.isSelected()));
-        tg.setProperty(ThreadGroup.DURATION, duration.getText());
-        tg.setProperty(ThreadGroup.DELAY, delay.getText());
-        sameUserBox.updateElement(tg);
+        toggleSchedulerFields();
     }
 
     @Override
     public void configure(TestElement tg) {
         super.configure(tg);
-        threadInput.setText(tg.getString(AbstractThreadGroupSchema.INSTANCE.getNumThreads()));
-        rampInput.setText(tg.getPropertyAsString(ThreadGroup.RAMP_TIME));
         loopPanel.configure((TestElement) tg.getProperty(AbstractThreadGroup.MAIN_CONTROLLER).getObjectValue());
-        if (showDelayedStart) {
-            delayedStart.updateUi(tg);
-        }
-        scheduler.setSelected(tg.getPropertyAsBoolean(ThreadGroup.SCHEDULER));
-
-        toggleSchedulerFields(scheduler.isSelected());
-
-        duration.setText(tg.getPropertyAsString(ThreadGroup.DURATION));
-        delay.setText(tg.getPropertyAsString(ThreadGroup.DELAY));
-        sameUserBox.updateUi(tg);
     }
 
     @Override
     public void itemStateChanged(ItemEvent ie) {
-        if (ie.getItem().equals(scheduler)) {
-            toggleSchedulerFields(scheduler.isSelected());
-        }
+        // Method kept for backward compatibility
     }
 
-    /**
-     * @param enable boolean used to enable/disable fields related to scheduler
-     */
-    private void toggleSchedulerFields(boolean enable) {
+    private void toggleSchedulerFields() {
+        boolean enable = !scheduler.getValue().equals(JEditableCheckBox.Value.of(false));
         duration.setEnabled(enable);
         durationLabel.setEnabled(enable);
         delay.setEnabled(enable);
@@ -171,16 +178,7 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
 
     // Initialise the gui field values
     private void initGui(){
-        threadInput.setText("1"); // $NON-NLS-1$
-        rampInput.setText("1"); // $NON-NLS-1$
         loopPanel.clearGui();
-        if (showDelayedStart) {
-            delayedStart.reset();
-        }
-        scheduler.setSelected(false);
-        delay.setText(""); // $NON-NLS-1$
-        duration.setText(""); // $NON-NLS-1$
-        sameUserBox.reset();
     }
 
     private void init() { // WARNING: called from ctor so must not be overridden (i.e. must be private or final)
@@ -211,7 +209,8 @@ public class ThreadGroupGui extends AbstractThreadGroupGui implements ItemListen
                     JMeterUtils.getResString("delayed_start")); // $NON-NLS-1$
             threadPropsPanel.add(delayedStart, "span 2");
         }
-        scheduler.addItemListener(this);
+        scheduler.addPropertyChangeListener(
+                JBooleanPropertyEditor.VALUE_PROPERTY, (ev) -> toggleSchedulerFields());
 
         threadPropsPanel.add(scheduler, "span 2");
 

--- a/src/core/src/main/kotlin/org/apache/jmeter/dsl/DslPrinterTraverser.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/dsl/DslPrinterTraverser.kt
@@ -115,11 +115,9 @@ public class DslPrinterTraverser(
                 if (prop == TestElementSchema.testClass && stringValue == te::class.java.name && canSkipTestClass) {
                     continue
                 }
-                if ((property is StringProperty && stringValue.isNullOrEmpty()) ||
-                    stringValue == prop?.defaultValueAsString
-                ) {
-                    continue
-                }
+                // It might be tempting to skip printing the property if its value matches the default value,
+                // However, it would be wrong because "unset" values might be overriden by "... Request Defaults",
+                // so we do not want accidental overrides if the user explicitly set some of the properties
             }
 
             if (prop == null) {

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/Binding.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/Binding.kt
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Binds a UI control to a [PropertyDescriptor], so JMeter can automatically update the test element
+ * from the UI state and vice versa.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public interface Binding {
+    /**
+     * Update [TestElement] based on the state of the UI.
+     * @param testElement element to update
+     */
+    public fun updateElement(testElement: TestElement)
+
+    /**
+     * Update UI based on the state of the given [TestElement].
+     * @param testElement element to get the state from
+     */
+    public fun updateUi(testElement: TestElement)
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/BindingGroup.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/BindingGroup.kt
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.apiguardian.api.API
+
+/**
+ * Manages a collection of [Binding]s.
+ * It enables to update a [TestElement] from the UI and vice versa with a common implementation.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public class BindingGroup() : Binding {
+    private val bindings = mutableListOf<Binding>()
+
+    public constructor(bindings: Collection<Binding>) : this() {
+        addAll(bindings)
+    }
+
+    public fun add(binding: Binding) {
+        bindings += binding
+    }
+
+    public fun addAll(bindings: Collection<Binding>) {
+        this.bindings.addAll(bindings)
+    }
+
+    override fun updateElement(testElement: TestElement) {
+        bindings.forEach { it.updateElement(testElement) }
+    }
+
+    override fun updateUi(testElement: TestElement) {
+        bindings.forEach { it.updateUi(testElement) }
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/FilePanelEntryBinding.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/FilePanelEntryBinding.kt
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.gui.util.FilePanelEntry
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Binds a [FilePanelEntry] to a [PropertyDescriptor], so JMeter can automatically update the test element
+ * from the UI state and vice versa.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public class FilePanelEntryBinding(
+    private val filePanelEntry: FilePanelEntry,
+    private val propertyDescriptor: PropertyDescriptor<*, *>,
+) : Binding {
+    override fun updateElement(testElement: TestElement) {
+        testElement[propertyDescriptor] = filePanelEntry.filename.takeIf { it.isNotEmpty() }
+    }
+
+    override fun updateUi(testElement: TestElement) {
+        filePanelEntry.filename =
+            if (testElement.getPropertyOrNull(propertyDescriptor) == null) {
+                ""
+            } else {
+                testElement.getString(propertyDescriptor)
+            }
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/JCheckBoxBinding.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/JCheckBoxBinding.kt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.schema.BooleanPropertyDescriptor
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apiguardian.api.API
+import javax.swing.JCheckBox
+
+/**
+ * Binds a [JCheckBox] to a [PropertyDescriptor], so JMeter can automatically update the test element
+ * from the UI state and vice versa.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public class JCheckBoxBinding(
+    private val checkbox: JCheckBox,
+    private val propertyDescriptor: BooleanPropertyDescriptor<*>,
+) : Binding {
+    override fun updateElement(testElement: TestElement) {
+        testElement[propertyDescriptor] = checkbox.isSelected.takeIf { it }
+    }
+
+    override fun updateUi(testElement: TestElement) {
+        checkbox.isSelected = testElement[propertyDescriptor]
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/JLabeledFieldBinding.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/JLabeledFieldBinding.kt
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apache.jorphan.gui.JLabeledField
+import org.apiguardian.api.API
+
+/**
+ * Binds a [JLabeledField] to a [PropertyDescriptor], so JMeter can automatically update the test element
+ * from the UI state and vice versa.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public class JLabeledFieldBinding(
+    private val labeledField: JLabeledField,
+    private val propertyDescriptor: PropertyDescriptor<*, *>,
+) : Binding {
+    override fun updateElement(testElement: TestElement) {
+        testElement[propertyDescriptor] = labeledField.text.takeIf { it.isNotEmpty() }
+    }
+
+    override fun updateUi(testElement: TestElement) {
+        labeledField.text =
+            if (testElement.getPropertyOrNull(propertyDescriptor) == null) {
+                ""
+            } else {
+                testElement.getString(propertyDescriptor)
+            }
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/JSyntaxTextAreaBinding.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/JSyntaxTextAreaBinding.kt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.gui.util.JSyntaxTextArea
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apiguardian.api.API
+
+/**
+ * Binds a [JSyntaxTextArea] to a [PropertyDescriptor], so JMeter can automatically update the test element
+ * from the UI state and vice versa.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public class JSyntaxTextAreaBinding(
+    private val syntaxTextArea: JSyntaxTextArea,
+    private val propertyDescriptor: PropertyDescriptor<*, *>,
+) : Binding {
+    override fun updateElement(testElement: TestElement) {
+        testElement[propertyDescriptor] = syntaxTextArea.text.takeIf { it.isNotEmpty() }
+    }
+
+    override fun updateUi(testElement: TestElement) {
+        syntaxTextArea.setInitialText(
+            if (testElement.getPropertyOrNull(propertyDescriptor) == null) {
+                ""
+            } else {
+                testElement.getString(propertyDescriptor)
+            }
+        )
+        syntaxTextArea.caretPosition = 0
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/gui/JTextComponentBinding.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/gui/JTextComponentBinding.kt
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.gui
+
+import org.apache.jmeter.testelement.TestElement
+import org.apache.jmeter.testelement.schema.PropertyDescriptor
+import org.apiguardian.api.API
+import javax.swing.JPasswordField
+import javax.swing.text.JTextComponent
+
+/**
+ * Binds a [JTextComponent] to a [PropertyDescriptor], so JMeter can automatically update the test element
+ * from the UI state and vice versa.
+ * @since 5.6.3
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "5.6.3")
+public class JTextComponentBinding(
+    private val textComponent: JTextComponent,
+    private val propertyDescriptor: PropertyDescriptor<*, *>,
+) : Binding {
+    override fun updateElement(testElement: TestElement) {
+        val text = when (val component = textComponent) {
+            is JPasswordField -> String(component.password)
+            else -> component.text
+        }
+        testElement[propertyDescriptor] = text.takeIf { it.isNotEmpty() }
+    }
+
+    override fun updateUi(testElement: TestElement) {
+        textComponent.text =
+            if (testElement.getPropertyOrNull(propertyDescriptor) == null) {
+                ""
+            } else {
+                testElement.getString(propertyDescriptor)
+            }
+    }
+}

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/TestElement.kt
@@ -285,13 +285,13 @@ public interface TestElement : Cloneable {
         getPropertyOrNull(property)?.stringValue ?: property.defaultValueAsString ?: ""
 
     /**
-     * Set property as string, or remove it if the given value is `null` or empty.
+     * Set property as string, or remove it if the given value is `null`.
      * @since 5.6
      */
     @JMeterPropertySchemaUnchecked
     @API(status = API.Status.EXPERIMENTAL, since = "5.6")
     public operator fun set(property: PropertyDescriptor<*, *>, value: String?) {
-        removeOrSet(value.isNullOrEmpty(), property.name) {
+        removeOrSet(value == null, property.name) {
             StringProperty(it, value)
         }
     }

--- a/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertiesAccessor.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/testelement/schema/PropertiesAccessor.kt
@@ -84,7 +84,7 @@ public class PropertiesAccessor<out TestElementClass : TestElement, out Schema :
     }
 
     // All properties can be set as strings
-    public operator fun set(property: PropertyDescriptor<Schema, *>, value: String) {
+    public operator fun set(property: PropertyDescriptor<Schema, *>, value: String?) {
         target[property] = value
     }
 
@@ -116,13 +116,13 @@ public class PropertiesAccessor<out TestElementClass : TestElement, out Schema :
     public inline operator fun get(propertySelector: Schema.() -> BooleanPropertyDescriptor<Schema>): Boolean =
         target[propertySelector(schema)]
 
-    public operator fun set(property: BooleanPropertyDescriptor<Schema>, value: Boolean) {
+    public operator fun set(property: BooleanPropertyDescriptor<Schema>, value: Boolean?) {
         target[property] = value
     }
 
     public inline operator fun set(
         propertySelector: Schema.() -> BooleanPropertyDescriptor<Schema>,
-        value: Boolean
+        value: Boolean?
     ) {
         target[propertySelector(schema)] = value
     }

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/gui/OpenModelThreadGroupGui.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/gui/OpenModelThreadGroupGui.kt
@@ -19,11 +19,12 @@ package org.apache.jmeter.threads.openmodel.gui
 
 import net.miginfocom.swing.MigLayout
 import org.apache.jmeter.engine.util.CompoundVariable
+import org.apache.jmeter.gui.JTextComponentBinding
 import org.apache.jmeter.gui.TestElementMetadata
 import org.apache.jmeter.testelement.TestElement
 import org.apache.jmeter.threads.gui.AbstractThreadGroupGui
-import org.apache.jmeter.threads.openmodel.DefaultThreadSchedule
 import org.apache.jmeter.threads.openmodel.OpenModelThreadGroup
+import org.apache.jmeter.threads.openmodel.OpenModelThreadGroupSchema
 import org.apache.jmeter.threads.openmodel.ThreadSchedule
 import org.apache.jmeter.threads.openmodel.ThreadScheduleStep
 import org.apache.jmeter.threads.openmodel.asSeconds
@@ -69,6 +70,12 @@ public class OpenModelThreadGroupGui : AbstractThreadGroupGui() {
                 updateExplanation()
             }
         })
+        bindingGroup.addAll(
+            listOf(
+                JTextComponentBinding(scheduleStringEditor, OpenModelThreadGroupSchema.schedule),
+                JTextComponentBinding(randomSeedEditor, OpenModelThreadGroupSchema.randomSeed)
+            )
+        )
     }
 
     private fun createPanel() =
@@ -87,6 +94,7 @@ public class OpenModelThreadGroupGui : AbstractThreadGroupGui() {
 
             add(explanation)
             add(targetRateChart, "height 200")
+            updateExplanation()
         }
 
     private fun templateButton(title: String) = JButton(title).apply {
@@ -131,36 +139,5 @@ public class OpenModelThreadGroupGui : AbstractThreadGroupGui() {
 
     private fun evaluate(input: String): String = CompoundVariable(input).execute()
 
-    override fun createTestElement(): TestElement =
-        OpenModelThreadGroup().also {
-            modifyTestElement(it)
-        }
-
-    override fun modifyTestElement(tg: TestElement) {
-        configureTestElement(tg)
-        tg as OpenModelThreadGroup
-        tg.scheduleString = scheduleStringEditor.text
-        tg.randomSeedString = randomSeedEditor.text
-    }
-
-    override fun configure(tg: TestElement) {
-        super.configure(tg)
-        tg as OpenModelThreadGroup
-        scheduleStringEditor.text = tg.scheduleString
-        randomSeedEditor.text = tg.randomSeedString
-    }
-
-    override fun clearGui() {
-        super.clearGui()
-        scheduleStringEditor.text = ""
-        randomSeedEditor.text = ""
-        targetRateChart.updateSchedule(
-            DefaultThreadSchedule(
-                listOf(
-                    ThreadScheduleStep.RateStep(0.0),
-                    ThreadScheduleStep.ArrivalsStep(ThreadScheduleStep.ArrivalType.RANDOM, 1.0)
-                )
-            )
-        )
-    }
+    override fun makeTestElement(): TestElement = OpenModelThreadGroup()
 }

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/gui/OpenModelThreadGroupGui.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/gui/OpenModelThreadGroupGui.kt
@@ -24,6 +24,7 @@ import org.apache.jmeter.gui.TestElementMetadata
 import org.apache.jmeter.testelement.TestElement
 import org.apache.jmeter.threads.gui.AbstractThreadGroupGui
 import org.apache.jmeter.threads.openmodel.OpenModelThreadGroup
+import org.apache.jmeter.threads.openmodel.OpenModelThreadGroupController
 import org.apache.jmeter.threads.openmodel.OpenModelThreadGroupSchema
 import org.apache.jmeter.threads.openmodel.ThreadSchedule
 import org.apache.jmeter.threads.openmodel.ThreadScheduleStep
@@ -140,4 +141,9 @@ public class OpenModelThreadGroupGui : AbstractThreadGroupGui() {
     private fun evaluate(input: String): String = CompoundVariable(input).execute()
 
     override fun makeTestElement(): TestElement = OpenModelThreadGroup()
+
+    override fun modifyTestElement(element: TestElement) {
+        super.modifyTestElement(element)
+        element[OpenModelThreadGroupSchema.mainController] = OpenModelThreadGroupController()
+    }
 }

--- a/src/core/src/test/kotlin/org/apache/jmeter/testelement/property/JMeterElementSchemaTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/testelement/property/JMeterElementSchemaTest.kt
@@ -29,10 +29,14 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class JMeterElementSchemaTest {
+    val warpDrive = WarpDriveElement()
+
     abstract class WarpDriveElementSchema : TestElementSchema() {
         companion object INSTANCE : WarpDriveElementSchema()
 
         val warpFactor by int("WarpDriveElement.warpFactor", default = 7)
+        val turbo by boolean("WarpDriveElement.turbo")
+        val description by string("WarpDriveElement.description")
     }
 
     open class WarpDriveElement : AbstractTestElement() {
@@ -44,7 +48,16 @@ class JMeterElementSchemaTest {
 
     @Test
     fun `getPropertyOrNull returns null for unset props`() {
-        val warpDrive = WarpDriveElement()
+        assertGetWarpDescription(
+            null,
+            warpDrive,
+            "${WarpDriveElementSchema.warpFactor} should be null for newly created element"
+        )
+        assertGetWarpTurbo(
+            null,
+            warpDrive,
+            "${WarpDriveElementSchema.warpFactor} should be null for newly created element"
+        )
         assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.warpFactor)) {
             "${WarpDriveElementSchema.warpFactor} should be null for newly created element, getPropertyOrNull(PropertyDescriptor)"
         }
@@ -54,27 +67,92 @@ class JMeterElementSchemaTest {
     }
 
     @Test
-    fun `get returns default value`() {
-        val warpDrive = WarpDriveElement()
+    fun `get int returns default value`() {
         assertGetWarpFactor(7, warpDrive, "element is empty, so default value expected")
     }
 
     @Test
-    fun `set modifies value`() {
-        val warpDrive = WarpDriveElement()
+    fun `set int modifies value`() {
         warpDrive[warpDrive.schema.warpFactor] = 8
 
         assertGetWarpFactor(8, warpDrive, "value was modified with [warpFactor] = 8")
     }
 
     @Test
-    fun `props set modifies value`() {
-        val warpDrive = WarpDriveElement()
+    fun `props set int modifies value`() {
         warpDrive.props {
             it[warpFactor] = 8
         }
 
         assertGetWarpFactor(8, warpDrive, "value was modified with props { it[warpFactor] = 8 }")
+    }
+
+    @Test
+    fun `set string modifies value`() {
+        var value = "new description"
+        warpDrive[warpDrive.schema.description] = value
+        assertGetWarpDescription(value, warpDrive, "value was modified with [description] = \"$value\"")
+
+        value = ""
+        warpDrive[warpDrive.schema.description] = value
+        assertGetWarpDescription(value, warpDrive, "value was modified with [description] = \"$value\"")
+
+        warpDrive[warpDrive.schema.description] = null
+        assertGetWarpDescription(null, warpDrive, "value should be removed after [description] = null")
+    }
+
+    @Test
+    fun `props set string modifies value`() {
+        var value = "new description"
+        warpDrive.props {
+            it[description] = value
+        }
+        assertGetWarpDescription(value, warpDrive, "value was modified with props { it[description] = \"$value\" }")
+
+        value = ""
+        warpDrive.props {
+            it[description] = value
+        }
+        assertGetWarpDescription(value, warpDrive, "value was modified with props { it[description] = \"$value\" }")
+
+        warpDrive.props {
+            it[description] = null
+        }
+        assertGetWarpDescription(null, warpDrive, "value should be removed after props { it[description] = null }")
+    }
+
+    @Test
+    fun `set boolean modifies value`() {
+        var value = true
+        warpDrive[warpDrive.schema.turbo] = value
+        assertGetWarpTurbo(value, warpDrive, "value was modified with [turbo] = \"$value\"")
+
+        value = false
+        warpDrive[warpDrive.schema.turbo] = value
+        assertGetWarpTurbo(value, warpDrive, "value was modified with [turbo] = \"$value\"")
+
+        warpDrive[warpDrive.schema.turbo] = null as Boolean?
+        assertGetWarpTurbo(null, warpDrive, "value should be removed after [turbo] = null")
+    }
+
+    @Test
+    fun `props set boolean modifies value`() {
+        var value = true
+        warpDrive.props {
+            it[turbo] = value
+        }
+        assertGetWarpTurbo(value, warpDrive, "value was modified with props { it[turbo] = \"$value\" }")
+
+        value = false
+        warpDrive.props {
+            it[turbo] = value
+        }
+        assertGetWarpTurbo(value, warpDrive, "value was modified with props { it[turbo] = \"$value\" }")
+
+        warpDrive.props {
+            it[turbo] = null as Boolean?
+        }
+        assertGetWarpTurbo(null, warpDrive, "value should be removed after props { it[turbo] = null }")
     }
 
     @Test
@@ -90,7 +168,6 @@ class JMeterElementSchemaTest {
 
     @Test
     fun `test string setter`() {
-        val warpDrive = WarpDriveElement()
         warpDrive.props {
             it[warpFactor] = "\${hello}"
         }
@@ -103,11 +180,57 @@ class JMeterElementSchemaTest {
         assertEquals(expected, warpDrive[warpDrive.schema.warpFactor]) {
             "get(warpFactor): ${WarpDriveElementSchema.warpFactor}, $message"
         }
-        assertEquals(expected, warpDrive.props[ { warpDrive.schema.warpFactor }]) {
+        assertEquals(expected, warpDrive.props[ { warpFactor }]) {
             "props.get[{warpFactor}]: ${WarpDriveElementSchema.warpFactor}, $message"
         }
         assertEquals(expected.toString(), warpDrive.getString(warpDrive.schema.warpFactor)) {
             "getString(warpFactor): ${WarpDriveElementSchema.warpFactor}, $message"
+        }
+    }
+
+    private fun assertGetWarpDescription(expected: String?, warpDrive: WarpDriveElement, message: String) {
+        assertEquals(expected ?: "", warpDrive[warpDrive.schema.description]) {
+            "get(description): ${WarpDriveElementSchema.description}, $message"
+        }
+        assertEquals(expected ?: "", warpDrive.props[ { description }]) {
+            "props.get[{description}]: ${WarpDriveElementSchema.description}, $message"
+        }
+        assertEquals(expected ?: "", warpDrive.getString(warpDrive.schema.description)) {
+            "getString(description): ${WarpDriveElementSchema.description}, $message"
+        }
+        assertEquals(expected ?: "", warpDrive.getPropertyAsString(warpDrive.schema.description.name)) {
+            "getPropertyAsString(description): ${WarpDriveElementSchema.description}, $message"
+        }
+        if (expected == null) {
+            assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.description)) {
+                "getPropertyOrNull(description) should return null for absent property, ${WarpDriveElementSchema.description}, $message"
+            }
+            assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.description.name)) {
+                "getPropertyOrNull(description.name) should return null for absent property, ${WarpDriveElementSchema.description}, $message"
+            }
+        }
+    }
+
+    private fun assertGetWarpTurbo(expected: Boolean?, warpDrive: WarpDriveElement, message: String) {
+        assertEquals(expected ?: false, warpDrive[warpDrive.schema.turbo]) {
+            "get(turbo): ${WarpDriveElementSchema.turbo}, $message"
+        }
+        assertEquals(expected ?: false, warpDrive.props[ { turbo }]) {
+            "props.get[{turbo}]: ${WarpDriveElementSchema.turbo}, $message"
+        }
+        assertEquals((expected ?: false).toString(), warpDrive.getString(warpDrive.schema.turbo)) {
+            "getString(turbo): ${WarpDriveElementSchema.turbo}, $message"
+        }
+        assertEquals(expected?.toString() ?: "", warpDrive.getPropertyAsString(warpDrive.schema.turbo.name)) {
+            "getPropertyAsString(turbo): ${WarpDriveElementSchema.turbo}, $message"
+        }
+        if (expected == null) {
+            assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.turbo)) {
+                "getPropertyOrNull(turbo) should return null for absent property, ${WarpDriveElementSchema.turbo}, $message"
+            }
+            assertNull(warpDrive.getPropertyOrNull(warpDrive.schema.turbo.name)) {
+                "getPropertyOrNull(turbo.name) should return null for absent property, ${WarpDriveElementSchema.turbo}, $message"
+            }
         }
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.protocol.http.config.gui;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
 import java.awt.Component;
 
 import javax.swing.BorderFactory;
@@ -93,9 +95,9 @@ public class GraphQLUrlConfigGui extends UrlConfigGui {
         final GraphQLRequestParams params = new GraphQLRequestParams(operationNameText.getText(),
                 queryContent.getText(), variablesContent.getText());
 
-        element.setProperty(OPERATION_NAME, params.getOperationName());
-        element.setProperty(QUERY, params.getQuery());
-        element.setProperty(VARIABLES, params.getVariables());
+        element.setProperty(OPERATION_NAME, defaultIfEmpty(params.getOperationName(), null));
+        element.setProperty(QUERY, defaultIfEmpty(params.getQuery(), null));
+        element.setProperty(VARIABLES, defaultIfEmpty(params.getVariables(), null));
         element.setProperty(HTTPSamplerBase.POST_BODY_RAW, !HTTPConstants.GET.equals(method));
 
         final Arguments args;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
@@ -58,12 +58,6 @@ public class GraphQLUrlConfigGui extends UrlConfigGui {
     private static final UrlConfigDefaults URL_CONFIG_DEFAULTS = new UrlConfigDefaults();
     static {
         URL_CONFIG_DEFAULTS.setValidMethods(new String[] { HTTPConstants.POST, HTTPConstants.GET });
-        URL_CONFIG_DEFAULTS.setDefaultMethod(HTTPConstants.POST);
-        URL_CONFIG_DEFAULTS.setAutoRedirects(false);
-        URL_CONFIG_DEFAULTS.setFollowRedirects(false);
-        URL_CONFIG_DEFAULTS.setUseBrowserCompatibleMultipartMode(false);
-        URL_CONFIG_DEFAULTS.setUseKeepAlive(true);
-        URL_CONFIG_DEFAULTS.setUseMultipart(false);
         URL_CONFIG_DEFAULTS.setUseMultipartVisible(false);
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigDefaults.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigDefaults.java
@@ -118,6 +118,7 @@ public class UrlConfigDefaults implements Serializable {
      * Return the default HTTP method to be selected in the {@link UrlConfigGui}.
      * @return the default HTTP method to be selected in the {@link UrlConfigGui}
      */
+    @Deprecated
     public String getDefaultMethod() {
         return defaultMethod;
     }
@@ -126,6 +127,7 @@ public class UrlConfigDefaults implements Serializable {
      * Set the default HTTP method to be selected in the {@link UrlConfigGui}.
      * @param defaultMethod the default HTTP method to be selected in the {@link UrlConfigGui}
      */
+    @Deprecated
     public void setDefaultMethod(String defaultMethod) {
         this.defaultMethod = defaultMethod;
     }
@@ -133,6 +135,7 @@ public class UrlConfigDefaults implements Serializable {
     /**
      * @return the default value to be set for the followRedirect checkbox in the {@link UrlConfigGui}.
      */
+    @Deprecated
     public boolean isFollowRedirects() {
         return followRedirects;
     }
@@ -141,6 +144,7 @@ public class UrlConfigDefaults implements Serializable {
      * Set the default value to be set for the followRedirect checkbox in the {@link UrlConfigGui}.
      * @param followRedirects flag whether redirects should be followed
      */
+    @Deprecated
     public void setFollowRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
     }
@@ -148,6 +152,7 @@ public class UrlConfigDefaults implements Serializable {
     /**
      * @return the default value to be set for the autoRedirects checkbox in the {@link UrlConfigGui}.
      */
+    @Deprecated
     public boolean isAutoRedirects() {
         return autoRedirects;
     }
@@ -156,6 +161,7 @@ public class UrlConfigDefaults implements Serializable {
      * Set the default value to be set for the autoRedirects checkbox in the {@link UrlConfigGui}.
      * @param autoRedirects flag whether redirects should be followed automatically
      */
+    @Deprecated
     public void setAutoRedirects(boolean autoRedirects) {
         this.autoRedirects = autoRedirects;
     }
@@ -163,6 +169,7 @@ public class UrlConfigDefaults implements Serializable {
     /**
      * @return the default value to be set for the useKeepAlive checkbox in the {@link UrlConfigGui}.
      */
+    @Deprecated
     public boolean isUseKeepAlive() {
         return useKeepAlive;
     }
@@ -171,6 +178,7 @@ public class UrlConfigDefaults implements Serializable {
      * Set the default value to be set for the useKeepAlive checkbox in the {@link UrlConfigGui}.
      * @param useKeepAlive flag whether to use keep-alive on HTTP requests
      */
+    @Deprecated
     public void setUseKeepAlive(boolean useKeepAlive) {
         this.useKeepAlive = useKeepAlive;
     }
@@ -178,6 +186,7 @@ public class UrlConfigDefaults implements Serializable {
     /**
      * @return the default value to be set for the useMultipart checkbox in the {@link UrlConfigGui}.
      */
+    @Deprecated
     public boolean isUseMultipart() {
         return useMultipart;
     }
@@ -186,6 +195,7 @@ public class UrlConfigDefaults implements Serializable {
      * Set the default value to be set for the useMultipart checkbox in the {@link UrlConfigGui}.
      * @param useMultipart flag whether request data should use multi-part feature
      */
+    @Deprecated
     public void setUseMultipart(boolean useMultipart) {
         this.useMultipart = useMultipart;
     }
@@ -193,6 +203,7 @@ public class UrlConfigDefaults implements Serializable {
     /**
      * @return the default value to be set for the useBrowserCompatibleMultipartMode checkbox in the {@link UrlConfigGui}.
      */
+    @Deprecated
     public boolean isUseBrowserCompatibleMultipartMode() {
         return useBrowserCompatibleMultipartMode;
     }
@@ -201,6 +212,7 @@ public class UrlConfigDefaults implements Serializable {
      * Set the default value to be set for the useBrowserCompatibleMultipartMode checkbox in the {@link UrlConfigGui}.
      * @param useBrowserCompatibleMultipartMode flag whether to use browser compatible multi-part mode
      */
+    @Deprecated
     public void setUseBrowserCompatibleMultipartMode(boolean useBrowserCompatibleMultipartMode) {
         this.useBrowserCompatibleMultipartMode = useBrowserCompatibleMultipartMode;
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
@@ -238,7 +238,9 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
     }
 
     public void assignDefaultValues(TestElement element) {
-        ((HTTPSamplerBase) element).setArguments(argsPanel.createTestElement());
+        HTTPSamplerBase httpSampler = (HTTPSamplerBase) element;
+        httpSampler.setPostBodyRaw(false);
+        httpSampler.setArguments(argsPanel.createTestElement());
     }
 
     // Just append all the parameter values, and use that as the post body

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/GraphQLHTTPSamplerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/GraphQLHTTPSamplerGui.java
@@ -22,6 +22,9 @@ import javax.swing.JPanel;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.config.gui.GraphQLUrlConfigGui;
 import org.apache.jmeter.protocol.http.config.gui.UrlConfigGui;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBaseSchema;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
+import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 
 /**
@@ -32,6 +35,15 @@ import org.apache.jmeter.util.JMeterUtils;
 public class GraphQLHTTPSamplerGui extends HttpTestSampleGui {
 
     private static final long serialVersionUID = 1L;
+
+    @Override
+    public void assignDefaultValues(TestElement element) {
+        super.assignDefaultValues(element);
+        HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
+        element.set(schema.getMethod(), HTTPConstants.POST);
+        element.set(schema.getUseBrowserCompatibleMultipart(), false);
+        element.set(schema.getUseMultipartPost(), false);
+    }
 
     public GraphQLHTTPSamplerGui() {
         super();

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/GraphQLHTTPSamplerGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/GraphQLHTTPSamplerGui.java
@@ -41,8 +41,20 @@ public class GraphQLHTTPSamplerGui extends HttpTestSampleGui {
         super.assignDefaultValues(element);
         HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
         element.set(schema.getMethod(), HTTPConstants.POST);
-        element.set(schema.getUseBrowserCompatibleMultipart(), false);
-        element.set(schema.getUseMultipartPost(), false);
+        element.set(schema.getPostBodyRaw(), true);
+        disableMultipart(element);
+    }
+
+    @Override
+    public void modifyTestElement(TestElement sampler) {
+        super.modifyTestElement(sampler);
+        disableMultipart(sampler);
+    }
+
+    private static void disableMultipart(TestElement sampler) {
+        HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
+        sampler.set(schema.getUseBrowserCompatibleMultipart(), false);
+        sampler.set(schema.getUseMultipartPost(), false);
     }
 
     public GraphQLHTTPSamplerGui() {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -19,10 +19,9 @@ package org.apache.jmeter.protocol.http.control.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.event.ItemEvent;
+import java.util.Arrays;
 
 import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -31,7 +30,10 @@ import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
+import org.apache.jmeter.gui.JBooleanPropertyEditor;
+import org.apache.jmeter.gui.JTextComponentBinding;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.VerticalPanel;
@@ -40,9 +42,11 @@ import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBaseSchema;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerFactory;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy;
+import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.gui.JEditableCheckBox;
 import org.apache.jorphan.gui.JFactory;
 
 import net.miginfocom.swing.MigLayout;
@@ -57,10 +61,16 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
     private static final long serialVersionUID = 242L;
 
     private UrlConfigGui urlConfigGui;
-    private JCheckBox retrieveEmbeddedResources;
-    private JCheckBox concurrentDwn;
+    private final JBooleanPropertyEditor retrieveEmbeddedResources = new JBooleanPropertyEditor(
+            HTTPSamplerBaseSchema.INSTANCE.getRetrieveEmbeddedResources(),
+            JMeterUtils.getResString("web_testing_retrieve_images"));
+    private final JBooleanPropertyEditor concurrentDwn = new JBooleanPropertyEditor(
+            HTTPSamplerBaseSchema.INSTANCE.getConcurrentDownload(),
+            JMeterUtils.getResString("web_testing_concurrent_download"));
     private JTextField concurrentPool;
-    private JCheckBox useMD5;
+    private final JBooleanPropertyEditor useMD5 = new JBooleanPropertyEditor(
+            HTTPSamplerBaseSchema.INSTANCE.getStoreAsMD5(),
+            JMeterUtils.getResString("response_save_as_md5")); // $NON-NLS-1$
     private JTextField embeddedAllowRE; // regular expression used to match against embedded resource URLs to allow
     private JTextField embeddedExcludeRE; // regular expression used to match against embedded resource URLs to exclude
     private JTextField sourceIpAddr; // does not apply to Java implementation
@@ -77,14 +87,40 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
     private final boolean isAJP;
 
     public HttpTestSampleGui() {
-        isAJP = false;
-        init();
+        this(false);
     }
 
     // For use by AJP
     protected HttpTestSampleGui(boolean ajp) {
         isAJP = ajp;
         init();
+        HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
+        bindingGroup.addAll(
+                Arrays.asList(
+                        retrieveEmbeddedResources,
+                        concurrentDwn,
+                        new JTextComponentBinding(concurrentPool, schema.getConcurrentDownloadPoolSize()),
+                        useMD5,
+                        new JTextComponentBinding(embeddedAllowRE, schema.getEmbeddedUrlAllowRegex()),
+                        new JTextComponentBinding(embeddedExcludeRE, schema.getEmbeddedUrlExcludeRegex())
+                )
+        );
+        if (!isAJP) {
+            bindingGroup.addAll(
+                    Arrays.asList(
+                            new JTextComponentBinding(sourceIpAddr, schema.getIpSource()),
+                            // TODO: sourceIpType
+                            new JTextComponentBinding(proxyScheme, schema.getProxy().getScheme()),
+                            new JTextComponentBinding(proxyHost, schema.getProxy().getHost()),
+                            new JTextComponentBinding(proxyPort, schema.getProxy().getPort()),
+                            new JTextComponentBinding(proxyUser, schema.getProxy().getUsername()),
+                            new JTextComponentBinding(proxyPass, schema.getProxy().getPassword()),
+                            // TODO: httpImplementation
+                            new JTextComponentBinding(connectTimeOut, schema.getConnectTimeout()),
+                            new JTextComponentBinding(responseTimeOut, schema.getResponseTimeout())
+                    )
+            );
+        }
     }
 
     /**
@@ -96,24 +132,9 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         final HTTPSamplerBase samplerBase = (HTTPSamplerBase) element;
         HTTPSamplerBaseSchema httpSchema = HTTPSamplerBaseSchema.INSTANCE;
         urlConfigGui.configure(element);
-        retrieveEmbeddedResources.setSelected(samplerBase.isImageParser());
-        concurrentDwn.setSelected(samplerBase.isConcurrentDwn());
-        concurrentPool.setText(samplerBase.getConcurrentPool());
-        useMD5.setSelected(samplerBase.useMD5());
-        embeddedAllowRE.setText(samplerBase.getEmbeddedUrlRE());
-        embeddedExcludeRE.setText(samplerBase.getEmbededUrlExcludeRE());
         if (!isAJP) {
-            sourceIpAddr.setText(samplerBase.getIpSource());
             sourceIpType.setSelectedIndex(samplerBase.getIpSourceType());
-
-            proxyScheme.setText(samplerBase.getString(httpSchema.getProxy().getScheme()));
-            proxyHost.setText(samplerBase.getString(httpSchema.getProxy().getHost()));
-            proxyPort.setText(samplerBase.getString(httpSchema.getProxy().getPort()));
-            proxyUser.setText(samplerBase.getString(httpSchema.getProxy().getUsername()));
-            proxyPass.setText(samplerBase.getString(httpSchema.getProxy().getPassword()));
             httpImplementation.setSelectedItem(samplerBase.getString(httpSchema.getImplementation()));
-            connectTimeOut.setText(samplerBase.getString(httpSchema.getConnectTimeout()));
-            responseTimeOut.setText(samplerBase.getString(httpSchema.getResponseTimeout()));
         }
     }
 
@@ -121,10 +142,19 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
      * {@inheritDoc}
      */
     @Override
-    public TestElement createTestElement() {
-        HTTPSamplerBase sampler = new HTTPSamplerProxy();
-        modifyTestElement(sampler);
-        return sampler;
+    public TestElement makeTestElement() {
+        return new HTTPSamplerProxy();
+    }
+
+    @Override
+    public void assignDefaultValues(TestElement element) {
+        super.assignDefaultValues(element);
+        HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
+        // It probably does not make much sense overriding HTTP method with HTTP Request Defaults, so we set it here
+        element.set(schema.getMethod(), HTTPConstants.GET);
+        element.set(schema.getFollowRedirects(), true);
+        element.set(schema.getUseKeepalive(), true);
+        urlConfigGui.assignDefaultValues(element);
     }
 
     /**
@@ -134,31 +164,19 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
      */
     @Override
     public void modifyTestElement(TestElement sampler) {
-        sampler.clear();
+        super.modifyTestElement(sampler);
         urlConfigGui.modifyTestElement(sampler);
         final HTTPSamplerBase samplerBase = (HTTPSamplerBase) sampler;
         HTTPSamplerBaseSchema httpSchema = samplerBase.getSchema();
-        samplerBase.setImageParser(retrieveEmbeddedResources.isSelected());
-        enableConcurrentDwn(retrieveEmbeddedResources.isSelected());
-        samplerBase.setConcurrentDwn(concurrentDwn.isSelected());
-        samplerBase.setConcurrentPool(concurrentPool.getText());
-        samplerBase.setMD5(useMD5.isSelected());
-        samplerBase.setEmbeddedUrlRE(embeddedAllowRE.getText());
-        samplerBase.setEmbeddedUrlExcludeRE(embeddedExcludeRE.getText());
+        enableConcurrentDwn();
         if (!isAJP) {
-            samplerBase.setIpSource(sourceIpAddr.getText());
-            samplerBase.setIpSourceType(sourceIpType.getSelectedIndex());
-
-            samplerBase.set(httpSchema.getProxy().getScheme(), proxyScheme.getText());
-            samplerBase.set(httpSchema.getProxy().getHost(), proxyHost.getText());
-            samplerBase.set(httpSchema.getProxy().getPort(), proxyPort.getText());
-            samplerBase.set(httpSchema.getProxy().getUsername(), proxyUser.getText());
-            samplerBase.set(httpSchema.getProxy().getPassword(), String.valueOf(proxyPass.getPassword()));
+            if (!StringUtils.isEmpty(sourceIpAddr.getText())) {
+                samplerBase.set(httpSchema.getIpSourceType(), sourceIpType.getSelectedIndex());
+            } else {
+                samplerBase.removeProperty(httpSchema.getIpSourceType());
+            }
             samplerBase.set(httpSchema.getImplementation(), String.valueOf(httpImplementation.getSelectedItem()));
-            samplerBase.set(httpSchema.getConnectTimeout(), connectTimeOut.getText());
-            samplerBase.set(httpSchema.getResponseTimeout(), responseTimeOut.getText());
         }
-        super.configureTestElement(sampler);
     }
 
     /**
@@ -279,18 +297,14 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
 
     protected JPanel createEmbeddedRsrcPanel() {
         // retrieve Embedded resources
-        retrieveEmbeddedResources = new JCheckBox(JMeterUtils.getResString("web_testing_retrieve_images")); // $NON-NLS-1$
         // add a listener to activate or not concurrent dwn.
-        retrieveEmbeddedResources.addItemListener(e -> {
-            if (e.getStateChange() == ItemEvent.SELECTED) { enableConcurrentDwn(true); }
-            else { enableConcurrentDwn(false); }
-        });
+        retrieveEmbeddedResources.addPropertyChangeListener(
+                JEditableCheckBox.VALUE_PROPERTY,
+                ev -> enableConcurrentDwn());
         // Download concurrent resources
-        concurrentDwn = new JCheckBox(JMeterUtils.getResString("web_testing_concurrent_download")); // $NON-NLS-1$
-        concurrentDwn.addItemListener(e -> {
-            if (retrieveEmbeddedResources.isSelected() && e.getStateChange() == ItemEvent.SELECTED) { concurrentPool.setEnabled(true); }
-            else { concurrentPool.setEnabled(false); }
-        });
+        concurrentDwn.addPropertyChangeListener(
+                JEditableCheckBox.VALUE_PROPERTY,
+                ev -> enableConcurrentDwn());
         concurrentPool = new JTextField(2); // 2 column size
         concurrentPool.setMinimumSize(new Dimension(10, (int) concurrentPool.getPreferredSize().getHeight()));
         concurrentPool.setMaximumSize(new Dimension(60, (int) concurrentPool.getPreferredSize().getHeight()));
@@ -341,8 +355,6 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         checkBoxPanel.setBorder(BorderFactory.createTitledBorder(
                 JMeterUtils.getResString("optional_tasks"))); // $NON-NLS-1$
 
-        // Use MD5
-        useMD5 = new JCheckBox(JMeterUtils.getResString("response_save_as_md5")); // $NON-NLS-1$
         checkBoxPanel.add(useMD5);
 
         return checkBoxPanel;
@@ -370,38 +382,19 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         return getMinimumSize();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void clearGui() {
         super.clearGui();
-        retrieveEmbeddedResources.setSelected(false);
-        concurrentDwn.setSelected(false);
-        concurrentPool.setText(String.valueOf(HTTPSamplerBase.CONCURRENT_POOL_SIZE));
-        enableConcurrentDwn(false);
-        useMD5.setSelected(false);
         urlConfigGui.clear();
-        embeddedAllowRE.setText(""); // $NON-NLS-1$
-        if (!isAJP) {
-            sourceIpAddr.setText(""); // $NON-NLS-1$
-            sourceIpType.setSelectedIndex(HTTPSamplerBase.SourceType.HOSTNAME.ordinal()); //default: IP/Hostname
-            proxyScheme.setText(""); // $NON-NLS-1$
-            proxyHost.setText(""); // $NON-NLS-1$
-            proxyPort.setText(""); // $NON-NLS-1$
-            proxyUser.setText(""); // $NON-NLS-1$
-            proxyPass.setText(""); // $NON-NLS-1$
-            httpImplementation.setSelectedItem(""); // $NON-NLS-1$
-            connectTimeOut.setText(""); // $NON-NLS-1$
-            responseTimeOut.setText(""); // $NON-NLS-1$
-        }
     }
 
-    private void enableConcurrentDwn(boolean enable) {
+    private void enableConcurrentDwn() {
+        boolean enable = !JEditableCheckBox.Value.of(false).equals(retrieveEmbeddedResources.getValue());
         concurrentDwn.setEnabled(enable);
         embeddedAllowRE.setEnabled(enable);
         embeddedExcludeRE.setEnabled(enable);
-        concurrentPool.setEnabled(concurrentDwn.isSelected() && enable);
+        // Allow editing the pool size if "download concurrently" checkbox is set or has expression
+        concurrentPool.setEnabled(enable && !concurrentDwn.getValue().equals(JEditableCheckBox.Value.of(false)));
     }
 
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -175,7 +175,8 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
             } else {
                 samplerBase.removeProperty(httpSchema.getIpSourceType());
             }
-            samplerBase.set(httpSchema.getImplementation(), String.valueOf(httpImplementation.getSelectedItem()));
+            String selectedImplementation = String.valueOf(httpImplementation.getSelectedItem());
+            samplerBase.set(httpSchema.getImplementation(), StringUtils.defaultIfBlank(selectedImplementation, null));
         }
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/AuthPanel.java
@@ -107,7 +107,8 @@ public class AuthPanel extends AbstractConfigGui implements ActionListener {
     public TestElement createTestElement() {
         AuthManager authMan = tableModel.manager;
         configureTestElement(authMan);
-        authMan.setClearEachIteration(clearEachIteration.isSelected());
+        authMan.setClearEachIteration(false);
+        authMan.setControlledByThread(false);
         return (TestElement) authMan.clone();
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/DNSCachePanel.java
@@ -140,10 +140,14 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
         configureTestElement(dnsRes);
         if (dnsRes instanceof DNSCacheManager) {
             DNSCacheManager dnsCacheManager = (DNSCacheManager) dnsRes;
+            // Init servers list
+            dnsCacheManager.getServers();
             for (int i = 0; i < dnsServersTableModel.getRowCount(); i++) {
                 String server = (String) dnsServersTableModel.getRowData(i)[0];
                 dnsCacheManager.addServer(server);
             }
+            // Init hosts list
+            dnsCacheManager.getHosts();
             for (int i = 0; i < dnsHostsTableModel.getRowCount(); i++) {
                 String host = (String) dnsHostsTableModel.getRowData(i)[0];
                 String addresses = (String) dnsHostsTableModel.getRowData(i)[1];
@@ -188,10 +192,19 @@ public class DNSCachePanel extends AbstractConfigGui implements ActionListener {
     }
 
     @Override
-    public TestElement createTestElement() {
-        DNSCacheManager dnsCacheManager = new DNSCacheManager();
-        modifyTestElement(dnsCacheManager);
-        return dnsCacheManager;
+    public TestElement makeTestElement() {
+        return new DNSCacheManager();
+    }
+
+    @Override
+    public void assignDefaultValues(TestElement element) {
+        super.assignDefaultValues(element);
+        DNSCacheManager manager = (DNSCacheManager) element;
+        // It sets empty list of servers and hosts
+        manager.getServers();
+        manager.getHosts();
+        manager.setClearEachIteration(true);
+        manager.setCustomResolver(false);
     }
 
     @Override

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
@@ -104,10 +104,10 @@ public class HTTPArgumentsPanel extends ArgumentsPanel {
     }
 
     @Override
-    public TestElement createTestElement() {
+    public Arguments createTestElement() {
         Arguments args = getUnclonedParameters();
-        super.configureTestElement(args);
-        return (TestElement) args.clone();
+        assignDefaultValues(args);
+        return (Arguments) args.clone();
     }
 
     /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -315,11 +315,12 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
         if (StringUtils.isNotEmpty(url.getQuery())) {
             path += "?" + url.getQuery();
         }
+        // setMethod must be before setPath as setPath uses method to determine if parameters should be parsed or not
+        httpSampler.setMethod(request.getMethod());
         httpSampler.setPath(path);
         httpSampler.setDomain(url.getHost());
         httpSampler.setUseKeepAlive(request.isKeepAlive());
         httpSampler.setFollowRedirects(true);
-        httpSampler.setMethod(request.getMethod());
         HeaderManager headerManager = createHeaderManager(request);
         httpSampler.addTestElement(headerManager);
         configureTimeout(request, httpSampler);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -17,6 +17,8 @@
 
 package org.apache.jmeter.protocol.http.proxy;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -174,9 +176,9 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
 
         if (params != null) {
             sampler.setProperty(TestElement.GUI_CLASS, GraphQLHTTPSamplerGui.class.getName());
-            sampler.setProperty(GraphQLUrlConfigGui.OPERATION_NAME, params.getOperationName());
-            sampler.setProperty(GraphQLUrlConfigGui.QUERY, params.getQuery());
-            sampler.setProperty(GraphQLUrlConfigGui.VARIABLES, params.getVariables());
+            sampler.setProperty(GraphQLUrlConfigGui.OPERATION_NAME, defaultIfEmpty(params.getOperationName(), null));
+            sampler.setProperty(GraphQLUrlConfigGui.QUERY, defaultIfEmpty(params.getQuery(), null));
+            sampler.setProperty(GraphQLUrlConfigGui.VARIABLES, defaultIfEmpty(params.getVariables(), null));
         }
     }
 

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBaseSchema.kt
@@ -65,7 +65,7 @@ public abstract class HTTPSamplerBaseSchema : TestElementSchema() {
         by testElement("HTTPSampler.dns_cache_manager")
 
     public val method: StringPropertyDescriptor<HTTPSamplerBaseSchema>
-        by string("HTTPSampler.method")
+        by string("HTTPSampler.method", default = HTTPSamplerBase.DEFAULT_METHOD)
 
     public val protocol: StringPropertyDescriptor<HTTPSamplerBaseSchema>
         by string("HTTPSampler.protocol", default = HTTPConstants.PROTOCOL_HTTP)

--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerPrintDslTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerPrintDslTest.kt
@@ -92,6 +92,8 @@ class HttpSamplerPrintDslTest : JMeterTestCase() {
             +element
         }
 
+        // "arguments" property is assigned in HTTPSamplerBase constructor, so it comes before
+        // name and guiClass common properties
         assertEquals(
             """
             org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy::class {
@@ -103,17 +105,19 @@ class HttpSamplerPrintDslTest : JMeterTestCase() {
                             it[testClass] = "org.apache.jmeter.config.Arguments"
                         }
                     }
+                    it[name] = "HTTP Request"
+                    it[guiClass] = "org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui"
                     it[method] = "GET"
                     it[followRedirects] = true
                     it[useKeepalive] = true
-                    it[implementation] = "HttpClient4"
-                    it[name] = "HTTP Request"
-                    it[guiClass] = "org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui"
                 }
             }
 
             """.trimIndent().replace("\r\n", "\n"),
-            DslPrinterTraverser().also { tree.traverse(it) }.toString().replace("\r\n", "\n")
+            DslPrinterTraverser().also { tree.traverse(it) }.toString().replace("\r\n", "\n"),
+            "HTTP request created with HttpTestSampleGui.createTestElement() should have expected output shape. " +
+                "DslPrinterTraverser does not print the values which are automatically assigned in constructor, " +
+                "so the expected output does not have it[testClass] = HTTPSamplerProxy, and empty list in arguments"
         )
     }
 
@@ -130,17 +134,14 @@ class HttpSamplerPrintDslTest : JMeterTestCase() {
                             it[testClass] = "org.apache.jmeter.config.Arguments"
                         }
                     }
+                    it[name] = "HTTP Request"
+                    it[guiClass] = "org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui"
                     it[method] = "GET"
                     it[followRedirects] = true
                     it[useKeepalive] = true
-                    it[implementation] = "HttpClient4"
-                    it[name] = "HTTP Request"
-                    it[guiClass] = "org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui"
                 }
             }
         }.keys.first() as TestElement
-
-        createdWithUi.traverse(RemoveDefaultValues)
 
         // We compare elements manually, and call assertEquals(toString, toString) so
         // the test output looks better (diff in IDE) in case of the failure

--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerPrintDslTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerPrintDslTest.kt
@@ -110,6 +110,7 @@ class HttpSamplerPrintDslTest : JMeterTestCase() {
                     it[method] = "GET"
                     it[followRedirects] = true
                     it[useKeepalive] = true
+                    it[postBodyRaw] = false
                 }
             }
 
@@ -139,6 +140,7 @@ class HttpSamplerPrintDslTest : JMeterTestCase() {
                     it[method] = "GET"
                     it[followRedirects] = true
                     it[useKeepalive] = true
+                    it[postBodyRaw] = false
                 }
             }
         }.keys.first() as TestElement

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/control/gui/BeanShellSamplerGui.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.protocol.java.control.gui;
 
 import java.awt.BorderLayout;
+import java.util.Arrays;
 
 import javax.swing.Box;
 import javax.swing.JLabel;
@@ -25,7 +26,10 @@ import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
+import org.apache.jmeter.gui.FilePanelEntryBinding;
 import org.apache.jmeter.gui.JBooleanPropertyEditor;
+import org.apache.jmeter.gui.JSyntaxTextAreaBinding;
+import org.apache.jmeter.gui.JTextComponentBinding;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.FilePanelEntry;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
@@ -55,51 +59,19 @@ public class BeanShellSamplerGui extends AbstractSamplerGui {
 
     public BeanShellSamplerGui() {
         init();
+        bindingGroup.addAll(
+                Arrays.asList(
+                        new JSyntaxTextAreaBinding(scriptField, BeanShellSamplerSchema.INSTANCE.getScript()),
+                        new FilePanelEntryBinding(filename, BeanShellSamplerSchema.INSTANCE.getFilename()),
+                        new JTextComponentBinding(parameters, BeanShellSamplerSchema.INSTANCE.getParameters()),
+                        resetInterpreter
+                )
+        );
     }
 
     @Override
-    public void configure(TestElement element) {
-        scriptField.setInitialText(element.get(BeanShellSamplerSchema.INSTANCE.getScript()));
-        scriptField.setCaretPosition(0);
-        filename.setFilename(element.get(BeanShellSamplerSchema.INSTANCE.getFilename()));
-        parameters.setText(element.get(BeanShellSamplerSchema.INSTANCE.getParameters()));
-        resetInterpreter.updateUi(element);
-        super.configure(element);
-    }
-
-    @Override
-    public TestElement createTestElement() {
-        BeanShellSampler sampler = new BeanShellSampler();
-        modifyTestElement(sampler);
-        return sampler;
-    }
-
-    /**
-     * Modifies a given TestElement to mirror the data in the gui components.
-     *
-     * @see org.apache.jmeter.gui.JMeterGUIComponent#modifyTestElement(TestElement)
-     */
-    @Override
-    public void modifyTestElement(TestElement te) {
-        te.clear();
-        super.configureTestElement(te);
-        te.set(BeanShellSamplerSchema.INSTANCE.getScript(), scriptField.getText());
-        te.set(BeanShellSamplerSchema.INSTANCE.getFilename(), filename.getFilename());
-        te.set(BeanShellSamplerSchema.INSTANCE.getParameters(), parameters.getText());
-        resetInterpreter.updateElement(te);
-    }
-
-    /**
-     * Implements JMeterGUIComponent.clearGui
-     */
-    @Override
-    public void clearGui() {
-        super.clearGui();
-
-        filename.setFilename(""); //$NON-NLS-1$
-        parameters.setText(""); //$NON-NLS-1$
-        scriptField.setInitialText(""); //$NON-NLS-1$
-        resetInterpreter.reset();
+    public TestElement makeTestElement() {
+        return new BeanShellSampler();
     }
 
     @Override

--- a/xdocs/usermanual/jmeter_tutorial.xml
+++ b/xdocs/usermanual/jmeter_tutorial.xml
@@ -259,6 +259,10 @@ component. The resource will have to be entered into JMeters <code>messages.prop
 (and possibly translations as well).</li>
     </ol>
   </li>
+  <li>Override <code>org.apache.jmeter.gui.JMeterGUIComponent.makeTestElement</code> method so it returns
+  the appropriate <code>TestElement</code>. JMeter will use <code>makeTestElement</code> when user creates the element
+  from the UI. In most cases it should be just creating the test element like
+  <code>return new SetupThreadGroup()</code>.</li>
   <li>Create your GUI. Whatever style you like, layout your GUI. Your class ultimately extends
     <code>JPanel</code>, so your layout must be in your class's own <code>ContentPane</code>.
     Do not hook up GUI elements to your <code>TestElement</code> class via actions and events.
@@ -287,10 +291,15 @@ private void init() {
       </li>
     </ol>
   </li>
-  <li>Implement <code>public void configure(TestElement el)</code>
+  <li>Then you need to wire UI elements with the properties of the new <code>TestElement</code>. If you create
+  <code>TestElementSchema</code> for your test element (see <code>ThreadGroupSchema</code>), then you could use
+  automatic wiring with <code>PropertyEditorCollection</code></li>
+  <li>If you do not use schema for wiring properties to UI control, or if you have non-trivial controls,
+    you might customize <code>TestElement</code> properties to UI control mapping by overriding <code>public void configure(TestElement el)</code>
     <ol>
       <li>Be sure to call <code>super.configure(e)</code>. This will populate some of the data for you, like
-         the name of the element.</li>
+      the name of the element. Note: JMeter reuses UI elements when user changes the active element in test tree,
+      so you need to set all the text fields in <code>configure</code> method to avoid displaying stale contents.</li>
       <li>Use this method to set data into your GUI elements. Example:
 <source>
 public void configure(TestElement el) {
@@ -312,16 +321,18 @@ public void configure(TestElement el) {
 }
 </source>
       </li>
-      <li>Implement <code>public void modifyTestElement(TestElement e)</code>. This is where you
-         move the data from your GUI elements to the <code>TestElement</code>. It is the logical reverse of the
-         previous method.
+      <li>If you do not use schema for wiring UI controls to <code>TestElement</code> properties,
+         or if you want customized behavior, you might override <code>public void modifyTestElement(TestElement e)</code>.
+         It is the logical reverse of <code>configure</code> method.
          <ol>
-           <li>Call <code>super.configureTestElement(e)</code>. This will take care of some default data for
+           <li>Call <code>super.modifyTestElement(e)</code>. This will take care of some default data for
              you.</li>
+           <li>Note: in most cases, you want to treat "empty field" as "absent property", so make sure to
+           remove the property if the input field is empty.</li>
            <li>Example:
 <source>
 public void modifyTestElement(TestElement e) {
-    super.configureTestElement(e);
+    super.modifyTestElement(e);
     e.setProperty(new BooleanProperty(
             RegexExtractor.USEHEADERS,
             useHeaders.isSelected()));
@@ -339,16 +350,9 @@ public void modifyTestElement(TestElement e) {
            </li>
          </ol>
        </li>
-       <li>Implement <code>public TestElement createTestElement()</code>. This method should create a
-         new instance of your <code>TestElement</code> class, and then pass it to the <code>modifyTestElement(TestElement)</code>
-         method you made above
-<source>
-public TestElement createTestElement() {
-    RegexExtractor extractor = new RegexExtractor();
-    modifyTestElement(extractor);
-    return extractor;
-}
-</source>
+       <li>If your UI includes controls that do not map to <code>TestElement</code> properties (sliders, tabs),
+         then you might want to reset them when user switches the controls. You can do that by overriding
+         <code>clearGui()</code> method and resetting the controls there.
        </li>
     </ol>
   </li>


### PR DESCRIPTION
## Description

Previously (e.g. in 5.6.2), `TestElement.set(PropertyDescriptor, String?)` was removing the property if the value was an empty string. I thought it was convenient for the UI, however now I realize that was a mistake. If the user calls `port = "whatever"` they expect the property should be set no matter if the value is empty string or if it accidentally matches a default one.

This PR changes `.set` behaviour so only `null` value would cause property removal.

## TODO

* [x] Ensure tests pass
* [x] Apply apply `JTextFieldBindEditor` to `Gui` classes that use `TestElementSchema` so they remove property when the field is empty
* [x] Add javadocs for the new classes, interfaces, and methods
* [x] Check if this PR somehow resolves https://github.com/apache/jmeter/issues/6076. The PR does resolve 6076
* [x] Analyze if we need an alternative to `org.apache.jmeter.gui.JMeterGUIComponent#modifyTestElement` that does not clear the element state. For most elements, `modifyTestElement` should reset the test element state, and then populate properties based on the UI state. However, if UI is composed from several sub-UI blocks, then we need to apply sub-block "UI to properties" transformation without clearing the properties. For instance, `HttpDefaultsGui` has `UrlConfigGui` block, and we would like to call something like `.modifyTestElement(element)` from `HttpDefaultsGui.modifyTestElement`, however, if `urlConfigGui.modifyTestElement` clears the properties, then we can't compose UI blocks.
  **Result**: "Gui extensions" can be a separate sub-class of `AbstractJMeterGuiComponent` or `JMeterGUIComponent` that does not call `super.modifyTestElement..`, so they do not reset the test element state.
* Check naming
  * [x] `interface Binding` (was `interface PropertyDescriptorBinder`) (it includes `updateElement` and `updateUi` methods)
  * [x] `class JTextComponentBinding` (was `class JTextComponentBindEditor`), `class JCheckBoxBinding` (was `class JCheckBoxBindEditor`): they wrap regular `JTextField` and link them with `PropertyDescriptors`
  * [x] `class BindingGroup` (was `class PropertyEditorCollection`) maintains a collection of `Binding` (was `PropertyDescriptorBinder`)
  * [x] `org.apache.jmeter.gui.JMeterGUIComponent#makeTestElement`. It is intended to "just create empty test element" when creating from UI
  * [x] `org.apache.jmeter.gui.JMeterGUIComponent#assignDefaultValues`. It should assign default values after creating the test element. By default it assigns name, guiClass, etc. Subclasses could set their defaults. For instance, GraphQL sampler inherits from HTTP Request, and it sets `method=post` in `assignDefaultValues`.

### Setting properties with API vs UI

1. If a property is set from code (e.g. from Java code), then we should store it in `TestElement` properties no matter if the value is empty or if the value is the same as default one. For instance, `HTTP Request Defaults` (and other "config" elements) override non-set properties only, so we might want to explicitly have a value in `HTTP Request` to avoid it being overridden by `HTTP Request Defaults`
2. If a UI element (e.g. `JTextField`) is empty (blank) we assume the value is unset. Currently, we have no way to distinguish between "value is empty string" vs "value is unset", so we just assume "blank" values to be the same as "unset". It means UI elements should convert "empty string text field" and "empty checkbox" to "property removal". Note that we can't integrate "remove empty property" into setter methods due to `1.`

I factor UI converters into UI classes to make it happen without much duplication. For instance, `JEditableCheckBox` calls into `removeProperty` for unset checkboxes.
I added `JTextFieldBindEditor` to make it easier to teach the existing UI classes to "remove property on empty string"

### Creating elements with UI

The way UI creates test elements is `org.apache.jmeter.gui.JMeterGUIComponent#createTestElement`. Historically, the recommendation was as follows:

```java
public TestElement createTestElement() {
    TestElementXYZ el = new TestElementXYZ();
    modifyTestElement(el);
    return el;
}
```

`modifyTestElement` is a method that assigns the state of UI controls to `TestElement's` properties.
The drawback is that UI controls (e.g. `JTextField`) must be initialized to the appropriate default values and then `modifyTestElement` grabs those defaults and puts them to `TestElementXYZ`.

I suggest we should drift away from using `modifyTestElement` when creating test elements, and we should just set the property values as property values. Then we have a workable `TestElement` which we can display with `JMeterGUIComponent#configure` (it extracts properties and populates UI accordingly).

I think the change is backward compatible, and there's no rush in editing every component at once, however, it makes code simpler when "set default values in `JTextField`" calls are removed.

#### Before

* `JMeterGUIComponent#createTestElement` creates test element **and** populates values based on UI controls (`modifyTestElement`).
* `JMeterGUIComponent#clearGui` sets all controls to their default values
* `JMeterGUIComponent#modifyTestElement` extracts data from UI and populates `TestElement's` properties
* `JMeterGUIComponent#configureTestElement` somewhat duplicates `modifyTestElement`
* `JMeterGUIComponent#configure` extracts data from `TestElement's` and populates UI elements

#### After

* `JMeterGUIComponent#createTestElement` is a `default` method `JMeterGUIComponent`:

  ```java
      default TestElement createTestElement() {
          TestElement element = makeTestElement();
          assignDefaultValues(element);
          return element;
      }
  ```

* `JMeterGUIComponent#makeTestElement` is a method plugin authors should implement to **instantiate** the `TestElement` instance

  ```java
      @Override
      public TestElement makeTestElement() {
          return new HTTPSamplerProxy();
      }
  ```

* `JMeterGUIComponent#assignDefaultValues` assigns default property values like `name`, `gui_class`, `test_class`. Plugin authors could override it to add their defaults. For instance, `HTTP Request` wants to set `method=GET`, `use_keepalive=true`, and the implementation could be as follows:

  ```java
      @Override
      public void assignDefaultValues(TestElement element) {
          super.assignDefaultValues(element);
          HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
          // It probably does not make much sense overriding HTTP method with HTTP Request Defaults, so we set it here
          element.set(schema.getMethod(), HTTPConstants.GET);
          element.set(schema.getFollowRedirects(), true);
          element.set(schema.getUseKeepalive(), true);
          urlConfigGui.assignDefaultValues(element);
      }
  ```

* `JMeterGUIComponent#clearGui`. In most (all?) cases, the method should not alter simple fields. When JMeter wants to display `TestElement` it calls `JMeterGUIComponent#configure`, and the expectation is that `configure` updates all the UI fields. That means there's no need to reset the fields. However, the UI might have extra state like "selected basic/advanced tab", and it might make sense to reset that state in `clearGui`.

* `JMeterGUIComponent#configure`. No changes. It should update all UI controls based on the properties of the test element even in the case the property is absent. Note: for now, "unset properties that have defaults" must be displayed as empty string to avoid confusion. For instance, `HTTP charset` has default of UTF-8, however, we do not want to display it as if the user put UTF-8 explicitly. 

* `JMeterGUIComponent#modifyTestElement` should extract data from UI and pass to `TestElement`. It should treat empty string as "absence of a value", so it should remove the corresponding property. Classes like `JTextFieldBindEditor` make it easier to retrofit the existing code and make the behaviour consistent across all fields.

* `JMeterGUIComponent#configureTestElement`. I suggest we deprecate `configureTestElement`. Of course, we can keep it in the source code, however, we should not use it. We should just add a default implementation of `modifyTestElement` and ask users to follow the regular pattern like:

  ```java
      @Override
      public void modifyTestElement(TestElement element) {
          super.modifyTestElement(element); // populate base properties like name, comments
          // populate custom properties
  ```

* `org.apache.jmeter.gui.AbstractJMeterGuiComponent#editors` is `PropertyEditorCollection` which helps to implement both `modifyTestElement` and `configure` at the same time. The idea is that we can link `JTextField` with a corresponding `PropertyDescriptor`, then it would know how to populate the field based on the given `TestElement`, and it would know how to get the UI value into the `TestElement`

Here's a sample for `HTTP Request Sampler` UI. `concurrentDwn`, `useMD5` are "editable checkboxes" which already were linked to the properties, so they are passed as is. The rest (e.g. `concurrentPool`) are regular `JTextField` instances, so we link them with a property, and remove the boilerplate from `modifyTestElement` and `configure`

  ```java
      protected HttpTestSampleGui(boolean ajp) {
          isAJP = ajp;
          init();
          HTTPSamplerBaseSchema schema = HTTPSamplerBaseSchema.INSTANCE;
          editors.addAll(
                  Arrays.asList(
                          retrieveEmbeddedResources,
                          concurrentDwn,
                          new JTextComponentBinding(concurrentPool, schema.getConcurrentDownloadPoolSize()),
                          useMD5,
                          new JTextComponentBinding(embeddedAllowRE, schema.getEmbeddedUrlAllowRegex()),
                          new JTextComponentBinding(embeddedExcludeRE, schema.getEmbeddedUrlExcludeRegex())
                  )
          );
          if (!isAJP) {
              editors.addAll(
                      Arrays.asList(
                              new JTextComponentBinding(sourceIpAddr, schema.getIpSource()),
                              // TODO: sourceIpType
                              new JTextComponentBinding(proxyScheme, schema.getProxy().getScheme()),
                              new JTextComponentBinding(proxyHost, schema.getProxy().getHost()),
                              new JTextComponentBinding(proxyPort, schema.getProxy().getPort()),
                              new JTextComponentBinding(proxyUser, schema.getProxy().getUsername()),
                              new JTextComponentBinding(proxyPass, schema.getProxy().getPassword()),
                              // TODO: httpImplementation
                              new JTextComponentBinding(connectTimeOut, schema.getConnectTimeout()),
                              new JTextComponentBinding(responseTimeOut, schema.getResponseTimeout())
                      )
              );
          }
      }
  ```
