### PR TITLE
feat: pass JDBCSampler.maxRows to Statement.setMaxRows so the driver does not fetch extra rows from the database

### DIFF
--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -167,6 +167,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement {
         if (SELECT.equals(currentQueryType)) {
             try (Statement stmt = conn.createStatement()) {
                 setQueryTimeout(stmt, getIntegerQueryTimeout());
+                configureMaxRows(stmt);
                 ResultSet rs = null;
                 try {
                     rs = stmt.executeQuery(getQuery());
@@ -198,6 +199,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement {
         } else if (PREPARED_SELECT.equals(currentQueryType)) {
             try (PreparedStatement pstmt = getPreparedStatement(conn)) {
                 setArguments(pstmt);
+                configureMaxRows(pstmt);
                 ResultSet rs = null;
                 try {
                     rs = pstmt.executeQuery();
@@ -236,7 +238,15 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement {
         }
     }
 
+    private void configureMaxRows(Statement stmt) throws SQLException {
+        int maxRows = getIntegerResultSetMaxRows();
+        if (maxRows >= 0) {
+           stmt.setMaxRows(maxRows);
+        }
+    }
+
     private String resultSetsToString(PreparedStatement pstmt, boolean result, int[] out) throws SQLException, UnsupportedEncodingException {
+        configureMaxRows(pstmt);
         StringBuilder sb = new StringBuilder();
         int updateCount = 0;
         boolean currentResult = result;

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
@@ -72,16 +72,17 @@ public class JDBCSampler extends AbstractJDBCTestElement implements Sampler, Tes
         Connection conn = null;
 
         try {
-            if (JOrphanUtils.isBlank(getDataSource())) {
+            String dataSource = getDataSource();
+            if (JOrphanUtils.isBlank(dataSource)) {
                 throw new IllegalArgumentException("Name for DataSoure must not be empty in " + getName());
             }
 
             try {
-                conn = DataSourceElement.getConnection(getDataSource());
+                conn = DataSourceElement.getConnection(dataSource);
             } finally {
                 res.connectEnd();
             }
-            res.setResponseHeaders(DataSourceElement.getConnectionInfo(getDataSource()));
+            res.setResponseHeaders(DataSourceElement.getConnectionInfo(dataSource));
             res.setResponseData(execute(conn, res));
         } catch (SQLException ex) {
             final String errCode = Integer.toString(ex.getErrorCode());

--- a/src/protocol/jdbc/src/test/kotlin/org/apache/jmeter/protocol/jdbc/sampler/JDBCSamplerTest.kt
+++ b/src/protocol/jdbc/src/test/kotlin/org/apache/jmeter/protocol/jdbc/sampler/JDBCSamplerTest.kt
@@ -80,6 +80,7 @@ class JDBCSamplerTest {
         val stmt = mockk<Statement> {
             every { executeQuery(any()) } returns rs
             justRun { queryTimeout = any() }
+            justRun { maxRows = any() }
             justRun { close() }
         }
         val conn = mockk<Connection> {
@@ -90,11 +91,13 @@ class JDBCSamplerTest {
         }
 
         sut.query = "SELECT"
+        sut.resultSetMaxRows = "10"
         val response = sut.executeForTest(conn, sample)
 
         verifyOrder {
             conn.createStatement()
             stmt.queryTimeout = 0
+            stmt.maxRows = 10
             stmt.executeQuery(any())
             sample.latencyEnd()
             // getStringFromResultSet

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -83,6 +83,7 @@ Summary
   <li><issue>6165</issue><pr>6192</pr>The Constant Throughput Timer is throwing a NullPointerException when using variables (vars.get) in "Target Throughput"-field</li>
   <li><issue>6162</issue>The Constant Timer is throwing a NullPointerException when using variables (vars.get) in "delay"-field</li>
   <li><pr>6193</pr>Log errors happening while JMeter starts the test (previously, errors from TestStateListener.testStarted were not logged)</li>
+  <li><pr>6216</pr>Pass JDBCSampler.maxRows to Statement.setMaxRows so the driver does not fetch extra rows from the database</li>
 </ul>
 
 <ch_section>Non-functional changes</ch_section>


### PR DESCRIPTION
## Description

Previously, maxRows was implemented as a limit on the client side, however, the driver might fetch more data than was needed.
