### PR TITLE
feat: #2870 SOAP request with attachments

### DIFF
--- a/bin/templates/build-webservice-test-plan.jmx
+++ b/bin/templates/build-webservice-test-plan.jmx
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jmeterTestPlan version="1.2" properties="2.5" jmeter="2.10-SNAPSHOT.20130803">
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.2">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
-      <stringProp name="TestPlan.comments"></stringProp>
       <boolProp name="TestPlan.functional_mode">false</boolProp>
       <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
-      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">false</boolProp>
     </TestPlan>
     <hashTree>
       <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
@@ -27,20 +26,13 @@
           <collectionProp name="Arguments.arguments"/>
         </elementProp>
         <stringProp name="HTTPSampler.domain">${host}</stringProp>
-        <stringProp name="HTTPSampler.port"></stringProp>
-        <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-        <stringProp name="HTTPSampler.response_timeout"></stringProp>
-        <stringProp name="HTTPSampler.protocol"></stringProp>
-        <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-        <stringProp name="HTTPSampler.path"></stringProp>
-        <stringProp name="HTTPSampler.concurrentPool">4</stringProp>
       </ConfigTestElement>
       <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Number of Users" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
-          <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">2</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
         </elementProp>
         <stringProp name="ThreadGroup.num_threads">5</stringProp>
         <stringProp name="ThreadGroup.ramp_time">5</stringProp>
@@ -49,6 +41,8 @@
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.delayedStart">false</boolProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
       </ThreadGroup>
       <hashTree>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Soap Request" enabled="true">
@@ -68,20 +62,18 @@
               </elementProp>
             </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain"></stringProp>
-          <stringProp name="HTTPSampler.port"></stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
           <stringProp name="HTTPSampler.path">/WeatherWS/Weather.asmx</stringProp>
           <stringProp name="HTTPSampler.method">POST</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-          <boolProp name="HTTPSampler.monitor">false</boolProp>
-          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+          <boolProp name="HTTPSampler.image_parser">false</boolProp>
+          <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+          <boolProp name="HTTPSampler.md5">false</boolProp>
+          <intProp name="HTTPSampler.ipSourceType">0</intProp>
         </HTTPSamplerProxy>
         <hashTree>
           <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
@@ -105,6 +97,7 @@
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
         </hashTree>
@@ -179,6 +172,130 @@
         <stringProp name="filename"></stringProp>
       </ResultCollector>
       <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="SwA - Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.delayedStart">false</boolProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="SOAP Request with attachments" enabled="true">
+          <elementProp name="HTTPsampler.Files" elementType="HTTPFileArgs">
+            <collectionProp name="HTTPFileArgs.files">
+              <elementProp name="logo.svg" elementType="HTTPFileArg">
+                <stringProp name="File.mimetype">image/svg+xml</stringProp>
+                <stringProp name="File.path">logo.svg</stringProp>
+                <stringProp name="File.paramname">file</stringProp>
+              </elementProp>
+              <elementProp name="README.md" elementType="HTTPFileArg">
+                <stringProp name="File.mimetype">text/html</stringProp>
+                <stringProp name="File.path">README.md</stringProp>
+                <stringProp name="File.paramname">file2</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="soap" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="HTTPArgument.content_type">text/xml</stringProp>
+                <stringProp name="Argument.name">soap</stringProp>
+                <stringProp name="Argument.value">&lt;?xml version=&quot;1.0&quot;?&gt; &lt;soap:Envelope xmlns:soap=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot; xmlns:ss=&quot;http://WebUpload/UploadService&quot;&gt;   &lt;soap:Header&gt;     &lt;ss:AuthHeader xmlns:ss=&quot;http://WebUpload/UploadService&quot;&gt;       &lt;ss:Username&gt;joep&lt;/ss:Username&gt;       &lt;ss:Password&gt;sdsfece&lt;/ss:Password&gt;     &lt;/ss:AuthHeader&gt;   &lt;/soap:Header&gt;   &lt;soap:Body&gt;     &lt;ss:StoreDocument xmlns:ss=&quot;http://WebUpload/UploadService&quot;&gt;       &lt;ss:metadata&gt;         &lt;ss:MetadataEntry&gt;           &lt;ss:Key&gt;TemplateID&lt;/ss:Key&gt;           &lt;ss:Value&gt;${templateId}&lt;/ss:Value&gt;         &lt;/ss:MetadataEntry&gt;         &lt;ss:MetadataEntry&gt;           &lt;ss:Key&gt;Project&lt;/ss:Key&gt;           &lt;ss:Value&gt;KarlI&lt;/ss:Value&gt;         &lt;/ss:MetadataEntry&gt;       &lt;/ss:metadata&gt;     &lt;/ss:StoreDocument&gt;   &lt;/soap:Body&gt; &lt;/soap:Envelope&gt;</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8080</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/UploadService.asmx</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">false</boolProp>
+          <boolProp name="HTTPSampler.image_parser">false</boolProp>
+          <boolProp name="HTTPSampler.concurrentDwn">false</boolProp>
+          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+          <boolProp name="HTTPSampler.md5">false</boolProp>
+          <intProp name="HTTPSampler.ipSourceType">0</intProp>
+          <stringProp name="TestPlan.comments">Add SOAP message into Parameters section with proper content type (variables can be used there). Add files into Files Upload section.</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+            <collectionProp name="HeaderManager.headers">
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">SOAPAction</stringProp>
+                <stringProp name="Header.value">&quot;http://WebUpload/UploadService#StoreDocument&quot;</stringProp>
+              </elementProp>
+              <elementProp name="" elementType="Header">
+                <stringProp name="Header.name">Content-Type</stringProp>
+                <stringProp name="Header.value">multipart/related</stringProp>
+              </elementProp>
+            </collectionProp>
+            <stringProp name="TestPlan.comments">The most important step is to change request content type to: multipart/related</stringProp>
+          </HeaderManager>
+          <hashTree/>
+          <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="templateId" elementType="Argument">
+                <stringProp name="Argument.name">templateId</stringProp>
+                <stringProp name="Argument.value">45</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </Arguments>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
     </hashTree>
   </hashTree>
 </jmeterTestPlan>

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPHC4Impl.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPHC4Impl.java
@@ -64,6 +64,21 @@ public class TestHTTPHC4Impl {
     }
 
     @Test
+    void testParameterWithMultipartAndOverridenSubtype() throws Exception {
+        HTTPSamplerBase sampler = (HTTPSamplerBase) new HttpTestSampleGui().createTestElement();
+        sampler.setThreadContext(jmctx);
+        sampler.setDoMultipart(true);
+        sampler.setDoBrowserCompatibleMultipart(true);
+        HttpEntityEnclosingRequestBase post = new HttpPost();
+        post.addHeader(HTTPConstants.HEADER_CONTENT_TYPE, "multipart/related");
+        sampler.setHTTPFiles(new HTTPFileArg[] {new HTTPFileArg("filename", "file", "application/octect; charset=utf-8")});
+        HTTPHC4Impl hc = new HTTPHC4Impl(sampler);
+        String requestData = hc.setupHttpEntityEnclosingRequestData(post);
+        assertEquals(0, post.getHeaders(HTTPConstants.HEADER_CONTENT_TYPE).length);
+        Assertions.assertTrue(post.getEntity().getContentType().getValue().startsWith("multipart/related"));
+        Assertions.assertTrue(requestData.contains("charset=utf-8"));
+    }
+    @Test
     void testParameterWithMultipartAndExplicitHeader() throws Exception {
         HTTPSamplerBase sampler = (HTTPSamplerBase) new HttpTestSampleGui().createTestElement();
         sampler.setThreadContext(jmctx);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -37,6 +37,8 @@ import java.util.regex.Matcher;
 
 import org.apache.jmeter.engine.util.ValueReplacer;
 import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jmeter.protocol.http.control.Header;
+import org.apache.jmeter.protocol.http.control.HeaderManager;
 import org.apache.jmeter.protocol.http.control.HttpMirrorServerExtension;
 import org.apache.jmeter.protocol.http.util.EncoderCache;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
@@ -136,6 +138,32 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
     public void testPostRequest_FileUpload3() throws Exception {
         // see https://issues.apache.org/jira/browse/HTTPCLIENT-1665
         testPostRequest_FileUpload(HTTP_SAMPLER3);
+    }
+
+    @Test
+    public void testPostRequest_FileUploadWithSubtypeOverride() throws Exception {
+        String titleField = "title";
+        String titleValue = "mytitle";
+        String descriptionField = "description";
+        String descriptionValue = "mydescription";
+        String fileField = "file1";
+        String fileMimeType = CONTENT_TYPE_TEXT_PLAIN;
+
+        // Override Content-type subtype
+        HTTPSamplerBase sampler = createHttpSampler(HTTP_SAMPLER3);
+        String contentEncoding = "";
+        setupUrl(sampler, contentEncoding);
+        setupFileUploadData(sampler, false, titleField, titleValue,
+                descriptionField, descriptionValue, fileField, temporaryFile,
+                fileMimeType);
+        HeaderManager headerManager = new HeaderManager();
+        headerManager.add(new Header(HTTPConstants.HEADER_CONTENT_TYPE, "multipart/related"));
+        sampler.setHeaderManager(headerManager);
+        HTTPSampleResult res = executeSampler(sampler);
+        checkPostRequestFileUpload(sampler, res,
+                contentEncoding, titleField, titleValue, descriptionField,
+                descriptionValue, fileField, temporaryFile, fileMimeType,
+                TEST_FILE_CONTENT, "multipart/related");
     }
 
     @Test
@@ -900,6 +928,22 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             File fileValue,
             String fileMimeType,
             byte[] fileContent) throws IOException {
+        checkPostRequestFileUpload(sampler, res, contentEncoding, titleField, titleValue, descriptionField,
+                descriptionValue, fileField, fileValue, fileMimeType, fileContent, "multipart/form-data");
+    }
+    private void checkPostRequestFileUpload(
+            HTTPSamplerBase sampler,
+            HTTPSampleResult res,
+            String contentEncoding,
+            String titleField,
+            String titleValue,
+            String descriptionField,
+            String descriptionValue,
+            String fileField,
+            File fileValue,
+            String fileMimeType,
+            byte[] fileContent,
+            String contentType) throws IOException {
         if (contentEncoding == null || contentEncoding.isEmpty()) {
             contentEncoding = DEFAULT_HTTP_CONTENT_ENCODING;
         }
@@ -912,7 +956,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
                 descriptionField, descriptionValue, fileField, fileValue,
                 fileMimeType, fileContent);
         // Check request headers
-        checkHeaderContentType(res.getRequestHeaders(), "multipart/form-data" + "; boundary=" + boundaryString);
+        checkHeaderContentType(res.getRequestHeaders(), contentType + "; boundary=" + boundaryString);
         // We cannot check post body from the result query string, since that will not contain
         // the actual file content, but placeholder text for file content
         //checkArraysHaveSameContent(expectedPostBody, res.getQueryString().getBytes(contentEncoding));
@@ -923,7 +967,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             fail("No header and body section found");
         }
         // Check response headers
-        checkHeaderContentType(headersSent, "multipart/form-data" + "; boundary=" + boundaryString);
+        checkHeaderContentType(headersSent, contentType + "; boundary=" + boundaryString);
         byte[] bodySent = getBodySent(res.getResponseData());
         assertNotNull(bodySent, "Sent body should not be null");
         // Check post body which was sent to the mirror server, and
@@ -1261,7 +1305,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
     }
 
     private String getBoundaryStringFromContentTypeWithJavaRegex(String requestHeaders) {
-        String regularExpression = "^" + HTTPConstants.HEADER_CONTENT_TYPE + ": multipart/form-data; boundary=(.+)$";
+        String regularExpression = "^" + HTTPConstants.HEADER_CONTENT_TYPE + ": multipart/.*; boundary=(.+)$";
         java.util.regex.Pattern pattern = JMeterUtils.compilePattern(regularExpression,
                 java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);
         Matcher localMatcher = pattern.matcher(requestHeaders);
@@ -1281,7 +1325,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
 
     private String getBoundaryStringFromContentTypeWithOroRegex(String requestHeaders) {
         Perl5Matcher localMatcher = JMeterUtils.getMatcher();
-        String regularExpression = "^" + HTTPConstants.HEADER_CONTENT_TYPE + ": multipart/form-data; boundary=(.+)$";
+        String regularExpression = "^" + HTTPConstants.HEADER_CONTENT_TYPE + ": multipart/.*; boundary=(.+)$";
         Pattern pattern = JMeterUtils.getPattern(regularExpression,
                 Perl5Compiler.READ_ONLY_MASK
                         | Perl5Compiler.CASE_INSENSITIVE_MASK

--- a/xdocs/usermanual/build-ws-test-plan.xml
+++ b/xdocs/usermanual/build-ws-test-plan.xml
@@ -85,6 +85,7 @@ Currently, only .NET uses SOAPAction, so it is normal to have a blank SOAPAction
 text area.</p>
 <figure width="955" height="501" image="ws_http_request.png">Figure &sect-num;.1.3 Webservice Body</figure>
 
+<p>For SOAP with attachments (SwA) requests there is an example under thread group "<code>SwA - Thread Group</code>"</p>
 
 </section>
 


### PR DESCRIPTION
## Description
Added possibility to set content type as "multipart/related" to be able to support SOAP with attachments (SwA} requests.

## Motivation and Context
To be able to send SwA requests.
https://github.com/apache/jmeter/issues/2870

## How Has This Been Tested?
Extended unit tests

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines