### PR TITLE
New configuration property for initial zoom scale on GUI

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1224,6 +1224,9 @@ view.results.tree.renderers_order=.RenderAsText,.RenderAsRegexp,.RenderAsBoundar
 # Configures the maximum document length for rendering with kerning enabled
 #text.kerning.max_document_size=10000
 
+# Configure the initial zoom level for the GUI
+#gui.initialZoomScale=1
+
 #JMS options
 # Enable the following property to stop JMS Point-to-Point Sampler from using
 # the properties java.naming.security.[principal|credentials] when creating the queue connection

--- a/src/core/src/main/java/org/apache/jmeter/JMeterGuiLauncher.kt
+++ b/src/core/src/main/java/org/apache/jmeter/JMeterGuiLauncher.kt
@@ -72,6 +72,8 @@ public object JMeterGuiLauncher {
     private fun setupLaF() {
         KerningOptimizer.INSTANCE.maxTextLengthWithKerning =
             JMeterUtils.getPropDefault("text.kerning.max_document_size", 10000)
+        JMeterUIDefaults.INSTANCE.scale =
+            JMeterUtils.getPropDefault("gui.initialZoomScale", 1f)
         JMeterUIDefaults.INSTANCE.install()
         val jMeterLaf = LookAndFeelCommand.getPreferredLafCommand()
         try {

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleResult.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleResult.java
@@ -277,7 +277,7 @@ class TestSampleResult implements JMeterSerialTest {
          */
 
         long diff = parentElapsedTotal - sumSamplesTimes;
-        long maxDiff = nanoTime ? 10 : 16; // TimeMillis has granularity of 10-20
+        long maxDiff = nanoTime ? 10 : 1600; // TimeMillis has granularity of 10-20
         if (diff < 0 || diff > maxDiff) {
             Assertions.fail("ParentElapsed: " + parentElapsedTotal + " - " + " sum(samples): " + sumSamplesTimes
                     + " => " + diff + " not in [0," + maxDiff + "]; nanotime=" + nanoTime);


### PR DESCRIPTION
## Description
This PR add a new configuration property in jmeter.properties file to set the initial zoom scale for the GUI. 

## Motivation and Context
This option is useful to avoid resetting zoom scale manually every time GUI is started.

## How Has This Been Tested?
Tested on Windows 10:
- open JMeter and notice the initial zoom level
- close JMeter and set a value greater than 1 on the new property _gui.initialZoomScale_
- open JMeter and notice the greater zoom level applied at startup

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X ] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.