### PR TITLE
 fix: The HTTP Header of `multipart/form-data` no longer includes `charset`.

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -1562,7 +1562,6 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
             }
             // Write the request to our own stream
             MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder.create();
-            multipartEntityBuilder.setCharset(charset);
             if (doBrowserCompatibleMultipart) {
                 multipartEntityBuilder.setLaxMode();
             } else {

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPHC4Impl.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPHC4Impl.java
@@ -98,6 +98,22 @@ public class TestHTTPHC4Impl {
     }
 
     @Test
+    void testMultipartFormHeaderWithoutCharset() throws Exception {
+        HTTPSamplerBase sampler = (HTTPSamplerBase) new HttpTestSampleGui().createTestElement();
+        sampler.setThreadContext(jmctx);
+        sampler.setDoMultipart(true);
+        sampler.setDoBrowserCompatibleMultipart(true);
+        HttpEntityEnclosingRequestBase post = new HttpPost();
+        post.addHeader(HTTPConstants.HEADER_CONTENT_TYPE, "application/json; charset=utf-8");
+        sampler.setHTTPFiles(new HTTPFileArg[] {new HTTPFileArg("filename", "file", "application/octect; charset=utf-8")});
+        HTTPHC4Impl hc = new HTTPHC4Impl(sampler);
+        String requestData = hc.setupHttpEntityEnclosingRequestData(post);
+
+        String contentTypeWithEntity = post.getEntity().getContentType().getValue();
+        Assertions.assertFalse(contentTypeWithEntity.contains("charset"));
+    }
+
+    @Test
     public void testNotifyFirstSampleAfterLoopRestartWhenThreadIterationIsSameUser() {
         jmvars.putObject(SAME_USER, true);
         jmctx.setVariables(jmvars);


### PR DESCRIPTION

## Description

close #6250 . 



## Motivation and Context

On some web server implementations, including charset in the request header `Content-Type` of `multipart/form-data` can result in parsing errors of the `boundary`, leading to a failure in sending form content.

This is inconsistent with the behavior in JMeter 5.6.2 and also does not comply with RFC.

Perhaps fixing this  in the httpclient would be a more elegant choice, but:
- The last update on httpclient 4.x was 2 years ago, so it would be slow.
- This issue occurred in JMeter 5.6.3 (#5987). This PR will revert JMeter's behavior to 5.6.2, reducing user frustration.


## How Has This Been Tested?
1.  A unittest case
2.  runGUI  then e2e test

## Screenshots (if appropriate):
After ：  remove charset
![image](https://github.com/apache/jmeter/assets/7629022/48669e70-8218-4014-b23d-e202eaca687a)

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
