### PR TITLE
merge properties which have same properties name by config

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1388,3 +1388,6 @@ jmeter.reportgenerator.apdex_tolerated_threshold=1500
 # Path to XSL file used to generate Schematic View of Test Plan
 # When empty, JMeter will use the embedded one in src/core/org/apache/jmeter/gui/action/schematic.xsl
 #docgeneration.schematic_xsl=
+
+# if you have multi ConfigTestElement, and some properties name is same in it ,you can config as below, then they can merge
+merge.property=HTTPSampler.path

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/StringProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/StringProperty.java
@@ -18,11 +18,16 @@
 package org.apache.jmeter.testelement.property;
 
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.util.JMeterUtils;
+
+import java.util.Arrays;
 
 /**
  */
 public class StringProperty extends AbstractProperty {
     private static final long serialVersionUID = 233L;
+
+    private static final String MERGE_PROPERTY = JMeterUtils.getPropDefault("merge.property", "");
 
     private String value;
 
@@ -102,5 +107,20 @@ public class StringProperty extends AbstractProperty {
         if (savedValue != null) {
             value = savedValue;
         }
+    }
+
+    @Override
+    public void mergeIn(JMeterProperty prop) {
+        // NOOP
+        boolean hit = shouldMerge(prop);
+        if (hit){
+            setObjectValue(prop.getStringValue()+getStringValue());
+        }
+    }
+
+    private boolean shouldMerge(JMeterProperty prop){
+        String propName = prop.getName();
+        return !MERGE_PROPERTY.isEmpty()
+                && Arrays.stream(MERGE_PROPERTY.split(",")).anyMatch(item -> (item.equalsIgnoreCase(propName) && item.equalsIgnoreCase(getName())));
     }
 }

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1577,6 +1577,11 @@ JMETER-SERVER</source>
     confirmation dialogue.<br/>
     Defaults to: <code>false</code>
 </property>
+  <property name="merge.property">
+    if you have multi ConfigTestElement, and some properties name is same in it ,you can config as below, then they can merge.Separate with commas.<br/>
+    eg,the full url is http://192.168.8.110:8088/local-xxx/xxx/mo/knowledge.json, other url have the same prefix:/local-xxx/xxx, we can config a globe ConfigTestElement with a property HTTPSampler.path=/local-xxx/xxx, then the HTTPSampler.path will merged with HttpSample .<br/>
+    Defaults to: <code>HTTPSampler.path</code>
+  </property>
 </properties>
 </section>
 <section name="&sect-num;.36 Classpath configuration" anchor="classpath">


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->
Add 1 configurable parameter to merge string-property which have same name. 
the value of configurable parameter is Separate with commas.
Parameters are defined in jmeter.properties file.
eg,merge.property=HTTPSampler.path

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

in multi ConfigTestElement, if we have same properties name, now is use pre value and no merge. but someties we may need common prefix ,the common prefix often changed by tester, and many HTTPSampler may use it.
eg, the full http url is http://192.168.8.110:8088/local-xxx/xxx/mo/knowledge.json, other http url have the same prefix:/local-xxx/xxx, we can config a globe ConfigTestElement with a property [HTTPSampler.path=/local-xxx/xxx], then the [HTTPSampler.path] will merged to HTTPSampler .


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run with multiple values in the .properties file, see the outcome.


## Screenshots (if appropriate):
![1712108894362](https://github.com/apache/jmeter/assets/13306569/f40503b7-ecaa-41cf-855b-3220bf5cf5f6)
![1712108929959](https://github.com/apache/jmeter/assets/13306569/fda1063d-4fd3-44a3-bc0b-ef38ffb30cd1)
![1712108966288](https://github.com/apache/jmeter/assets/13306569/119db502-ae52-4e6c-b91e-fab640b80643)
1 and 2 will be merge, as 3.

## Types of changes
- New feature 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
