### PR TITLE
fix: trim whitespace when parsing numeric properties

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/AbstractProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/AbstractProperty.java
@@ -108,11 +108,11 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public int getIntValue() {
         String val = getStringValue();
-        if (val == null || val.length()==0) {
+        if (val == null || val.isEmpty()) {
             return 0;
         }
         try {
-            return Integer.parseInt(val);
+            return Integer.parseInt(val.trim());
         } catch (NumberFormatException e) {
             return 0;
         }
@@ -126,11 +126,11 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public long getLongValue() {
         String val = getStringValue();
-        if (val == null || val.length()==0) {
+        if (val == null || val.isEmpty()) {
             return 0;
         }
         try {
-            return Long.parseLong(val);
+            return Long.parseLong(val.trim());
         } catch (NumberFormatException e) {
             return 0;
         }
@@ -144,11 +144,11 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public double getDoubleValue() {
         String val = getStringValue();
-        if (val == null || val.length()==0) {
+        if (val == null || val.isEmpty()) {
             return 0;
         }
         try {
-            return Double.parseDouble(val);
+            return Double.parseDouble(val.trim());
         } catch (NumberFormatException e) {
             log.error("Tried to parse a non-number string to an integer", e);
             return 0;
@@ -163,11 +163,11 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public float getFloatValue() {
         String val = getStringValue();
-        if (val == null || val.length()==0) {
+        if (val == null || val.isEmpty()) {
             return 0;
         }
         try {
-            return Float.parseFloat(val);
+            return Float.parseFloat(val.trim());
         } catch (NumberFormatException e) {
             log.error("Tried to parse a non-number string to an integer", e);
             return 0;
@@ -182,10 +182,10 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public boolean getBooleanValue() {
         String val = getStringValue();
-        if (val == null || val.length()==0) {
+        if (val == null || val.isEmpty()) {
             return false;
         }
-        return Boolean.parseBoolean(val);
+        return Boolean.parseBoolean(val.trim());
     }
 
     /**

--- a/src/core/src/test/kotlin/org/apache/jmeter/threads/ThreadGroupTest.kt
+++ b/src/core/src/test/kotlin/org/apache/jmeter/threads/ThreadGroupTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.threads
+
+import org.apache.jmeter.control.LoopController
+import org.apache.jmeter.junit.JMeterTestCase
+import org.apache.jmeter.test.assertions.executePlanAndCollectEvents
+import org.apache.jmeter.test.samplers.ThreadSleep
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class ThreadGroupTest : JMeterTestCase() {
+    @Test
+    fun `threadNum with trailing whitespace`() {
+        val events = executePlanAndCollectEvents(10.seconds) {
+            ThreadGroup::class {
+                props {
+                    it[numThreads] = "1 "
+                }
+                rampUp = 0
+                scheduler = true
+                delay = 0
+                duration = 1
+                setSamplerController(
+                    LoopController().apply {
+                        loops = 1
+                        setContinueForever(false)
+                    }
+                )
+
+                ThreadSleep::class {
+                    duration = 0.seconds
+                }
+            }
+        }
+        assertEquals(1, events.size) {
+            "ThreadGroup.threadNum has trailing whitespace, it should be trimmed, so one event should be generated. " +
+                "Actual events are $events"
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context

If the value parses after trimming, then it would likely be the one the user wants.

Currently, a trailing whitespace in UI is hard to notice, and it breaks test execution. For instance `ThreadGroup.threadNum` becomes `0` without any warning, and it invalidates test results.
