### PR TITLE
Fixed typo ("IT S" to "ITS")

### DIFF
--- a/src/jorphan/src/main/java/org/apache/jorphan/exec/KeyToolUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/exec/KeyToolUtils.java
@@ -53,7 +53,7 @@ public class KeyToolUtils {
     /** Name of property that can be used to override the default keytool location */
     private static final String KEYTOOL_DIRECTORY = "keytool.directory"; // $NON-NLS-1$
 
-    private static final String DNAME_INTERMEDIATE_CA_KEY  = "cn=JMeter Intermediate CA for recording (INSTALL ONLY IF IT S YOURS)"; // $NON-NLS-1$
+    private static final String DNAME_INTERMEDIATE_CA_KEY  = "cn=JMeter Intermediate CA for recording (INSTALL ONLY IF ITS YOURS)"; // $NON-NLS-1$
 
     public static final String ROOT_CACERT_CRT_PFX = "ApacheJMeterTemporaryRootCA"; // $NON-NLS-1$ (do not change)
     private static final String ROOT_CACERT_CRT = ROOT_CACERT_CRT_PFX + ".crt"; // $NON-NLS-1$ (Firefox and Windows)
@@ -73,7 +73,7 @@ public class KeyToolUtils {
     static {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("CN=_ JMeter Root CA for recording (INSTALL ONLY IF IT S YOURS)"); // $NON-NLS-1$
+        sb.append("CN=_ JMeter Root CA for recording (INSTALL ONLY IF ITS YOURS)"); // $NON-NLS-1$
         String userName = System.getProperty("user.name"); // $NON-NLS-1$
         userName = userName.replace('\\','/'); // Backslash is special (Bugzilla 56178)
         addElement(sb, "OU=Username: ", userName); // $NON-NLS-1$

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -6832,9 +6832,9 @@ As a consequence:
 <li>The browser should display a dialogue asking if you want to accept the certificate or not. For example:
 <source>
 1) The server's name "<code>www.example.com</code>" does not match the certificate's name
-   "<code>_ JMeter Root CA for recording (INSTALL ONLY IF IT S YOURS)</code>". Somebody may be trying to eavesdrop on you.
-2) The certificate for "<code>_ JMeter Root CA for recording (INSTALL ONLY IF IT S YOURS)</code>" is signed by the unknown Certificate Authority
-   "<code>_ JMeter Root CA for recording (INSTALL ONLY IF IT S YOURS)</code>". It is not possible to verify that this is a valid certificate.
+   "<code>_ JMeter Root CA for recording (INSTALL ONLY IF ITS YOURS)</code>". Somebody may be trying to eavesdrop on you.
+2) The certificate for "<code>_ JMeter Root CA for recording (INSTALL ONLY IF ITS YOURS)</code>" is signed by the unknown Certificate Authority
+   "<code>_ JMeter Root CA for recording (INSTALL ONLY IF ITS YOURS)</code>". It is not possible to verify that this is a valid certificate.
 </source>
 You will need to accept the certificate in order to allow the JMeter Proxy to intercept the SSL traffic in order to
 record it.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->

I noted a typo in the console output while recording a test using the HTTP recorder.

I am proposing changing "IT S" to "ITS" in the docs and in `KeyToolUtils.java`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This is not an important problem with functionality.  It is a nitpick.  It was cheap to fix and will hopefully be cheap to include in an upcoming version.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I haven't tested the change as I am not a Java developer and do not have a development environment setup.

I think that this is okay as I have only updated a string value assignment and documentation.

## Screenshots (if appropriate):

![image](https://github.com/apache/jmeter/assets/47242934/981ba74a-76fe-48f1-a3a4-0f8a3e5cfff6)

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
