### PR TITLE
Apply HiDPI mode on GUI setup

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/JMeterGuiLauncher.kt
+++ b/src/core/src/main/java/org/apache/jmeter/JMeterGuiLauncher.kt
@@ -93,8 +93,6 @@ public object JMeterGuiLauncher {
             // Allow UI updates
             yield()
         }
-        setProgress(1)
-        JMeterUtils.applyHiDPIOnFonts()
         log.debug("Setup tree")
         setProgress(5)
         val treeModel = JMeterTreeModel()

--- a/src/core/src/main/java/org/apache/jmeter/JMeterGuiLauncher.kt
+++ b/src/core/src/main/java/org/apache/jmeter/JMeterGuiLauncher.kt
@@ -83,6 +83,7 @@ public object JMeterGuiLauncher {
     }
 
     private suspend fun startGuiInternal(testFile: String?) {
+        JMeterUtils.applyHiDPIOnFonts()
         setupLaF()
         val splash = SplashScreen()
         splash.showScreen()


### PR DESCRIPTION
## Description
Apply HiDPI fonts on GUI startup according to `jmeter.hidpi.mode` and `jmeter.hidpi.scale.factor` properties.

## Motivation and Context
Useful to avoid setting zoom scale manually every time GUI is started.

## How Has This Been Tested?
Tested on Windows 11:
- open JMeter and notice the initial zoom level
- close JMeter and set `jmeter.hidpi.mode=true` and `jmeter.hidpi.scale.factor=2` in jmeter.properties
- open JMeter and notice the greater zoom level applied at startup

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.