### PR TITLE
fix typo in a private method name: startUdpDdaemon -> startUdpDaemon

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -1040,7 +1040,7 @@ public class JMeter implements JMeterPlugin {
                 testListener.setStartedRemoteEngines(engines);
                 distributedRunner.start();
             }
-            startUdpDdaemon(engines);
+            startUdpDaemon(engines);
         } catch (ConfigurationException e) {
             throw e;
         } catch (Exception e) {
@@ -1379,7 +1379,7 @@ public class JMeter implements JMeterPlugin {
         return "true".equals(System.getProperty(JMeter.JMETER_NON_GUI)); //$NON-NLS-1$
     }
 
-    private static void startUdpDdaemon(final List<? extends JMeterEngine> engines) {
+    private static void startUdpDaemon(final List<? extends JMeterEngine> engines) {
         int port = JMeterUtils.getPropDefault("jmeterengine.nongui.port", UDP_PORT_DEFAULT); // $NON-NLS-1$
         int maxPort = JMeterUtils.getPropDefault("jmeterengine.nongui.maxport", 4455); // $NON-NLS-1$
         if (port > 1000){


### PR DESCRIPTION
update org.apache.jmeter.JMeter#startUdpDdaemon to org.apache.jmeter.JMeter#startUdpDaemon

Closes 6325

## Description
fix issue : https://github.com/apache/jmeter/issues/6325
## Motivation and Context
When i read jmeter source code, i find this method name looks like  is misspelled ， so i create a issue and try to fix it

## How Has This Been Tested?
 org.apache.jmeter.JMeter#startUdpDdaemon is a private static Method， so i could change it.

## Screenshots (if appropriate):

## Types of changes
BugFix

## Checklist:
- Run `./gradlew check`

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
