### PR TITLE
Use current time as start time for OMTG

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/timers/poissonarrivals/PreciseThroughputTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/poissonarrivals/PreciseThroughputTimer.java
@@ -99,7 +99,7 @@ public class PreciseThroughputTimer extends AbstractTestElement implements Clone
             nextEvent = events.next();
         }
         long now = System.currentTimeMillis();
-        long testStarted = JMeterContextService.getTestStartTime();
+        long testStarted = JMeterContextService.getContext().getThreadGroup().getStartTime();
         long delay = (long) (nextEvent * TimeUnit.SECONDS.toMillis(1) + testStarted - now);
         if (log.isDebugEnabled()) {
             log.debug("Calculated delay is {}", delay);
@@ -117,7 +117,7 @@ public class PreciseThroughputTimer extends AbstractTestElement implements Clone
     }
 
     private EventProducer getEventProducer() {
-        long testStarted = JMeterContextService.getTestStartTime();
+        long testStarted = JMeterContextService.getContext().getThreadGroup().getStartTime();
         long prevStarted = PREV_TEST_STARTED.get();
         if (prevStarted != testStarted && PREV_TEST_STARTED.compareAndSet(prevStarted, testStarted)) {
             // Reset counters if we are calculating throughput for a new test, see https://github.com/apache/jmeter/issues/6165

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -574,6 +574,7 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
             threadGroupTree.add(group, testLevelElements);
 
             groups.add(group);
+            group.setStartTime(System.currentTimeMillis());
             group.start(groupCount, notifier, threadGroupTree, this);
         } catch (JMeterStopTestException ex) { // NOSONAR Reported by log
             JMeterUtils.reportErrorToUser("Error occurred starting thread group :" + group.getName()+ ", error message:"+ex.getMessage()

--- a/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.IdentityHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.control.IteratingController;
@@ -86,6 +87,8 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
 
     private final AtomicInteger numberOfThreads = new AtomicInteger(0); // Number of active threads in this group
 
+    private final AtomicLong startTime = new AtomicLong(0);
+
     @Override
     public AbstractThreadGroupSchema getSchema() {
         return AbstractThreadGroupSchema.INSTANCE;
@@ -95,6 +98,23 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
     @Override
     public PropertiesAccessor<? extends AbstractThreadGroup, ? extends AbstractThreadGroupSchema> getProps() {
         return new PropertiesAccessor<>(this, getSchema());
+    }
+
+    /**
+     * Get the time when this thread group has been started
+     * @return time in milliseconds since epoch
+     */
+    public long getStartTime() {
+        return startTime.get();
+    }
+
+    /**
+     * Set the time when this thread group has been started.<br>
+     * Will probably be set by StandardJMeterEngine.
+     * @param startTime time in milliseconds since epoch
+     */
+    public void setStartTime(long startTime) {
+        this.startTime.set(startTime);
     }
 
     /** {@inheritDoc} */

--- a/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.IdentityHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.control.IteratingController;
@@ -87,7 +86,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
 
     private final AtomicInteger numberOfThreads = new AtomicInteger(0); // Number of active threads in this group
 
-    private final AtomicLong startTime = new AtomicLong(0);
+    private long startTime;
 
     @Override
     public AbstractThreadGroupSchema getSchema() {
@@ -105,7 +104,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      * @return time in milliseconds since epoch
      */
     public long getStartTime() {
-        return startTime.get();
+        return startTime;
     }
 
     /**
@@ -114,7 +113,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      * @param startTime time in milliseconds since epoch
      */
     public void setStartTime(long startTime) {
-        this.startTime.set(startTime);
+        this.startTime = startTime;
     }
 
     /** {@inheritDoc} */

--- a/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -101,6 +101,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
 
     /**
      * Get the time when this thread group has been started
+     * @since 6.0.0
      * @return time in milliseconds since epoch
      */
     public long getStartTime() {
@@ -110,6 +111,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
     /**
      * Set the time when this thread group has been started.<br>
      * Will probably be set by StandardJMeterEngine.
+     * @since 6.0.0
      * @param startTime time in milliseconds since epoch
      */
     public void setStartTime(long startTime) {

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroup.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroup.kt
@@ -204,7 +204,7 @@ public class OpenModelThreadGroup :
             val seed = randomSeed
             val rnd = if (seed == 0L) Random() else Random(seed)
             val gen = ThreadScheduleProcessGenerator(rnd, parsedSchedule)
-            val testStartTime = System.currentTimeMillis()
+            val testStartTime = this.startTime
             val executorService = Executors.newCachedThreadPool()
             this.executorService = executorService
             val starter = ThreadsStarter(testStartTime, executorService, activeThreads, gen) { threadNumber ->

--- a/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroup.kt
+++ b/src/core/src/main/kotlin/org/apache/jmeter/threads/openmodel/OpenModelThreadGroup.kt
@@ -204,7 +204,7 @@ public class OpenModelThreadGroup :
             val seed = randomSeed
             val rnd = if (seed == 0L) Random() else Random(seed)
             val gen = ThreadScheduleProcessGenerator(rnd, parsedSchedule)
-            val testStartTime = JMeterContextService.getTestStartTime()
+            val testStartTime = System.currentTimeMillis()
             val executorService = Executors.newCachedThreadPool()
             this.executorService = executorService
             val starter = ThreadsStarter(testStartTime, executorService, activeThreads, gen) { threadNumber ->

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -57,7 +57,7 @@ JMeter 6.x requires Java 17 or later for execution (Java 21 is recommended).
 Summary
 </p>
 <ul>
-<li><a href="#Bug fixes">Bug fixes</a></li>
+<li><a href="#Changes">Changes</a></li>
 </ul>
 
   <ch_section>Changes</ch_section>
@@ -65,6 +65,8 @@ Summary
   <ul>
     <li><pr>6220</pr> Require Java 17 or later for running JMeter</li>
     <li><pr>6274</pr> Change references to old MySQL driver to new class <code>com.mysql.cj.jdbc.Driver</code></li>
+    <li><issue>6352</issue> Calculate delays in Open Model Thread Group and Precise Throughput
+        Timer relative to start of Thread Group instead of the start of the test.</li>
   </ul>
 
  <!--  =================== Thanks =================== -->


### PR DESCRIPTION
## Description
Use current time as of actually starting the open model thread group 

## Motivation and Context
When we use the test start time via JMeterContextService#getTestStartTime, we might create a storm of test samples at the beginning, when a setup thread group made us wait.

Related to #6352 

## How Has This Been Tested?
Used the test plan attached and looked at the req/s values. They should be in the range of 1 req/s.
[omtg-and-setup-group.jmx.zip](https://github.com/user-attachments/files/17116744/omtg-and-setup-group.jmx.zip)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- *Might be a* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
