### PR TITLE
Add new thread variable __jmv_THREAD_START_TIME_ITERATION contains the currentTimeMillis when the thread iteration start.

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
@@ -728,6 +728,8 @@ public class JMeterThread implements Runnable, Interruptible {
      */
     private IterationListener initRun(JMeterContext threadContext) {
         threadVars.putObject(JMeterVariables.VAR_IS_SAME_USER_KEY, isSameUserOnNextIteration);
+        threadVars.putObject(JMeterVariables.VAR_THREAD_START_TIME_ITERATION, threadVars.getStartThreadTimeIteration());
+
         threadContext.setVariables(threadVars);
         threadContext.setThreadNum(getThreadNum());
         setLastSampleOk(threadVars, true);
@@ -1029,6 +1031,8 @@ public class JMeterThread implements Runnable, Interruptible {
 
     void notifyTestListeners() {
         threadVars.incIteration();
+        threadVars.resetStartThreadTimeIteration();
+        threadVars.putObject(JMeterVariables.VAR_THREAD_START_TIME_ITERATION, threadVars.getStartThreadTimeIteration());
         for (TestIterationListener listener : testIterationStartListeners) {
             listener.testIterationStart(new LoopIterationEvent(threadGroupLoopController, threadVars.getIteration()));
             if (listener instanceof TestElement) {

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterVariables.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterVariables.java
@@ -33,6 +33,7 @@ public class JMeterVariables {
     private final Map<String, Object> variables = new HashMap<>();
 
     private int iteration = 0;
+    private long startTimeThreadIteration = System.currentTimeMillis();
 
     // Property names to preload into JMeter variables:
     private static final String [] PRE_LOAD = {
@@ -43,7 +44,7 @@ public class JMeterVariables {
     };
 
     static final String VAR_IS_SAME_USER_KEY = "__jmv_SAME_USER";
-
+    static final String VAR_THREAD_START_TIME_ITERATION ="__jmv_THREAD_START_TIME_ITERATION";
     /**
      * Constructor, that preloads the variables from the JMeter properties
      */
@@ -177,5 +178,13 @@ public class JMeterVariables {
      */
     public boolean isSameUserOnNextIteration() {
         return Boolean.TRUE.equals(variables.get(VAR_IS_SAME_USER_KEY));
+    }
+
+    public void resetStartThreadTimeIteration() {
+        startTimeThreadIteration = System.currentTimeMillis();
+    }
+
+    public long getStartThreadTimeIteration() {
+        return startTimeThreadIteration;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/threads/UnmodifiableJMeterVariables.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/UnmodifiableJMeterVariables.java
@@ -92,6 +92,16 @@ class UnmodifiableJMeterVariables extends JMeterVariables {
     }
 
     @Override
+    public long getStartThreadTimeIteration() {
+        return variables.getStartThreadTimeIteration();
+    }
+
+    @Override
+    public void resetStartThreadTimeIteration() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/src/jorphan/src/main/kotlin/org/apache/jorphan/gui/JEditableCheckBox.kt
+++ b/src/jorphan/src/main/kotlin/org/apache/jorphan/gui/JEditableCheckBox.kt
@@ -18,10 +18,12 @@
 package org.apache.jorphan.gui
 
 import org.apiguardian.api.API
+import java.awt.Color
 import java.awt.Container
 import java.awt.FlowLayout
 import java.awt.event.ActionEvent
 import javax.swing.AbstractAction
+import javax.swing.BorderFactory
 import javax.swing.Box
 import javax.swing.JCheckBox
 import javax.swing.JComboBox
@@ -105,6 +107,8 @@ public open class JEditableCheckBox(
 
     private val checkbox: JCheckBox = JCheckBox(label).apply {
         val cb = this
+        cb.setBorderPainted(true)
+        cb.setBorder(BorderFactory.createLineBorder(Color(51,204,255))) // Very light blue
         componentPopupMenu = JPopupMenu().apply {
             add(useExpressionAction)
         }

--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -1765,6 +1765,8 @@ However some variables are defined internally by JMeter. These are listed below.
 <li><code>JMeterThread.last_sample_ok</code> - whether or not the last sample was OK - <code>true</code>/<code>false</code>.
 Note: this is updated after PostProcessors and Assertions have been run.
 </li>
+<li><code>__jmv_SAME_USER</code> - is the same user for each iteration ? <code>true</code>/<code>false</code>. Mainly impacts clean cookie, cache data and new connection</li>
+<li><code>__jmv_THREAD_START_TIME_ITERATION</code> - contains the epoch unit milliseconds of the thread start iteration. Call System.currentTimeMillis()</li>
 <li><code>START</code> variables (see next section)</li>
 </ul>
 </subsection>


### PR DESCRIPTION
Corresponding to the issue (new feature): https://github.com/apache/jmeter/issues/6319

## Description
Add a new unmodifiable JMeter Thread variable named "__jmv_THREAD_START_TIME_ITERATION"

## Motivation and Context

It is interesting to know the start timestamp of a thread iteration to calculate cadences or pacing.

This variable can also be used to help other Thread Groups calculate cadences (E.g : Concurrency Thread Group or may be Open Model Thread Group)

## How Has This Been Tested?
Yes, add a groovy sampler first sampler of the thread group and compute the delta between the value in the variable __jmv_THREAD_START_TIME_ITERATION and the current time System.currentTimeMillis() in the groovy sampler.

Groovy code 
+++++++++++++++++++++++++++
long currentTime = System.currentTimeMillis();
long startThreadIter = Long.parseLong(vars.get("__jmv_THREAD_START_TIME_ITERATION"));
long delta = currentTime - startThreadIter;
return delta;
+++++++++++++++++++++++++++
Results 0 or 1 ms
## Screenshots (if appropriate):

## Types of changes
- New feature 

## Checklist:
- [x ] My code follows the [code style][style-guide] of this project.
- [ x] I have updated the documentation accordingly.
Add new variable __jmv_THREAD_START_TIME_ITERATION in the documentation : 
functions.xml, section 6 Pre-defined Variables

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
