### PR TITLE
Ensure directories are writable when generating reports from read-only sources

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/TemplateVisitor.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/TemplateVisitor.java
@@ -93,6 +93,9 @@ public class TemplateVisitor extends SimpleFileVisitor<Path> {
                             "{}, found non empty folder with following content {}, will be ignored",
                     file, newDir, ex.getMessage(), newDir.toFile().listFiles());
         }
+        if (!newDir.toFile().canWrite()) {
+            newDir.toFile().setWritable(true);
+        }
         return FileVisitResult.CONTINUE;
     }
 

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -65,6 +65,7 @@ Summary
   <ul>
     <li><pr>6220</pr> Require Java 17 or later for running JMeter</li>
     <li><pr>6274</pr> Change references to old MySQL driver to new class <code>com.mysql.cj.jdbc.Driver</code></li>
+    <li><issue>6357</issue> Ensure writable directories when copying template files while report generation.</li>
   </ul>
 
  <!--  =================== Thanks =================== -->


### PR DESCRIPTION
## Description

When copying files while generating reports, make newly created directories writeable.

## Motivation and Context

As reported in #6357 some distributions of JMeter provide the template directories read-only, only. As that is probably a good idea, we should support those kind of setups.

## How Has This Been Tested?

Made some directories in ./bin/report-templates read-only and generated a report. With the current released version of JMeter we will get an exception as described in #6357. With the fix, the report is generated without problems.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
