### PR TITLE
Large request problem

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JSyntaxTextArea.java
@@ -34,6 +34,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.gui.ui.TextComponentUI;
+import org.apache.jorphan.util.StringWrap;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rsyntaxtextarea.Theme;
@@ -292,6 +293,30 @@ public class JSyntaxTextArea extends RSyntaxTextArea {
             undoManager.setLimit(MAX_UNDOS);
         }
         return undoManager;
+    }
+
+    // Default limited to 110K
+    private static final int MAX_LINE_SIZE =
+            JMeterUtils.getPropDefault("view.results.tree.max_line_size", 110_000); // $NON-NLS-1$
+
+    // Limit the soft wrap to 100K (hard limit divided by 1.1)
+    private static final int SOFT_WRAP_LINE_SIZE =
+            JMeterUtils.getPropDefault("view.results.tree.soft_wrap_line_size", (int) (MAX_LINE_SIZE / 1.1f)); // $NON-NLS-1$
+
+    private static String wrapLongLines(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        if (SOFT_WRAP_LINE_SIZE > 0 && MAX_LINE_SIZE > 0) {
+            StringWrap stringWrap = new StringWrap(SOFT_WRAP_LINE_SIZE, MAX_LINE_SIZE);
+            return stringWrap.wrap(input, "\n");
+        }
+        return input;
+    }
+
+    @Override
+    public void setText(String t) {
+        super.setText(wrapLongLines(t));
     }
 
     /**

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/StringWrap.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/StringWrap.java
@@ -126,7 +126,7 @@ public class StringWrap {
             }
             // Try adding the next line if it does not exceed maxWrap
             int next = nextLineSeparator;
-            if (next != -1 && pos - next <= maxWrap) {
+            if (next != -1 && next - pos <= maxWrap) {
                 // The existing lines do not exceed maxWrap, just reuse them
                 next++; // include newline
                 sb.append(input, pos, next);

--- a/src/jorphan/src/test/java/org/apache/jorphan/util/StringWrapTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/util/StringWrapTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class StringWrapTest {
     static Stream<Arguments> data() {
         return Stream.of(
+                arguments(2, 3, "a\nab\nabc\nabcd\nabcde", "a\nab\nabc\nabc|d\nabc|de"),
                 arguments(2, 2, "0123456789", "01|23|45|67|89"),
                 arguments(2, 5, "0123456789", "01234|56789"),
                 arguments(3, 3, "0123456789", "012|345|678|9"),


### PR DESCRIPTION
## Description

Should fix large responses/requests in ViewResultRreader when no linebreaks can be found

## Motivation and Context

As described in #6336 JMeter seems to crash, when large request bodies are used in HTTP sampler. This is caused by the used TextArea, which tries to find a good place for breaking and uses too much CPU for this.

One fix, we tried earlier, was to add linebreaks, when large responses are shown. We forgot about requests.
This fix is basically two fixes.

1) There seems to be a bug in our StringWrap class, that does the insertion of linebreaks.
2) Move the use of StringWrap into the problematic JSyntaxTextArea, so that all data that is shown by the problematic component is automatically wrapped with linebreaks.

If this fix seems to help, we could remove the usage of StringWrap in the old places.

## How Has This Been Tested?

Used a simple test plan, that generates a HTTP body with `${__groovy("abc" * 1_000_000)}`. Without this patch, JMeter seems to be crashed. With the fix, it will be responsive (after a short while).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
  This will insert linebreaks in large data chunks that are displayed with JSyntaxTextArea

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
