### PR TITLE
Use same spelling sampleResult in all dynamic samplers, functions, assertions and listeners

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
@@ -37,7 +37,7 @@ public class BSFAssertion extends BSFTestElement implements Cloneable, Assertion
         BSFManager mgr =null;
         try {
             mgr = getManager();
-            mgr.declareBean("SampleResult", response, SampleResult.class);
+            mgr.declareBean("sampleResult", response, SampleResult.class);
             mgr.declareBean("AssertionResult", result, AssertionResult.class);
             processFileOrScript(mgr);
             result.setError(false);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/BeanShellAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/BeanShellAssertion.java
@@ -88,6 +88,7 @@ public class BeanShellAssertion extends BeanShellTestElement implements Assertio
 
             // Add SamplerData for consistency with BeanShell Sampler
             bshInterpreter.set("SampleResult", response); //$NON-NLS-1$
+            bshInterpreter.set("sampleResult", response); //$NON-NLS-1$
             bshInterpreter.set("Response", response); //$NON-NLS-1$
             bshInterpreter.set("ResponseData", response.getResponseData());//$NON-NLS-1$
             bshInterpreter.set("ResponseCode", response.getResponseCode());//$NON-NLS-1$

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
@@ -46,6 +46,7 @@ public class JSR223Assertion extends JSR223TestElement implements Cloneable, Ass
             ScriptEngine scriptEngine = getScriptEngine();
             Bindings bindings = scriptEngine.createBindings();
             bindings.put("SampleResult", response);
+            bindings.put("sampleResult", response);
             bindings.put("AssertionResult", result);
             processFileOrScript(scriptEngine, bindings);
             result.setError(false);

--- a/src/functions/src/main/java/org/apache/jmeter/functions/BeanShell.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/BeanShell.java
@@ -90,6 +90,7 @@ public class BeanShell extends AbstractFunction {
 
             if (previousResult != null) {
                 bshInterpreter.set("SampleResult", previousResult); //$NON-NLS-1$
+                bshInterpreter.set("sampleResult", previousResult); //$NON-NLS-1$
             }
 
             // Allow access to context and variables directly

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BSFSampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BSFSampler.java
@@ -82,6 +82,7 @@ public class BSFSampler extends BSFTestElement implements Sampler, TestBean, Con
         try {
             initManager(mgr);
             mgr.declareBean("SampleResult", res, res.getClass()); // $NON-NLS-1$
+            mgr.declareBean("sampleResult", res, res.getClass()); // $NON-NLS-1$
 
             // N.B. some engines (e.g. Javascript) cannot handle certain declareBean() calls
             // after the engine has been initialised, so create the engine last

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/BeanShellSampler.java
@@ -114,6 +114,7 @@ public class BeanShellSampler extends BeanShellTestElement implements Sampler, I
         }
         try {
             bshInterpreter.set("SampleResult", res); //$NON-NLS-1$
+            bshInterpreter.set("sampleResult", res); //$NON-NLS-1$
 
             // Set default values
             bshInterpreter.set("ResponseCode", "200"); //$NON-NLS-1$

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -69,6 +69,7 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
             ScriptEngine scriptEngine = getScriptEngine();
             Bindings bindings = scriptEngine.createBindings();
             bindings.put("SampleResult",result);
+            bindings.put("sampleResult",result);
             Object ret = processFileOrScript(scriptEngine, bindings);
             if (ret != null && (result.getResponseData() == null || result.getResponseData().length==0)){
                 result.setResponseData(ret.toString(), null);

--- a/src/protocol/java/src/test/java/org/apache/jmeter/protocol/java/sampler/JSR223SamplerTest.java
+++ b/src/protocol/java/src/test/java/org/apache/jmeter/protocol/java/sampler/JSR223SamplerTest.java
@@ -21,14 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jmeter.samplers.SampleResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JSR223SamplerTest {
 
-    @Test
-    void sampleWithEndTimeSet() {
+    @ParameterizedTest
+    @ValueSource(strings={"sampleResult", "SampleResult"})
+    void sampleWithEndTimeSet(String sampleResultVariableName) {
         JSR223Sampler sampler = new JSR223Sampler();
         sampler.setName("jsr223Test");
-        sampler.setScript("SampleResult.setEndTime(42); 'OK'");
+        sampler.setScript(sampleResultVariableName + ".setEndTime(42); 'OK'");
         sampler.setScriptLanguage("groovy");
         SampleResult sampleResult = sampler.sample(null);
         assertEquals(42, sampleResult.getEndTime());

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -68,6 +68,7 @@ Summary
     <li><issue>6352</issue> Calculate delays in Open Model Thread Group and Precise Throughput
         Timer relative to start of Thread Group instead of the start of the test.</li>
     <li><issue>6357</issue><pr>6358</pr> Ensure writable directories when copying template files while report generation.</li>
+    <li><issue>6368</issue> Use same spelling <code>sampleResult</code> to reference SampleResult in all JSR223/BeanShell/JavaScript listeners, samplers and assertions.</li>
   </ul>
 
  <!--  =================== Thanks =================== -->

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -1094,7 +1094,7 @@ BeanShell does not currently support Java 5 syntax such as generics and the enha
         <li><code>FileName</code> - the file name, if any</li>
         <li><code>Parameters</code> - text from the Parameters field</li>
         <li><code>bsh.args</code> - the parameters, split as described above</li>
-        <li><code>SampleResult</code> - pointer to the current <apilink href="org/apache/jmeter/samplers/SampleResult.html"><code>SampleResult</code></apilink></li>
+        <li><code>sampleResult</code> - pointer to the current <apilink href="org/apache/jmeter/samplers/SampleResult.html"><code>SampleResult</code></apilink></li>
             <li><code>ResponseCode</code> defaults to <code>200</code></li>
             <li><code>ResponseMessage</code> defaults to "<code>OK</code>"</li>
             <li><code>IsSuccess</code> defaults to <code>true</code></li>
@@ -1109,7 +1109,7 @@ vars.putObject("OBJ1",new Object());</source></li>
 props.put("PROP1","1234");</source></li>
         </ul>
         <p>When the script completes, control is returned to the Sampler, and it copies the contents
-            of the following script variables into the corresponding variables in the <apilink href="org/apache/jmeter/samplers/SampleResult.html"><code>SampleResult</code></apilink>:</p>
+            of the following script variables into the corresponding variables in the <apilink href="org/apache/jmeter/samplers/SampleResult.html"><code>sampleResult</code></apilink>:</p>
             <ul>
             <li><code>ResponseCode</code> - for example <code>200</code></li>
             <li><code>ResponseMessage</code> - for example "<code>OK</code>"</li>
@@ -1117,24 +1117,26 @@ props.put("PROP1","1234");</source></li>
             </ul>
             <p>The SampleResult ResponseData is set from the return value of the script.
             If the script returns null, it can set the response directly, by using the method
-            <code>SampleResult.setResponseData(data)</code>, where data is either a String or a byte array.
+            <code>sampleResult.setResponseData(data)</code>, where data is either a String or a byte array.
             The data type defaults to "<code>text</code>", but can be set to binary by using the method
-            <code>SampleResult.setDataType(SampleResult.BINARY)</code>.
+            <code>sampleResult.setDataType(SampleResult.BINARY)</code>.
             </p>
-            <p>The <code>SampleResult</code> variable gives the script full access to all the fields and
+            <p>The <code>sampleResult</code> variable gives the script full access to all the fields and
                 methods in the <code>SampleResult</code>. For example, the script has access to the methods
-                <code>setStopThread(boolean)</code> and <code>setStopTest(boolean)</code>.
+                <code>setStopThread(boolean)</code> and <code>setStopTest(boolean)</code>.</p>
 
-                Here is a simple (not very useful!) example script:</p>
+            <p>Here is a simple (not very useful!) example script:</p>
 
 <source>
 if (bsh.args[0].equalsIgnoreCase("StopThread")) {
     log.info("Stop Thread detected!");
-    SampleResult.setStopThread(true);
+    sampleResult.setStopThread(true);
 }
 return "Data from sample with Label "+Label;
-//or
-SampleResult.setResponseData("My data");
+</source>
+or
+<source>
+sampleResult.setResponseData("My data");
 return null;
 </source>
 <p>Another example:<br></br> ensure that the property <code>beanshell.sampler.init=BeanShellSampler.bshrc</code> is defined in <code>jmeter.properties</code>.
@@ -1155,12 +1157,12 @@ Beware however that misuse of any methods can cause subtle faults that may be di
 The JSR223 Sampler allows JSR223 script code to be used to perform a sample or some computation required to create/update variables.
 <note>
 If you don't want to generate a <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink> when this sampler is run, call the following method:
-<source>SampleResult.setIgnore();</source>
+<source>sampleResult.setIgnore();</source>
 This call will have the following impact:
 <ul>
-    <li>SampleResult will not be delivered to SampleListeners like View Results Tree, Summariser ...</li>
-    <li>SampleResult will not be evaluated in Assertions nor PostProcessors</li>
-    <li>SampleResult will be evaluated to computing last sample status (${JMeterThread.last_sample_ok}),
+    <li>SampleResult will not be delivered to SampleListeners like View Results Tree, Summariser, &hellip;</li>
+    <li>SampleResult will neither be evaluated in Assertions nor in PostProcessors</li>
+    <li>SampleResult will be evaluated to compute last sample status (<code>${JMeterThread.last_sample_ok}</code>),
     and ThreadGroup "Action to be taken after a Sampler error" (since JMeter 5.4)</li>
 </ul>
 </note>
@@ -1227,7 +1229,7 @@ Note that these are JSR223 variables - i.e. they can be used directly in the scr
 <li><code>FileName</code> - the file name, if any</li>
 <li><code>Parameters</code> - text from the Parameters field</li>
 <li><code>args</code> - the parameters, split as described above</li>
-<li><code>SampleResult</code> - pointer to the current <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink></li>
+<li><code>sampleResult</code> - pointer to the current <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink></li>
 <li><code>sampler</code> - (<apilink href="org/apache/jmeter/samplers/Sampler.html">Sampler</apilink>) - pointer to current Sampler</li>
 <li><code>ctx</code> - <apilink href="org/apache/jmeter/threads/JMeterContext.html">JMeterContext</apilink></li>
 <li><code>vars</code> - <apilink href="org/apache/jmeter/threads/JMeterVariables.html">JMeterVariables</apilink>  - e.g.
@@ -1243,12 +1245,12 @@ props.put("PROP1","1234");</source></li>
 <p>
 The <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink> ResponseData is set from the return value of the script.
 If the script returns <code>null</code>, it can set the response directly, by using the method
-<code>SampleResult.setResponseData(data)</code>, where data is either a String or a byte array.
+<code>sampleResult.setResponseData(data)</code>, where data is either a String or a byte array.
 The data type defaults to "<code>text</code>", but can be set to binary by using the method
-<code>SampleResult.setDataType(SampleResult.BINARY)</code>.
+<code>sampleResult.setDataType(SampleResult.BINARY)</code>.
 </p>
 <p>
-The SampleResult variable gives the script full access to all the fields and
+The <code>sampleResult</code> variable gives the script full access to all the fields and
 methods in the SampleResult. For example, the script has access to the methods
 <code>setStopThread(boolean)</code> and <code>setStopTest(boolean)</code>.
 </p>
@@ -1257,9 +1259,9 @@ Unlike the BeanShell Sampler, the JSR223 Sampler does not set the <code>Response
 Currently the only way to changes these is via the <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink> methods:
 </p>
 <ul>
-<li><code>SampleResult.setSuccessful(true/false)</code></li>
-<li><code>SampleResult.setResponseCode("code")</code></li>
-<li><code>SampleResult.setResponseMessage("message")</code></li>
+<li><code>sampleResult.setSuccessful(true/false)</code></li>
+<li><code>sampleResult.setResponseCode("code")</code></li>
+<li><code>sampleResult.setResponseMessage("message")</code></li>
 </ul>
 </component>
 
@@ -4798,7 +4800,7 @@ These are strings unless otherwise noted:
 </p>
 <ul>
   <li><code>log</code> - the <a href="https://www.slf4j.org/api/org/slf4j/Logger.html">Logger</a> Object. (e.g.) <code>log.warn("Message"[,Throwable])</code></li>
-  <li><code>SampleResult</code>, <code>prev</code> - the <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink> Object; read-write</li>
+  <li><code>sampleResult</code>, <code>prev</code> - the <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink> Object; read-write</li>
   <li><code>Response</code> - the response Object; read-write</li>
   <li><code>Failure</code> - boolean; read-write; used to set the Assertion status</li>
   <li><code>FailureMessage</code> - String; read-write; used to set the Assertion message</li>
@@ -4973,7 +4975,7 @@ vars.getObject("OBJ2");
 props.get("START.HMS");
 props.put("PROP1","1234");
 </source></li>
-<li><code>SampleResult</code>, <code>prev</code> - (<apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink>) - gives access to the previous SampleResult (if any)</li>
+<li><code>sampleResult</code>, <code>prev</code> - (<apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink>) - gives access to the previous SampleResult (if any)</li>
 <li><code>sampler</code> - (<apilink href="org/apache/jmeter/samplers/Sampler.html">Sampler</apilink>) - gives access to the current sampler</li>
 <li><code>OUT</code> - <code>System.out</code> - e.g. <code>OUT.println("message")</code></li>
 <li><code>AssertionResult</code> - (<apilink href="org/apache/jmeter/assertions/AssertionResult.html">AssertionResult</apilink>) - the assertion result</li>

--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -942,7 +942,7 @@ The following variables are set before the script is executed:
 <li><code>props</code> - JMeterProperties (class <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html"><code>java.util.Properties</code></a>) object</li>
 <li><code>threadName</code> - the threadName (String)</li>
 <li><code>Sampler</code> - the current <apilink href="org/apache/jmeter/samplers/Sampler.html">Sampler</apilink>, if any</li>
-<li><code>SampleResult</code> - the current <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink>, if any</li>
+<li><code>sampleResult</code> - the current <apilink href="org/apache/jmeter/samplers/SampleResult.html">SampleResult</apilink>, if any</li>
 </ul>
 (*) means that this is set before the init file, if any, is processed.
 Other variables vary from invocation to invocation.


### PR DESCRIPTION
## Description

Harmonize the spelling of the SampleResult variables used in scripting components.

## Motivation and Context 

In scripting listeners, assertions functions and samplers the SampleResult object is often given in the the scripting context via a variable. That variable should have the same name in all those components. This PR uses the spelling `sampleResult` in favour of `SampleResult`, as the variable points to an instance and in Java instances are named starting with a lowercase character.

This issue has been described in #6368.

One could argue to use the old name `SampleResult` as it might be found in more existing test cases.

As the next version of JMeter will be a major version, we could use this to deprecate the old writing and remove those in a later major version.

## How Has This Been Tested?

Test cases have been adapted to use the new and old spelling.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
