### PR TITLE
Fix KeyManage log when using CLI mode

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/util/SSLManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/SSLManager.java
@@ -223,9 +223,9 @@ public abstract class SSLManager {
                 }
                 System.setProperty(KEY_STORE_PASSWORD, this.defaultpw);
                 password = this.defaultpw;
+            } else {
+                log.warn("No password provided, and no GUI present so cannot prompt");
             }
-        } else {
-            log.warn("No password provided, and no GUI present so cannot prompt");
         }
         return password;
     }


### PR DESCRIPTION
Without this patch, whenever a KeyStore is used (for example for client certificates) in CLI mode, there is a message that no password was provided.
This was caused by the else of the condition being on the wrong if statement, and can cause people to spend a lot of time trying to debug why the key store won't work.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
