### PR TITLE
style(StandardJmeterEngine): remove unnecessary code in StandardJMeterEngine#startThreadGroup

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -579,7 +579,6 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         } catch (JMeterStopTestException ex) { // NOSONAR Reported by log
             JMeterUtils.reportErrorToUser("Error occurred starting thread group :" + group.getName()+ ", error message:"+ex.getMessage()
                 +", \r\nsee log file for more details", ex);
-            return; // no point continuing
         }
     }
 


### PR DESCRIPTION
## Description
Delete "return" in a private void method

## Motivation and Context
clean unnecessary code

## How Has This Been Tested?
org.apache.jmeter.engine.StandardJMeterEngine#startThreadGroup is a private void method , This change simply removes useless "return" statements without running tests.

## Screenshots (if appropriate):

## Types of changes
style

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
