### PR TITLE
Bump xstream version from 1.4.20 to 1.4.21 for CVE-2024-47072.

### DIFF
--- a/src/bom-thirdparty/build.gradle.kts
+++ b/src/bom-thirdparty/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
         api("com.miglayout:miglayout-core:5.3")
         api("com.miglayout:miglayout-swing:5.3")
         api("com.sun.activation:javax.activation:1.2.0")
-        api("com.thoughtworks.xstream:xstream:1.4.20")
+        api("com.thoughtworks.xstream:xstream:1.4.21")
         api("commons-codec:commons-codec:1.16.0")
         api("commons-collections:commons-collections:3.2.2")
         api("commons-io:commons-io:2.15.1")

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -137,4 +137,4 @@
 7188,xmlpull-1.1.3.1.jar
 1027769,xmlresolver-5.2.1-data.jar
 165689,xmlresolver-5.2.1.jar
-644649,xstream-1.4.20.jar
+644649,xstream-1.4.21.jar


### PR DESCRIPTION
## Description
Bump xstream version from 1.4.20 to 1.4.21 for CVE-2024-47072.

## Motivation and Context
Fixes CVE-2024-47072.
Addresses [link](https://github.com/apache/jmeter/issues/6398)

## How Has This Been Tested?
Ran 'gradlew check' and 'gradlew test'.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
Security vulnerability fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
