### PR TITLE
Upgrade dnsjava:dnsjava to 3.6.2 for CVE-2023-50387.

### DIFF
--- a/lib/aareadme.txt
+++ b/lib/aareadme.txt
@@ -97,7 +97,7 @@ darcula
 https://github.com/bulenkov/Darcula/
 - Look and Feel
 
-dnsjava-2.1.9
+dnsjava-3.6.2
 -----------------
 https://github.com/dnsjava/dnsjava
 - DNSCacheManager

--- a/src/dist/src/dist/expected_release_jars.csv
+++ b/src/dist/src/dist/expected_release_jars.csv
@@ -50,7 +50,7 @@
 353322,datamodel-jvm-4.1.0.jar
 98115,dec-0.1.2.jar
 95287,deprecated-in-v4-jvm-4.1.0.jar
-320748,dnsjava-2.1.9.jar
+320748,dnsjava-3.6.2.jar
 16829,error_prone_annotations-2.24.0.jar
 1736381,freemarker-2.3.32.jar
 32359,geronimo-jms_1.1_spec-1.1.1.jar

--- a/src/licenses/build.gradle.kts
+++ b/src/licenses/build.gradle.kts
@@ -104,7 +104,7 @@ val gatherBinaryLicenses by tasks.registering(GatherLicenseTask::class) {
     // That enables to have "version-independent" MIT license in licenses/slf4j-api, and
     // it would be copied provided the detected license for slf4j-api is MIT.
 
-    overrideLicense("dnsjava:dnsjava:2.1.9") {
+    overrideLicense("dnsjava:dnsjava:3.6.2") {
         expectedLicense = SpdxLicense.BSD_2_Clause
     }
 


### PR DESCRIPTION
Issue is #6400.

## Description
Upgrade dnsjave to 3.6.2 for high severity vulnerability CVE-2023-50387

## Motivation and Context
Fix a high vulnerability issue

## How Has This Been Tested?
Ran gradew check and gradlew build.  All tests passed

## Screenshots (if appropriate):

## Types of changes
Upgraded dependency

## Checklist:
- [ X] My code follows the [code style][style-guide] of this project.
- [ X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
