### PR TITLE
Correct mirror server class path

### DIFF
--- a/bin/mirror-server.cmd
+++ b/bin/mirror-server.cmd
@@ -26,9 +26,7 @@ set JMETER_CMD_LINE_ARGS=%*
 
 cd /D %~dp0
 
-set CP=..\lib\ext\ApacheJMeter_http.jar;..\lib\ext\ApacheJMeter_core.jar;..\lib\jorphan.jar;..\lib\oro-2.0.8.jar
-set CP=%CP%;..\lib\slf4j-api-1.7.25.jar;..\lib\jcl-over-slf4j-1.7.25.jar;..\lib\log4j-slf4j-impl-2.11.1.jar
-set CP=%CP%;..\lib\log4j-api-2.11.1.jar;..\lib\log4j-core-2.11.1.jar;..\lib\log4j-1.2-api-2.11.1.jar
+set CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/*
 
 java -cp %CP% org.apache.jmeter.protocol.http.control.HttpMirrorServer %JMETER_CMD_LINE_ARGS%
 

--- a/bin/mirror-server.cmd
+++ b/bin/mirror-server.cmd
@@ -26,7 +26,9 @@ set JMETER_CMD_LINE_ARGS=%*
 
 cd /D %~dp0
 
-set CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/*
+set CP=..\lib\ext\ApacheJMeter_http.jar;..\lib\ext\ApacheJMeter_core.jar;..\lib\jorphan.jar;..\lib\oro-2.0.8.jar
+set CP=%CP%;..\lib\slf4j-api-1.7.36.jar;..\lib\jcl-over-slf4j-1.7.36.jar;..\lib\log4j-slf4j-impl-2.22.1.jar
+set CP=%CP%;..\lib\log4j-api-2.22.1.jar;..\lib\log4j-core-2.22.1.jar;..\lib\log4j-1.2-api-2.22.1.jar
 
 java -cp %CP% org.apache.jmeter.protocol.http.control.HttpMirrorServer %JMETER_CMD_LINE_ARGS%
 

--- a/bin/mirror-server.sh
+++ b/bin/mirror-server.sh
@@ -21,8 +21,6 @@
 
 cd "$(dirname "$0")" || exit 1
 
-CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/jorphan.jar:../lib/oro-2.0.8.jar
-CP=${CP}:../lib/slf4j-api-1.7.25.jar:../lib/jcl-over-slf4j-1.7.25.jar:../lib/log4j-slf4j-impl-2.11.0.jar
-CP=${CP}:../lib/log4j-api-2.11.1.jar:../lib/log4j-core-2.11.1.jar:../lib/log4j-1.2-api-2.11.1.jar
+CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/*
 
 java -cp $CP org.apache.jmeter.protocol.http.control.HttpMirrorServer "$@"

--- a/bin/mirror-server.sh
+++ b/bin/mirror-server.sh
@@ -21,6 +21,8 @@
 
 cd "$(dirname "$0")" || exit 1
 
-CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/*
+CP=../lib/ext/ApacheJMeter_http.jar:../lib/ext/ApacheJMeter_core.jar:../lib/jorphan.jar:../lib/oro-2.0.8.jar
+CP=${CP}:../lib/slf4j-api-1.7.36.jar:../lib/jcl-over-slf4j-1.7.36.jar:../lib/log4j-slf4j-impl-2.22.1.jar
+CP=${CP}:../lib/log4j-api-2.22.1.jar:../lib/log4j-core-2.22.1.jar:../lib/log4j-1.2-api-2.22.1.jar
 
 java -cp $CP org.apache.jmeter.protocol.http.control.HttpMirrorServer "$@"


### PR DESCRIPTION
## Description
Correct mirror server class path

## Motivation and Context
Original CP was wrong.
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/logging/log4j/Level
        at org.apache.jmeter.protocol.http.control.HttpMirrorServer.main(HttpMirrorServer.java:214)
Caused by: java.lang.ClassNotFoundException: org.apache.logging.log4j.Level
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 1 more

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
