### PR TITLE
Fix typo that caused exportToPNG to fail

### DIFF
--- a/bin/report-template/content/pages/ResponseTimes.html.fmkr
+++ b/bin/report-template/content/pages/ResponseTimes.html.fmkr
@@ -217,7 +217,7 @@
                                         </li>
                                         <li><a href="#syntheticResponseTimeDistribution" onClick="uncheckAll('choicesSyntheticResponseTimeDistribution');">Hide all samples</a>
                                         </li>
-                                        <li><a href="#syntheticResponseTimeDistribution" onclick="exportToPNG('flotSyntheticResponseTimesDistribution', this);">Save as PNG</a></li>
+                                        <li><a href="#syntheticResponseTimeDistribution" onclick="exportToPNG('flotSyntheticResponseTimeDistribution', this);">Save as PNG</a></li>
                                     </ul>
                                     <button type="button" class="btn btn-link btn-xs dropdown-toggle" data-toggle="collapse" href="#bodySyntheticResponseTimeDistribution" aria-expanded="true" aria-controls="bodySyntheticResponseTimeDistribution">
                                         <i class="fa fa-chevron-down"></i>


### PR DESCRIPTION
##  Description
Fixed a typo in the element ID that was preventing the "Save as PNG" functionality from working correctly in the synthetic response time distribution dropdown menu.
##  Motivation and Context
This change fixes a functional bug where the "Save as PNG" feature was not working due to an incorrect element ID reference in the onclick handler. The typo in the element ID caused the export functionality to fail.
##  How Has This Been Tested?
Verified that the "Save as PNG" functionality now works correctly after fixing the element ID. Tested by clicking the menu option and confirming that the PNG export occurs as expected.
##  Screenshots (if appropriate):
N/A
##  Types of changes

Bug fix (non-breaking change which fixes an issue)