### PR TITLE
String with only sep would produce an invalid size default value

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
@@ -70,7 +70,7 @@ public class JSONPostProcessor
         List<String> jsonResponses = extractJsonResponse(context, vars);
         String[] refNames = getRefNames().split(SEPARATOR);
         String[] jsonPathExpressions = getJsonPathExpressions().split(SEPARATOR);
-        String[] defaultValues = getDefaultValues().split(SEPARATOR);
+        String[] defaultValues = getDefaultValues().split(SEPARATOR, -1);
         int[] matchNumbers = getMatchNumbersAsInt(defaultValues.length);
 
         validateSameLengthOfArguments(refNames, jsonPathExpressions, defaultValues);

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestJSONPostProcessor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestJSONPostProcessor.java
@@ -317,6 +317,35 @@ class TestJSONPostProcessor {
         assertEquals("3", vars.get(VAR_NAME + "_matchNr"));
     }
 
+    @Test
+    void testProcessDefaultsWithAllEmptyStrings() {
+        JMeterContext context = JMeterContextService.getContext();
+        // Use match number 1 for simplicity
+        JSONPostProcessor processor = setupProcessor(context, "1", false);
+        JMeterVariables vars = new JMeterVariables();
+        context.setVariables(vars);
+
+        // Set up sample result that won't match JSON Paths
+        SampleResult sampleResult = createSampleResult("{}"); // Empty JSON
+        context.setPreviousResult(sampleResult);
+
+        // Configure the processor
+        // Three paths and names, corresponding to the three empty defaults
+        processor.setJsonPathExpressions("$.key1;$.key2;$.key3");
+        processor.setRefNames("var1;var2;var3");
+        // *** Default values string containing only separators ***
+        // This should split into ["", "", ""] with the fix
+        processor.setDefaultValues(";;"); // Represents 3 empty default values
+        processor.setScopeAll(); // Ensure it processes the main sample
+
+        // Process the sample
+        processor.process();
+
+        // Assertions: Verify all variables received an empty string default
+        assertEquals("", vars.get("var1"), "Variable var1 should get the first (empty) default value");
+        assertEquals("", vars.get("var2"), "Variable var2 should get the second (empty) default value");
+        assertEquals("", vars.get("var3"), "Variable var3 should get the third (empty) default value");
+    }
 
     private static JSONPostProcessor setupProcessor(JMeterContext context, String matchNumbers) {
         return setupProcessor(context, matchNumbers, true);


### PR DESCRIPTION
## Description
Fixes a bug in `JSONPostProcessor` where default values containing trailing empty strings (e.g., `"val1;;val3;"` intended as `["val1", "", "val3", ""]`) were not parsed correctly due to the behavior of `String.split(separator)`.

The fix utilizes the `String.split(separator, -1)` overload, which preserves trailing empty strings, ensuring that default values are split into the expected array elements.



## Motivation and Context
The `String.split(String regex)` method used to parse the `defaultValues` string discards trailing empty strings resulting from the split. This means that if a user configures default values ending with the separator (e.g., `a;b;;` with ';' as separator) to indicate empty defaults at the end, these empty values are lost during parsing. This leads to an incorrect number of default values being available compared to the number of reference names or JSON path expressions, potentially causing `IndexOutOfBoundsException` or incorrect variable assignments later in the `process` method.

This change corrects the parsing logic to accurately reflect the user's intended default values, including trailing empty ones.

## How Has This Been Tested?
*Manual testing is recommended with various `defaultValues` inputs, focusing on cases with trailing separators:*
  * `"a;b;c"` (no trailing)
  * `"a;b;"` (one trailing empty)
  * `";;c"` (leading empty)
  * `";;"` (only empty)
  * `""` (single empty string)
  * `"a"` (single non-empty string)

*Verify that the resulting `defaultValues` array has the expected size and content in each case.*
*Confirm that the processor correctly assigns default values when JSON path expressions yield no results, especially matching the behavior with the newly parsed trailing empty defaults.*

## Screenshots:
Before:
![image](https://github.com/user-attachments/assets/81a99bd1-30c0-41bb-971f-b78bbe5e0cd3)

After:
![image](https://github.com/user-attachments/assets/85d09b0e-1f85-427f-b347-a45ba0c5cbc9)


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines