### PR TITLE
Caching the length/size in a variable for collections in order to avo…

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -442,7 +442,6 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
         int[] rowsSelected = table.getSelectedRows();
         GuiUtils.stopTableEditing(table);
         int selectedRowsCount = rowsSelected.length;
-
         if (selectedRowsCount > 0 && rowsSelected[selectedRowsCount - 1] < table.getRowCount() - 1) {
             table.clearSelection();
             for (int i = selectedRowsCount - 1; i >= 0; i--) {

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -441,10 +441,11 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
         // or the selected rows will be unselected
         int[] rowsSelected = table.getSelectedRows();
         GuiUtils.stopTableEditing(table);
+        int selectedRowsCount = rowsSelected.length;
 
-        if (rowsSelected.length > 0 && rowsSelected[rowsSelected.length - 1] < table.getRowCount() - 1) {
+        if (selectedRowsCount > 0 && rowsSelected[selectedRowsCount - 1] < table.getRowCount() - 1) {
             table.clearSelection();
-            for (int i = rowsSelected.length - 1; i >= 0; i--) {
+            for (int i = selectedRowsCount - 1; i >= 0; i--) {
                 int rowSelected = rowsSelected[i];
                 tableModel.moveRow(rowSelected, rowSelected + 1, rowSelected + 1);
             }
@@ -535,8 +536,9 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
         int[] rowsSelected = table.getSelectedRows();
         int anchorSelection = table.getSelectionModel().getAnchorSelectionIndex();
         table.clearSelection();
-        if (rowsSelected.length > 0) {
-            for (int i = rowsSelected.length - 1; i >= 0; i--) {
+        int selectedRowsCount = rowsSelected.length;
+        if (selectedRowsCount > 0) {
+            for (int i = selectedRowsCount - 1; i >= 0; i--) {
                 tableModel.removeRow(rowsSelected[i]);
             }
 

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/RowDetailDialog.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/RowDetailDialog.java
@@ -243,7 +243,8 @@ public class RowDetailDialog extends JDialog implements ActionListener, Document
      * @param selectedRow Selected row
      */
     private void setValues(int selectedRow) {
-        for (int i = 0; i < tableModel.getColumnCount(); i++) {
+        int columnCount = tableModel.getColumnCount();
+        for (int i = 0; i < columnCount; i++) {
             final JComponent component = dataComponents.get(i);
             if (component instanceof JTextComponent) {
                 JTextComponent dataArea = (JTextComponent) component;
@@ -263,7 +264,8 @@ public class RowDetailDialog extends JDialog implements ActionListener, Document
      * @param actionEvent the event that led to this call
      */
     protected void doUpdate(ActionEvent actionEvent) {
-        for (int i = 0; i < tableModel.getColumnCount(); i++) {
+        int columnCount = tableModel.getColumnCount();
+        for (int i = 0; i < columnCount; i++) {
             final JComponent component = dataComponents.get(i);
             if (component instanceof JTextComponent) {
                 tableModel.setValueAt(((JTextComponent) component).getText(), selectedRow, i);

--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -715,7 +715,8 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
                 KeyStrokes.CTRL_1, KeyStrokes.CTRL_2, KeyStrokes.CTRL_3,
                 KeyStrokes.CTRL_4, KeyStrokes.CTRL_5, KeyStrokes.CTRL_6,
                 KeyStrokes.CTRL_7, KeyStrokes.CTRL_8, KeyStrokes.CTRL_9,};
-        for (int n = 0; n < keyStrokes.length; n++) {
+        int keyStrokeCount = keyStrokes.length;
+        for (int n = 0; n < keyStrokeCount; n++) {
             treevar.getActionMap().put(ActionNames.QUICK_COMPONENT + String.valueOf(n), quickComponent);
             inputMap.put(keyStrokes[n], ActionNames.QUICK_COMPONENT + String.valueOf(n));
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/TreeState.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/TreeState.java
@@ -50,7 +50,8 @@ public interface TreeState {
             int savedSelected = tree.getMinSelectionRow();
             ArrayList<Integer> savedExpanded = new ArrayList<>();
 
-            for (int rowN = 0; rowN < tree.getRowCount(); rowN++) {
+            int treeRowCount = tree.getRowCount();
+            for (int rowN = 0; rowN < treeRowCount; rowN++) {
                 if (tree.isExpanded(rowN)) {
                     savedExpanded.add(rowN);
                 }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/CheckDirty.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/CheckDirty.java
@@ -98,7 +98,8 @@ public class CheckDirty extends AbstractAction implements HashTreeTraverser, Act
             JMeterTreeNode[] nodes = guiPackage.getTreeListener().getSelectedNodes();
             removeMode = true;
             try {
-                for (int i = nodes.length - 1; i >= 0; i--) {
+                int selectedNodesCount = nodes.length;
+                for (int i = selectedNodesCount - 1; i >= 0; i--) {
                     guiPackage.getTreeModel().getCurrentSubTree(nodes[i]).traverse(this);
                 }
             } finally {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/CollapseExpand.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/CollapseExpand.java
@@ -68,13 +68,14 @@ public class CollapseExpand extends AbstractAction {
         boolean collapse=ActionNames.COLLAPSE_ALL.equals(e.getActionCommand());
         GuiPackage guiInstance = GuiPackage.getInstance();
         JTree jTree = guiInstance.getMainFrame().getTree();
+        int treeRowCount = jTree.getRowCount();
         if (collapse) {
-            for (int i = jTree.getRowCount() - 1; i >= 0; i--) {
+            for (int i = treeRowCount - 1; i >= 0; i--) {
                 jTree.collapseRow(i);
             }
             return;
         }
-        for(int i = 0; i < jTree.getRowCount(); i++) {
+        for(int i = 0; i < treeRowCount; i++) {
             jTree.expandRow(i);
         }
     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Copy.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Copy.java
@@ -98,9 +98,10 @@ public class Copy extends AbstractAction {
      */
     static JMeterTreeNode[] keepOnlyAncestors(JMeterTreeNode[] currentNodes) {
         List<JMeterTreeNode> nodes = new ArrayList<>();
-        for (int i = 0; i < currentNodes.length; i++) {
+        int currentNodesCount = currentNodes.length;
+        for (int i = 0; i < currentNodesCount; i++) {
             boolean exclude = false;
-            for (int j = 0; j < currentNodes.length; j++) {
+            for (int j = 0; j < currentNodesCount; j++) {
                 if(i!=j && currentNodes[i].isNodeAncestor(currentNodes[j])) {
                     exclude = true;
                     break;
@@ -130,8 +131,9 @@ public class Copy extends AbstractAction {
     }
 
     public static JMeterTreeNode[] cloneTreeNodes(JMeterTreeNode[] nodes) {
-        JMeterTreeNode[] treeNodes = new JMeterTreeNode[nodes.length];
-        for (int i = 0; i < nodes.length; i++) {
+        int nodesCount = nodes.length;
+        JMeterTreeNode[] treeNodes = new JMeterTreeNode[nodesCount];
+        for (int i = 0; i < nodesCount; i++) {
             treeNodes[i] = cloneTreeNode(nodes[i]);
         }
         return treeNodes;

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Duplicate.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Duplicate.java
@@ -56,7 +56,8 @@ public class Duplicate extends AbstractAction {
         JMeterTreeNode currentNode = treeListener.getCurrentNode();
         JMeterTreeNode parentNode = (JMeterTreeNode) currentNode.getParent();
         JMeterTreeModel treeModel = instance.getTreeModel();
-        for (int nodeIndex = copiedNodes.length - 1; nodeIndex >= 0; nodeIndex--) {
+        int copiedNodesCount = copiedNodes.length;
+        for (int nodeIndex = copiedNodesCount - 1; nodeIndex >= 0; nodeIndex--) {
             JMeterTreeNode copiedNode = copiedNodes[nodeIndex];
             int index = parentNode.getIndex(currentNode) + 1;
             treeModel.insertNodeInto(copiedNode, parentNode, index);

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Paste.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Paste.java
@@ -84,7 +84,8 @@ public class Paste extends AbstractAction {
             // Add this node
             JMeterTreeNode newNode = GuiPackage.getInstance().getTreeModel().addComponent(node.getTestElement(), parent);
             // Add all the child nodes of the node we are adding
-            for (int i = 0; i < node.getChildCount(); i++) {
+            int numberOfChildren = node.getChildCount();
+            for (int i = 0; i < numberOfChildren; i++) {
                 addNode(newNode, (JMeterTreeNode)node.getChildAt(i));
             }
         } catch (IllegalUserActionException iuae) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Remove.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Remove.java
@@ -78,7 +78,8 @@ public class Remove extends AbstractAction {
             JMeterTreeNode[] nodes = guiPackage.getTreeListener().getSelectedNodes();
             TreePath newTreePath = // Save parent node for later
             guiPackage.getTreeListener().removedSelectedNode();
-            for (int i = nodes.length - 1; i >= 0; i--) {
+            int nodesCount = nodes.length;
+            for (int i = nodesCount - 1; i >= 0; i--) {
                 removeNode(nodes[i]);
             }
             guiPackage.getTreeListener().getJTree().setSelectionPath(newTreePath);

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Restart.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Restart.java
@@ -180,7 +180,8 @@ public class Restart extends AbstractActionWithNoRunningTest implements MenuCrea
     private static void processRemainingArgs(List<? super String> processArgs, String[] mainCommand) {
         boolean paramValue = false;
         StringBuilder partialParamValue = new StringBuilder();
-        for (int i = 1; i < mainCommand.length; i++) {
+        int commandCount = mainCommand.length;
+        for (int i = 1; i < commandCount; i++) {
             String currentPart = mainCommand[i];
             if (paramValue) {
                 if (currentPart.startsWith("-")) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
@@ -177,7 +177,8 @@ public class TemplateManager {
         document.getDocumentElement().normalize();
         Map<String, Template> templates = new TreeMap<>();
         NodeList templateNodes = document.getElementsByTagName("template");
-        for (int i = 0; i < templateNodes.getLength(); i++) {
+        int nodeCount = templateNodes.getLength();
+        for (int i = 0; i < nodeCount; i++) {
             Node node = templateNodes.item(i);
             parseTemplateNode(templates, node);
         }
@@ -212,7 +213,8 @@ public class TemplateManager {
 
     private static Map<String, String> parseParameterNodes(NodeList parameterNodes) {
         Map<String, String> parametersMap = new HashMap<>();
-        for (int i = 0; i < parameterNodes.getLength(); i++) {
+        int nodeCount = parameterNodes.getLength();
+        for (int i = 0; i < nodeCount; i++) {
             Element element =  (Element) parameterNodes.item(i);
             parametersMap.put(element.getAttribute("key"), element.getAttribute("defaultValue"));
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeListener.java
@@ -125,8 +125,9 @@ public class JMeterTreeListener implements TreeSelectionListener, MouseListener,
         if (paths == null) {
             return new JMeterTreeNode[] { getCurrentNode() };
         }
-        JMeterTreeNode[] nodes = new JMeterTreeNode[paths.length];
-        for (int i = 0; i < paths.length; i++) {
+        int numberOfPaths = paths.length;
+        JMeterTreeNode[] nodes = new JMeterTreeNode[numberOfPaths];
+        for (int i = 0; i < numberOfPaths; i++) {
             nodes[i] = (JMeterTreeNode) paths[i].getLastPathComponent();
         }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeTransferHandler.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeTransferHandler.java
@@ -76,10 +76,11 @@ public class JMeterTreeTransferHandler extends TransferHandler {
             sortTreePathByRow(paths, tree);
 
             // if child and a parent are selected : only keep the parent
-            boolean[] toRemove = new boolean[paths.length];
-            int size = paths.length;
-            for (int i = 0; i < paths.length; i++) {
-                for (int j = 0; j < paths.length; j++) {
+            int pathCount = paths.length;
+            boolean[] toRemove = new boolean[pathCount];
+            int size = pathCount;
+            for (int i = 0; i < pathCount; i++) {
+                for (int j = 0; j < pathCount; j++) {
                     if(i!=j && ((JMeterTreeNode)paths[i].getLastPathComponent()).isNodeAncestor((JMeterTreeNode)paths[j].getLastPathComponent())) {
                         toRemove[i] = true;
                         size--;
@@ -91,7 +92,7 @@ public class JMeterTreeTransferHandler extends TransferHandler {
             // remove unneeded nodes
             JMeterTreeNode[] nodes = new JMeterTreeNode[size];
             size = 0;
-            for (int i = 0; i < paths.length; i++) {
+            for (int i = 0; i < pathCount; i++) {
                 if(!toRemove[i]) {
                     JMeterTreeNode node = (JMeterTreeNode) paths[i].getLastPathComponent();
                     nodes[size++] = node;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FileListPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FileListPanel.java
@@ -164,7 +164,8 @@ public class FileListPanel extends JPanel implements ActionListener {
     public String[] getFiles() {
         GuiUtils.stopTableEditing(files);
         String[] filesArray = new String[tableModel.getRowCount()];
-        for (int idx=0; idx < filesArray.length; idx++) {
+        int fileCount = filesArray.length;
+        for (int idx = 0; idx < fileCount; idx++) {
             filesArray[idx] = (String)tableModel.getValueAt(idx,0);
         }
         return filesArray;

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -624,13 +624,14 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
     }
 
     private void getRemoteItems() {
-        if (remoteHosts.length > 0) {
+        int hostCount = remoteHosts.length;
+        if (hostCount > 0) {
             remoteStart = makeMenuRes("remote_start"); //$NON-NLS-1$
             remoteStop = makeMenuRes("remote_stop"); //$NON-NLS-1$
             remoteShut = makeMenuRes("remote_shut"); //$NON-NLS-1$
             remoteExit = makeMenuRes("remote_exit"); //$NON-NLS-1$
 
-            for (int i = 0; i < remoteHosts.length; i++) {
+            for (int i = 0; i < hostCount; i++) {
                 remoteHosts[i] = remoteHosts[i].trim();
 
                 JMenuItem item = makeMenuItemNoRes(remoteHosts[i], ActionNames.REMOTE_START);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/PowerTableModel.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/PowerTableModel.java
@@ -55,11 +55,12 @@ public class PowerTableModel extends DefaultTableModel {
     }
 
     public void setRowValues(int row, Object[] values) {
-        if (values.length != model.getHeaderCount()){
+        int valueCount = values.length;
+        if (valueCount != model.getHeaderCount()){
             throw new IllegalArgumentException("Incorrect number of data items");
         }
         model.setCurrentPos(row);
-        for (int i = 0; i < values.length; i++) {
+        for (int i = 0; i < valueCount; i++) {
             model.addColumnValue(model.getHeaders()[i], values[i]);
         }
     }
@@ -110,11 +111,12 @@ public class PowerTableModel extends DefaultTableModel {
 
     @Override
     public void addRow(Object[] data) {
-        if (data.length != model.getHeaderCount()){
+        int dataCount = data.length;
+        if (dataCount != model.getHeaderCount()){
             throw new IllegalArgumentException("Incorrect number of data items");
         }
         model.setCurrentPos(model.size());
-        for (int i = 0; i < data.length; i++) {
+        for (int i = 0; i < dataCount; i++) {
             model.addColumnValue(model.getHeaders()[i], data[i]);
         }
     }
@@ -145,7 +147,8 @@ public class PowerTableModel extends DefaultTableModel {
 
     private Object[] createDefaultRow() {
         Object[] rowData = new Object[getColumnCount()];
-        for (int i = 0; i < rowData.length; i++) {
+        int rowDataCount = rowData.length;
+        for (int i = 0; i < rowDataCount; i++) {
             rowData[i] = createDefaultValue(i);
         }
         return rowData;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
@@ -164,7 +164,8 @@ public class CsvFileSampleSource extends AbstractSampleSource {
         SampleContext context = getSampleContext();
         Validate.validState(context != null, "Set a sample context before producing samples.");
 
-        for (int i = 0; i < csvReaders.length; i++) {
+        int readerCount = csvReaders.length;
+        for (int i = 0; i < readerCount; i++) {
             long sampleCount = 0;
             long start = now();
             CsvSampleReader csvReader = csvReaders[i];

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsBySamplerConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/Top5ErrorsBySamplerConsumer.java
@@ -97,7 +97,8 @@ public class Top5ErrorsBySamplerConsumer extends
             Object[][] top5 = data.getTop5ErrorsMetrics();
 
             int numberOfValues = 0;
-            for (int i = 0; i < top5.length; i++) {
+            int top5Count = top5.length;
+            for (int i = 0; i < top5Count; i++) {
                 result.addResult(new ValueResultData(top5[i][0]));
                 result.addResult(new ValueResultData(top5[i][1]));
                 numberOfValues++;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/SyntheticResponseTimeDistributionGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/SyntheticResponseTimeDistributionGraphConsumer.java
@@ -132,7 +132,8 @@ public class SyntheticResponseTimeDistributionGraphConsumer extends
         String[] colors = new String[]{
                 SATISFIED_COLOR, TOLERATED_COLOR, UNTOLERATED_COLOR, FAILED_COLOR
         };
-        for (int i = 0; i < seriesLabels.length; i++) {
+        int seriesCount = seriesLabels.length;
+        for (int i = 0; i < seriesCount; i++) {
             ListResultData array = new ListResultData();
             array.addResult(new ValueResultData(i));
             array.addResult(new ValueResultData(seriesLabels[i]));
@@ -144,7 +145,8 @@ public class SyntheticResponseTimeDistributionGraphConsumer extends
 
     private void initializeSeries(MapResultData parentResult, String[] series, String[] colors) {
         ListResultData listResultData = (ListResultData) parentResult.getResult("series");
-        for (int i = 0; i < series.length; i++) {
+        int seriesCount = series.length;
+        for (int i = 0; i < seriesCount; i++) {
             listResultData.addResult(create(series[i], colors[i]));
         }
     }

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleEvent.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleEvent.java
@@ -233,7 +233,8 @@ public class SampleEvent implements Serializable {
         sb.append(", isTransactionSampleEvent=").append(isTransactionSampleEvent);
         if (values != null && values.length > 0) {
             sb.append("values=[");
-            for (int i = 0; i < variableNames.length; i++) {
+            int variableNameCount = variableNames.length;
+            for (int i = 0; i < variableNameCount; i++) {
                 if (i > 0) {
                     sb.append(", ");
                 }

--- a/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/CSVSaveService.java
@@ -437,7 +437,8 @@ public final class CSVSaveService {
         appendFields(saveConfig.saveIdleTime(), text, delim, CSV_IDLETIME);
         appendFields(saveConfig.saveConnectTime(), text, delim, CSV_CONNECT_TIME);
 
-        for (int i = 0; i < SampleEvent.getVarCount(); i++) {
+        int sampleVariableCount = SampleEvent.getVarCount();
+        for (int i = 0; i < sampleVariableCount; i++) {
             text.append(VARIABLE_NAME_QUOTE_CHAR);
             text.append(SampleEvent.getVarName(i));
             text.append(VARIABLE_NAME_QUOTE_CHAR);
@@ -594,7 +595,8 @@ public final class CSVSaveService {
         String[] parts = headerLine.split("\\Q" + delim);// $NON-NLS-1$
         int previous = -1;
         // Check if the line is a header
-        for (int i = 0; i < parts.length; i++) {
+        int partsCount = parts.length;
+        for (int i = 0; i < partsCount; i++) {
             final String label = parts[i];
             // Check for Quoted variable names
             if (isVariableName(label)) {
@@ -666,7 +668,8 @@ public final class CSVSaveService {
         final char DELIM = ',';
         final char[] SPECIALS = new char[] { DELIM, QUOTING_CHAR };
         if (headers != null) {
-            for (int i = 0; i < headers.length; i++) {
+            int headerCount = headers.length;
+            for (int i = 0; i < headerCount; i++) {
                 if (i > 0) {
                     writer.write(DELIM);
                 }
@@ -676,7 +679,8 @@ public final class CSVSaveService {
         }
         for (Object o : data) {
             List<?> row = (List<?>) o;
-            for (int idy = 0; idy < row.size(); idy++) {
+            int rowSize = row.size();
+            for (int idy = 0; idy < rowSize; idy++) {
                 if (idy > 0) {
                     writer.write(DELIM);
                 }
@@ -943,7 +947,8 @@ public final class CSVSaveService {
             text.append(sample.getConnectTime());
         }
 
-        for (int i = 0; i < SampleEvent.getVarCount(); i++) {
+        int sampleVarCount = SampleEvent.getVarCount();
+        for (int i = 0; i < sampleVarCount; i++) {
             text.append(event.getVarValue(i));
         }
 
@@ -986,10 +991,11 @@ public final class CSVSaveService {
         if (StringUtils.containsNone(input, specialChars)) {
             return input;
         }
-        StringBuilder buffer = new StringBuilder(input.length() + 10);
+        int inputLength = input.length();
+        StringBuilder buffer = new StringBuilder(inputLength + 10);
         final char quote = specialChars[1];
         buffer.append(quote);
-        for (int i = 0; i < input.length(); i++) {
+        for (int i = 0; i < inputLength; i++) {
             char c = input.charAt(i);
             if (c == quote) {
                 buffer.append(quote); // double the quote char

--- a/src/core/src/main/java/org/apache/jmeter/save/converters/SampleResultConverter.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/converters/SampleResultConverter.java
@@ -335,7 +335,8 @@ public class SampleResultConverter extends AbstractCollectionConverter {
             if (save.saveHostname()){
                 writer.addAttribute(ATT_HOSTNAME, event.getHostname());
             }
-            for (int i = 0; i < SampleEvent.getVarCount(); i++){
+            int sampleVarCount = SampleEvent.getVarCount();
+            for (int i = 0; i < sampleVarCount; i++){
                writer.addAttribute(SampleEvent.getVarName(i), ConversionHelp.encode(event.getVarValue(i)));
             }
         }

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/BeanInfoSupport.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/BeanInfoSupport.java
@@ -245,7 +245,8 @@ public abstract class BeanInfoSupport extends SimpleBeanInfo {
      */
     protected void createPropertyGroup(String group, String[] names) {
         String name;
-        for (int i = 0; i < names.length; i++) { // i is used below
+        int namesLength = names.length;
+        for (int i = 0; i < namesLength; i++) { // i is used below
             name = names[i];
             log.debug("Getting property for: {}", name);
             PropertyDescriptor p = property(name);

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -216,10 +216,11 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
         Arrays.sort(descriptors, new PropertyComparator(beanInfo));
 
         // Obtain the propertyEditors:
-        editors = new PropertyEditor[descriptors.length];
+        int descriptorsCount = descriptors.length;
+        editors = new PropertyEditor[descriptorsCount];
         int scriptLanguageIndex = 0;
         int textAreaEditorIndex = 0;
-        for (int i = 0; i < descriptors.length; i++) { // Index is also used for accessing editors array
+        for (int i = 0; i < descriptorsCount; i++) { // Index is also used for accessing editors array
             PropertyDescriptor descriptor = descriptors[i];
             String name = descriptor.getName();
 
@@ -503,7 +504,8 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
         }
 
         // Now set the editors to the element's values:
-        for (int i = 0; i < editors.length; i++) {
+        int editorsCount = editors.length;
+        for (int i = 0; i < editorsCount; i++) {
             if (editors[i] == null) {
                 continue;
             }
@@ -556,7 +558,8 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
         String currentGroup = DEFAULT_GROUP;
         int y = 0;
 
-        for (int i = 0; i < editors.length; i++) {
+        int editorsCount = editors.length;
+        for (int i = 0; i < editorsCount; i++) {
             if (editors[i] == null) {
                 continue;
             }
@@ -733,7 +736,8 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
      * Save values from the GUI fields into the property map
      */
     void saveGuiFields() {
-        for (int i = 0; i < editors.length; i++) {
+        int editorsCount = editors.length;
+        for (int i = 0; i < editorsCount; i++) {
             PropertyEditor propertyEditor=editors[i]; // might be null (e.g. in testing)
             if (propertyEditor != null) {
                 Object value = propertyEditor.getValue();
@@ -750,7 +754,8 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
     }
 
     void clearGuiFields() {
-        for (int i = 0; i < editors.length; i++) {
+        int editorsCount = editors.length;
+        for (int i = 0; i < editorsCount; i++) {
             PropertyEditor propertyEditor=editors[i]; // might be null (e.g. in testing)
             if (propertyEditor != null) {
                 try {

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
@@ -322,7 +322,8 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
 
                     model.addRow(clazz.getDeclaredConstructor().newInstance());
 
-                    for (int i=0; i < columns.length; i++) {
+                    int columnsCount = columns.length;
+                    for (int i = 0; i < columnsCount; i++) {
                         model.setValueAt(columns[i], model.getRowCount() - 1, i);
                     }
                 }
@@ -392,9 +393,10 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
             GuiUtils.cancelEditing(table);
 
             int[] rowsSelected = table.getSelectedRows();
-            if (rowsSelected.length > 0 && rowsSelected[rowsSelected.length - 1] < table.getRowCount() - 1) {
+            int selectedRowsCount = rowsSelected.length;
+            if (selectedRowsCount > 0 && rowsSelected[selectedRowsCount - 1] < table.getRowCount() - 1) {
                 table.clearSelection();
-                for (int i = rowsSelected.length - 1; i >= 0; i--) {
+                for (int i = selectedRowsCount - 1; i >= 0; i--) {
                     int rowSelected = rowsSelected[i];
                     model.moveRow(rowSelected, rowSelected + 1, rowSelected + 1);
                 }

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -159,7 +159,8 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
 
     public void setTestPlanClasspathArray(String[] text) {
         StringBuilder cat = new StringBuilder();
-        for (int idx=0; idx < text.length; idx++) {
+        int textLength = text.length;
+        for (int idx = 0; idx < textLength; idx++) {
             if (idx > 0) {
                 cat.append(CLASSPATH_SEPARATOR);
             }

--- a/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
@@ -203,7 +203,8 @@ public class TestCompiler implements HashTreeTraverser {
         List<Assertion> assertions = new ArrayList<>();
         List<PostProcessor> posts = new ArrayList<>();
         List<PreProcessor> pres = new ArrayList<>();
-        for (int i = stack.size(); i > 0; i--) {
+        int stackSize = stack.size();
+        for (int i = stackSize; i > 0; i--) {
             addDirectParentControllers(controllers, stack.get(i - 1));
             List<PreProcessor>  tempPre = new ArrayList<>();
             List<PostProcessor> tempPost = new ArrayList<>();
@@ -248,7 +249,8 @@ public class TestCompiler implements HashTreeTraverser {
         List<Assertion> assertions = new ArrayList<>();
         List<PostProcessor> posts = new ArrayList<>();
         List<PreProcessor> pres = new ArrayList<>();
-        for (int i = stack.size(); i > 0; i--) {
+        int stackSize = stack.size();
+        for (int i = stackSize; i > 0; i--) {
             addDirectParentControllers(controllers, stack.get(i - 1));
             for (Object item : testTree.list(stack.subList(0, i))) {
                 if (item instanceof SampleListener) {

--- a/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
@@ -203,8 +203,7 @@ public class TestCompiler implements HashTreeTraverser {
         List<Assertion> assertions = new ArrayList<>();
         List<PostProcessor> posts = new ArrayList<>();
         List<PreProcessor> pres = new ArrayList<>();
-        int stackSize = stack.size();
-        for (int i = stackSize; i > 0; i--) {
+        for (int i = stack.size(); i > 0; i--) {
             addDirectParentControllers(controllers, stack.get(i - 1));
             List<PreProcessor>  tempPre = new ArrayList<>();
             List<PostProcessor> tempPost = new ArrayList<>();
@@ -249,8 +248,7 @@ public class TestCompiler implements HashTreeTraverser {
         List<Assertion> assertions = new ArrayList<>();
         List<PostProcessor> posts = new ArrayList<>();
         List<PreProcessor> pres = new ArrayList<>();
-        int stackSize = stack.size();
-        for (int i = stackSize; i > 0; i--) {
+        for (int i = stack.size(); i > 0; i--) {
             addDirectParentControllers(controllers, stack.get(i - 1));
             for (Object item : testTree.list(stack.subList(0, i))) {
                 if (item instanceof SampleListener) {

--- a/src/core/src/main/java/org/apache/jmeter/util/CustomX509TrustManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/CustomX509TrustManager.java
@@ -54,7 +54,8 @@ public class CustomX509TrustManager implements X509TrustManager
     @Override
     public void checkClientTrusted(X509Certificate[] certificates, String authType) { // NOSONAR JMeter is a pentest and perf testing tool
         if (log.isDebugEnabled() && certificates != null) {
-            for (int i = 0; i < certificates.length; i++) {
+            int certificatesCount = certificates.length;
+            for (int i = 0; i < certificatesCount; i++) {
                 X509Certificate cert = certificates[i];
                 log.debug(
                         " Client certificate {}:\n"
@@ -80,7 +81,8 @@ public class CustomX509TrustManager implements X509TrustManager
     public void checkServerTrusted(X509Certificate[] certificates,String authType) // NOSONAR JMeter is a pentest and perf testing tool
             throws CertificateException {
         if (log.isDebugEnabled() && certificates != null) {
-            for (int i = 0; i < certificates.length; i++) {
+            int certificatesCount = certificates.length;
+            for (int i = 0; i < certificatesCount; i++) {
                 X509Certificate cert = certificates[i];
                 log.debug(
                         " Server certificate {}:\n"

--- a/src/core/src/main/java/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/HttpSSLProtocolSocketFactory.java
@@ -97,7 +97,8 @@ public class HttpSSLProtocolSocketFactory
 
     private static String join(String[] strings) {
         StringBuilder sb = new StringBuilder();
-        for (int i=0;i<strings.length;i++){
+        int stringsCount = strings.length;
+        for (int i = 0; i< stringsCount; i++){
             if (i>0) {
                 sb.append(' ');
             }

--- a/src/core/src/main/java/org/apache/jmeter/util/JsseSSLManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JsseSSLManager.java
@@ -213,15 +213,14 @@ public class JsseSSLManager extends SSLManager {
         JmeterKeyStore keys = this.getKeyStore();
         managerFactory.init(null, defaultpw == null ? new char[]{} : defaultpw.toCharArray());
         KeyManager[] managers = managerFactory.getKeyManagers();
-        int managersCount = managers.length;
-        KeyManager[] newManagers = new KeyManager[managersCount];
+        KeyManager[] newManagers = new KeyManager[managers.length];
 
         if (log.isDebugEnabled()) {
             log.debug("JmeterKeyStore type: {}", keys.getClass());
         }
 
         // Now wrap the default managers with our key manager
-        for (int i = 0; i < managersCount; i++) {
+        for (int i = 0; i < managers.length; i++) {
             if (managers[i] instanceof X509KeyManager) {
                 X509KeyManager manager = (X509KeyManager) managers[i];
                 newManagers[i] = new WrappedX509KeyManager(manager, keys);
@@ -237,8 +236,7 @@ public class JsseSSLManager extends SSLManager {
 
         // Wrap the defaults in our custom trust manager
         TrustManager[] trustmanagers = tmfactory.getTrustManagers();
-        int trustManagersCount = trustmanagers.length;
-        for (int i = 0; i < trustManagersCount; i++) {
+        for (int i = 0; i < trustmanagers.length; i++) {
             if (trustmanagers[i] instanceof X509TrustManager) {
                 trustmanagers[i] = new CustomX509TrustManager(
                     (X509TrustManager)trustmanagers[i]);

--- a/src/core/src/main/java/org/apache/jmeter/util/JsseSSLManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JsseSSLManager.java
@@ -213,14 +213,15 @@ public class JsseSSLManager extends SSLManager {
         JmeterKeyStore keys = this.getKeyStore();
         managerFactory.init(null, defaultpw == null ? new char[]{} : defaultpw.toCharArray());
         KeyManager[] managers = managerFactory.getKeyManagers();
-        KeyManager[] newManagers = new KeyManager[managers.length];
+        int managersCount = managers.length;
+        KeyManager[] newManagers = new KeyManager[managersCount];
 
         if (log.isDebugEnabled()) {
             log.debug("JmeterKeyStore type: {}", keys.getClass());
         }
 
         // Now wrap the default managers with our key manager
-        for (int i = 0; i < managers.length; i++) {
+        for (int i = 0; i < managersCount; i++) {
             if (managers[i] instanceof X509KeyManager) {
                 X509KeyManager manager = (X509KeyManager) managers[i];
                 newManagers[i] = new WrappedX509KeyManager(manager, keys);
@@ -236,7 +237,8 @@ public class JsseSSLManager extends SSLManager {
 
         // Wrap the defaults in our custom trust manager
         TrustManager[] trustmanagers = tmfactory.getTrustManagers();
-        for (int i = 0; i < trustmanagers.length; i++) {
+        int trustManagersCount = trustmanagers.length;
+        for (int i = 0; i < trustManagersCount; i++) {
             if (trustmanagers[i] instanceof X509TrustManager) {
                 trustmanagers[i] = new CustomX509TrustManager(
                     (X509TrustManager)trustmanagers[i]);

--- a/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
@@ -261,7 +261,8 @@ public final class JmeterKeyStore {
 
     private static X509Certificate[] toX509Certificates(Certificate[] chain) {
         X509Certificate[] x509certs = new X509Certificate[chain.length];
-        for (int i = 0; i < x509certs.length; i++) {
+        int certificatesCount = x509certs.length;
+        for (int i = 0; i < certificatesCount; i++) {
             x509certs[i] = (X509Certificate) chain[i];
         }
         return x509certs;


### PR DESCRIPTION

## Description
Caching the length/size in a variable for collections in order to avoid repeated calls within loops, which can slightly improve performance and readability.

## Motivation and Context
While reading High Performance with Java ([link](https://learning.oreilly.com/library/view/high-performance-with/9781835469736/B21942_03.xhtml#_idParaDest-63)), I came across a useful performance tip: it's recommended to cache the size of a collection before entering a loop, instead of calling .size() in the loop condition.


Instead of:

```
for (int i = 0; i < list.size(); i++) {
    // logic
}
```
Prefer:

```
int size = list.size();
for (int i = 0; i < size; i++) {
    // logic
}
```

## How Has This Been Tested?
* gradlew build was executed and 99% passed (only testInterfaces() failed)
* gradlew createDist was executed and play with compiled .jar file locally

## Types of changes
- Refactor foor loops

