### PR TITLE
chore: trust -javadoc, -sources, and gradle:gradle artifacts

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,11 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>true</verify-signatures>
+      <trusted-artifacts>
+         <trust group="gradle" name="gradle"/>
+         <trust file=".*-javadoc[.]jar" regex="true"/>
+         <trust file=".*-sources[.]jar" regex="true"/>
+      </trusted-artifacts>
       <ignored-keys>
          <ignored-key id="995EFBF4A3D20BEB" reason="Key couldn't be downloaded from any key server"/>
       </ignored-keys>


### PR DESCRIPTION
Those artifacts are used by IDEs when downloading dependency sources.
