### PR TITLE
chore: remove removeUnusedImports() rule

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.autostyle.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.autostyle.gradle.kts
@@ -75,7 +75,6 @@ plugins.withId("java") {
         java {
             license()
             importOrder("static ", "java.", "javax", "org", "net", "com", "")
-            removeUnusedImports()
             indentWithSpaces(4)
         }
     }

--- a/src/components/src/main/java/org/apache/jmeter/assertions/SizeAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/SizeAssertion.java
@@ -249,7 +249,7 @@ public class SizeAssertion extends AbstractScopedAssertion implements Serializab
         if (operator == null) {
             return "ERROR - invalid condition";
         }
-        
+
         if (operator.evaluate(resultSize, allowedSize)) {
             return "";
         } else {

--- a/src/functions/src/main/java/org/apache/jmeter/functions/ChangeCase.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/ChangeCase.java
@@ -86,7 +86,7 @@ public class ChangeCase extends AbstractFunction {
             LOGGER.error("Unknown mode {}, returning {} unchanged", mode, originalString);
             return originalString;
         }
-        
+
         return switch (changeCaseMode) {
             case UPPER -> StringUtils.upperCase(originalString);
             case LOWER -> StringUtils.lowerCase(originalString);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/proxy/TestHttpRequestHdr.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/proxy/TestHttpRequestHdr.java
@@ -81,7 +81,7 @@ public class TestHttpRequestHdr extends JMeterTestCase {
                 Content-type: %s\r
                 Content-length: %d\r
                 \r
-                %s""".formatted(url, HTTPConstants.APPLICATION_X_WWW_FORM_URLENCODED, 
+                %s""".formatted(url, HTTPConstants.APPLICATION_X_WWW_FORM_URLENCODED,
                               getBodyLength(postBody, contentEncoding), postBody);
         s = getSamplerForRequest(url, testPostRequest, contentEncoding);
         assertEquals(HTTPConstants.POST, s.getMethod());
@@ -597,15 +597,15 @@ public class TestHttpRequestHdr extends JMeterTestCase {
     private String createMultipartFormBody(String titleValue, String descriptionValue,
             String contentEncoding, boolean includeExtraHeaders,
             String boundary, String endOfLine) {
-        
+
         String titleHeaders = includeExtraHeaders ? """
                 Content-Type: text/plain; charset=%s%s\
                 Content-Transfer-Encoding: 8bit%s""".formatted(contentEncoding, endOfLine, endOfLine) : "";
-        
+
         String descriptionHeaders = includeExtraHeaders ? """
                 Content-Type: text/plain; charset=%s%s\
                 Content-Transfer-Encoding: 8bit%s""".formatted(contentEncoding, endOfLine, endOfLine) : "";
-        
+
         return """
                 --%s%s\
                 Content-Disposition: form-data; name="title"%s\


### PR DESCRIPTION
removeUnusedImports causes issues with parsing newer Java, and google-java-format requires --add-exports when running with Java 17+

We'd better use OpenRewrite for imports.
