### PR TITLE
feat: allow expressions for TestElement.enabled property

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -41,6 +41,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestElementSchema;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Printable;
+import org.apache.jorphan.gui.JEditableCheckBox;
 import org.apache.jorphan.gui.JFactory;
 import org.apiguardian.api.API;
 import org.slf4j.Logger;
@@ -70,9 +71,6 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     /** Logging */
     private static final Logger log = LoggerFactory.getLogger(AbstractJMeterGuiComponent.class);
 
-    /** Flag indicating whether this component is enabled. */
-    private boolean enabled = true;
-
     /**
      *  A GUI panel containing the name of this component.
      * @deprecated use {@link #getName()} or {@link AbstractJMeterGuiComponent#createTitleLabel()} for better alignment of the fields
@@ -83,6 +81,10 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     protected NamePanel namePanel;
 
     private final JTextArea commentField = JFactory.tabMovesFocus(new JTextArea());
+
+    private final JBooleanPropertyEditor enabled = new JBooleanPropertyEditor(
+            TestElementSchema.INSTANCE.getEnabled(),
+            JMeterUtils.getResString("enable"));
 
     /**
      * Stores a collection of property editors, so GuiCompoenent can have default implementations that
@@ -99,6 +101,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     protected AbstractJMeterGuiComponent() {
         namePanel = new NamePanel();
         init();
+        bindingGroup.add(enabled);
     }
 
     /**
@@ -127,7 +130,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
      */
     @Override
     public boolean isEnabled() {
-        return enabled;
+        return enabled.getValue().equals(JEditableCheckBox.Value.of(true));
     }
 
     /**
@@ -137,7 +140,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     @Override
     public void setEnabled(boolean enabled) {
         log.debug("Setting enabled: {}", enabled);
-        this.enabled = enabled;
+        this.enabled.setValue(JEditableCheckBox.Value.of(enabled));
     }
 
     /**
@@ -211,7 +214,6 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     @Override
     public void configure(TestElement element) {
         setName(element.getName());
-        enabled = element.isEnabled();
         commentField.setText(element.getComment());
         bindingGroup.updateUi(element);
     }
@@ -225,7 +227,6 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     @Override
     public void clearGui() {
         initGui();
-        enabled = true;
     }
 
     private void initGui() {
@@ -241,7 +242,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     @API(status = EXPERIMENTAL, since = "5.6.3")
     public void modifyTestElement(TestElement element) {
         JMeterGUIComponent.super.modifyTestElement(element);
-        modifyTestElementEnabledAndComment(element);
+        modifyTestElementComment(element);
         bindingGroup.updateElement(element);
     }
 
@@ -264,7 +265,10 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
         TestElementSchema schema = TestElementSchema.INSTANCE;
         mc.set(schema.getGuiClass(), getClass());
         mc.set(schema.getTestClass(), mc.getClass());
-        modifyTestElementEnabledAndComment(mc);
+        modifyTestElementComment(mc);
+        // This stores the state of the TestElement
+        log.debug("setting element to enabled: {}", enabled.getValue());
+        enabled.updateElement(mc);
     }
 
     /**
@@ -272,14 +276,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
      *
      * @param mc test element
      */
-    private void modifyTestElementEnabledAndComment(TestElement mc) {
-        // This stores the state of the TestElement
-        log.debug("setting element to enabled: {}", enabled);
-        // We can skip storing "enabled" state if it's true, as it's default value.
-        // JMeter removes disabled elements early from the tree, so configuration elements
-        // with enabled=false (~HTTP Request Defaults) can't unexpectedly override the regular ones
-        // like HTTP Request.
-        mc.set(TestElementSchema.INSTANCE.getEnabled(), enabled ? null : Boolean.FALSE);
+    private void modifyTestElementComment(TestElement mc) {
         // Note: we can't use editors for "comments" as getComments() is not a final method, so plugins might
         // override it and provide a different implementation.
         mc.setComment(StringUtils.defaultIfEmpty(getComment(), null));
@@ -305,6 +302,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
         commentField.setWrapStyleWord(true);
         commentField.setLineWrap(true);
         titlePanel.add(commentField);
+        titlePanel.add(enabled, "span 2");
 
         // Note: VerticalPanel has a workaround for Box layout which aligns elements, so we can't
         // use trivial JPanel.

--- a/src/core/src/main/java/org/apache/jmeter/threads/ListenerNotifier.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ListenerNotifier.java
@@ -54,6 +54,9 @@ public class ListenerNotifier implements Serializable {
     public void notifyListeners(SampleEvent res, List<SampleListener> listeners) {
         for (SampleListener sampleListener : listeners) {
             try {
+                if (!((TestElement) sampleListener).isEnabled()) {
+                    continue;
+                }
                 TestBeanHelper.prepare((TestElement) sampleListener);
                 sampleListener.sampleOccurred(res);
             } catch (RuntimeException e) {

--- a/src/functions/src/test/kotlin/org/apache/jmeter/control/EnabledWithVariablesTest.kt
+++ b/src/functions/src/test/kotlin/org/apache/jmeter/control/EnabledWithVariablesTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.control
+
+import org.apache.jmeter.junit.JMeterTestCase
+import org.apache.jmeter.sampler.DebugSampler
+import org.apache.jmeter.test.assertions.executePlanAndCollectEvents
+import org.apache.jmeter.threads.ThreadGroup
+import org.apache.jmeter.treebuilder.TreeBuilder
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class EnabledWithVariablesTest : JMeterTestCase() {
+    fun TreeBuilder.oneThread(loops: Int, body: ThreadGroup.() -> Unit) {
+        ThreadGroup::class {
+            numThreads = 1
+            rampUp = 0
+            setSamplerController(
+                LoopController().apply {
+                    this.loops = loops
+                }
+            )
+            body()
+        }
+    }
+
+    @Test
+    fun `sampler with conditional enable function`() {
+        val events = executePlanAndCollectEvents(5.seconds) {
+            oneThread(loops = 4) {
+                DebugSampler::class {
+                    name = "Conditionally enabled: \${__jm____idx}"
+                    props {
+                        it[enabled] = "\${__javaScript(vars.get('__jm____idx')%2==1)}"
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(
+            "[Conditionally enabled: 1, Conditionally enabled: 3]",
+            events.map { it.result.sampleLabel }.toString(),
+            "Test should complete within reasonable time, and the test has 2 debug samplers, so we expect 2 events"
+        )
+    }
+}


### PR DESCRIPTION
## Description

This is a proof-of-concept implementation for conditional `TestElement.enabled`.
The downside is that `isEnabled()` call would be added for every sampler, listener, pre-processor, pos-processor, and so on which might slow down the execution.

## Motivation and Context

See https://github.com/apache/jmeter/issues/6006

## How Has This Been Tested?

See `EnabledWithVariablesTest`

## Screenshots (if appropriate):

WIP:
<img width="452" height="208" alt="debug sampler with expression in enable property" src="https://github.com/user-attachments/assets/8a77282b-c3d1-4abf-a413-bfd064a36d23" />

```xml
<hashTree>
  <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="true">
    <boolProp name="displayJMeterProperties">false</boolProp>
    <boolProp name="displayJMeterVariables">true</boolProp>
    <boolProp name="displaySystemProperties">false</boolProp>
  </DebugSampler>
  <hashTree/>
  <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="false">
    <boolProp name="displayJMeterProperties">false</boolProp>
    <boolProp name="displayJMeterVariables">true</boolProp>
    <boolProp name="displaySystemProperties">false</boolProp>
  </DebugSampler>
  <hashTree/>
  <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="${__javaScript(false)}">
    <boolProp name="displayJMeterProperties">false</boolProp>
    <boolProp name="displayJMeterVariables">true</boolProp>
    <boolProp name="displaySystemProperties">false</boolProp>
  </DebugSampler>
  <hashTree/>
</hashTree>
```

## Checklist:
- [ ] UI: select the location and the control style
- [x] UI: implement saving the plan to jmx
- [ ] UI: implement loading the plan from jmx
- [ ] Verify if TestBean-based components work as well
- [ ] Support `..RequestDefaults`. The logic of `merge...Element` probably needs ignoring disabled elements
- [ ] Decide if `interface JMeterGUIComponent` needs to support expressions. Currently there's `boolean getEnabled()` and `setEnabled(boolean)`
- [ ] Add documentation
- [ ] Analyze if the following is still needed: https://github.com/apache/jmeter/blob/91ed1279438cbc2553121c8ea1afded0605b38e5/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterTreeModel.java#L169-L175
