### PR TITLE
chore: fix release-drafter so it uses the version from gradle.properties

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,13 +8,36 @@ on:
       - 'release/**'
   # pull_request_target allows PR from forks to access secrets, so please NEVER add pull_request_target
 
+# Declare default permissions as read-only.
+permissions: read-all
+
 jobs:
   update_release_draft:
     # Skip release drafts in forks
-    if: github.repository_owner == 'apache'
+    if: vars.RUN_RELEASE_DRAFTER == 'true'
     name: Update Release Draft
     runs-on: ubuntu-latest
+    permissions:
+      # write permission is required to create a github release
+      contents: write
     steps:
+      - name: Get the current version
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        id: current_version
+        with:
+          # language=javascript
+          script: |
+            const response = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'gradle.properties',
+              ref: context.sha
+            });
+            const content = Buffer.from(response.data.content, 'base64').toString();
+            const version = content.match(/^jmeter\.version=(.+)$/m)[1];
+            console.log(`Version is ${version}`);
+            return version;
+
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Update release body draft
         uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
@@ -23,5 +46,8 @@ jobs:
         with:
         #   config-name: my-config.yml
            disable-autolabeler: true
+           publish: false
+           latest: ${{ github.ref_name == github.event.repository.default_branch }}
+           version: ${{ steps.current_version.outputs.result }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously, release drafter was inferring v0.0.1.
Now we force the proper version for the draft.
