### PR TITLE
chore: remove stale release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,6 @@
 # See https://github.com/release-drafter/release-drafter#configuration-options
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'rel/v$RESOLVED_VERSION'
-# Filter previous releases to consider only those with the target matching the current branch
-filter-by-commitish: true
-tag-prefix: REL
 exclude-labels:
   - 'skip-changelog'
 categories:


### PR DESCRIPTION
Release drafts are visible to repository comitters only (it is GitHub's behaviour).
Here's a preview:

<img width="706" height="947" alt="release draft for jmeter v6.0.0" src="https://github.com/user-attachments/assets/c9e5351c-e8c1-4fa0-b34e-8820942b541f" />
