### PR TITLE
chore: try reducing -Xmx so the build could execute in smaller VMs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-org.gradle.jvmargs=-Xmx1500m -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx1000m -XX:MaxMetaspaceSize=768m
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true


### PR DESCRIPTION
Renovate uses 3G limit for their machines. Let us see if we can reduce memory consumption.