### PR TITLE
Docs: clarify how to always get the latest JMeter version

### DIFF
--- a/xdocs/download_jmeter.xml
+++ b/xdocs/download_jmeter.xml
@@ -78,6 +78,19 @@
       <a href="https://www.apache.org/dist/jmeter/KEYS">KEYS</a>
       </p>
     </section>
+
+        </section>
+
+    <section name="Getting the Latest Version">
+      <p>
+        The latest stable release of Apache JMeter is always announced on the
+        <a href="https://jmeter.apache.org/download_jmeter.cgi">official download page</a>.
+        You can also track releases on
+        <a href="https://search.maven.org/artifact/org.apache.jmeter/ApacheJMeter">Maven Central</a>
+        or the <a href="https://github.com/apache/jmeter/releases">GitHub releases page</a>.
+      </p>
+    </section>
+
     <section name="Apache JMeter &release; (Requires Java 17+)">
       <subsection name="Binaries" anchor="binaries">
         <table>


### PR DESCRIPTION
## Description
This PR updates the documentation in xdocs/download_jmeter.xml to clarify how users can always find the latest JMeter release.
A new section, “Getting the Latest Version”, has been added with references to:
- The official JMeter download page
- Maven Central
- GitHub releases

## Motivation and Context
Users asked in issue #6499 about the best way to obtain the latest JMeter version immediately after release.
This change makes the documentation clearer and provides direct links to trusted sources.

## How Has This Been Tested?
- Verified that the updated XML is well-formed.
- Ensured the section renders correctly in the download_jmeter.xml structure.
- Checked that the links resolve to the latest available JMeter versions.

## Screenshots (if appropriate):

## Types of changes
- Bug fix - Documentation update (non-breaking change which fixes an issue)


## Checklist:
- My code follows the [code style](https://wiki.apache.org/jmeter/CodeStyleGuidelines) of this project.
- I have updated the documentation accordingly.

Closes #6499

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
