### PR TITLE
Fix File->Open recent showing old files

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterMenuBar.java
@@ -39,6 +39,8 @@ import javax.swing.KeyStroke;
 import javax.swing.MenuElement;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
 
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.action.ActionNames;
@@ -531,6 +533,30 @@ public class JMeterMenuBar extends JMenuBar implements LocaleChangeListener {
         fileLoadRecentFiles = LoadRecentProject.getRecentFileMenuItems();
         fileLoadRecentFiles.forEach(jc -> recentFilesOpen.add(jc));
         recentFilesOpen.setEnabled(LoadRecentProject.hasVisibleMenuItem(fileLoadRecentFiles));
+
+        // Add menu listener to refresh recent files when menu is selected
+        recentFilesOpen.addMenuListener(new MenuListener() {
+            @Override
+            public void menuSelected(MenuEvent e) {
+                // Clear existing recent files from menu
+                recentFilesOpen.removeAll();
+
+                // Reload recent files
+                fileLoadRecentFiles = LoadRecentProject.getRecentFileMenuItems();
+                fileLoadRecentFiles.forEach(jc -> recentFilesOpen.add(jc));
+                recentFilesOpen.setEnabled(LoadRecentProject.hasVisibleMenuItem(fileLoadRecentFiles));
+            }
+
+            @Override
+            public void menuDeselected(MenuEvent e) {
+                // Not needed
+            }
+
+            @Override
+            public void menuCanceled(MenuEvent e) {
+                // Not needed
+            }
+        });
 
         addPluginsMenuItems(fileMenu, menuCreators, MENU_LOCATION.FILE);
 


### PR DESCRIPTION
## Description
When working with multiple JMeter instances in parallel, in GUI mode, the Open recent files doesn't get updated in the GUI but it does behind the scene, in the registry/shared storage. So what ones believes it opens, actually leads to opening another file.

## Motivation and Context
Open what one wants, not some random file; in current state, the feature is unusable.

## How Has This Been Tested?
Manual testing, multiple JMeter GUI instances, in each open various files, check the "File->Open recent" being refreshed in all GUI instances.

## Screenshots (if appropriate):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
