### PR TITLE
JSR223 uniform and verbose logging

### DIFF
--- a/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/BSFAssertion.java
@@ -42,7 +42,7 @@ public class BSFAssertion extends BSFTestElement implements Cloneable, Assertion
             processFileOrScript(mgr);
             result.setError(false);
         } catch (BSFException e) {
-            log.warn("Problem in BSF script", e);
+            log.warn("Problem in BSF element named: '{}'", getName(), e);
             result.setFailure(true);
             result.setError(true);
             result.setFailureMessage(e.toString());

--- a/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/JSR223Assertion.java
@@ -50,7 +50,7 @@ public class JSR223Assertion extends JSR223TestElement implements Cloneable, Ass
             processFileOrScript(scriptEngine, bindings);
             result.setError(false);
         } catch (IOException | ScriptException e) {
-            log.error("Problem in JSR223 script: {}", getName(), e);
+            log.error("Problem in JSR223 element named: '{}'", getName(), e);
             result.setError(true);
             result.setFailureMessage(e.toString());
         }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BSFPostProcessor.java
@@ -39,7 +39,7 @@ public class BSFPostProcessor extends BSFTestElement implements Cloneable, PostP
             processFileOrScript(mgr);
         } catch (BSFException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BSF script: {}", e.toString());
+                log.warn("Problem in BSF element named: '{}'", getName(), e);
             }
         } finally {
             if (mgr != null) {

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSR223PostProcessor.java
@@ -44,7 +44,7 @@ public class JSR223PostProcessor extends JSR223TestElement implements Cloneable,
             ScriptEngine scriptEngine = getScriptEngine();
             processFileOrScript(scriptEngine, null);
         } catch (ScriptException | IOException e) {
-            log.error("Problem in JSR223 script, {}", getName(), e);
+            log.error("Problem in JSR223 element named: '{}'", getName(), e);
         }
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BSFPreProcessor.java
@@ -42,7 +42,7 @@ public class BSFPreProcessor extends BSFTestElement implements Cloneable, PrePro
             processFileOrScript(mgr);
         } catch (BSFException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BSF script. {}", e.toString());
+                log.warn("Problem in BSF element named: '{}'", getName(), e);
             }
         } finally {
             if (mgr != null) {

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/BeanShellPreProcessor.java
@@ -62,7 +62,7 @@ public class BeanShellPreProcessor extends BeanShellTestElement
             processFileOrScript(bshInterpreter);
         } catch (JMeterException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BeanShell script. {}", e.toString());
+                log.warn("Problem in BeanShell element named: '{}'", getName(), e);
             }
         }
     }

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/JSR223PreProcessor.java
@@ -44,7 +44,7 @@ public class JSR223PreProcessor extends JSR223TestElement implements Cloneable, 
             ScriptEngine scriptEngine = getScriptEngine();
             processFileOrScript(scriptEngine, null);
         } catch (ScriptException | IOException e) {
-            log.error("Problem in JSR223 script, {}", getName(), e);
+            log.error("Problem in JSR223 element named: '{}'", getName(), e);
         }
     }
 

--- a/src/components/src/main/java/org/apache/jmeter/timers/BSFTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BSFTimer.java
@@ -44,7 +44,7 @@ public class BSFTimer extends BSFTestElement implements Cloneable, Timer, TestBe
             delay = Long.parseLong(o.toString());
         } catch (NumberFormatException | BSFException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BSF script. {}", e.toString());
+                log.warn("Problem in BSF element named: '{}'", getName(), e);
             }
         } finally {
             if(mgr != null) {

--- a/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/BeanShellTimer.java
@@ -59,7 +59,7 @@ public class BeanShellTimer extends BeanShellTestElement implements Cloneable, T
             }
         } catch (JMeterException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BeanShell script. {}", e.toString());
+                log.warn("Problem in BeanShell element named: '{}'", getName(), e);
             }
         }
         try {

--- a/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
+++ b/src/components/src/main/java/org/apache/jmeter/timers/JSR223Timer.java
@@ -47,7 +47,7 @@ public class JSR223Timer extends JSR223TestElement implements Cloneable, Timer, 
             }
             delay = Long.parseLong(o.toString());
         } catch (NumberFormatException | IOException | ScriptException e) {
-            log.error("Problem in JSR223 script, {}", getName(), e);
+            log.error("Problem in JSR223 element named: '{}'", getName(), e);
         }
         return delay;
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BSFListener.java
@@ -52,7 +52,7 @@ public class BSFListener extends BSFTestElement
             processFileOrScript(mgr);
         } catch (BSFException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BSF script. {}", e.toString());
+                log.warn("Problem in BSF element named: '{}'", getName(), e);
             }
         } finally {
             if (mgr != null) {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/BeanShellListener.java
@@ -66,7 +66,7 @@ public class BeanShellListener extends BeanShellTestElement
             processFileOrScript(bshInterpreter);
         } catch (JMeterException e) {
             if (log.isWarnEnabled()) {
-                log.warn("Problem in BeanShell script. {}", e.toString());
+                log.warn("Problem in BeanShell element named: '{}'", getName(), e);
             }
         }
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/JSR223Listener.java
@@ -53,7 +53,7 @@ public class JSR223Listener extends JSR223TestElement
             bindings.put("sampleResult", event.getResult());
             processFileOrScript(scriptEngine, bindings);
         } catch (ScriptException | IOException e) {
-            log.error("Problem in JSR223 script, {}", getName(), e);
+            log.error("Problem in JSR223 element named: '{}'", getName(), e);
         }
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/CompileJSR223TestElements.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/CompileJSR223TestElements.java
@@ -70,16 +70,16 @@ public class CompileJSR223TestElements extends AbstractAction implements MenuCre
                 JSR223TestElement element = (JSR223TestElement) userObject;
                 TestBeanHelper.prepare(element);
                 try {
-                    log.info("Compiling {}", element.getName());
+                    log.info("Compiling JSR223 element named: '{}'", element.getName());
                     if(!element.compile()) {
                         elementsWithCompilationErrors++;
                         treeNode.setMarkedBySearch(true);
                     } else {
-                        log.info("Compilation succeeded for {}", element.getName());
+                        log.info("Compilation succeeded for JSR223 element named: '{}'", element.getName());
                     }
                 } catch (Exception e) {
                     treeNode.setMarkedBySearch(true);
-                    log.error("Error compiling test element {}", element.getName(), e);
+                    log.error("Error compiling JSR223 element named: '{}'", element.getName(), e);
                 }
             }
         }

--- a/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
@@ -114,7 +114,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
         String lang = getScriptLanguageWithDefault();
         ScriptEngine scriptEngine = getInstance().getEngineByName(lang);
         if (scriptEngine == null) {
-            throw new ScriptException("Cannot find engine named: '"+lang+"', ensure you set language field in JSR223 Test Element: "+getName());
+            throw new ScriptException("Cannot find engine named: '"+lang+"', ensure you set language field in JSR223 element named: " + getName());
         }
 
         return scriptEngine;
@@ -192,11 +192,11 @@ public abstract class JSR223TestElement extends ScriptingTestElement
             if (!StringUtils.isEmpty(filename)) {
                 if (!scriptFile.isFile()) {
                     throw new ScriptException("Script file '" + scriptFile.getAbsolutePath()
-                            + "' is not a file for element: " + getName());
+                            + "' is not a file for JSR223 element named: " + getName());
                 }
                 if (!scriptFile.canRead()) {
                     throw new ScriptException("Script file '" + scriptFile.getAbsolutePath()
-                            + "' is not readable for element:" + getName());
+                            + "' is not readable for JSR223 element named: " + getName());
                 }
                 if (!supportsCompilable) {
                     try (BufferedReader fileReader = Files.newBufferedReader(scriptFile.toPath())) {
@@ -232,7 +232,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
                     return scriptEngine.eval(script, bindings);
                 }
             } else {
-                throw new ScriptException("Both script file and script text are empty for element:" + getName());
+                throw new ScriptException("Both script file and script text are empty for JSR223 element named: " + getName());
             }
         } catch (ScriptException ex) {
             Throwable rootCause = ex.getCause();
@@ -257,11 +257,11 @@ public abstract class JSR223TestElement extends ScriptingTestElement
         } catch (ScriptCompilationInvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause instanceof IOException) {
-                cause.addSuppressed(new IllegalStateException("Unable to compile script " + newCacheKey));
+                cause.addSuppressed(new IllegalStateException("Unable to compile JSR223 script: " + newCacheKey));
                 throw (IOException) cause;
             }
             if (cause instanceof ScriptException) {
-                cause.addSuppressed(new IllegalStateException("Unable to compile script " + newCacheKey));
+                cause.addSuppressed(new IllegalStateException("Unable to compile JSR223 script: " + newCacheKey));
                 throw (ScriptException) cause;
             }
             throw e;
@@ -287,7 +287,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
                 ((Compilable) scriptEngine).compile(getScript());
                 return true;
             } catch (ScriptException e) { // NOSONAR
-                logger.error("Error compiling script for test element {}, error:{}", getName(), e.getMessage());
+                logger.error("Error compiling script for JSR223 element named: '{}', error: {}", getName(), e.getMessage());
                 return false;
             }
         } else {
@@ -297,7 +297,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
                     ((Compilable) scriptEngine).compile(fileReader);
                     return true;
                 } catch (ScriptException e) { // NOSONAR
-                    logger.error("Error compiling script for test element {}, error:{}", getName(), e.getMessage());
+                    logger.error("Error compiling script for JSR223 element named: '{}', error: {}", getName(), e.getMessage());
                     return false;
                 }
             }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/Groovy.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/Groovy.java
@@ -130,7 +130,7 @@ public class Groovy extends AbstractFunction {
             }
         } catch (Exception ex) // Mainly for bsh.EvalError
         {
-            log.warn("Error running Groovy script in element named: {}", currentSampler.getName(), ex);
+            log.warn("Error running Groovy script in element named: '{}'", currentSampler.getName(), ex);
         }
         log.debug("__groovy({},{})={}",script, varName, resultStr);
         return resultStr;

--- a/src/functions/src/main/java/org/apache/jmeter/functions/Groovy.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/Groovy.java
@@ -130,7 +130,7 @@ public class Groovy extends AbstractFunction {
             }
         } catch (Exception ex) // Mainly for bsh.EvalError
         {
-            log.warn("Error running groovy script", ex);
+            log.warn("Error running Groovy script in element named: {}", currentSampler.getName(), ex);
         }
         log.debug("__groovy({},{})={}",script, varName, resultStr);
         return resultStr;

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/sampler/JSR223Sampler.java
@@ -74,7 +74,7 @@ public class JSR223Sampler extends JSR223TestElement implements Cloneable, Sampl
                 result.setResponseData(ret.toString(), null);
             }
         } catch (IOException | ScriptException e) {
-            log.error("Problem in JSR223 script {}, message: {}", getName(), e, e);
+            log.error("Problem in JSR223 element named: '{}'", getName(), e);
             result.setSuccessful(false);
             result.setResponseCode("500"); // $NON-NLS-1$
             result.setResponseMessage(e.toString());


### PR DESCRIPTION
## Description
JSR223 compile errors show in various formats in log and more impacting is the fact that one doesn't always has access to sampler name or it's not clear where it starts and where it ends; also, stack traces are sometimes duplicated, making reading a lot harder.
I've simply unified the log statements for JSR223 elements while sampler name is included between simple quotes and removed double stack trace printing.

## Motivation and Context
Hard to debug or to analyze root cause of a JSR223 related failure.

## How Has This Been Tested?
Run various JSR223 elements with incorrect scripts to force compilation failure.

## Screenshots (if appropriate):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
