### PR TITLE
chore: suppress checkstyle warnings for text blocks with long strings

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -73,6 +73,13 @@
     <property name="max" value="160"/>
     <property name="fileExtensions" value="java, kt, kts, groovy"/>
   </module>
+  <!-- See https://checkstyle.sourceforge.io/checks/sizes/linelength.html#Example6-config -->
+  <!-- See https://github.com/checkstyle/checkstyle/issues/17707 -->
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="checkFormat" value="LineLength"/>
+    <property name="offCommentFormat" value='^.*"""$'/>
+    <property name="onCommentFormat" value='^\s*"""\s*(?:[,;]|.+)$'/>
+  </module>
 
   <module name="TreeWalker">
 


### PR DESCRIPTION
We can't make those strings shorter, and we can't wrap them.
