### PR TITLE
chore: add errorprone rule to enforce braces for control flow

### DIFF
--- a/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
+++ b/build-logic/verification/src/main/kotlin/build-logic.errorprone.gradle.kts
@@ -47,6 +47,7 @@ if (buildParameters.enableErrorprone) {
                 disableWarningsInGeneratedCode.set(true)
                 enable(
                     "MissingDefault",
+                    "MissingBraces",
                     "PackageLocation",
                     "RedundantOverride",
                     "StronglyTypeTime",


### PR DESCRIPTION
See:
* https://errorprone.info/bugpattern/MissingBraces
* https://google.github.io/styleguide/javaguide.html#s4.1.1-braces-always-used
