### PR TITLE
chore: replace all commons-lang3 usages with core Java, drop commons-lang3 dependency

### DIFF
--- a/src/bom-thirdparty/build.gradle.kts
+++ b/src/bom-thirdparty/build.gradle.kts
@@ -96,7 +96,9 @@ dependencies {
         api("org.apache.commons:commons-dbcp2:2.9.0")
         api("org.apache.commons:commons-jexl3:3.2.1")
         api("org.apache.commons:commons-jexl:2.1.1")
-        api("org.apache.commons:commons-lang3:3.14.0")
+        api("org.apache.commons:commons-lang3:3.14.0") {
+            because("User might still rely on commons-lang3")
+        }
         api("org.apache.commons:commons-math3:3.6.1")
         api("org.apache.commons:commons-pool2:2.12.0")
         api("org.apache.commons:commons-text:1.11.0")

--- a/src/components/build.gradle.kts
+++ b/src/components/build.gradle.kts
@@ -67,7 +67,6 @@ dependencies {
     implementation("org.apache.httpcomponents:httpasyncclient")
     implementation("org.apache.httpcomponents:httpcore-nio")
     implementation("org.jsoup:jsoup")
-    implementation("org.apache.commons:commons-lang3")
     implementation("net.sf.jtidy:jtidy")
     implementation("org.apache.commons:commons-collections4")
     implementation("org.apache.commons:commons-math3")

--- a/src/components/src/main/java/org/apache/jmeter/assertions/HTMLAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/HTMLAssertion.java
@@ -29,13 +29,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.LongProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.tidy.Node;
@@ -192,7 +192,7 @@ public class HTMLAssertion extends AbstractTestElement implements Serializable, 
         String filename = getFilename();
 
         // check if filename defined
-        if (StringUtils.isNotBlank(filename)) {
+        if (StringUtilities.isNotBlank(filename)) {
             try (Writer writer = Files.newBufferedWriter(Paths.get(filename))) {
                 // write to file
                 writer.write(inOutput);
@@ -248,7 +248,7 @@ public class HTMLAssertion extends AbstractTestElement implements Serializable, 
      *            used
      */
     public void setDoctype(String inDoctype) {
-        if (StringUtils.isAllBlank(inDoctype)) {
+        if (StringUtilities.isBlank(inDoctype)) {
             setProperty(new StringProperty(DOCTYPE_KEY, DEFAULT_DOCTYPE));
         } else {
             setProperty(new StringProperty(DOCTYPE_KEY, inDoctype));

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.assertions.gui.AssertionGui;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractScopedAssertion;
@@ -35,6 +34,7 @@ import org.apache.jmeter.testelement.property.NullProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.Document;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Compiler;
@@ -312,7 +312,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
 
         log.debug("Test Type Info: contains={}, notTest={}, orTest={}", contains, notTest, orTest);
 
-        if (StringUtils.isEmpty(toCheck)) {
+        if (StringUtilities.isEmpty(toCheck)) {
             if (notTest) { // Not should always succeed against an empty result
                 return result;
             }
@@ -365,7 +365,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
                         log.debug("Failed: {}", stringPattern);
                         result.setFailure(true);
                         String customMsg = getCustomFailureMessage();
-                        if (StringUtils.isEmpty(customMsg)) {
+                        if (StringUtilities.isEmpty(customMsg)) {
                             result.setFailureMessage(getFailText(stringPattern, toCheck));
                         } else {
                             result.setFailureMessage(customMsg);
@@ -378,7 +378,7 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
             if (orTest && !hasTrue){
                 result.setFailure(true);
                 String customMsg = getCustomFailureMessage();
-                if (StringUtils.isEmpty(customMsg)) {
+                if (StringUtilities.isEmpty(customMsg)) {
                     result.setFailureMessage(
                             allCheckMessage.stream()
                                     .collect(Collectors.joining("\t", "", "\t")));

--- a/src/components/src/main/java/org/apache/jmeter/assertions/SMIMEAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/SMIMEAssertion.java
@@ -39,7 +39,7 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
 import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -279,7 +279,7 @@ class SMIMEAssertion {
     private static void checkEmail(SMIMEAssertionTestElement testElement, AssertionResult res,
             X509CertificateHolder cert, StringBuilder failureMessage) {
         String email = testElement.getSignerEmail();
-        if (!JOrphanUtils.isBlank(email)) {
+        if (StringUtilities.isNotBlank(email)) {
             List<String> emailFromCert = getEmailFromCert(cert);
             if (!emailFromCert.contains(email)) {
                 res.setFailure(true);
@@ -295,7 +295,7 @@ class SMIMEAssertion {
     private static void checkSerial(SMIMEAssertionTestElement testElement, AssertionResult res,
             X509CertificateHolder cert, StringBuilder failureMessage) {
         String serial = testElement.getSignerSerial();
-        if (!JOrphanUtils.isBlank(serial)) {
+        if (StringUtilities.isNotBlank(serial)) {
             BigInteger serialNbr = readSerialNumber(serial);
             if (!serialNbr.equals(cert.getSerialNumber())) {
                 res.setFailure(true);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/XMLSchemaAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/XMLSchemaAssertion.java
@@ -28,6 +28,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.ErrorHandler;
@@ -64,7 +65,7 @@ public class XMLSchemaAssertion extends AbstractTestElement implements Serializa
 
         String xsdFileName = getXsdFileName();
         log.debug("xmlString: {}, xsdFileName: {}", resultData, xsdFileName);
-        if (xsdFileName == null || xsdFileName.length() == 0) {
+        if (StringUtilities.isEmpty(xsdFileName)) {
             result.setResultForFailure(FILE_NAME_IS_REQUIRED);
         } else {
             setSchemaResult(result, resultData, xsdFileName);

--- a/src/components/src/main/java/org/apache/jmeter/assertions/XPath2Assertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/XPath2Assertion.java
@@ -20,12 +20,12 @@ package org.apache.jmeter.assertions;
 import java.io.Serializable;
 import java.util.concurrent.CompletionException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractScopedAssertion;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.XPathUtil;
+import org.apache.jorphan.util.StringUtilities;
 
 import net.sf.saxon.s9api.SaxonApiException;
 
@@ -56,7 +56,7 @@ public class XPath2Assertion extends AbstractScopedAssertion implements Serializ
         String responseData = null;
         if (isScopeVariable()) {
             String inputString = getThreadContext().getVariables().get(getVariableName());
-            if (!StringUtils.isEmpty(inputString)) {
+            if (StringUtilities.isNotEmpty(inputString)) {
                 responseData = inputString;
             }
         } else {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/XPathAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/XPathAssertion.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractScopedAssertion;
 import org.apache.jmeter.testelement.property.BooleanProperty;
@@ -32,6 +31,7 @@ import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.TidyException;
 import org.apache.jmeter.util.XPathUtil;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -80,7 +80,7 @@ public class XPathAssertion extends AbstractScopedAssertion implements Serializa
         try {
             if (isScopeVariable()){
                 String inputString=getThreadContext().getVariables().get(getVariableName());
-                if (!StringUtils.isEmpty(inputString)) {
+                if (StringUtilities.isNotEmpty(inputString)) {
                     responseData = inputString.getBytes(StandardCharsets.UTF_8);
                 }
             } else {

--- a/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/gui/MD5HexAssertionGUI.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * GUI class supporting the MD5Hex assertion functionality.
@@ -100,7 +101,7 @@ public class MD5HexAssertionGUI extends AbstractAssertionGui {
         configureTestElement(element);
         String md5HexString = this.md5HexInput.getText();
         // initialize to empty string, this will fail the assertion
-        if (md5HexString == null || md5HexString.length() == 0) {
+        if (StringUtilities.isEmpty(md5HexString)) {
             md5HexString = "";
         }
         ((MD5HexAssertion) element).setAllowedMD5Hex(md5HexString);

--- a/src/components/src/main/java/org/apache/jmeter/config/CSVDataSet.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/CSVDataSet.java
@@ -23,7 +23,6 @@ import java.beans.Introspector;
 import java.io.IOException;
 import java.util.ResourceBundle;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.engine.util.NoConfigMerge;
@@ -40,6 +39,7 @@ import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JMeterStopThreadException;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -204,7 +204,7 @@ public class CSVDataSet extends ConfigTestElement
         String fileName = getFilename().trim();
         setAlias(context, fileName);
         final String names = getVariableNames();
-        if (StringUtils.isEmpty(names)) {
+        if (StringUtilities.isEmpty(names)) {
             String header = server.reserveFile(fileName, getFileEncoding(), alias, true);
             try {
                 vars = CSVSaveService.csvSplitString(header, delim.charAt(0));

--- a/src/components/src/main/java/org/apache/jmeter/config/CSVDataSetBeanInfo.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/CSVDataSetBeanInfo.java
@@ -24,6 +24,7 @@ import org.apache.jmeter.testbeans.gui.FileEditor;
 import org.apache.jmeter.testbeans.gui.TypeEditor;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 public class CSVDataSetBeanInfo extends BeanInfoSupport {
 
@@ -106,7 +107,7 @@ public class CSVDataSetBeanInfo extends BeanInfoSupport {
     }
 
     public static int getShareModeAsInt(String mode) {
-        if (mode == null || mode.length() == 0){
+        if (StringUtilities.isEmpty(mode)){
             return SHARE_ALL; // default (e.g. if test plan does not have definition)
         }
         for (int i = 0; i < SHARE_TAGS.length; i++) {

--- a/src/components/src/main/java/org/apache/jmeter/config/KeystoreConfig.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/KeystoreConfig.java
@@ -17,13 +17,13 @@
 
 package org.apache.jmeter.config;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.SSLManager;
 import org.apache.jorphan.util.JMeterStopTestException;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,13 +67,13 @@ public class KeystoreConfig extends ConfigTestElement implements TestBean, TestS
     @Override
     public void testStarted(String host) {
         String reuseSSLContext = JMeterUtils.getProperty("https.use.cached.ssl.context");
-        if(StringUtils.isEmpty(reuseSSLContext)||"true".equals(reuseSSLContext)) {
+        if (StringUtilities.isEmpty(reuseSSLContext) || "true".equals(reuseSSLContext)) {
             log.warn("https.use.cached.ssl.context property must be set to false to ensure Multiple Certificates are used");
         }
         int startIndexAsInt = JMeterUtils.getPropDefault(KEY_STORE_START_INDEX, 0);
         int endIndexAsInt = JMeterUtils.getPropDefault(KEY_STORE_END_INDEX, -1);
 
-        if(!StringUtils.isEmpty(this.startIndex)) {
+        if(!(this.startIndex == null || this.startIndex.isEmpty())) {
             try {
                 startIndexAsInt = Integer.parseInt(this.startIndex);
             } catch(NumberFormatException e) {
@@ -82,7 +82,7 @@ public class KeystoreConfig extends ConfigTestElement implements TestBean, TestS
             }
         }
 
-        if(!StringUtils.isEmpty(this.endIndex)) {
+        if(!(this.endIndex == null || this.endIndex.isEmpty())) {
             try {
                 endIndexAsInt = Integer.parseInt(this.endIndex);
             } catch(NumberFormatException e) {

--- a/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfig.java
+++ b/src/components/src/main/java/org/apache/jmeter/config/RandomVariableConfig.java
@@ -20,7 +20,6 @@ package org.apache.jmeter.config;
 import java.text.DecimalFormat;
 import java.util.Random;
 
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.jmeter.engine.event.LoopIterationEvent;
 import org.apache.jmeter.engine.event.LoopIterationListener;
 import org.apache.jmeter.engine.util.NoConfigMerge;
@@ -30,6 +29,7 @@ import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,9 +87,18 @@ public class RandomVariableConfig extends ConfigTestElement
      */
     private void init(){
         final String minAsString = getMinimumValue();
-        minimum = NumberUtils.toLong(minAsString);
+        try {
+            minimum = Long.parseLong(minAsString);
+        } catch (NumberFormatException e) {
+            log.warn("Unable to parse minimum value as long: {}", minAsString, e);
+        }
         final String maxAsString = getMaximumValue();
-        long maximum = NumberUtils.toLong(maxAsString);
+        long maximum = 0;
+        try {
+            maximum = Long.parseLong(maxAsString);
+        } catch (NumberFormatException e) {
+            log.warn("Unable to parse maximum value as long: {}", maxAsString, e);
+        }
         long rangeL=maximum-minimum+1; // This can overflow
         if (minimum > maximum){
             log.error("maximum({}) must be >= minimum({})", maxAsString, minAsString);
@@ -130,7 +139,7 @@ public class RandomVariableConfig extends ConfigTestElement
     // Use format to create number; if it fails, use the default
     private String formatNumber(long value){
         String format = getOutputFormat();
-        if (format != null && format.length() > 0) {
+        if (StringUtilities.isNotEmpty(format)) {
             try {
                 DecimalFormat myFormatter = new DecimalFormat(format);
                 return myFormatter.format(value);

--- a/src/components/src/main/java/org/apache/jmeter/control/CriticalSectionController.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/CriticalSectionController.java
@@ -20,11 +20,11 @@ package org.apache.jmeter.control;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.testelement.property.StringProperty;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +124,8 @@ public class CriticalSectionController extends GenericController implements
      */
     @Override
     public Sampler next() {
-        if (StringUtils.isEmpty(getLockName())) {
+        String lockName = getLockName();
+        if (StringUtilities.isEmpty(lockName)) {
             if (log.isWarnEnabled()) {
                 log.warn("Empty lock name in Critical Section Controller: {}", getName());
             }
@@ -140,7 +141,7 @@ public class CriticalSectionController extends GenericController implements
             long endTime = System.currentTimeMillis();
             if (log.isDebugEnabled()) {
                 log.debug("Thread ('{}') acquired lock: '{}' in Critical Section Controller {}  in: {} ms",
-                        Thread.currentThread(), getLockName(), getName(), endTime - startTime);
+                        Thread.currentThread(), lockName, getName(), endTime - startTime);
             }
         }
         return super.next();

--- a/src/components/src/main/java/org/apache/jmeter/control/IncludeController.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/IncludeController.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.testelement.TestPlan;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +129,7 @@ public class IncludeController extends GenericController implements ReplaceableC
         // only try to load the JMX test plan if there is one
         final String includePath = getIncludePath();
         HashTree tree = null;
-        if (includePath != null && includePath.length() > 0) {
+        if (StringUtilities.isNotEmpty(includePath)) {
             String fileName=PREFIX+includePath;
             try {
                 File file = new File(fileName.trim());

--- a/src/components/src/main/java/org/apache/jmeter/control/SwitchController.java
+++ b/src/components/src/main/java/org/apache/jmeter/control/SwitchController.java
@@ -19,10 +19,10 @@ package org.apache.jmeter.control;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.StringProperty;
+import org.apache.jorphan.util.StringUtilities;
 
 // For unit tests @see TestSwitchController
 
@@ -88,11 +88,11 @@ public class SwitchController extends GenericController implements Serializable 
     private int getSelectionAsInt() {
         getProperty(SWITCH_VALUE).recoverRunningVersion(null);
         String sel = getSelection();
-        if (StringUtils.isEmpty(sel)) {
+        if (StringUtilities.isEmpty(sel)) {
             return 0;
         } else {
             try {
-                if(StringUtils.isNumeric(sel)) {
+                if (StringUtilities.isNumeric(sel)) {
                     int ret = Integer.parseInt(sel);
                     if (ret < 0 || ret >= getSubControllers().size()) {
                         // Out of range, we return first one

--- a/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/BoundaryExtractor.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.samplers.SampleResult;
@@ -34,6 +33,7 @@ import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.Document;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,17 +92,17 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
         if (log.isDebugEnabled()) {
             log.debug("Boundary Extractor {}: processing result", getName());
         }
-        if (StringUtils.isEmpty(getRefName())) {
+        String refName = getRefName();
+        if (StringUtilities.isEmpty(refName)) {
             throw new IllegalArgumentException(
                     "One of the mandatory properties is missing in Boundary Extractor:" + getName());
         }
 
         JMeterVariables vars = context.getVariables();
 
-        String refName = getRefName();
         final String defaultValue = getDefaultValue();
 
-        if (StringUtils.isNotBlank(defaultValue) || isEmptyDefaultValue()) {
+        if (StringUtilities.isNotBlank(defaultValue) || isEmptyDefaultValue()) {
             vars.put(refName, defaultValue);
         }
 
@@ -261,11 +261,11 @@ public class BoundaryExtractor extends AbstractScopedTestElement implements Post
      */
     @VisibleForTesting
     static List<String> extract(String leftBoundary, String rightBoundary, int matchNumber, String inputString) {
-        if (StringUtils.isBlank(inputString)) {
+        if (StringUtilities.isBlank(inputString)) {
             return Collections.emptyList();
         }
-        boolean isEmptyLeftBoundary = StringUtils.isEmpty(leftBoundary);
-        boolean isEmptyRightBoundary = StringUtils.isEmpty(rightBoundary);
+        boolean isEmptyLeftBoundary = StringUtilities.isEmpty(leftBoundary);
+        boolean isEmptyRightBoundary = StringUtilities.isEmpty(rightBoundary);
         if (isEmptyLeftBoundary && isEmptyRightBoundary) {
             return Collections.singletonList(inputString);
         }

--- a/src/components/src/main/java/org/apache/jmeter/extractor/HtmlExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/HtmlExtractor.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractScopedTestElement;
@@ -30,6 +29,7 @@ import org.apache.jmeter.testelement.property.IntegerProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -166,7 +166,7 @@ public class HtmlExtractor extends AbstractScopedTestElement implements PostProc
         List<String> result = new ArrayList<>();
         if (isScopeVariable()){
             String inputString=vars.get(getVariableName());
-            if (!StringUtils.isEmpty(inputString)) {
+            if (StringUtilities.isNotEmpty(inputString)) {
                 getExtractorImpl().extract(expression, attribute, matchNumber, inputString, result, found, "-1");
             } else {
                 if (inputString==null && log.isWarnEnabled()) {

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JSoupExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JSoupExtractor.java
@@ -20,7 +20,7 @@ package org.apache.jmeter.extractor;
 import java.util.List;
 
 import org.apache.jmeter.threads.JMeterContextService;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -79,7 +79,7 @@ public class JSoupExtractor implements Extractor {
      * @return String value
      */
     private static String extractValue(String attribute, Element element) {
-        if (!JOrphanUtils.isBlank(attribute)) {
+        if (StringUtilities.isNotBlank(attribute)) {
             return element.attr(attribute);
         } else {
             return element.text().trim();

--- a/src/components/src/main/java/org/apache/jmeter/extractor/JoddExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/JoddExtractor.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -95,7 +95,7 @@ public class JoddExtractor implements Extractor {
 
 
     private static String extractValue(String attribute, Node element) {
-        if (!JOrphanUtils.isBlank(attribute)) {
+        if (StringUtilities.isNotBlank(attribute)) {
             return element.getAttribute(attribute);
         } else {
             return element.getTextContent().trim();

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jmespath/JMESPathExtractor.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractScopedTestElement;
@@ -33,6 +32,7 @@ import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,10 +74,11 @@ public class JMESPathExtractor extends AbstractScopedTestElement
         String refName = getRefName();
         String defaultValue = getDefaultValue();
         int matchNumber;
-        if (StringUtils.isBlank(getMatchNumber())) {
+        String matchNumberText = getMatchNumber();
+        if (StringUtilities.isBlank(matchNumberText)) {
             matchNumber = 0;
         } else {
-            matchNumber = Integer.parseInt(getMatchNumber());
+            matchNumber = Integer.parseInt(matchNumberText);
         }
         final String jsonPathExpression = getJmesPathExpression().trim();
         clearOldRefVars(vars, refName);
@@ -181,7 +182,7 @@ public class JMESPathExtractor extends AbstractScopedTestElement
             if (previousResult != null) {
                 List<String> results = getSampleList(previousResult).stream()
                         .map(SampleResult::getResponseDataAsString)
-                        .filter(StringUtils::isNotBlank)
+                        .filter(StringUtilities::isNotBlank)
                         .collect(Collectors.toList());
                 if (log.isDebugEnabled()) {
                     log.debug("JMESExtractor {} working on Responses: {}", getName(), results);

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/jsonpath/JSONPostProcessor.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractScopedTestElement;
@@ -34,7 +33,7 @@ import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +225,7 @@ public class JSONPostProcessor
             if (previousResult != null) {
                 List<String> results = getSampleList(previousResult).stream()
                         .map(SampleResult::getResponseDataAsString)
-                        .filter(StringUtils::isNotBlank)
+                        .filter(StringUtilities::isNotBlank)
                         .collect(Collectors.toList());
                 if (log.isDebugEnabled()) {
                     log.debug("JSON Extractor {} working on Responses: {}", getName(), results);
@@ -304,7 +303,7 @@ public class JSONPostProcessor
 
         String matchNumbersAsString = getMatchNumbers();
         int[] result = new int[arraySize];
-        if (JOrphanUtils.isBlank(matchNumbersAsString)) {
+        if (StringUtilities.isBlank(matchNumbersAsString)) {
             Arrays.fill(result, 0);
         } else {
             String[] matchNumbersAsStringArray =

--- a/src/components/src/main/java/org/apache/jmeter/extractor/json/render/AbstractRenderAsJsonRenderer.java
+++ b/src/components/src/main/java/org/apache/jmeter/extractor/json/render/AbstractRenderAsJsonRenderer.java
@@ -42,6 +42,7 @@ import org.apache.jmeter.visualizers.ResultRenderer;
 import org.apache.jmeter.visualizers.ViewResultsFullVisualizer;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.StringUtilities;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 
 
@@ -103,7 +104,7 @@ abstract class AbstractRenderAsJsonRenderer implements ResultRenderer, ActionLis
      * @param textToParse the text that will be parsed
      */
     protected void executeTester(String textToParse) {
-        if (textToParse != null && textToParse.length() > 0
+        if (StringUtilities.isNotEmpty(textToParse)
                 && this.expressionField.getText().length() > 0) {
             this.resultField.setText(process(textToParse));
             this.resultField.setCaretPosition(0); // go to first line

--- a/src/components/src/main/java/org/apache/jmeter/modifiers/CounterConfig.java
+++ b/src/components/src/main/java/org/apache/jmeter/modifiers/CounterConfig.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.testelement.property.LongProperty;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,7 +124,7 @@ public class CounterConfig extends AbstractTestElement
     // Use format to create number; if it fails, use the default
     private String formatNumber(long value){
         String format = getFormat();
-        if (format != null && format.length() > 0) {
+        if (StringUtilities.isNotEmpty(format)) {
             try {
                 DecimalFormat myFormatter = new DecimalFormat(format);
                 return myFormatter.format(value);

--- a/src/components/src/main/java/org/apache/jmeter/reporters/MailerModel.java
+++ b/src/components/src/main/java/org/apache/jmeter/reporters/MailerModel.java
@@ -35,10 +35,10 @@ import javax.mail.internet.MimeMessage;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -360,7 +360,7 @@ public class MailerModel extends AbstractTestElement implements Serializable {
                 }
         }
 
-        if(!StringUtils.isEmpty(user)) {
+        if (StringUtilities.isNotEmpty(user)) {
             authenticator =
                     new javax.mail.Authenticator() {
                         @Override
@@ -425,7 +425,7 @@ public class MailerModel extends AbstractTestElement implements Serializable {
     }
 
     public void setSmtpPort(String value) {
-        if(StringUtils.isEmpty(value)) {
+        if (StringUtilities.isEmpty(value)) {
             value = DEFAULT_SMTP_PORT;
         }
         setProperty(PORT_KEY, value, DEFAULT_SMTP_PORT);

--- a/src/components/src/main/java/org/apache/jmeter/sampler/TestAction.java
+++ b/src/components/src/main/java/org/apache/jmeter/sampler/TestAction.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
@@ -35,6 +34,7 @@ import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContext.TestLogicalAction;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.timers.TimerService;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,7 +143,7 @@ public class TestAction extends AbstractSampler implements Interruptible {
     private void pause(String timeInMillis) {
         long millis;
         try {
-            if (!StringUtils.isEmpty(timeInMillis)) {
+            if (StringUtilities.isNotEmpty(timeInMillis)) {
                 millis = Long.parseLong(timeInMillis);
             } else {
                 log.warn("Duration value is empty, defaulting to 0");

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsBoundaryExtractor.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsBoundaryExtractor.java
@@ -34,12 +34,12 @@ import javax.swing.JTextArea;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.extractor.BoundaryExtractor;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.google.auto.service.AutoService;
 
@@ -73,7 +73,7 @@ public class RenderAsBoundaryExtractor implements ResultRenderer, ActionListener
     public void actionPerformed(ActionEvent e) {
         String command = e.getActionCommand();
         String boundaryExtractorDataFieldText = boundaryExtractorDataField.getText();
-        if (StringUtils.isNotEmpty(boundaryExtractorDataFieldText) && BOUNDARY_EXTRACTOR_TESTER_COMMAND.equals(command)) {
+        if (StringUtilities.isNotEmpty(boundaryExtractorDataFieldText) && BOUNDARY_EXTRACTOR_TESTER_COMMAND.equals(command)) {
             executeAndShowBoundaryExtractorTester(boundaryExtractorDataFieldText);
         }
     }
@@ -83,7 +83,7 @@ public class RenderAsBoundaryExtractor implements ResultRenderer, ActionListener
      * @param textToParse
      */
     private void executeAndShowBoundaryExtractorTester(String textToParse) {
-        if (textToParse != null && textToParse.length() > 0
+        if (StringUtilities.isNotEmpty(textToParse)
                 && this.boundaryExtractorFieldLeft.getText().length() > 0
                 && this.boundaryExtractorFieldRight.getText().length() > 0) {
             this.boundaryExtractorResultField.setText(process(textToParse));

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsCssJQuery.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsCssJQuery.java
@@ -37,7 +37,6 @@ import javax.swing.JTextArea;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.extractor.Extractor;
 import org.apache.jmeter.extractor.HtmlExtractor;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
@@ -47,6 +46,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.StringUtilities;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 
 import com.google.auto.service.AutoService;
@@ -101,7 +101,7 @@ public class RenderAsCssJQuery implements ResultRenderer, ActionListener {
     public void actionPerformed(ActionEvent e) {
         String command = e.getActionCommand();
         String cssJqueryDataFieldText = cssJqueryDataField.getText();
-        if (StringUtils.isNotEmpty(cssJqueryDataFieldText) && CSSJQUEY_TESTER_COMMAND.equals(command)) {
+        if (StringUtilities.isNotEmpty(cssJqueryDataFieldText) && CSSJQUEY_TESTER_COMMAND.equals(command)) {
             executeAndShowCssJqueryTester(cssJqueryDataFieldText);
         }
     }
@@ -111,7 +111,7 @@ public class RenderAsCssJQuery implements ResultRenderer, ActionListener {
      * @param textToParse
      */
     private void executeAndShowCssJqueryTester(String textToParse) {
-        if (textToParse != null && textToParse.length() > 0
+        if (StringUtilities.isNotEmpty(textToParse)
                 && this.cssJqueryField.getText().length() > 0) {
             this.cssJqueryResultField.setText(process(textToParse));
             this.cssJqueryResultField.setCaretPosition(0); // go to first line

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsJSON.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsJSON.java
@@ -19,7 +19,6 @@ package org.apache.jmeter.visualizers;
 
 import java.io.IOException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -91,7 +90,7 @@ public class RenderAsJSON extends SamplerResultTab implements ResultRenderer {
 
     private static class PrettyJSONStyle extends JSONStyle {
         private int level = 0;
-        private String indentString = TAB_SEPARATOR;
+        private final String indentString;
 
         public PrettyJSONStyle(String indentString) {
             this.indentString = indentString;
@@ -99,7 +98,9 @@ public class RenderAsJSON extends SamplerResultTab implements ResultRenderer {
 
         private void indent(Appendable out) throws IOException {
             out.append('\n');
-            out.append(StringUtils.repeat(indentString, level));
+            for (int i = 0; i < level; i++) {
+                 out.append(indentString);
+            }
         }
 
         @Override

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsRegexp.java
@@ -37,11 +37,11 @@ import javax.swing.JTextArea;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.PatternCacheLRU;
 import org.apache.oro.text.regex.MatchResult;
@@ -98,7 +98,7 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
     public void actionPerformed(ActionEvent e) {
         String command = e.getActionCommand();
         String xmlDataFieldText = regexpDataField.getText();
-        if (StringUtils.isNotEmpty(xmlDataFieldText) && REGEXP_TESTER_COMMAND.equals(command)) {
+        if (StringUtilities.isNotEmpty(xmlDataFieldText) && REGEXP_TESTER_COMMAND.equals(command)) {
             executeAndShowRegexpTester(xmlDataFieldText);
         }
     }
@@ -108,7 +108,7 @@ public class RenderAsRegexp implements ResultRenderer, ActionListener {
      * @param textToParse
      */
     private void executeAndShowRegexpTester(String textToParse) {
-        if (textToParse != null && !textToParse.isEmpty()
+        if (StringUtilities.isNotEmpty(textToParse)
                 && !this.regexpField.getText().isEmpty()) {
             this.regexpResultField.setText(process(textToParse));
             this.regexpResultField.setCaretPosition(0); // go to first line

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath.java
@@ -40,8 +40,6 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.jmeter.assertions.gui.XMLConfPanel;
 import org.apache.jmeter.extractor.XPathExtractor;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
@@ -52,7 +50,9 @@ import org.apache.jmeter.util.TidyException;
 import org.apache.jmeter.util.XPathUtil;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.ExceptionUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,7 +113,7 @@ public class RenderAsXPath implements ResultRenderer, ActionListener {
     public void actionPerformed(ActionEvent e) {
         String command = e.getActionCommand();
         String xmlDataFieldText = xmlDataField.getText();
-        if (StringUtils.isNotEmpty(xmlDataFieldText) && XPATH_TESTER_COMMAND.equals(command)) {
+        if (StringUtilities.isNotEmpty(xmlDataFieldText) && XPATH_TESTER_COMMAND.equals(command)) {
             XPathExtractor extractor = new XPathExtractor();
             xmlConfPanel.modifyTestElement(extractor);
             extractor.setFragment(getFragment.isSelected());
@@ -126,7 +126,7 @@ public class RenderAsXPath implements ResultRenderer, ActionListener {
      * @param textToParse
      */
     private void executeAndShowXPathTester(String textToParse, XPathExtractor extractor) {
-        if (textToParse != null && textToParse.length() > 0
+        if (StringUtilities.isNotEmpty(textToParse)
                 && this.xpathExpressionField.getText().length() > 0) {
             this.xpathResultField.setText(process(textToParse, extractor));
             this.xpathResultField.setCaretPosition(0); // go to first line

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath2.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RenderAsXPath2.java
@@ -36,14 +36,14 @@ import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.jmeter.extractor.XPath2Extractor;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
 import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.XPathUtil;
+import org.apache.jorphan.util.ExceptionUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +103,7 @@ public class RenderAsXPath2 implements ResultRenderer, ActionListener {
     public void actionPerformed(ActionEvent e) {
         String command = e.getActionCommand();
         String xmlDataFieldText = xmlDataField.getText();
-        if (StringUtils.isEmpty(xmlDataFieldText)) {
+        if (StringUtilities.isEmpty(xmlDataFieldText)) {
             return;
         }
         if (XPATH_TESTER_COMMAND.equals(command)) {
@@ -121,7 +121,7 @@ public class RenderAsXPath2 implements ResultRenderer, ActionListener {
      * @param textToParse
      */
     private void executeAndShowXPathTester(String textToParse, XPath2Extractor extractor) {
-        if (textToParse != null && textToParse.length() > 0
+        if (StringUtilities.isNotEmpty(textToParse)
                 && this.xpathExpressionField.getText().length() > 0) {
             this.xpathResultField.setText(process(textToParse, extractor));
             this.xpathResultField.setCaretPosition(0); // go to first line

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RequestViewRaw.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RequestViewRaw.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.gui.util.JTextScrollPane;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.google.auto.service.AutoService;
 
@@ -95,12 +96,12 @@ public class RequestViewRaw implements RequestView {
             SampleResult sampleResult = (SampleResult) objectResult;
             // Don't display Request headers label if rh is null or empty
             String rh = sampleResult.getRequestHeaders();
-            if (rh != null && !rh.isEmpty()) {
+            if (StringUtilities.isNotEmpty(rh)) {
                 headerData.setInitialText(rh);
                 sampleDataField.setCaretPosition(0);
             }
             String data = sampleResult.getSamplerData();
-            if (data != null && !data.isEmpty()) {
+            if (StringUtilities.isNotEmpty(data)) {
                 sampleDataField.setText(data);
                 sampleDataField.setCaretPosition(0);
             } else {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/RespTimeGraphVisualizer.java
@@ -50,7 +50,6 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeListener;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
@@ -68,6 +67,7 @@ import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.math.StatCalculatorLong;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -279,7 +279,7 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
     }
 
     private static String[] keys(Map<String, ?> map) {
-        return map.keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+        return map.keySet().toArray(new String[0]);
     }
 
     @Override
@@ -543,7 +543,7 @@ public class RespTimeGraphVisualizer extends AbstractVisualizer implements Actio
             } else if (forceReloadData) {
                 pattern = null;
             }
-            if (getFile() != null && getFile().length() > 0) {
+            if (StringUtilities.isNotEmpty(getFile())) {
                 // Reload data from file
                 clearData();
                 FilePanel filePanel = (FilePanel) getFilePanel();

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTreePanel.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/SearchTreePanel.java
@@ -34,7 +34,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.tree.DefaultMutableTreeNode;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.Searchable;
 import org.apache.jmeter.gui.action.KeyStrokes;
 import org.apache.jmeter.gui.action.RawTextSearcher;
@@ -43,6 +42,7 @@ import org.apache.jmeter.gui.action.Searcher;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.utils.Colors;
 import org.apache.jorphan.gui.JFactory;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,7 +165,7 @@ public class SearchTreePanel extends JPanel implements ActionListener {
      */
     private boolean doSearch() {
         String wordToSearch = searchTF.getText();
-        if (StringUtils.isEmpty(wordToSearch)) {
+        if (StringUtilities.isEmpty(wordToSearch)) {
             return false;
         }
         Searcher searcher = isRegexpCB.isSelected() ?

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/StatGraphVisualizer.java
@@ -64,7 +64,6 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableCellRenderer;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
@@ -337,7 +336,7 @@ public class StatGraphVisualizer extends AbstractVisualizer implements Clearable
     }
 
     private static String[] keys(Map<String, ?> map) {
-        return map.keySet().toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+        return map.keySet().toArray(new String[0]);
     }
 
     /**

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/ViewResultsFullVisualizer.java
@@ -62,7 +62,6 @@ import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
 import org.apache.commons.collections4.queue.CircularFifoQueue;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.JMeter;
 import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
@@ -74,6 +73,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractVisualizer;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.reflect.LogAndIgnoreServiceLoadExceptionHandler;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.jorphan.util.StringWrap;
 import org.apiguardian.api.API;
 import org.slf4j.Logger;
@@ -413,8 +413,9 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
      * @return true if sampleResult is text or has empty content type
      */
     protected static boolean isTextDataType(SampleResult sampleResult) {
-        return SampleResult.TEXT.equals(sampleResult.getDataType())
-                || StringUtils.isEmpty(sampleResult.getDataType());
+        String dataType = sampleResult.getDataType();
+        return SampleResult.TEXT.equals(dataType) ||
+                StringUtilities.isEmpty(dataType);
     }
 
     private synchronized Component createLeftPanel() {
@@ -563,7 +564,7 @@ implements ActionListener, TreeSelectionListener, Clearable, ItemListener {
 
     @API(status = API.Status.INTERNAL, since = "5.5")
     public static String wrapLongLines(String input) {
-        if (input == null || input.isEmpty()) {
+        if (StringUtilities.isEmpty(input)) {
             return input;
         }
         if (SOFT_WRAP_LINE_SIZE > 0 && MAX_LINE_SIZE > 0) {

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/XMLDefaultMutableTreeNode.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/XMLDefaultMutableTreeNode.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.visualizers;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Attr;
@@ -160,7 +161,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      */
     private static void initCommentNode(Comment node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String data = node.getData();
-        if (data != null && data.length() > 0) {
+        if (StringUtilities.isNotEmpty(data)) {
             String value = "<!--" + node.getData() + "-->"; // $NON-NLS-1$ $NON-NLS-2$
             XMLDefaultMutableTreeNode commentNode = new XMLDefaultMutableTreeNode(value, node);
             mTreeNode.add(commentNode);
@@ -176,7 +177,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      */
     private static void initCDATASectionNode(CDATASection node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String data = node.getData();
-        if (data != null && data.length() > 0) {
+        if (StringUtilities.isNotEmpty(data)) {
             String value = "<!-[CDATA" + node.getData() + "]]>"; // $NON-NLS-1$ $NON-NLS-2$
             XMLDefaultMutableTreeNode commentNode = new XMLDefaultMutableTreeNode(value, node);
             mTreeNode.add(commentNode);
@@ -192,7 +193,7 @@ public class XMLDefaultMutableTreeNode extends DefaultMutableTreeNode {
      */
     private static void initTextNode(Text node, DefaultMutableTreeNode mTreeNode) throws SAXException {
         String text = node.getNodeValue().trim();
-        if (text != null && text.length() > 0) {
+        if (StringUtilities.isNotEmpty(text)) {
             XMLDefaultMutableTreeNode textNode = new XMLDefaultMutableTreeNode(text, node);
             mTreeNode.add(textNode);
         }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/BackendListenerGui.java
@@ -32,7 +32,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -44,6 +43,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.gui.AbstractListenerGui;
 import org.apache.jorphan.reflect.LogAndIgnoreServiceLoadExceptionHandler;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -196,7 +196,7 @@ public class BackendListenerGui extends AbstractListenerGui implements ActionLis
                 // values that they did in the original test.
                 if (currArgsMap.containsKey(name)) {
                     String newVal = currArgsMap.get(name);
-                    if (StringUtils.isNotBlank(newVal)) {
+                    if (StringUtilities.isNotBlank(newVal)) {
                         value = newVal;
                     }
                 }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/ErrorMetric.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/ErrorMetric.java
@@ -19,9 +19,9 @@ package org.apache.jmeter.visualizers.backend;
 
 import java.util.Locale;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.report.utils.MetricUtils;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Object representing an error by a response code and response message
@@ -43,9 +43,10 @@ public class ErrorMetric {
     }
 
     public ErrorMetric(SampleResult result) {
+        // TODO: responseCode is known to be empty here, so condition seems useless
         if (MetricUtils.isSuccessCode(responseCode) ||
-                (StringUtils.isEmpty(responseCode) &&
-                        !StringUtils.isEmpty(result.getFirstAssertionFailureMessage()))) {
+                (StringUtilities.isEmpty(responseCode) &&
+                        StringUtilities.isNotEmpty(result.getFirstAssertionFailureMessage()))) {
             responseCode = MetricUtils.ASSERTION_FAILED;
             responseMessage = result.getFirstAssertionFailureMessage();
         } else {
@@ -69,7 +70,7 @@ public class ErrorMetric {
      * @return the response message, 'none' if the code is empty
      */
     public String getResponseMessage() {
-        if (responseMessage == null || responseMessage.isEmpty()) {
+        if (StringUtilities.isEmpty(responseMessage)) {
             return "None";
         } else {
             return responseMessage.trim();

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/graphite/AbstractGraphiteMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/graphite/AbstractGraphiteMetricsSender.java
@@ -19,9 +19,9 @@ package org.apache.jmeter.visualizers.backend.graphite;
 
 import java.time.Duration;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Base class for {@link GraphiteMetricsSender}
@@ -63,7 +63,6 @@ abstract class AbstractGraphiteMetricsSender implements GraphiteMetricsSender {
      * @return the sanitized text
      */
     static String sanitizeString(String s) {
-        // String#replace uses regexp
-        return StringUtils.replaceChars(s, "\\ .", "--_");
+        return StringUtilities.replaceChars(s, "\\ .", "--_");
     }
 }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/graphite/GraphiteBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/graphite/GraphiteBackendListenerClient.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
@@ -41,6 +40,7 @@ import org.apache.jmeter.visualizers.backend.BackendListenerClient;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 import org.apache.jmeter.visualizers.backend.SamplerMetric;
 import org.apache.jmeter.visualizers.backend.UserMetric;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,7 +313,7 @@ public class GraphiteBackendListenerClient extends AbstractBackendListenerClient
         allPercentiles = new HashMap<>(percentilesStringArray.length);
         Arrays.stream(percentilesStringArray)
                 .map(String::trim)
-                .filter(StringUtils::isNotEmpty)
+                .filter(StringUtilities::isNotEmpty)
                 .forEach(this::initPercentileMaps);
         Class<?> clazz = Class.forName(graphiteMetricsSenderClass);
         this.graphiteMetricsManager = (GraphiteMetricsSender) clazz.getDeclaredConstructor().newInstance();

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
@@ -43,6 +42,7 @@ import org.apache.http.nio.reactor.ConnectingIOReactor;
 import org.apache.http.util.EntityUtils;
 import org.apache.jmeter.report.utils.MetricUtils;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,7 +141,7 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
 
         HttpPost currentHttpRequest = new HttpPost(url.toURI());
         currentHttpRequest.setConfig(defaultRequestConfig);
-        if (StringUtils.isNotBlank(token)) {
+        if (StringUtilities.isNotBlank(token)) {
             currentHttpRequest.setHeader(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_VALUE + token);
         }
         log.debug("Created InfluxDBMetricsSender with url: {}", url);

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxDBRawBackendListenerClient.java
@@ -21,11 +21,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.visualizers.backend.BackendListenerClient;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
+import org.apache.jorphan.util.StringUtilities;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,12 +135,32 @@ public class InfluxDBRawBackendListenerClient implements BackendListenerClient {
         boolean isError = sampleResult.getErrorCount() != 0;
         String status = isError ? TAG_KO : TAG_OK;
         // remove surrounding quotes and spaces from sample label
-        String label = StringUtils.strip(sampleResult.getSampleLabel(), "\" ");
+        String label = StringUtilities.strip(sampleResult.getSampleLabel(), "\" ");
         String transaction = AbstractInfluxdbMetricsSender.tagToStringValue(label);
-        String threadName = StringUtils.deleteWhitespace(sampleResult.getThreadName());
+        String threadName = deleteWhitespace(sampleResult.getThreadName());
         return "status=" + status
                 + ",transaction=" + transaction
                 + ",threadName=" + threadName;
+    }
+
+    /**
+     * Deletes all whitespace from a string.
+     *
+     * @param str the string to remove whitespace from, may be null
+     * @return the string without whitespace, or null if input was null
+     */
+    private static String deleteWhitespace(String str) {
+        if (str == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(str.length());
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (!Character.isWhitespace(c)) {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     @VisibleForTesting

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/InfluxdbBackendListenerClient.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
@@ -41,6 +40,7 @@ import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 import org.apache.jmeter.visualizers.backend.ErrorMetric;
 import org.apache.jmeter.visualizers.backend.SamplerMetric;
 import org.apache.jmeter.visualizers.backend.UserMetric;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -349,10 +349,10 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         // Check if more rows which started with 'TAG_' are filled ( corresponding to user tag )
         StringBuilder userTagBuilder = new StringBuilder();
         context.getParameterNamesIterator().forEachRemaining(name -> {
-            if (StringUtils.isNotBlank(name)
+            if (StringUtilities.isNotBlank(name)
                     && !DEFAULT_ARGS.containsKey(name.trim())
                     && name.startsWith("TAG_")
-                    && StringUtils.isNotBlank(context.getParameter(name))) {
+                    && StringUtilities.isNotBlank(context.getParameter(name))) {
                 final String tagName = name.trim().substring(4);
                 final String tagValue = context.getParameter(name).trim();
                 userTagBuilder.append(',')
@@ -374,7 +374,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
         DecimalFormat format = new DecimalFormat("0.##");
         for (String percentile : percentilesStringArray) {
             String trimmedPercentile = percentile.trim();
-            if (StringUtils.isEmpty(trimmedPercentile)) {
+            if (StringUtilities.isEmpty(trimmedPercentile)) {
                 continue;
             }
             try {
@@ -438,7 +438,7 @@ public class InfluxdbBackendListenerClient extends AbstractBackendListenerClient
     private void addAnnotation(boolean isStartOfTest) {
         String tags = TAG_APPLICATION + applicationName +
                 ",title=ApacheJMeter" + userTag +
-                (StringUtils.isNotEmpty(testTags) ? TAGS + testTags : "");
+                (StringUtilities.isNotEmpty(testTags) ? TAGS + testTags : "");
         String field = TEXT +
                 AbstractInfluxdbMetricsSender.fieldToStringValue(
                         testTitle + (isStartOfTest ? " started" : " ended")) + "\"";

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestXPathExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestXPathExtractor.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.UnsupportedEncodingException;
 import java.util.Locale;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.assertions.AssertionResult;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContext;
@@ -122,8 +121,8 @@ public class TestXPathExtractor {
         extractor.setMatchNumber(0);
         extractor.process();
         assertEquals("1", vars.get(VAL_NAME_NR));
-        assertTrue(StringUtils.isNoneEmpty(vars.get(VAL_NAME)));
-        assertTrue(StringUtils.isNoneEmpty(vars.get(VAL_NAME + "_1")));
+        assertTrue(vars.get(VAL_NAME) != null && !vars.get(VAL_NAME).isEmpty());
+        assertTrue(vars.get(VAL_NAME + "_1") != null && !vars.get(VAL_NAME + "_1").isEmpty());
         assertNull(vars.get(VAL_NAME + "_2"));
         assertNull(vars.get(VAL_NAME + "_3"));
 

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -60,7 +60,6 @@ import org.apache.commons.cli.avalon.CLOptionDescriptor;
 import org.apache.commons.cli.avalon.CLUtil;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.control.ReplaceableController;
 import org.apache.jmeter.engine.ClientJMeterEngine;
 import org.apache.jmeter.engine.DistributedRunner;
@@ -98,6 +97,7 @@ import org.apache.jorphan.reflect.ClassTools;
 import org.apache.jorphan.util.HeapDumper;
 import org.apache.jorphan.util.JMeterException;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.jorphan.util.ThreadDumper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -645,7 +645,8 @@ public class JMeter implements JMeterPlugin {
             log.info("Running JSR-223 init script in file: {}", jsr223Init);
             File file = new File(jsr223Init);
             if(file.exists() && file.canRead()) {
-                String extension = StringUtils.defaultIfBlank(FilenameUtils.getExtension(jsr223Init), "Groovy");
+                String ext = FilenameUtils.getExtension(jsr223Init);
+                String extension = StringUtilities.isBlank(ext) ? "Groovy" : ext;
                 try (Reader reader = Files.newBufferedReader(file.toPath())) {
                     ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
                     ScriptEngine engine = scriptEngineManager.getEngineByExtension(extension);
@@ -712,7 +713,7 @@ public class JMeter implements JMeterPlugin {
             String proxyScheme = null;
             if (parser.getArgumentById(PROXY_SCHEME) != null) {
                 proxyScheme = parser.getArgumentById(PROXY_SCHEME).getArgument();
-                if(!StringUtils.isBlank(proxyScheme)){
+                if (StringUtilities.isNotBlank(proxyScheme)) {
                     System.setProperty("http.proxyScheme",  proxyScheme );// $NON-NLS-1$
                 }
             }

--- a/src/core/src/main/java/org/apache/jmeter/config/Argument.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/Argument.java
@@ -19,10 +19,9 @@ package org.apache.jmeter.config;
 
 import java.io.Serializable;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Class representing an argument. Each argument consists of a name/value pair,
@@ -122,7 +121,7 @@ public class Argument extends AbstractTestElement implements Serializable {
      */
     @Override
     public void setName(String newName) {
-        set(getSchema().getArgumentName(), StringUtils.strip(newName));
+        set(getSchema().getArgumentName(), (newName == null ? null : newName.strip()));
     }
 
     /**
@@ -195,7 +194,7 @@ public class Argument extends AbstractTestElement implements Serializable {
     @Override
     public String toString() {
         final String desc = getDescription();
-        if (desc == null || desc.isEmpty()) {
+        if (StringUtilities.isEmpty(desc)) {
             return getName() + getMetaData() + getValue();
         } else {
             return getName() + getMetaData() + getValue() + " //" + getDescription();
@@ -210,7 +209,7 @@ public class Argument extends AbstractTestElement implements Serializable {
      * @return true if parameter should be skipped
      */
     public boolean isSkippable(String parameterName) {
-        if (JOrphanUtils.isBlank(parameterName)){
+        if (StringUtilities.isBlank(parameterName)){
             return true; // Skip parameters with a blank name (allows use of optional variables in parameter lists)
         }
         // TODO: improve this test

--- a/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
+++ b/src/core/src/main/java/org/apache/jmeter/config/gui/ArgumentsPanel.java
@@ -42,7 +42,6 @@ import javax.swing.JTable;
 import javax.swing.JViewport;
 import javax.swing.ListSelectionModel;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.gui.TestElementMetadata;
@@ -53,6 +52,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * A GUI panel allowing the user to enter name-value argument pairs. These
@@ -300,7 +300,7 @@ public class ArgumentsPanel extends AbstractConfigGui implements ActionListener 
             Iterator<Argument> modelData = (Iterator<Argument>) tableModel.iterator();
             while (modelData.hasNext()) {
                 Argument arg = modelData.next();
-                if(StringUtils.isEmpty(arg.getName()) && StringUtils.isEmpty(arg.getValue())) {
+                if (StringUtilities.isEmpty(arg.getName()) && StringUtilities.isEmpty(arg.getValue())) {
                     continue;
                 }
                 arg.setMetaData("="); // $NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/CompoundVariable.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/CompoundVariable.java
@@ -32,6 +32,7 @@ import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.reflect.LogAndIgnoreServiceLoadExceptionHandler;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,7 +178,7 @@ public class CompoundVariable implements Function {
 
     public void setParameters(String parameters) throws InvalidVariableException {
         this.rawParameters = parameters;
-        if (parameters == null || parameters.length() == 0) {
+        if (StringUtilities.isEmpty(parameters)) {
             return;
         }
 

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/ReplaceFunctionsWithStrings.java
@@ -24,7 +24,7 @@ import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jmeter.util.StringUtilities;
+import org.apache.jorphan.util.JOrphanUtils;
 import org.apache.oro.text.regex.MalformedPatternException;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.PatternCompiler;
@@ -97,7 +97,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
                     log.warn("Malformed pattern: {}", value);
                 }
             } else {
-                input = StringUtilities.substitute(input, value, FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
+                input = JOrphanUtils.substitute(input, value, FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
             }
         }
         return new StringProperty(prop.getName(), input);
@@ -119,7 +119,7 @@ public class ReplaceFunctionsWithStrings extends AbstractTransformer {
                     log.warn("Malformed pattern: {}", value);
                 }
             } else {
-                input = StringUtilities.substitute(input, value, FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
+                input = JOrphanUtils.substitute(input, value, FUNCTION_REF_PREFIX + key + FUNCTION_REF_SUFFIX);
             }
         }
         return new StringProperty(prop.getName(), input);

--- a/src/core/src/main/java/org/apache/jmeter/engine/util/UndoVariableReplacement.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/util/UndoVariableReplacement.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.jmeter.functions.InvalidVariableException;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.property.StringProperty;
-import org.apache.jmeter.util.StringUtilities;
+import org.apache.jorphan.util.JOrphanUtils;
 
 /**
  * Replaces ${key} by value extracted from
@@ -41,7 +41,7 @@ public class UndoVariableReplacement extends AbstractTransformer {
         for (Map.Entry<String, String> entry : getVariables().entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            input = StringUtilities.substitute(input, "${" + key + "}", value);
+            input = JOrphanUtils.substitute(input, "${" + key + "}", value);
         }
         return new StringProperty(prop.getName(), input);
     }

--- a/src/core/src/main/java/org/apache/jmeter/functions/AbstractFunction.java
+++ b/src/core/src/main/java/org/apache/jmeter/functions/AbstractFunction.java
@@ -19,13 +19,13 @@ package org.apache.jmeter.functions;
 
 import java.util.Collection;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Provides common methods for all functions
@@ -154,7 +154,7 @@ public abstract class AbstractFunction implements Function {
     protected final void addVariableValue(String value, CompoundVariable[] values, int index) {
         if (values.length > index) {
             String variableName = values[index].execute().trim();
-            if (StringUtils.isNotEmpty(variableName)) {
+            if (StringUtilities.isNotEmpty(variableName)) {
                 JMeterVariables vars = getVariables();
                 if (vars != null) {
                     vars.put(variableName, value);

--- a/src/core/src/main/java/org/apache/jmeter/functions/gui/FunctionHelper.java
+++ b/src/core/src/main/java/org/apache/jmeter/functions/gui/FunctionHelper.java
@@ -41,7 +41,6 @@ import javax.swing.JRootPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -67,6 +66,7 @@ import org.apache.jorphan.gui.ComponentUtil;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -254,8 +254,7 @@ public class FunctionHelper extends JDialog implements ActionListener, ChangeLis
                 resultTextArea.setText(function.execute().trim());
             } catch(Exception ex) {
                 log.error("Error calling function {}", functionCall, ex);
-                resultTextArea.setText(ex.getMessage() + ", \nstacktrace:\n "+
-                        ExceptionUtils.getStackTrace(ex));
+                resultTextArea.setText(ex.getMessage() + ", \nstacktrace:\n "+ ExceptionUtils.getStackTrace(ex));
                 resultTextArea.setCaretPosition(0);
             }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -35,7 +35,6 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.border.Border;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.util.VerticalPanel;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestElementSchema;
@@ -260,7 +259,8 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
      */
     @API(status = DEPRECATED, since = "5.6.3")
     protected void configureTestElement(TestElement mc) {
-        mc.setName(StringUtils.defaultIfEmpty(getName(), null));
+        String name = getName();
+        mc.setName(name.isEmpty() ? null : name);
         TestElementSchema schema = TestElementSchema.INSTANCE;
         mc.set(schema.getGuiClass(), getClass());
         mc.set(schema.getTestClass(), mc.getClass());
@@ -282,7 +282,8 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
         mc.set(TestElementSchema.INSTANCE.getEnabled(), enabled ? null : Boolean.FALSE);
         // Note: we can't use editors for "comments" as getComments() is not a final method, so plugins might
         // override it and provide a different implementation.
-        mc.setComment(StringUtils.defaultIfEmpty(getComment(), null));
+        String comment = getComment();
+        mc.setComment(comment.isEmpty() ? null : comment);
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/gui/JMeterGUIComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/JMeterGUIComponent.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 
 import javax.swing.JPopupMenu;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.TestElementSchema;
 import org.apiguardian.api.API;
@@ -155,7 +154,8 @@ public interface JMeterGUIComponent extends ClearGui {
      * @param element test element to configure
      */
     default void assignDefaultValues(TestElement element) {
-        element.setName(StringUtils.defaultIfEmpty(getStaticLabel(), null));
+        String label = getStaticLabel();
+        element.setName(label.isEmpty() ? null : label);
         TestElementSchema schema = TestElementSchema.INSTANCE;
         element.set(schema.getGuiClass(), getClass());
         element.set(schema.getTestClass(), element.getClass());
@@ -201,7 +201,8 @@ public interface JMeterGUIComponent extends ClearGui {
         // TODO: should we keep .clear() here? It probably makes it easier to remove all properties before populating
         //   the values from UI, however, it might be inefficient.
         element.clear();
-        element.setName(StringUtils.defaultIfEmpty(getName(), null));
+        String name = getName();
+        element.setName(name.isEmpty() ? null : name);
         TestElementSchema schema = TestElementSchema.INSTANCE;
         element.set(schema.getGuiClass(), getClass());
         element.set(schema.getTestClass(), element.getClass());

--- a/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/MainFrame.java
@@ -78,7 +78,6 @@ import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
 import org.apache.jmeter.gui.action.KeyStrokes;
@@ -104,6 +103,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.ComponentUtil;
 import org.apache.jorphan.gui.JMeterUIDefaults;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -408,7 +408,7 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
         }
         stoppingMessage = new EscapeDialog(this, JMeterUtils.getResString("stopping_test_title"), true); //$NON-NLS-1$
         String label = JMeterUtils.getResString("stopping_test"); //$NON-NLS-1
-        if (!StringUtils.isEmpty(host)) {
+        if (StringUtilities.isNotEmpty(host)) {
             label = label + " " + JMeterUtils.getResString("stopping_test_host") + ": " + host;
         }
         JLabel stopLabel = new JLabel(label); //$NON-NLS-1$$NON-NLS-2$
@@ -673,8 +673,8 @@ public class MainFrame extends JFrame implements TestStateListener, Remoteable, 
                         Object testElement = ((DefaultMutableTreeNode) treeNode).getUserObject();
                         if (testElement instanceof TestElement) {
                             String comment = ((TestElement) testElement).getComment();
-                            if (StringUtils.isNotBlank(comment)) {
-                                return StringUtils.abbreviate(comment, 80);
+                            if (StringUtilities.isNotBlank(comment)) {
+                                return comment.length() <= 80 ? comment : comment.substring(0, 77) + "...";
                             }
                         }
                     }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/ChangeParent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/ChangeParent.java
@@ -27,7 +27,6 @@ import javax.swing.JTree;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.JMeterGUIComponent;
@@ -35,6 +34,7 @@ import org.apache.jmeter.gui.tree.JMeterTreeModel;
 import org.apache.jmeter.gui.tree.JMeterTreeNode;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +87,7 @@ public class ChangeParent extends AbstractAction {
         Controller currentController = (Controller) currentNode.getUserObject();
         JMeterGUIComponent currentGui = guiPackage.getCurrentGui();
         String defaultName = JMeterUtils.getResString(currentGui.getLabelResource());
-        if(StringUtils.isNotBlank(currentController.getName())
+        if (StringUtilities.isNotBlank(currentController.getName())
                 && !currentController.getName().equals(defaultName)){
             newParent.setName(currentController.getName());
         }

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/RawTextSearcher.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/RawTextSearcher.java
@@ -19,7 +19,9 @@ package org.apache.jmeter.gui.action;
 
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
+
+import kotlin.text.StringsKt;
 
 /**
  * Searcher implementation that searches text as is
@@ -44,8 +46,8 @@ public class RawTextSearcher implements Searcher {
     @Override
     public boolean search(List<String> textTokens) {
         return textTokens.stream()
-                .filter(StringUtils::isNotEmpty)
-                .anyMatch(token -> caseSensitive ? token.contains(textToSearch) : StringUtils.containsAnyIgnoreCase(token, textToSearch));
+                .filter(StringUtilities::isNotEmpty)
+                .anyMatch(token -> StringsKt.contains(token, textToSearch, !caseSensitive));
     }
 
     @Override

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/RegexpSearcher.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/RegexpSearcher.java
@@ -20,7 +20,7 @@ package org.apache.jmeter.gui.action;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Regexp search implementation
@@ -52,7 +52,7 @@ public class RegexpSearcher implements Searcher {
             pattern = Pattern.compile(regexp, Pattern.CASE_INSENSITIVE);
         }
         return textTokens.stream()
-                .filter(token -> !StringUtils.isEmpty(token))
+                .filter(StringUtilities::isNotEmpty)
                 .anyMatch(token -> pattern.matcher(token).find());
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/Restart.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/Restart.java
@@ -32,10 +32,10 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.MenuElement;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.plugin.MenuCreator;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +108,7 @@ public class Restart extends AbstractActionWithNoRunningTest implements MenuCrea
     public static void restartApplication(Runnable runBeforeRestart) {
         String javaCommand = System.getProperty(SUN_JAVA_COMMAND);
         List<String> processArgs = new ArrayList<>();
-        if(StringUtils.isEmpty(javaCommand)) {
+        if (StringUtilities.isEmpty(javaCommand)) {
             JOptionPane.showMessageDialog(GuiPackage.getInstance().getMainFrame(),
                     JMeterUtils.getResString("restart_error")+":\n This command is only supported on Open JDK or Oracle JDK" ,  //$NON-NLS-1$  //$NON-NLS-2$
                     JMeterUtils.getResString("error_title"), JOptionPane.ERROR_MESSAGE); //$NON-NLS-1$

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/SchematicView.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/SchematicView.java
@@ -39,11 +39,11 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.plugin.MenuCreator;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.collections.HashTree;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +77,7 @@ public class SchematicView extends AbstractAction implements MenuCreator {
                     "net.sf.saxon.BasicTransformerFactory", Thread.currentThread().getContextClassLoader());
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             Source xslt;
-            if (!StringUtils.isEmpty(DEFAULT_XSL_FILE)) {
+            if (StringUtilities.isNotEmpty(DEFAULT_XSL_FILE)) {
                 log.info("Will use file {} for Schematic View generation", DEFAULT_XSL_FILE);
                 xslt = new StreamSource(new File(DEFAULT_XSL_FILE));
             } else {

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/template/TemplateManager.java
@@ -28,8 +28,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -91,7 +91,7 @@ public class TemplateManager {
 
         final String[] templateFiles = TEMPLATE_FILES.split(",");
         for (String templateFile : templateFiles) {
-            if(!StringUtils.isEmpty(templateFile)) {
+            if (StringUtilities.isNotEmpty(templateFile)) {
                 final File file = new File(JMeterUtils.getJMeterHome(), templateFile);
                 try {
                     if(file.exists() && file.canRead()) {

--- a/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventAppender.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/logging/GuiLogEventAppender.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.gui.logging;
 import java.io.Serializable;
 
 import org.apache.jmeter.gui.GuiPackage;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
@@ -56,7 +57,7 @@ public class GuiLogEventAppender extends AbstractAppender {
         if (instance != null) {
             final String serializedString = getStringLayout().toSerializable(logEvent);
 
-            if (serializedString != null && !serializedString.isEmpty()) {
+            if (StringUtilities.isNotEmpty(serializedString)) {
                 LogEventObject logEventObject = new LogEventObject(logEvent, serializedString);
                 instance.getLogEventBus().postEvent(logEventObject);
             }

--- a/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/tree/JMeterCellRenderer.java
@@ -26,8 +26,7 @@ import javax.swing.JTree;
 import javax.swing.border.Border;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Class to render the test tree - sets the enabled/disabled versions of the icons
@@ -37,7 +36,7 @@ public class JMeterCellRenderer extends DefaultTreeCellRenderer {
 
     private static final int DEFAULT_LENGTH = 15;
 
-    private static final String BLANK = StringUtils.repeat(' ', DEFAULT_LENGTH);
+    private static final String BLANK = " ".repeat(DEFAULT_LENGTH);
 
     private static final Border RED_BORDER = BorderFactory.createLineBorder(Color.red);
     private static final Border BLUE_BORDER = BorderFactory.createLineBorder(Color.blue);
@@ -49,7 +48,7 @@ public class JMeterCellRenderer extends DefaultTreeCellRenderer {
             boolean leaf, int row, boolean p_hasFocus) {
         JMeterTreeNode node = (JMeterTreeNode) value;
         super.getTreeCellRendererComponent(tree,
-                JOrphanUtils.isBlank(node.getName()) ? BLANK : node.getName(),
+                StringUtilities.isBlank(node.getName()) ? BLANK : node.getName(),
                         sel, expanded, leaf, row, p_hasFocus);
         boolean enabled = node.isEnabled();
         ImageIcon ic = node.getIcon(enabled);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/FileDialoger.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/FileDialoger.java
@@ -24,9 +24,9 @@ import java.util.Arrays;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.gui.JMeterFileFilter;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -203,7 +203,7 @@ public final class FileDialoger {
 
     private static void setCurrentDirOnJFC(String... dirNames) {
         for (String dirName : dirNames) {
-            if (StringUtils.isBlank(dirName)) {
+            if (StringUtilities.isBlank(dirName)) {
                 continue;
             }
             File possibleDir = new File(dirName);

--- a/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/util/JMeterToolBar.java
@@ -32,7 +32,6 @@ import javax.swing.JButton;
 import javax.swing.JOptionPane;
 import javax.swing.JToolBar;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.UndoHistory;
 import org.apache.jmeter.gui.action.ActionNames;
 import org.apache.jmeter.gui.action.ActionRouter;
@@ -44,6 +43,8 @@ import org.slf4j.LoggerFactory;
 
 import com.github.weisj.darklaf.icons.ThemedSVGIcon;
 import com.github.weisj.darklaf.ui.button.DarkButtonUI;
+
+import kotlin.text.StringsKt;
 
 /**
  * The JMeter main toolbar class
@@ -159,7 +160,7 @@ public class JMeterToolBar extends JToolBar implements LocaleChangeListener {
         if (imageURL == null) {
             throw new IllegalArgumentException("No icon for: " + iconBean.getActionName());
         }
-        if (StringUtils.endsWithIgnoreCase(iconBean.getIconPath(), ".svg")) {
+        if (StringsKt.endsWith(iconBean.getIconPath(), ".svg", true)) {
             return new ThemedSVGIcon(imageURL.toURI(), iconBean.getWidth(), iconBean.getHeight());
         }
         return new ImageIcon(imageURL);

--- a/src/core/src/main/java/org/apache/jmeter/report/config/ReportGeneratorConfiguration.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/config/ReportGeneratorConfiguration.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -666,13 +666,13 @@ public class ReportGeneratorConfiguration {
                 REPORT_GENERATOR_KEY_END_DATE, String.class);
 
         String rangeDateFormat = getOptionalProperty(props, REPORT_GENERATOR_KEY_RANGE_DATE_FORMAT, String.class);
-        if (StringUtils.isEmpty(rangeDateFormat)) {
+        if (StringUtilities.isEmpty(rangeDateFormat)) {
             rangeDateFormat = RANGE_DATE_FORMAT_DEFAULT;
         }
         SimpleDateFormat dateFormat = new SimpleDateFormat(rangeDateFormat, Locale.ENGLISH);
 
         try {
-            if(!StringUtils.isEmpty(startDateValue)) {
+            if (StringUtilities.isNotEmpty(startDateValue)) {
                 reportStartDate = dateFormat.parse(startDateValue);
                 configuration.setStartDate(reportStartDate);
             }
@@ -681,7 +681,7 @@ public class ReportGeneratorConfiguration {
                     startDateValue, rangeDateFormat, e);
         }
         try {
-            if(!StringUtils.isEmpty(endDateValue)) {
+            if (StringUtilities.isNotEmpty(endDateValue)) {
                 reportEndDate = dateFormat.parse(endDateValue);
                 configuration.setEndDate(reportEndDate);
             }
@@ -728,8 +728,7 @@ public class ReportGeneratorConfiguration {
      */
     public static Map<String, Long[]> getApdexPerTransactionParts(String apdexPerTransaction) {
         Map <String, Long[]> specificApdexes = new HashMap<>();
-        if (StringUtils.isEmpty(apdexPerTransaction) ||
-                apdexPerTransaction.trim().length() == 0) {
+        if (StringUtilities.isBlank(apdexPerTransaction)) {
             log.info("apdex_per_transaction is empty, not APDEX per transaction customization");
         } else {
             // data looks like : sample(\d+):1000|2000;samples12:3000|4000;scenar01-12:5000|6000
@@ -771,7 +770,7 @@ public class ReportGeneratorConfiguration {
      * @return the filteredSamplesPattern
      */
     public Pattern getFilteredSamplesPattern() {
-        if(StringUtils.isEmpty(sampleFilter)) {
+        if (StringUtilities.isEmpty(sampleFilter)) {
             return null;
         }
         if(filteredSamplesPattern == null) {

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleReader.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleReader.java
@@ -28,8 +28,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.save.CSVSaveService;
@@ -116,9 +116,9 @@ public class CsvSampleReader implements Closeable{
         }
         boolean usingHeadersInCsv = true;
         if (metadata == null) {
-            Pair<Boolean, SampleMetadata> localMd = readMetadata(separator, useSaveSampleCfg);
-            this.metadata = localMd.getRight();
-            usingHeadersInCsv = localMd.getLeft();
+            Map.Entry<Boolean, SampleMetadata> localMd = readMetadata(separator, useSaveSampleCfg);
+            this.metadata = localMd.getValue();
+            usingHeadersInCsv = localMd.getKey();
         } else {
             this.metadata = metadata;
         }
@@ -135,7 +135,7 @@ public class CsvSampleReader implements Closeable{
         this.lastSampleRead = nextSample();
     }
 
-    private Pair<Boolean, SampleMetadata> readMetadata(char separator, boolean useSaveSampleCfg) {
+    private Map.Entry<Boolean, SampleMetadata> readMetadata(char separator, boolean useSaveSampleCfg) {
         try {
             SampleMetadata result;
             // Read first line
@@ -166,7 +166,7 @@ public class CsvSampleReader implements Closeable{
                 result = new SampleMetaDataParser(separator).parse(line);
                 hasHeaders = true;
             }
-            return Pair.of(hasHeaders, result);
+            return Map.entry(hasHeaders, result);
         } catch (Exception e) {
             throw new SampleException("Could not read metadata !", e);
         }

--- a/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleWriter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/CsvSampleWriter.java
@@ -21,8 +21,6 @@ import java.io.File;
 import java.io.OutputStream;
 import java.io.Writer;
 
-import org.apache.commons.lang3.CharUtils;
-import org.apache.commons.lang3.Validate;
 import org.apache.jmeter.save.CSVSaveService;
 
 /**
@@ -117,7 +115,9 @@ public class CsvSampleWriter extends AbstractSampleWriter {
      * header information will be written in the middle of the file.
      */
     public void writeHeader() {
-        Validate.validState(writer != null, "No writer set! Call setWriter() first!");
+        if (writer == null) {
+            throw new IllegalStateException("No writer set! Call setWriter() first!");
+        }
         StringBuilder row = new StringBuilder();
         for (int i = 0; i < columnCount; i++) {
             row.append(metadata.getColumnName(i));
@@ -130,10 +130,12 @@ public class CsvSampleWriter extends AbstractSampleWriter {
 
     @Override
     public long write(Sample sample) {
-        Validate.validState(writer != null, "No writer set! Call setWriter() first!");
+        if (writer == null) {
+            throw new IllegalStateException("No writer set! Call setWriter() first!");
+        }
         StringBuilder row = new StringBuilder();
         char[] specials = new char[] { separator,
-                CSVSaveService.QUOTING_CHAR, CharUtils.CR, CharUtils.LF };
+                CSVSaveService.QUOTING_CHAR, '\r', '\n' };
         for (int i = 0; i < columnCount; i++) {
             String data = sample.getData(i);
             row.append(CSVSaveService.quoteDelimiters(data, specials))

--- a/src/core/src/main/java/org/apache/jmeter/report/core/JsonUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/JsonUtil.java
@@ -19,8 +19,6 @@ package org.apache.jmeter.report.core;
 
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-
 /**
  * The class JsonUtil provides helper functions to generate Json.
  *
@@ -36,7 +34,7 @@ public final class JsonUtil {
      * @return the json string
      */
     public static String toJsonArray(final String... array) {
-        return '[' + StringUtils.join(array, ", ") + ']';
+        return '[' + String.join(", ", array) + ']';
     }
 
     /**
@@ -55,7 +53,7 @@ public final class JsonUtil {
                 array[index] = '"' + entry.getKey() + "\": " + entry.getValue();
                 index++;
             }
-            result += StringUtils.join(array, ", ");
+            result += String.join(", ", array);
         }
         return result + "}";
     }

--- a/src/core/src/main/java/org/apache/jmeter/report/core/Sample.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/Sample.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.report.core;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -139,7 +138,7 @@ public class Sample {
      */
     @Override
     public String toString() {
-        return StringUtils.join(data, metadata.getSeparator());
+        return String.join(String.valueOf(metadata.getSeparator()), data);
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetadata.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/core/SampleMetadata.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.TreeMap;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.save.CSVSaveService;
 
@@ -226,6 +225,6 @@ public class SampleMetadata {
      */
     @Override
     public String toString() {
-        return StringUtils.join(columns, separator);
+        return String.join(String.valueOf(separator), columns);
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/AbstractDataExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/AbstractDataExporter.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.report.dashboard;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.report.config.ConfigurationException;
 import org.apache.jmeter.report.config.SubConfiguration;
 import org.apache.jmeter.report.processor.MapResultData;
@@ -73,7 +72,7 @@ public abstract class AbstractDataExporter implements DataExporter {
      * @return the ResultData matching the data name
      */
     protected static ResultData findData(String data, ResultData root) {
-        String[] pathItems = StringUtils.split(data, '.');
+        String[] pathItems = data.split("\\.");
         if (pathItems == null || !(root instanceof MapResultData)) {
             return null;
         }

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/HtmlTemplateExporter.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jmeter.JMeter;
 import org.apache.jmeter.report.config.ExporterConfiguration;
@@ -46,6 +45,7 @@ import org.apache.jmeter.report.processor.ValueResultData;
 import org.apache.jmeter.report.processor.graph.AbstractGraphConsumer;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -317,7 +317,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
         File outputDir = getPropertyFromConfig(exportCfg, OUTPUT_DIR,
                 new File(JMeterUtils.getJMeterBinDir(), OUTPUT_DIR_NAME_DEFAULT), File.class);
         String globallyDefinedOutputDir = JMeterUtils.getProperty(JMeter.JMETER_REPORT_OUTPUT_DIR_PROPERTY);
-        if(!StringUtils.isEmpty(globallyDefinedOutputDir)) {
+        if (StringUtilities.isNotEmpty(globallyDefinedOutputDir)) {
             outputDir = new File(globallyDefinedOutputDir);
         }
 
@@ -337,7 +337,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
         // Add the series filter to the context
         final String seriesFilter = exportCfg.getSeriesFilter();
         Pattern filterPattern = null;
-        if (StringUtils.isNotBlank(seriesFilter)) {
+        if (StringUtilities.isNotBlank(seriesFilter)) {
             try {
                 filterPattern = Pattern.compile(seriesFilter);
             } catch (PatternSyntaxException ex) {
@@ -428,7 +428,7 @@ public class HtmlTemplateExporter extends AbstractDataExporter {
                 dataContext);
 
         // Add report title to the context
-        if (StringUtils.isNotEmpty(configuration.getReportTitle())) {
+        if (StringUtilities.isNotEmpty(configuration.getReportTitle())) {
             dataContext.put(DATA_CTX_REPORT_TITLE, StringEscapeUtils.escapeHtml4(configuration.getReportTitle()));
         }
 

--- a/src/core/src/main/java/org/apache/jmeter/report/dashboard/JsonExporter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/dashboard/JsonExporter.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.JMeter;
 import org.apache.jmeter.report.config.ExporterConfiguration;
 import org.apache.jmeter.report.config.ReportGeneratorConfiguration;
@@ -36,6 +35,7 @@ import org.apache.jmeter.report.processor.SampleContext;
 import org.apache.jmeter.report.processor.ValueResultData;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,7 +107,7 @@ public class JsonExporter extends AbstractDataExporter {
         File outputDir = getPropertyFromConfig(exportCfg, HtmlTemplateExporter.OUTPUT_DIR,
                 new File(JMeterUtils.getJMeterBinDir(), HtmlTemplateExporter.OUTPUT_DIR_NAME_DEFAULT), File.class);
         String globallyDefinedOutputDir = JMeterUtils.getProperty(JMeter.JMETER_REPORT_OUTPUT_DIR_PROPERTY);
-        if(!StringUtils.isEmpty(globallyDefinedOutputDir)) {
+        if (StringUtilities.isNotEmpty(globallyDefinedOutputDir)) {
             outputDir = new File(globallyDefinedOutputDir);
         }
 

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ApdexSummaryConsumer.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.report.processor;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jmeter.report.core.Sample;
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -57,8 +56,7 @@ public class ApdexSummaryConsumer extends
         ApdexThresholdsInfo thresholdsInfo = data.getApdexThresholdInfo();
         Long satisfiedThreshold = thresholdsInfo.getSatisfiedThreshold();
         Long toleratedThreshold = thresholdsInfo.getToleratedThreshold();
-        String keyOrDefault = ObjectUtils.defaultIfNull(
-                key, JMeterUtils.getResString("reportgenerator_summary_total"));
+        String keyOrDefault = (key != null ? key : JMeterUtils.getResString("reportgenerator_summary_total"));
 
         ListResultData result = new ListResultData();
         result.addResult(new ValueResultData(apdex));

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/CsvFileSampleSource.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang3.Validate;
 import org.apache.jmeter.report.core.CsvSampleReader;
 import org.apache.jmeter.report.core.Sample;
 import org.apache.jmeter.report.core.SampleException;
@@ -162,7 +161,9 @@ public class CsvFileSampleSource extends AbstractSampleSource {
      */
     private void produce() {
         SampleContext context = getSampleContext();
-        Validate.validState(context != null, "Set a sample context before producing samples.");
+        if (context == null) {
+            throw new IllegalStateException("Set a sample context before producing samples.");
+        }
 
         for (int i = 0; i < csvReaders.length; i++) {
             long sampleCount = 0;

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ErrorsSummaryConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ErrorsSummaryConsumer.java
@@ -17,12 +17,12 @@
 
 package org.apache.jmeter.report.processor;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jmeter.report.core.Sample;
 import org.apache.jmeter.report.utils.MetricUtils;
 import org.apache.jmeter.samplers.SampleSaveConfiguration;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
@@ -93,16 +93,16 @@ public class ErrorsSummaryConsumer extends AbstractSummaryConsumer<Long> {
         }
         String responseCode = sample.getResponseCode();
         String responseMessage = sample.getResponseMessage();
-        String key = responseCode + (!StringUtils.isEmpty(responseMessage) ?
+        String key = responseCode + (StringUtilities.isNotEmpty(responseMessage) ?
                  "/" + escapeJson(responseMessage) : "");
 
         if (MetricUtils.isSuccessCode(responseCode) ||
-                (StringUtils.isEmpty(responseCode) &&
-                   StringUtils.isNotBlank(sample.getFailureMessage()))) {
+                (StringUtilities.isEmpty(responseCode) &&
+                   StringUtilities.isNotBlank(sample.getFailureMessage()))) {
             key = MetricUtils.ASSERTION_FAILED;
             if (ASSERTION_RESULTS_FAILURE_MESSAGE) {
                 String msg = sample.getFailureMessage();
-                if (StringUtils.isNotBlank(msg)) {
+                if (StringUtilities.isNotBlank(msg)) {
                     key = escapeJson(msg);
                 }
             }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/ExternalSampleSorter.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/ExternalSampleSorter.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.lang3.Validate;
 import org.apache.jmeter.report.core.CsvFile;
 import org.apache.jmeter.report.core.CsvSampleReader;
 import org.apache.jmeter.report.core.CsvSampleWriter;
@@ -271,8 +270,9 @@ public class ExternalSampleSorter extends AbstractSampleConsumer {
 
     @Override
     public void startConsuming() {
-        Validate.validState(sampleComparator != null,
-                "sampleComparator is not set, call setSampleComparator() first.");
+        if (sampleComparator == null) {
+            throw new IllegalStateException("sampleComparator is not set, call setSampleComparator() first.");
+        }
 
         File workDir = getWorkingDirectory();
         workDir.mkdir();

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractSeriesSelector.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/AbstractSeriesSelector.java
@@ -19,7 +19,8 @@ package org.apache.jmeter.report.processor.graph;
 
 import java.util.Arrays;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
+
 
 /**
  * The class AbstractSeriesSelector provide an abstract base class for
@@ -66,6 +67,6 @@ public abstract class AbstractSeriesSelector implements GraphSeriesSelector {
      * @return input or default value wrapped in a list
      */
     protected Iterable<String> withDefaultIfEmpty(String value, String defaultValue) {
-        return Arrays.asList(StringUtils.defaultIfBlank(value, defaultValue));
+        return Arrays.asList(StringUtilities.isBlank(value) ? defaultValue : value);
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CustomGraphConsumer.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/processor/graph/impl/CustomGraphConsumer.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.report.core.ConvertException;
 import org.apache.jmeter.report.core.Converters;
 import org.apache.jmeter.report.core.Sample;
@@ -38,6 +37,7 @@ import org.apache.jmeter.report.processor.graph.GraphValueSelector;
 import org.apache.jmeter.report.processor.graph.GroupInfo;
 import org.apache.jmeter.report.processor.graph.TimeStampKeysSelector;
 import org.apache.jmeter.save.CSVSaveService;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * The class CustomGraphConsumer is added by the custom Graphs plugin.
@@ -208,7 +208,7 @@ public class CustomGraphConsumer extends AbstractOverTimeGraphConsumer implement
                         + CSVSaveService.VARIABLE_NAME_QUOTE_CHAR);
             }
 
-            if (StringUtils.isEmpty(value) || "null".equals(value)) {
+            if (StringUtilities.isEmpty(value) || "null".equals(value)) {
                 return null;
             }
 

--- a/src/core/src/main/java/org/apache/jmeter/report/utils/MetricUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/report/utils/MetricUtils.java
@@ -17,7 +17,7 @@
 
 package org.apache.jmeter.report.utils;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * @since 5.0
@@ -41,7 +41,7 @@ public class MetricUtils {
      * @return whether in range 200-399 or not
      */
     public static boolean isSuccessCode(String codeAsString) {
-        if (StringUtils.isNumeric(codeAsString)) {
+        if (StringUtilities.isNumeric(codeAsString)) {
             try {
                 int code = Integer.parseInt(codeAsString);
                 return isSuccessCode(code);

--- a/src/core/src/main/java/org/apache/jmeter/reporters/ResultCollector.java
+++ b/src/core/src/main/java/org/apache/jmeter/reporters/ResultCollector.java
@@ -51,6 +51,7 @@ import org.apache.jmeter.testelement.property.ObjectProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Visualizer;
 import org.apache.jorphan.util.JMeterError;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -438,7 +439,7 @@ public class ResultCollector extends AbstractListenerElement implements SampleLi
 
     private static PrintWriter getFileWriter(final String pFilename, SampleSaveConfiguration saveConfig)
             throws IOException {
-        if (pFilename == null || pFilename.length() == 0) {
+        if (StringUtilities.isEmpty(pFilename)) {
             return null;
         }
         if(log.isDebugEnabled()) {

--- a/src/core/src/main/java/org/apache/jmeter/rmi/RmiUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/rmi/RmiUtils.java
@@ -23,9 +23,8 @@ import java.rmi.RemoteException;
 import java.rmi.server.RMIClientSocketFactory;
 import java.rmi.server.RMIServerSocketFactory;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,12 +84,11 @@ public final class RmiUtils {
             log.info("Disabling SSL for RMI as server.rmi.ssl.disable is set to 'true'");
             return null;
         }
-        if (StringUtils.isBlank(KEYSTORE_FILE)) {
-            Validate.validState(SSL_DISABLED,
+        if (StringUtilities.isBlank(KEYSTORE_FILE)) {
+            throw new IllegalStateException(
                     "No keystore for RMI over SSL specified. Set 'server.rmi.ssl.disable' to true, if this is intentional,"
                     + "if not run create-rmi-keystore.bat/create-rmi-keystore.sh to create a keystore and distribute it on client and servers"
                     + "used for distributed testing.");
-            return null;
         }
         final SSLRMIClientSocketFactory factory = new SSLRMIClientSocketFactory();
         factory.setAlias(KEYSTORE_ALIAS);
@@ -104,10 +102,9 @@ public final class RmiUtils {
             log.info("Disabling SSL for RMI as server.rmi.ssl.disable is set to 'true'");
             return null;
         }
-        if (StringUtils.isBlank(KEYSTORE_FILE)) {
-            Validate.validState(SSL_DISABLED,
+        if (StringUtilities.isBlank(KEYSTORE_FILE)) {
+            throw new IllegalStateException(
                     "No keystore for RMI over SSL specified. Set 'server.rmi.ssl.disable' to true, if this is intentional.");
-            return new RMIServerSocketFactoryImpl(getRmiHost());
         }
         SSLRMIServerSocketFactory factory = new SSLRMIServerSocketFactory(getRmiHost());
         factory.setAlias(KEYSTORE_ALIAS);

--- a/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
+++ b/src/core/src/main/java/org/apache/jmeter/samplers/SampleResult.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.testelement.TestPlan;
 import org.apache.jmeter.threads.JMeterContext.TestLogicalAction;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1003,7 +1004,7 @@ public class SampleResult implements Serializable, Cloneable, Searchable {
      * @return the value of the dataEncoding or the provided default
      */
     protected String getDataEncodingWithDefault(String defaultEncoding) {
-        if (dataEncoding != null && dataEncoding.length() > 0) {
+        if (StringUtilities.isNotEmpty(dataEncoding)) {
             return dataEncoding;
         }
         return defaultEncoding;

--- a/src/core/src/main/java/org/apache/jmeter/save/SaveService.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/SaveService.java
@@ -37,16 +37,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.jmeter.reporters.ResultCollectorHelper;
 import org.apache.jmeter.samplers.SampleEvent;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.NameUpdater;
 import org.apache.jorphan.collections.HashTree;
+import org.apache.jorphan.util.ExceptionUtils;
 import org.apache.jorphan.util.JMeterError;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -358,7 +358,7 @@ public class SaveService {
      */
     private static String showDebuggingInfo(SampleResult result) {
         try {
-            return "class:"+result.getClass()+",content:"+ToStringBuilder.reflectionToString(result);
+            return "class:"+result.getClass()+",content:"+result.toString();
         } catch(Exception e) {
             return "Exception occurred creating debug from event, message:"+e.getMessage();
         }
@@ -461,6 +461,7 @@ public class SaveService {
         }
 
     }
+
     private static InputStreamReader getInputStreamReader(InputStream inStream) {
         // Check if we have a encoding to use from properties
         Charset charset = getFileEncodingCharset();
@@ -481,7 +482,7 @@ public class SaveService {
      */
     // Used by ResultCollector when creating output files
     public static String getFileEncoding(String dflt){
-        if(fileEncoding != null && fileEncoding.length() > 0) {
+        if (StringUtilities.isNotEmpty(fileEncoding)) {
             return fileEncoding;
         }
         else {
@@ -492,7 +493,7 @@ public class SaveService {
     // @NotNull
     private static Charset getFileEncodingCharset() {
         // Check if we have a encoding to use from properties
-        if(fileEncoding != null && fileEncoding.length() > 0) {
+        if (StringUtilities.isNotEmpty(fileEncoding)) {
             return Charset.forName(fileEncoding);
         }
         else {

--- a/src/core/src/main/java/org/apache/jmeter/save/converters/TestResultWrapperConverter.java
+++ b/src/core/src/main/java/org/apache/jmeter/save/converters/TestResultWrapperConverter.java
@@ -24,6 +24,7 @@ import org.apache.jmeter.reporters.ResultCollectorHelper;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.save.SaveService;
 import org.apache.jmeter.save.TestResultWrapper;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
@@ -83,7 +84,7 @@ public class TestResultWrapperConverter extends AbstractCollectionConverter {
         TestResultWrapper results = new TestResultWrapper();
         Collection<SampleResult> samples = new ArrayList<>();
         String ver = reader.getAttribute("version");  //$NON-NLS-1$
-        if (ver == null || ver.length() == 0) {
+        if (StringUtilities.isEmpty(ver)) {
             ver = "1.0";  //$NON-NLS-1$
         }
         results.setVersion(ver);

--- a/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
+++ b/src/core/src/main/java/org/apache/jmeter/services/FileServer.java
@@ -38,7 +38,7 @@ import org.apache.commons.io.input.BOMInputStream;
 import org.apache.jmeter.gui.JMeterFileFilter;
 import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,7 +252,7 @@ public class FileServer {
      * @throws IllegalArgumentException if header could not be read or filename is null or empty
      */
     public synchronized String reserveFile(String filename, String charsetName, String alias, boolean hasHeader) {
-        if (filename == null || filename.isEmpty()){
+        if (StringUtilities.isEmpty(filename)){
             throw new IllegalArgumentException("Filename must not be null or empty");
         }
         if (alias == null){
@@ -428,7 +428,7 @@ public class FileServer {
         InputStreamReader isr = null;
         // If file encoding is specified, read using that encoding, otherwise use default platform encoding
         String charsetName = fileEntry.charSetEncoding;
-        if(!JOrphanUtils.isBlank(charsetName)) {
+        if (StringUtilities.isNotBlank(charsetName)) {
             isr = new InputStreamReader(fis, charsetName);
         } else if (fis.hasBOM()) {
             isr = new InputStreamReader(fis, fis.getBOM().getCharsetName());
@@ -461,7 +461,7 @@ public class FileServer {
         OutputStreamWriter osw;
         // If file encoding is specified, write using that encoding, otherwise use default platform encoding
         String charsetName = fileEntry.charSetEncoding;
-        if(!JOrphanUtils.isBlank(charsetName)) {
+        if (StringUtilities.isNotBlank(charsetName)) {
             osw = new OutputStreamWriter(fos, charsetName);
         } else {
             @SuppressWarnings("DefaultCharset")

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/ComboStringEditor.java
@@ -30,7 +30,6 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
 import javax.swing.text.JTextComponent;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.jmeter.gui.ClearGui;
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -109,7 +108,7 @@ class ComboStringEditor extends PropertyEditorSupport implements ItemListener, C
 
     ComboStringEditor(String []pTags, boolean noEdit, boolean noUndefined, ResourceBundle rb) {
 
-        tags = pTags == null ? ArrayUtils.EMPTY_STRING_ARRAY : pTags.clone();
+        tags = pTags == null ? new String[0] : pTags.clone();
 
         model = new DefaultComboBoxModel<>();
 

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/GenericTestBeanCustomizer.java
@@ -39,7 +39,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingConstants;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.jmeter.gui.ClearGui;
 import org.apache.jmeter.testbeans.TestBeanHelper;
 import org.apache.jmeter.util.JMeterUtils;
@@ -333,7 +332,7 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
         } else {
             final Class<?> defltClass = deflt.getClass(); // the DEFAULT class
             // Convert int to Integer etc:
-            final Class<?> propClass = ClassUtils.primitiveToWrapper(pd.getPropertyType());
+            final Class<?> propClass = primitiveToWrapper(pd.getPropertyType());
             if (!propClass.isAssignableFrom(defltClass) ){
                 if (log.isWarnEnabled()) {
                     log.warn("{} has a DEFAULT of class {}", getDetails(pd), defltClass.getCanonicalName());
@@ -358,6 +357,43 @@ public class GenericTestBeanCustomizer extends JPanel implements SharedCustomize
                 log.warn("{} does not appear to have been configured", getDetails(pd));
             }
         }
+    }
+
+    /**
+     * Convert primitive class to its wrapper class.
+     * @param cls the class to convert
+     * @return wrapper class for primitives, or the class itself if not primitive
+     */
+    private static Class<?> primitiveToWrapper(Class<?> cls) {
+        if (cls == null || !cls.isPrimitive()) {
+            return cls;
+        }
+        Class<?> res = null;
+        if (cls == boolean.class) {
+            res = Boolean.class;
+        }
+        if (cls == byte.class) {
+            res = Byte.class;
+        }
+        if (cls == char.class) {
+            res = Character.class;
+        }
+        if (cls == short.class) {
+            res = Short.class;
+        }
+        if (cls == int.class) {
+            res = Integer.class;
+        }
+        if (cls == long.class) {
+            res = Long.class;
+        }
+        if (cls == float.class) {
+            res = Float.class;
+        }
+        if (cls == double.class) {
+            res = Double.class;
+        }
+        return res;
     }
 
     /**

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TableEditor.java
@@ -43,13 +43,13 @@ import javax.swing.ListSelectionModel;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.ClearGui;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +226,7 @@ public class TableEditor extends PropertyEditorSupport implements FocusListener,
                 throw new RuntimeException("attribute OBJECT_PROPERTIES must be a String array");
             }
             List<String> props = Arrays.stream((String[]) value)
-                    .map(StringUtils::capitalize)
+                    .map(StringUtilities::capitalize)
                     .collect(Collectors.toList());
             Functor[] writers = createWriters(props);
             Functor[] readers = createReaders(clazz, props);

--- a/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/TestPlan.java
@@ -29,6 +29,7 @@ import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.threads.AbstractThreadGroup;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -236,7 +237,7 @@ public class TestPlan extends AbstractTestElement implements Serializable, TestS
      */
     @Override
     public void testStarted() {
-        if (getBasedir() != null && getBasedir().length() > 0) {
+        if (StringUtilities.isNotEmpty(getBasedir())) {
             try {
                 FileServer.getFileServer().setBasedir(FileServer.getFileServer().getBaseDir() + getBasedir());
             } catch (IllegalStateException e) {

--- a/src/core/src/main/java/org/apache/jmeter/testelement/property/AbstractProperty.java
+++ b/src/core/src/main/java/org/apache/jmeter/testelement/property/AbstractProperty.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +109,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public int getIntValue() {
         String val = getStringValue();
-        if (val == null || val.isEmpty()) {
+        if (StringUtilities.isEmpty(val)) {
             return 0;
         }
         try {
@@ -126,7 +127,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public long getLongValue() {
         String val = getStringValue();
-        if (val == null || val.isEmpty()) {
+        if (StringUtilities.isEmpty(val)) {
             return 0;
         }
         try {
@@ -144,7 +145,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public double getDoubleValue() {
         String val = getStringValue();
-        if (val == null || val.isEmpty()) {
+        if (StringUtilities.isEmpty(val)) {
             return 0;
         }
         try {
@@ -163,7 +164,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public float getFloatValue() {
         String val = getStringValue();
-        if (val == null || val.isEmpty()) {
+        if (StringUtilities.isEmpty(val)) {
             return 0;
         }
         try {
@@ -182,7 +183,7 @@ public abstract class AbstractProperty implements JMeterProperty {
     @Override
     public boolean getBooleanValue() {
         String val = getStringValue();
-        if (val == null || val.isEmpty()) {
+        if (StringUtilities.isEmpty(val)) {
             return false;
         }
         return Boolean.parseBoolean(val.trim());

--- a/src/core/src/main/java/org/apache/jmeter/util/BeanShellInterpreter.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/BeanShellInterpreter.java
@@ -20,8 +20,8 @@ package org.apache.jmeter.util;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JMeterException;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +72,7 @@ public class BeanShellInterpreter {
                 log.warn("Can't set logger variable", e);
             }
         }
-        if (StringUtils.isNotBlank(initFile)) {
+        if (StringUtilities.isNotBlank(initFile)) {
             String fileToUse=initFile;
             // Check file so we can distinguish file error from script error
             File in = new File(fileToUse);

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Properties;
 import java.util.ResourceBundle;
@@ -57,8 +58,6 @@ import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jmeter.gui.GuiPackage;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jorphan.gui.JFactory;
@@ -68,6 +67,7 @@ import org.apache.jorphan.reflect.ServiceLoadExceptionHandler;
 import org.apache.jorphan.test.UnitTestManager;
 import org.apache.jorphan.util.JMeterError;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.PatternCacheLRU;
 import org.apache.oro.text.regex.Pattern;
@@ -108,13 +108,13 @@ public class JMeterUtils implements UnitTestManager {
         private LazyJavaPatternCacheHolder() {
             super();
         }
-        public static final LoadingCache<Pair<String, Integer>, java.util.regex.Pattern> INSTANCE =
+        public static final LoadingCache<Map.Entry<String, Integer>, java.util.regex.Pattern> INSTANCE =
                 Caffeine
                         .newBuilder()
                         .maximumSize(getPropDefault("jmeter.regex.patterncache.size", 1000))
                         .build(key -> {
                             //noinspection MagicConstant
-                            return java.util.regex.Pattern.compile(key.getLeft(), key.getRight().intValue());
+                            return java.util.regex.Pattern.compile(key.getKey(), key.getValue().intValue());
                         });
     }
 
@@ -281,7 +281,7 @@ public class JMeterUtils implements UnitTestManager {
     }
 
     public static java.util.regex.Pattern compilePattern(String expression, int flags) {
-        return LazyJavaPatternCacheHolder.INSTANCE.get(Pair.of(expression, Integer.valueOf(flags)));
+        return LazyJavaPatternCacheHolder.INSTANCE.get(Map.entry(expression, Integer.valueOf(flags)));
     }
 
     public static PatternCacheLRU getPatternCache() {
@@ -821,7 +821,7 @@ public class JMeterUtils implements UnitTestManager {
     public static String[] getArrayPropDefault(String propName, String[] defaultVal) {
         try {
             String strVal = appProperties.getProperty(propName);
-            if (StringUtils.isNotBlank(strVal)) {
+            if (StringUtilities.isNotBlank(strVal)) {
                 return strVal.trim().split("\\s+");
             }
         } catch (Exception e) {

--- a/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JSR223TestElement.java
@@ -33,7 +33,6 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.TestStateListener;
@@ -41,6 +40,7 @@ import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +125,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
      */
     private String getScriptLanguageWithDefault() {
         String lang = getScriptLanguage();
-        if (StringUtils.isNotEmpty(lang)) {
+        if (StringUtilities.isNotEmpty(lang)) {
             return lang;
         }
         return DEFAULT_SCRIPT_LANGUAGE;
@@ -189,7 +189,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
         boolean supportsCompilable = scriptEngine instanceof Compilable
                 && !"bsh.engine.BshScriptEngine".equals(scriptEngine.getClass().getName()); // NOSONAR // $NON-NLS-1$
         try {
-            if (!StringUtils.isEmpty(filename)) {
+            if (StringUtilities.isNotEmpty(filename)) {
                 if (!scriptFile.isFile()) {
                     throw new ScriptException("Script file '" + scriptFile.getAbsolutePath()
                             + "' is not a file for JSR223 element named: " + getName());
@@ -216,7 +216,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
                 return compiledScript.eval(bindings);
             }
             String script = getScript();
-            if (!StringUtils.isEmpty(script)) {
+            if (StringUtilities.isNotEmpty(script)) {
                 if (supportsCompilable &&
                         !ScriptingBeanInfoSupport.FALSE_AS_STRING.equals(cacheKey)) {
                     computeScriptMD5(script);
@@ -282,7 +282,7 @@ public abstract class JSR223TestElement extends ScriptingTestElement
         if(!supportsCompilable) {
             return true;
         }
-        if (!StringUtils.isEmpty(getScript())) {
+        if (!(getScript() == null || getScript().isEmpty())) {
             try {
                 ((Compilable) scriptEngine).compile(getScript());
                 return true;

--- a/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/PropertiesBasedPrefixResolver.java
@@ -26,8 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.xml.utils.PrefixResolver;
 import org.apache.xml.utils.PrefixResolverDefault;
 import org.slf4j.Logger;
@@ -43,7 +43,7 @@ public class PropertiesBasedPrefixResolver extends PrefixResolverDefault {
     private static final Map<String, String> NAMESPACE_MAP = new HashMap<>();
     static {
         String pathToNamespaceConfig = JMeterUtils.getPropDefault(XPATH_NAMESPACE_CONFIG, "");
-        if(!StringUtils.isEmpty(pathToNamespaceConfig)) {
+        if (StringUtilities.isNotEmpty(pathToNamespaceConfig)) {
             Properties properties = new Properties();
             InputStream inputStream = null;
             try {

--- a/src/core/src/main/java/org/apache/jmeter/util/StringUtilities.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/StringUtilities.java
@@ -17,6 +17,11 @@
 
 package org.apache.jmeter.util;
 
+import org.apache.jorphan.util.JOrphanUtils;
+import org.apiguardian.api.API;
+
+@Deprecated
+@API(since = "6.0.0", status = API.Status.DEPRECATED)
 public final class StringUtilities {
 
     /**
@@ -36,17 +41,9 @@ public final class StringUtilities {
      * @param sub - replacement
      * @return the updated string
      */
+    @Deprecated
+    @API(since = "6.0.0", status = API.Status.DEPRECATED)
     public static String substitute(final String input, final String pattern, final String sub) {
-        StringBuilder ret = new StringBuilder(input.length());
-        int start = 0;
-        int index = -1;
-        final int length = pattern.length();
-        while ((index = input.indexOf(pattern, start)) >= start) {
-            ret.append(input.substring(start, index));
-            ret.append(sub);
-            start = index + length;
-        }
-        ret.append(input.substring(start));
-        return ret.toString();
+        return JOrphanUtils.substitute(input, pattern, sub);
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathQueryCacheLoader.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathQueryCacheLoader.java
@@ -19,7 +19,7 @@ package org.apache.jmeter.util;
 
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.jmeter.util.XPathUtil.XPathCacheKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,15 +35,15 @@ import com.github.benmanes.caffeine.cache.CacheLoader;
  * Return the compiled XPathQuery with the associated
  * namespaces.
  */
-public class XPathQueryCacheLoader implements CacheLoader<ImmutablePair<String, String>, XPathExecutable> {
+public class XPathQueryCacheLoader implements CacheLoader<XPathCacheKey, XPathExecutable> {
 
     private static final Logger log = LoggerFactory.getLogger(XPathQueryCacheLoader.class);
 
     @Override
-    public XPathExecutable load(ImmutablePair<String, String> key)
+    public XPathExecutable load(XPathCacheKey key)
             throws Exception {
-        String xPathQuery = key.left;
-        String namespacesString = key.right;
+        String xPathQuery = key.query();
+        String namespacesString = key.namespaces();
 
         Processor processor = XPathUtil.getProcessor();
         XPathCompiler xPathCompiler = processor.newXPathCompiler();

--- a/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/XPathUtil.java
@@ -46,9 +46,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.jmeter.assertions.AssertionResult;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.xml.utils.PrefixResolver;
 import org.apache.xpath.XPathAPI;
 import org.apache.xpath.objects.XObject;
@@ -81,9 +80,14 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
  */
 public class XPathUtil {
 
+    /**
+     * Simple record to hold a pair of values for cache keys.
+     */
+    public record XPathCacheKey(String query, String namespaces) {}
+
     private static final Logger log = LoggerFactory.getLogger(XPathUtil.class);
 
-    private static final LoadingCache<ImmutablePair<String, String>, XPathExecutable> XPATH_CACHE;
+    private static final LoadingCache<XPathCacheKey, XPathExecutable> XPATH_CACHE;
     static {
         final int cacheSize = JMeterUtils.getPropDefault(
                 "xpath2query.parser.cache.size", 400);
@@ -419,11 +423,11 @@ public class XPathUtil {
             throws SaxonApiException, FactoryConfigurationError {
 
         // generating the cache key
-        final ImmutablePair<String, String> key = ImmutablePair.of(xPathQuery, namespaces);
+        final XPathCacheKey key = new XPathCacheKey(xPathQuery, namespaces);
 
         //check the cache
         XPathExecutable xPathExecutable;
-        if(StringUtils.isNotEmpty(xPathQuery)) {
+        if (StringUtilities.isNotEmpty(xPathQuery)) {
             xPathExecutable = XPATH_CACHE.get(key);
         }
         else {
@@ -522,7 +526,7 @@ public class XPathUtil {
             throws XMLStreamException, FactoryConfigurationError{
         List<String[]> res= new ArrayList<>();
         XMLStreamReader reader;
-        if(StringUtils.isNotEmpty(xml)) {
+        if (StringUtilities.isNotEmpty(xml)) {
             reader = XMLInputFactory.newFactory().createXMLStreamReader(new StringReader(xml));
             while (reader.hasNext()) {
                 int event = reader.next();
@@ -674,10 +678,10 @@ public class XPathUtil {
    public static void computeAssertionResultUsingSaxon(AssertionResult result, String xmlFile, String xPathQuery,
            String namespaces, Boolean isNegated) throws SaxonApiException, FactoryConfigurationError {
        // generating the cache key
-       final ImmutablePair<String, String> key = ImmutablePair.of(xPathQuery, namespaces);
+       final XPathCacheKey key = new XPathCacheKey(xPathQuery, namespaces);
        // check the cache
        XPathExecutable xPathExecutable;
-       if (StringUtils.isNotEmpty(xPathQuery)) {
+       if (StringUtilities.isNotEmpty(xPathQuery)) {
            xPathExecutable = XPATH_CACHE.get(key);
        } else {
            log.warn("Error : {}", JMeterUtils.getResString("xpath2_extractor_empty_query"));

--- a/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/keystore/JmeterKeyStore.java
@@ -40,9 +40,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jmeter.threads.JMeterContextService;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +225,7 @@ public final class JmeterKeyStore {
     }
 
     private static String decodeSanList(Collection<? extends List<?>> subjectAlternativeNames) {
-        List<Pair<String, String>> decodedEntries = new ArrayList<>();
+        List<Map.Entry<String, String>> decodedEntries = new ArrayList<>();
         for (List<?> entry : subjectAlternativeNames) {
             Object indexData = entry.get(0);
             Object data = entry.get(1);
@@ -234,7 +233,7 @@ public final class JmeterKeyStore {
                 Integer generalNameIndex = (Integer) indexData;
                 String description = sanGeneralNameIndexToName(generalNameIndex);
                 String valueString = sanDataToString(data);
-                decodedEntries.add(Pair.of(description, valueString));
+                decodedEntries.add(Map.entry(description, valueString));
             }
         }
         return decodedEntries.stream()
@@ -304,9 +303,9 @@ public final class JmeterKeyStore {
      *                                  is not empty and no key for this alias could be found
      */
     public String getAlias() {
-        if (StringUtils.isNotEmpty(clientCertAliasVarName)) {
+        if (StringUtilities.isNotEmpty(clientCertAliasVarName)) {
             String aliasName = JMeterContextService.getContext().getVariables().get(clientCertAliasVarName);
-            if (StringUtils.isEmpty(aliasName)) {
+            if (StringUtilities.isEmpty(aliasName)) {
                 log.error("No var called '{}' found", clientCertAliasVarName);
                 throw new IllegalArgumentException("No var called '" + clientCertAliasVarName + "' found");
             }

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
@@ -153,7 +153,6 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
         assertTrue(a.equals(b), "Objects should be equal");
         assertTrue(b.equals(a), "Objects should be equal");
         assertTrue(a.strictDateFormatter().equals(b.strictDateFormatter()), "Objects should be equal");
-        assertTrue(a.threadSafeLenientFormatter().equals(b.threadSafeLenientFormatter()), "Objects should be equal");
     }
 
     @Test

--- a/src/core/src/test/java/org/apache/jmeter/util/JSR223TestElementTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/JSR223TestElementTest.java
@@ -19,10 +19,10 @@ package org.apache.jmeter.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.apache.commons.lang3.JavaVersion;
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 public class JSR223TestElementTest {
 
@@ -31,11 +31,8 @@ public class JSR223TestElementTest {
     };
 
     @Test
+    @DisabledForJreRange(min = JRE.JAVA_15, max = JRE.OTHER, disabledReason = "The default JavaScript engine has been removed in Java 15+")
     public void testGetScriptEngineJS() throws Exception {
-        Assumptions.assumeTrue(
-                JavaVersion.JAVA_RECENT.atMost(JavaVersion.JAVA_14),
-                "The default JavaScript engine has been removed in Java 15+, current Java is " + JavaVersion.JAVA_RECENT
-        );
         element.setScriptLanguage("JavaScript");
         assertThat(element.getScriptEngine().getFactory().getLanguageName(),
                 CoreMatchers.containsString("Script"));

--- a/src/core/src/test/java/org/apache/jmeter/util/StringUtilitiesTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/util/StringUtilitiesTest.java
@@ -20,6 +20,7 @@ package org.apache.jmeter.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.apache.jorphan.util.JOrphanUtils;
 import org.junit.jupiter.api.Test;
 
 public class StringUtilitiesTest {
@@ -36,7 +37,7 @@ public class StringUtilitiesTest {
         String input = "http://jakarta.apache.org/jmeter/index.html";
         String pattern = "jakarta.apache.org";
         String sub = "${server}";
-        assertEquals("http://${server}/jmeter/index.html", StringUtilities.substitute(input, pattern, sub));
+        assertEquals("http://${server}/jmeter/index.html", JOrphanUtils.substitute(input, pattern, sub));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class StringUtilitiesTest {
         String input = "arg1=param1;param1";
         String pattern = "param1";
         String sub = "${value}";
-        assertEquals("arg1=${value};${value}", StringUtilities.substitute(input, pattern, sub));
+        assertEquals("arg1=${value};${value}", JOrphanUtils.substitute(input, pattern, sub));
     }
 
     @Test
@@ -52,7 +53,7 @@ public class StringUtilitiesTest {
         String input = "jakarta.apache.org";
         String pattern = "jakarta.apache.org";
         String sub = "${server}";
-        assertEquals("${server}", StringUtilities.substitute(input, pattern, sub));
+        assertEquals("${server}", JOrphanUtils.substitute(input, pattern, sub));
     }
 
     @Test
@@ -60,7 +61,7 @@ public class StringUtilitiesTest {
         String input = "//a///b////c";
         String pattern = "//";
         String sub = "/";
-        assertEquals("/a//b//c", StringUtilities.substitute(input, pattern, sub));
+        assertEquals("/a//b//c", JOrphanUtils.substitute(input, pattern, sub));
     }
 
 }

--- a/src/dist-check/build.gradle.kts
+++ b/src/dist-check/build.gradle.kts
@@ -35,9 +35,6 @@ dependencies {
 
     testImplementation(testFixtures(projects.src.core))
     testImplementation(testFixtures(projects.src.components))
-    testImplementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
     testImplementation("commons-io:commons-io") {
         because("IOUtils")
     }

--- a/src/dist-check/src/test/java/org/apache/jmeter/functions/ComponentReferenceFunctionTest.java
+++ b/src/dist-check/src/test/java/org/apache/jmeter/functions/ComponentReferenceFunctionTest.java
@@ -32,10 +32,10 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.junit.JMeterTest;
 import org.apache.jmeter.junit.JMeterTestCase;
+import org.apache.jorphan.util.StringUtilities;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -110,7 +110,7 @@ public class ComponentReferenceFunctionTest extends JMeterTestCase {
                             components.item(j);
                     funcTitles.put(comp.getAttribute("name"), Boolean.FALSE);
                     String tag = comp.getAttribute("tag");
-                    if (!StringUtils.isEmpty(tag)){
+                    if (StringUtilities.isNotEmpty(tag)){
                         funcTitles.put(tag, Boolean.FALSE);
                     }
                 }

--- a/src/dist-check/src/test/java/org/apache/jmeter/junit/JMeterTest.java
+++ b/src/dist-check/src/test/java/org/apache/jmeter/junit/JMeterTest.java
@@ -56,7 +56,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.gui.ObsoleteGui;
 import org.apache.jmeter.control.IfControllerSchema;
 import org.apache.jmeter.control.LoopControllerSchema;
@@ -95,6 +94,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.backend.BackendListenerGui;
 import org.apache.jorphan.reflect.ClassFinder;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
@@ -203,7 +203,7 @@ public class JMeterTest extends JMeterTestCase {
                     org.w3c.dom.Element comp = (org.w3c.dom.Element)
                             components.item(j);
                     String tag = comp.getAttribute("tag");
-                    if (!StringUtils.isEmpty(tag)){
+                    if (StringUtilities.isNotEmpty(tag)){
                         guiTags.put(tag, Boolean.FALSE);
                     }
                 }
@@ -279,7 +279,7 @@ public class JMeterTest extends JMeterTestCase {
             }
             String name = guiItem.getClass().getName();
             if (// Is this a work in progress or an internal GUI component?
-                title != null && !title.isEmpty() // Will be "" for internal components
+                StringUtilities.isNotEmpty(title) // Will be "" for internal components
                 && !title.toUpperCase(Locale.ENGLISH).contains("(ALPHA")
                 && !title.toUpperCase(Locale.ENGLISH).contains("(BETA")
                 && !title.toUpperCase(Locale.ENGLISH).contains("(DEPRECATED")
@@ -337,7 +337,7 @@ public class JMeterTest extends JMeterTestCase {
         assertEquals(name, el.getPropertyAsString(TestElement.GUI_CLASS), "GUI-CLASS: Failed on " + name);
 
         assertEquals(guiItem.getName(), el.getName(), () -> "NAME: Failed on " + name);
-        if (StringUtils.isEmpty(el.getName())) {
+        if (StringUtilities.isEmpty(el.getName())) {
             fail("Name of the element must not be blank. Gui class " + name + ", element class " + el.getClass().getName());
         }
         assertEquals(el.getClass().getName(), el
@@ -467,7 +467,7 @@ public class JMeterTest extends JMeterTestCase {
         TestElement el = guiItem.createTestElement();
 
         assertFalse(
-                StringUtils.isEmpty(el.getName()),
+                StringUtilities.isEmpty(el.getName()),
                 () -> "Name should be non-blank for element " + componentHolder);
         PropertyIterator it = el.propertyIterator();
         while (it.hasNext()) {

--- a/src/functions/build.gradle.kts
+++ b/src/functions/build.gradle.kts
@@ -27,9 +27,6 @@ dependencies {
     implementation("commons-codec:commons-codec")
     implementation("org.apache.commons:commons-jexl")
     implementation("org.apache.commons:commons-jexl3")
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
     implementation("commons-io:commons-io") {
         because("FileUtils")
     }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/ChangeCase.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/ChangeCase.java
@@ -23,11 +23,11 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +71,7 @@ public class ChangeCase extends AbstractFunction {
         if (values.length > 1) {
             mode = values[1].execute();
         }
-        if(StringUtils.isEmpty(mode)){
+        if (StringUtilities.isEmpty(mode)){
             mode = ChangeCaseMode.UPPER.getName(); // default
         }
         String targetString = changeCase(originalString, mode);
@@ -87,10 +87,14 @@ public class ChangeCase extends AbstractFunction {
             return originalString;
         }
 
+        if (originalString == null) {
+            return null;
+        }
+
         return switch (changeCaseMode) {
-            case UPPER -> StringUtils.upperCase(originalString);
-            case LOWER -> StringUtils.lowerCase(originalString);
-            case CAPITALIZE -> StringUtils.capitalize(originalString);
+            case UPPER -> originalString.toUpperCase(Locale.ROOT);
+            case LOWER -> originalString.toLowerCase(Locale.ROOT);
+            case CAPITALIZE -> StringUtilities.capitalize(originalString);
         };
     }
 

--- a/src/functions/src/main/java/org/apache/jmeter/functions/DateTimeConvertFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/DateTimeConvertFunction.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +76,7 @@ public class DateTimeConvertFunction extends AbstractFunction {
                     .ofPattern(targetDateFormat)
                     .withZone(ZoneId.systemDefault());
             String newDate;
-            if (sourceDateFormat != null && !sourceDateFormat.isEmpty()) {
+            if (StringUtilities.isNotEmpty(sourceDateFormat)) {
                 DateTimeFormatter sourceDateFormatter = DateTimeFormatter
                         .ofPattern(sourceDateFormat)
                         .withZone(ZoneId.systemDefault());

--- a/src/functions/src/main/java/org/apache/jmeter/functions/DigestEncodeFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/DigestEncodeFunction.java
@@ -26,11 +26,11 @@ import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +81,7 @@ public class DigestEncodeFunction extends AbstractFunction {
         try {
             MessageDigest md = MessageDigest.getInstance(digestAlgorithm);
             md.update(stringToEncode.getBytes(StandardCharsets.UTF_8));
-            if (StringUtils.isNotEmpty(salt)) {
+            if (StringUtilities.isNotEmpty(salt)) {
                 md.update(salt.getBytes(StandardCharsets.UTF_8));
             }
             byte[] bytes = md.digest();

--- a/src/functions/src/main/java/org/apache/jmeter/functions/FileRowColContainer.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/FileRowColContainer.java
@@ -28,6 +28,7 @@ import java.util.StringTokenizer;
 
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public class FileRowColContainer {
              * N.B. Stop reading the file if we get a blank line: This allows
              * for trailing comments in the file
              */
-            while (line != null && line.length() > 0) {
+            while (StringUtilities.isNotEmpty(line)) {
                 fileData.add(splitLine(line, delimiter));
                 line = myBread.readLine();
             }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/Groovy.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/Groovy.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
@@ -38,6 +37,7 @@ import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.util.JSR223TestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +144,7 @@ public class Groovy extends AbstractFunction {
         scriptEngine = JSR223TestElement.getInstance().getEngineByName(GROOVY_ENGINE_NAME); //$NON-NLS-N$
 
         String fileName = JMeterUtils.getProperty(INIT_FILE);
-        if(!StringUtils.isEmpty(fileName)) {
+        if (StringUtilities.isNotEmpty(fileName)) {
             File file = new File(fileName);
             if(!(file.exists() && file.canRead())) {
                 // File maybe relative to JMeter home

--- a/src/functions/src/main/java/org/apache/jmeter/functions/LongSum.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/LongSum.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.google.auto.service.AutoService;
 
@@ -79,7 +80,7 @@ public class LongSum extends AbstractFunction {
         }
 
         String totalString = Long.toString(sum);
-        if (vars != null && varName != null && varName.length() > 0){// vars will be null on TestPlan
+        if (vars != null && StringUtilities.isNotEmpty(varName)){// vars will be null on TestPlan
             vars.put(varName, totalString);
         }
 

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomDate.java
@@ -31,11 +31,11 @@ import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.commons.lang3.LocaleUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,13 +137,13 @@ public class RandomDate extends AbstractFunction {
         DateTimeFormatter formatter;
         if(values.length>3) {
             String localeAsString = values[3].execute().trim();
-            if (!localeAsString.trim().isEmpty()) {
+            if (!localeAsString.isEmpty()) {
                 locale = LocaleUtils.toLocale(localeAsString);
             }
         }
 
         String format = values[0].execute().trim();
-        if (!StringUtils.isEmpty(format)) {
+        if (StringUtilities.isNotEmpty(format)) {
             try {
                 LocaleFormatObject lfo = new LocaleFormatObject(format, locale);
                 formatter = dateRandomFormatterCache.get(lfo, key -> createFormatter((LocaleFormatObject) key));

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomFromMultipleVars.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomFromMultipleVars.java
@@ -22,12 +22,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +78,7 @@ public class RandomFromMultipleVars extends AbstractFunction {
             List<String> results = new ArrayList<>();
             String[] variables = variablesNamesSplitBySeparatorValue.split(SEPARATOR);
             for (String currentVarName : variables) {
-                if(!StringUtils.isEmpty(currentVarName)) {
+                if (StringUtilities.isNotEmpty(currentVarName)) {
                     extractVariableValuesToList(currentVarName, vars, results);
                 }
             }
@@ -115,7 +115,7 @@ public class RandomFromMultipleVars extends AbstractFunction {
             JMeterVariables vars, List<? super String> results) {
         String matchNumberAsStr = vars.get(variableName+"_matchNr");
         int matchNumber = 0;
-        if(!StringUtils.isEmpty(matchNumberAsStr)) {
+        if (StringUtilities.isNotEmpty(matchNumberAsStr)) {
             matchNumber = Integer.parseInt(matchNumberAsStr);
         }
         if(matchNumber > 0) {
@@ -124,7 +124,7 @@ public class RandomFromMultipleVars extends AbstractFunction {
             }
         } else {
             String value = vars.get(variableName);
-            if(!StringUtils.isEmpty(value)) {
+            if (StringUtilities.isNotEmpty(value)) {
                 results.add(value);
             }
         }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RandomString.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RandomString.java
@@ -22,12 +22,12 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,8 +89,8 @@ public class RandomString extends AbstractFunction {
             myName = values[PARAM_NAME - 1].execute().trim();
         }
 
-        String myValue = null;
-        if(StringUtils.isEmpty(charsToUse)) {
+        String myValue;
+        if (StringUtilities.isEmpty(charsToUse)) {
             myValue = RandomStringUtils.random(length);
         } else {
             myValue = RandomStringUtils.random(length, charsToUse);

--- a/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/RegexFunction.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.regex.MatchResult;
 import org.apache.oro.text.regex.Pattern;
@@ -149,7 +150,7 @@ public class RegexFunction extends AbstractFunction {
             textToMatch = previousResult.getResponseDataAsString();
         }
 
-        if (textToMatch == null || textToMatch.isEmpty()) {
+        if (StringUtilities.isEmpty(textToMatch)) {
             return defaultValue;
         }
 

--- a/src/functions/src/main/java/org/apache/jmeter/functions/StringFromFile.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/StringFromFile.java
@@ -273,7 +273,7 @@ public class StringFromFile extends AbstractFunction implements TestStateListene
             }
         }
 
-        if (myName.length() > 0) {
+        if (!myName.isEmpty()) {
             JMeterVariables vars = getVariables();
             if (vars != null) {// Can be null if called from Config item testEnded() method
                 vars.put(myName, myValue);

--- a/src/functions/src/main/java/org/apache/jmeter/functions/StringToFile.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/StringToFile.java
@@ -33,11 +33,11 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +96,7 @@ public class StringToFile extends AbstractFunction {
         Charset charset = StandardCharsets.UTF_8;
         if (values.length == 4) {
             String charsetParamValue = ((CompoundVariable) values[3]).execute();
-            if (StringUtils.isNotEmpty(charsetParamValue)) {
+            if (StringUtilities.isNotEmpty(charsetParamValue)) {
                 charset = Charset.forName(charsetParamValue);
             }
         }

--- a/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/TimeShift.java
@@ -32,12 +32,12 @@ import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.lang3.LocaleUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.engine.util.CompoundVariable;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,7 +145,7 @@ public class TimeShift extends AbstractFunction {
         ZonedDateTime zonedDateTimeToShift = ZonedDateTime.now(systemDefaultZoneID);
 
         DateTimeFormatter formatter = null;
-        if (!StringUtils.isEmpty(format)) {
+        if (StringUtilities.isNotEmpty(format)) {
             try {
                 LocaleFormatObject lfo = new LocaleFormatObject(format, locale);
                 formatter = dateTimeFormatterCache.get(lfo, TimeShift::createFormatter);
@@ -172,7 +172,7 @@ public class TimeShift extends AbstractFunction {
         }
 
         // Check amount value to shift
-        if (!StringUtils.isEmpty(amountToShift)) {
+        if (StringUtilities.isNotEmpty(amountToShift)) {
             try {
                 Duration duration = Duration.parse(amountToShift);
                 zonedDateTimeToShift = zonedDateTimeToShift.plus(duration);
@@ -190,7 +190,7 @@ public class TimeShift extends AbstractFunction {
             dateString = String.valueOf(zonedDateTimeToShift.toInstant().toEpochMilli());
         }
 
-        if (!StringUtils.isEmpty(variableName)) {
+        if (StringUtilities.isNotEmpty(variableName)) {
             JMeterVariables vars = getVariables();
             if (vars != null) {// vars will be null on TestPlan
                 vars.put(variableName, dateString);
@@ -232,7 +232,7 @@ public class TimeShift extends AbstractFunction {
             variableName = ((CompoundVariable) values[3]).execute().trim();
         } else {
             String localeAsString = ((CompoundVariable) values[3]).execute().trim();
-            if (!localeAsString.trim().isEmpty()) {
+            if (!localeAsString.isEmpty()) {
                 locale = LocaleUtils.toLocale(localeAsString);
             }
             variableName = ((CompoundVariable) values[4]).execute().trim();

--- a/src/jorphan/build.gradle.kts
+++ b/src/jorphan/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
 
     implementation("commons-io:commons-io")
     implementation("org.apache.commons:commons-collections4")
-    implementation("org.apache.commons:commons-lang3")
     implementation("org.apache.commons:commons-math3")
     implementation("org.apache.commons:commons-text")
 

--- a/src/jorphan/src/main/java/org/apache/jorphan/exec/KeyToolUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/exec/KeyToolUtils.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,8 +92,9 @@ public class KeyToolUtils {
         } else {
             keytoolPath = KEYTOOL;
             if (!checkKeytool(keytoolPath)) { // Not found on PATH, check Java Home
-                File javaHome = SystemUtils.getJavaHome();
-                if (javaHome != null) {
+                String javaHomePath = System.getProperty("java.home");
+                if (javaHomePath != null) {
+                    File javaHome = new File(javaHomePath);
                     keytoolPath = new File(new File(javaHome, "bin"), KEYTOOL).getPath(); // $NON-NLS-1$
                     if (!checkKeytool(keytoolPath)) {
                         keytoolPath = null;
@@ -314,7 +313,7 @@ public class KeyToolUtils {
      * @return a string that is safe to use as subject name
      */
     private static String guardSubjectName(String subject) {
-        if (NumberUtils.isDigits(subject.substring(0,1))) {
+        if (!subject.isEmpty() && Character.isDigit(subject.charAt(0))) {
             return "ip" + subject;
         }
         return subject;
@@ -328,7 +327,7 @@ public class KeyToolUtils {
      * @return prefixed extension
      */
     private static String chooseExtension(String subject) {
-        if (NumberUtils.isDigits(subject.substring(0,1))) {
+        if (!subject.isEmpty() && Character.isDigit(subject.charAt(0))) {
             return "ip:" + subject;
         }
         return "dns:" + subject;

--- a/src/jorphan/src/main/java/org/apache/jorphan/exec/SystemCommand.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/exec/SystemCommand.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Utility class for invoking native system applications
@@ -77,7 +78,7 @@ public class SystemCommand {
     }
 
     private static InputStream checkIn(String stdin) throws FileNotFoundException {
-        String in = JOrphanUtils.nullifyIfEmptyTrimmed(stdin);
+        String in = StringUtilities.trimToNull(stdin);
         if (in == null) {
             return null;
         } else {
@@ -86,7 +87,7 @@ public class SystemCommand {
     }
 
     private static OutputStream checkOut(String path) throws IOException {
-        String in = JOrphanUtils.nullifyIfEmptyTrimmed(path);
+        String in = StringUtilities.trimToNull(path);
         if (in == null) {
             return null;
         } else {

--- a/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/gui/ObjectTableSorter.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 
-import org.apache.commons.lang3.ObjectUtils;
 
 /**
  * Implementation of a {@link RowSorter} for {@link ObjectTableModel}
@@ -148,7 +147,7 @@ public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
      */
     public ObjectTableSorter setValueComparator(int column, Comparator<?> comparator) {
         invalidate();
-        valueComparators[column] = ObjectUtils.defaultIfNull(comparator, getDefaultComparator(column));
+        valueComparators[column] = comparator != null ? comparator : getDefaultComparator(column);
         return this;
     }
 
@@ -185,7 +184,7 @@ public class ObjectTableSorter extends RowSorter<ObjectTableModel> {
      */
     public ObjectTableSorter setFallbackComparator(Comparator<Row> comparator) {
         invalidate();
-        fallbackComparator = ObjectUtils.defaultIfNull(comparator, Comparator.comparingInt(Row::getIndex));
+        fallbackComparator = Objects.requireNonNullElse(comparator, Comparator.comparingInt(Row::getIndex));
         return this;
     }
 

--- a/src/jorphan/src/main/java/org/apache/jorphan/reflect/ClassTools.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/reflect/ClassTools.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.jorphan.util.JMeterException;
 
 /**
@@ -40,7 +39,7 @@ public class ClassTools {
     public static Object construct(String className) throws JMeterException {
         Object instance = null;
         try {
-            instance = ClassUtils.getClass(className).getDeclaredConstructor().newInstance();
+            instance = Class.forName(className).getDeclaredConstructor().newInstance();
         } catch (IllegalArgumentException | ReflectiveOperationException | SecurityException e) {
             throw new JMeterException(e);
         }
@@ -58,7 +57,7 @@ public class ClassTools {
     {
         Object instance = null;
         try {
-            Class<?> clazz = ClassUtils.getClass(className);
+            Class<?> clazz = Class.forName(className);
             Constructor<?> constructor = clazz.getConstructor(Integer.TYPE);
             instance = constructor.newInstance(parameter);
         } catch (ClassNotFoundException | InvocationTargetException
@@ -112,7 +111,7 @@ public class ClassTools {
     {
         Method m;
         try {
-            m = ClassUtils.getPublicMethod(instance.getClass(), methodName, new Class [] {});
+            m = instance.getClass().getMethod(methodName);
             m.invoke(instance, (Object [])null);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new JMeterException(e);

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/BooleanUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/BooleanUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.util;
+
+import org.apiguardian.api.API;
+
+@API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+public class BooleanUtils {
+    private BooleanUtils() {
+    }
+
+    /**
+     * Converts a String to a Boolean object based on predefined values.
+     * "true", "on", "y", "t", "yes" or "1" (case-insensitive) will return {@code true}.
+     * "false", "off", "n", "f", "no" or "0" (case-insensitive) will return {@code false}.
+     * Otherwise, {@code null} is returned.
+     *
+     * @param s the String to convert, may be null
+     * @return {@link Boolean#TRUE}, {@link Boolean#FALSE}, or {@code null}
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+    public static Boolean toBooleanObject(String s) {
+        if (StringUtilities.isEmpty(s)) {
+            return null;
+        }
+
+        int len = s.length();
+        char firstChar = s.charAt(0);
+
+        @SuppressWarnings("NullTernary")
+        Boolean result = switch (firstChar) {
+            case 't', 'T' -> len == 1 || "true".equalsIgnoreCase(s) ? Boolean.TRUE : null;
+            case 'y', 'Y' -> len == 1 || "yes".equalsIgnoreCase(s) ? Boolean.TRUE : null;
+            case 'o', 'O' -> "on".equalsIgnoreCase(s) ? Boolean.TRUE : (
+                    "off".equalsIgnoreCase(s) ? Boolean.FALSE : null
+            );
+            case '1' -> len == 1 ? Boolean.TRUE : null;
+            case 'f', 'F' -> len == 1 || "false".equalsIgnoreCase(s) ? Boolean.FALSE : null;
+            case 'n', 'N' -> len == 1 || "no".equalsIgnoreCase(s) ? Boolean.FALSE : null;
+            case '0' -> len == 1 ? Boolean.FALSE : null;
+            default -> null;
+        };
+        return result;
+    }
+}

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/CharUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/CharUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.util;
+
+public class CharUtils {
+    private CharUtils() {
+    }
+
+    /**
+     * Checks if the given character is an ASCII printable character.
+     *
+     * @param c the character to check
+     * @return true if the character is an ASCII printable character, false otherwise
+     */
+    public static boolean isAscii(char c) {
+        return c >= 32 && c <= 126;
+    }
+}

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/ExceptionUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/ExceptionUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+
+import org.apiguardian.api.API;
+
+@API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+public class ExceptionUtils {
+    private ExceptionUtils() {
+    }
+
+    /**
+     * Converts the stack trace of a {@code Throwable} into a string representation.
+     *
+     * @param throwable the {@code Throwable} whose stack trace is to be converted to a string
+     * @return the string representation of the stack trace of the specified {@code Throwable}
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+    public static String getStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            throwable.printStackTrace(pw);
+        }
+        return sw.toString();
+    }
+
+    /**
+     * Converts the stack trace of a {@code Throwable} into a byte array representation using PrintStream.
+     *
+     * @param throwable the {@code Throwable} whose stack trace is to be converted to bytes
+     * @param charset the character set to be used for encoding the stack trace
+     * @return the byte array representation of the stack trace of the specified {@code Throwable}
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+    public static byte[] getStackTraceAsBytes(Throwable throwable, Charset charset) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (PrintStream ps = new PrintStream(baos, false, charset)) {
+            throwable.printStackTrace(ps);
+        }
+        return baos.toByteArray();
+    }
+
+    /**
+     * Helper method to get the root cause message from a throwable.
+     *
+     * @param t the throwable
+     * @return the root cause message
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+    public static String getRootCauseMessage(Throwable t) {
+        Throwable cause = t;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage();
+    }
+}

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/JOrphanUtils.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/JOrphanUtils.java
@@ -34,8 +34,8 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.RandomStringGenerator;
+import org.apiguardian.api.API;
 
 /**
  * This class contains frequently-used static utility methods.
@@ -517,16 +517,12 @@ public final class JOrphanUtils {
      *
      * @param input String
      * @return trimmed input or {@code null}
+     * @deprecated use {@link StringUtilities#trimToNull(String)}
      */
+    @Deprecated
+    @API(since = "6.0.0", status = API.Status.DEPRECATED)
     public static String nullifyIfEmptyTrimmed(final String input) {
-        if (input == null) {
-            return null;
-        }
-        String trimmed = input.trim();
-        if (trimmed.length() == 0) {
-            return null;
-        }
-        return trimmed;
+        return StringUtilities.trimToNull(input);
     }
 
     /**
@@ -534,9 +530,12 @@ public final class JOrphanUtils {
      *
      * @param value Value
      * @return {@code true} if the String is not empty (""), not {@code null} and not whitespace only.
+     * @deprecated use {@link StringUtilities#isBlank(CharSequence)}
      */
+    @Deprecated
+    @API(since = "6.0.0", status = API.Status.DEPRECATED)
     public static boolean isBlank(final String value) {
-        return StringUtils.isBlank(value);
+        return StringUtilities.isBlank(value);
     }
 
     /**
@@ -719,7 +718,7 @@ public final class JOrphanUtils {
      * @return number of matches that were replaced
      */
     public static int replaceValue(String regex, String replaceBy, boolean caseSensitive, String value, Consumer<? super String> setter) {
-        if (StringUtils.isBlank(value)) {
+        if (StringUtilities.isBlank(value)) {
             return 0;
         }
         Object[] result = replaceAllWithRegex(value, regex, replaceBy, caseSensitive);

--- a/src/jorphan/src/main/java/org/apache/jorphan/util/StringUtilities.java
+++ b/src/jorphan/src/main/java/org/apache/jorphan/util/StringUtilities.java
@@ -20,9 +20,13 @@ package org.apache.jorphan.util;
 import org.apiguardian.api.API;
 
 /**
- * Functions that are missing in other libraries.
+ * Utility class for performing various String-related operations.
+ * This class provides methods to manipulate and evaluate strings, including
+ * checking if strings are empty, blank, or contain specific characters,
+ * as well as methods for replacing, capitalizing, and trimming strings.
  *
- * @since 5.6
+ * This class is marked as {@code @API(status = API.Status.EXPERIMENTAL)}, indicating
+ * its API is still evolving and might change in future releases.
  */
 @API(status = API.Status.EXPERIMENTAL, since = "5.6")
 public class StringUtilities {
@@ -47,5 +51,177 @@ public class StringUtilities {
             idx++;
         }
         return count;
+    }
+
+    /**
+     * Checks if a CharSequence is empty (""), null, or contains only whitespace characters.
+     *
+     * @param cs the CharSequence to check, may be null
+     * @return true if the CharSequence is null, empty, or only contains whitespace; false otherwise
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static boolean isBlank(CharSequence cs) {
+        if (cs == null) {
+            return true;
+        }
+        if (cs instanceof String s) {
+            return s.isBlank(); // fast path
+        }
+        int strLen = cs.length();
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks if a CharSequence is not empty, not null, and does not contain only whitespace characters.
+     *
+     * @param cs the CharSequence to check, may be null
+     * @return true if the CharSequence is not null, not empty, and contains at least one non-whitespace character; false otherwise
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static boolean isNotBlank(CharSequence cs) {
+        return !isBlank(cs);
+    }
+
+    /**
+     * Checks if a CharSequence is null or empty ("").
+     *
+     * @param cs the CharSequence to check, may be null
+     * @return true if the CharSequence is null or empty; false otherwise
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static boolean isEmpty(CharSequence cs) {
+        return cs == null || cs.isEmpty();
+    }
+
+    /**
+     * Checks if a CharSequence is not null and not empty ("").
+     *
+     * @param cs the CharSequence to check, may be null
+     * @return true if the CharSequence is not null and not empty; false otherwise
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static boolean isNotEmpty(CharSequence cs) {
+        return !isEmpty(cs);
+    }
+
+    /**
+     * Replaces multiple characters in a string.
+     *
+     * @param str the string to modify, may be null
+     * @param searchChars the characters to search for, may be null
+     * @param replaceChars the characters to replace with, may be null
+     * @return the modified string, or null if input was null
+     */
+    public static String replaceChars(String str, String searchChars, String replaceChars) {
+        if (StringUtilities.isEmpty(str) || StringUtilities.isEmpty(searchChars)) {
+            return str;
+        }
+        StringBuilder sb = new StringBuilder(str.length());
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            int index = searchChars.indexOf(c);
+            if (index < 0) {
+                sb.append(c);
+            } else {
+                if (replaceChars != null && index < replaceChars.length()) {
+                    sb.append(replaceChars.charAt(index));
+                }
+                // If replaceChars is null or index is out of bounds, character is deleted
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Trims the string and returns null if the result is empty.
+     *
+     * @param str the String to be trimmed, may be null
+     * @return the trimmed String, or null if empty or null input
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static String trimToNull(String str) {
+        if (str == null) {
+            return null;
+        }
+        String trimmed = str.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    /**
+     * Capitalizes a string by converting the first character to title case.
+     * Properly handles Unicode surrogate pairs.
+     *
+     * @param str the string to capitalize, may be null
+     * @return the capitalized string, or null if input was null
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static String capitalize(String str) {
+        if (StringUtilities.isEmpty(str)) {
+            return str;
+        }
+        int firstCodepoint = str.codePointAt(0);
+        int titleCaseCodepoint = Character.toTitleCase(firstCodepoint);
+
+        if (firstCodepoint == titleCaseCodepoint) {
+            // No change needed
+            return str;
+        }
+
+        StringBuilder sb = new StringBuilder(str.length());
+        sb.appendCodePoint(titleCaseCodepoint);
+        sb.append(str, Character.charCount(firstCodepoint), str.length());
+        return sb.toString();
+    }
+
+    /**
+     * Strips any of the specified characters from the start and end of a string.
+     *
+     * @param str the string to strip, may be null
+     * @param stripChars the characters to remove, null treated as whitespace
+     * @return the stripped string, or null if input was null
+     */
+    @API(since = "6.0.0", status = API.Status.EXPERIMENTAL)
+    public static String strip(String str, String stripChars) {
+        if (StringUtilities.isEmpty(str)) {
+            return str;
+        }
+        int start = 0;
+        int end = str.length();
+
+        // Strip from start
+        while (start < end && stripChars.indexOf(str.charAt(start)) >= 0) {
+            start++;
+        }
+
+        // Strip from end
+        while (start < end && stripChars.indexOf(str.charAt(end - 1)) >= 0) {
+            end--;
+        }
+
+        return str.substring(start, end);
+    }
+
+    /**
+     * Checks if the string contains only digits (0-9).
+     *
+     * @param str the string to check
+     * @return true if all characters are digits, false otherwise
+     */
+    @API(status = API.Status.EXPERIMENTAL, since = "6.0.0")
+    public static boolean isNumeric(String str) {
+        if (isEmpty(str)) {
+            return false;
+        }
+        for (int i = 0; i < str.length(); i++) {
+            if (!Character.isDigit(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/jorphan/src/test/java/org/apache/jorphan/util/TestJorphanUtils.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/util/TestJorphanUtils.java
@@ -288,6 +288,7 @@ public class TestJorphanUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testNullifyIfEmptyTrimmed() {
         assertNull(JOrphanUtils.nullifyIfEmptyTrimmed(null));
         assertNull(JOrphanUtils.nullifyIfEmptyTrimmed("\u0001"));
@@ -295,6 +296,7 @@ public class TestJorphanUtils {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testIsBlank() {
         assertTrue(JOrphanUtils.isBlank(""));
         assertTrue(JOrphanUtils.isBlank(null));

--- a/src/jorphan/src/test/kotlin/org/apache/jorphan/util/BooleanUtilsTest.kt
+++ b/src/jorphan/src/test/kotlin/org/apache/jorphan/util/BooleanUtilsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jorphan.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class BooleanUtilsTest {
+    @ParameterizedTest
+    @CsvSource(
+        textBlock = """
+        abc,
+        ,
+        true,true
+        on,true
+        y,true
+        t,true
+        yes,true
+        1,true
+        abc,
+        false,false
+        off,false
+        n,false
+        f,false
+        no,false
+        0,false
+        TRUE,true
+        ON,true
+        Y,true
+        T,true
+        YES,true
+        1,true
+        ABC,
+        FALSE,false
+        OFF,false
+        N,false
+        F,false
+        NO,false
+        0,false"""
+    )
+    fun test(input: String?, expected: Boolean?) {
+        assertEquals(expected, BooleanUtils.toBooleanObject(input)) {
+            "BooleanUtils.toBooleanObject($input)"
+        }
+    }
+}

--- a/src/launcher/src/main/java/org/apache/jmeter/NewDriver.java
+++ b/src/launcher/src/main/java/org/apache/jmeter/NewDriver.java
@@ -79,7 +79,7 @@ public final class NewDriver {
             }
         } else {// e.g. started from IDE with full classpath
             tmpDir = System.getProperty("jmeter.home", System.getenv("JMETER_HOME"));// Allow override $NON-NLS-1$ $NON-NLS-2$
-            if (tmpDir == null || tmpDir.length() == 0) {
+            if (tmpDir == null || tmpDir.isEmpty()) {
                 File userDir = new File(System.getProperty("user.dir"));// $NON-NLS-1$
                 tmpDir = userDir.getAbsoluteFile().getParent();
             }

--- a/src/protocol/bolt/build.gradle.kts
+++ b/src/protocol/bolt/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     api(projects.src.core)
 
     implementation("org.neo4j.driver:neo4j-java-driver")
-    implementation("org.apache.commons:commons-lang3")
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
 

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/AbstractBoltTestElement.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/AbstractBoltTestElement.java
@@ -19,9 +19,8 @@ package org.apache.jmeter.protocol.bolt.sampler;
 
 import java.time.Duration;
 
-import org.apache.commons.lang3.EnumUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testelement.AbstractTestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.TransactionConfig;
@@ -51,8 +50,11 @@ public abstract class AbstractBoltTestElement extends AbstractTestElement {
     }
 
     public void setAccessMode(String accessMode) {
-        if (EnumUtils.isValidEnum(AccessMode.class, accessMode)) {
+        try {
+            AccessMode.valueOf(accessMode);
             this.accessMode = accessMode;
+        } catch (IllegalArgumentException ignored) {
+            // ignore
         }
     }
 
@@ -93,7 +95,7 @@ public abstract class AbstractBoltTestElement extends AbstractTestElement {
         SessionConfig.Builder sessionConfigBuilder = SessionConfig.builder()
                 .withDefaultAccessMode(Enum.valueOf(AccessMode.class, getAccessMode()));
 
-        if (StringUtils.isNotBlank(database)) {
+        if (StringUtilities.isNotBlank(database)) {
             sessionConfigBuilder.withDatabase(database);
         }
 

--- a/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
+++ b/src/protocol/bolt/src/main/java/org/apache/jmeter/protocol/bolt/sampler/BoltSampler.java
@@ -24,9 +24,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.util.ConfigMergabilityIndicator;
 import org.apache.jmeter.gui.TestElementMetadata;
@@ -36,6 +36,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
@@ -132,14 +133,14 @@ public class BoltSampler extends AbstractBoltTestElement implements Sampler, Tes
             res.setResponseCode("500");
         }
         res.setResponseData(
-                ObjectUtils.defaultIfNull(ex.getMessage(), "NO MESSAGE"),
+                Objects.requireNonNullElse(ex.getMessage(), "NO MESSAGE"),
                 res.getDataEncodingNoDefault());
         res.setSuccessful(false);
         return res;
     }
 
     private Map<String, Object> getParamsAsMap() throws IOException {
-        if (getParams() != null && getParams().length() > 0) {
+        if (StringUtilities.isNotEmpty(getParams())) {
             return Holder.OBJECT_READER.readValue(getParams());
         } else {
             return Collections.emptyMap();

--- a/src/protocol/ftp/build.gradle.kts
+++ b/src/protocol/ftp/build.gradle.kts
@@ -26,9 +26,6 @@ dependencies {
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
 
     testImplementation(testFixtures(projects.src.core))
 }

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/sampler/FTPSampler.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/sampler/FTPSampler.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPReply;
@@ -45,6 +44,7 @@ import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.Interruptible;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,7 +273,7 @@ public class FTPSampler extends AbstractSampler implements Interruptible {
             } else {
                 res.setResponseCode("501");
                 String replyString = ftp.getReplyString();
-                if(StringUtils.isEmpty(replyString)) {
+                if (StringUtilities.isEmpty(replyString)) {
                     res.setResponseMessage("Could not connect");
                 }
                 else {

--- a/src/protocol/http/build.gradle.kts
+++ b/src/protocol/http/build.gradle.kts
@@ -39,9 +39,6 @@ dependencies {
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
     implementation("org.apache.commons:commons-text") {
         because("StringEscapeUtils")
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/MultipartUrlConfig.java
@@ -20,7 +20,6 @@ package org.apache.jmeter.protocol.http.config;
 import java.io.Serializable;
 import java.util.regex.Matcher;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HeaderElement;
 import org.apache.http.NameValuePair;
 import org.apache.http.ParseException;
@@ -30,6 +29,7 @@ import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPFileArgs;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Compiler;
 import org.apache.oro.text.regex.Perl5Matcher;
@@ -113,7 +113,7 @@ public class MultipartUrlConfig implements Serializable {
         Arguments myArgs = getArguments();
         // The value is not encoded
         HTTPArgument arg = new HTTPArgument(name, value, false);
-        if(!StringUtils.isEmpty(contentType)) {
+        if (StringUtilities.isNotEmpty(contentType)) {
             int indexOfSemiColon = contentType.indexOf(';');
             if(indexOfSemiColon > 0) {
                 arg.setContentType(contentType.substring(0, indexOfSemiColon));
@@ -157,7 +157,7 @@ public class MultipartUrlConfig implements Serializable {
                         path = getParameterValue(element, "filename", null);
                     }
                 }
-                if (path != null && !path.isEmpty()) {
+                if (StringUtilities.isNotEmpty(path)) {
                     // Set the values retrieved for the file upload
                     files.addHTTPFileArg(path, name, contentType);
                 } else {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/GraphQLUrlConfigGui.java
@@ -25,7 +25,6 @@ import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.gui.util.JSyntaxTextArea;
@@ -39,6 +38,7 @@ import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Extending {@link UrlConfigGui}, GraphQL over HTTP Request configuration GUI, providing more convenient UI elements
@@ -95,9 +95,11 @@ public class GraphQLUrlConfigGui extends UrlConfigGui {
         final GraphQLRequestParams params = new GraphQLRequestParams(operationNameText.getText(),
                 queryContent.getText(), variablesContent.getText());
 
-        element.setProperty(OPERATION_NAME, defaultIfEmpty(params.getOperationName(), null));
+        String operationName = params.getOperationName();
+        element.setProperty(OPERATION_NAME, defaultIfEmpty(operationName, null));
         element.setProperty(QUERY, defaultIfEmpty(params.getQuery(), null));
-        element.setProperty(VARIABLES, defaultIfEmpty(params.getVariables(), null));
+        String variables = params.getVariables();
+        element.setProperty(VARIABLES, defaultIfEmpty(variables, null));
         element.setProperty(HTTPSamplerBase.POST_BODY_RAW, !HTTPConstants.GET.equals(method));
 
         final Arguments args;
@@ -105,16 +107,16 @@ public class GraphQLUrlConfigGui extends UrlConfigGui {
         if (HTTPConstants.GET.equals(method)) {
             args = createHTTPArgumentsTestElement();
 
-            if (StringUtils.isNotBlank(params.getOperationName())) {
-                args.addArgument(createHTTPArgument("operationName", params.getOperationName().trim(), true));
+            if (StringUtilities.isNotBlank(operationName)) {
+                args.addArgument(createHTTPArgument("operationName", operationName.trim(), true));
             }
 
             args.addArgument(createHTTPArgument("query",
                     GraphQLRequestParamUtils.queryToGetParamValue(params.getQuery()), true));
 
-            if (StringUtils.isNotBlank(params.getVariables())) {
+            if (StringUtilities.isNotBlank(variables)) {
                 final String variablesParamValue = GraphQLRequestParamUtils
-                        .variablesToGetParamValue(params.getVariables());
+                        .variablesToGetParamValue(variables);
                 if (variablesParamValue != null) {
                     args.addArgument(createHTTPArgument("variables", variablesParamValue, true));
                 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/HttpDefaultsGui.java
@@ -29,7 +29,6 @@ import javax.swing.JPasswordField;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
@@ -46,6 +45,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JEditableCheckBox;
 import org.apache.jorphan.gui.JFactory;
+import org.apache.jorphan.util.StringUtilities;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -144,7 +144,8 @@ public class HttpDefaultsGui extends AbstractConfigGui {
             config.removeProperty(httpSchema.getConcurrentDownloadPoolSize());
         }
 
-        if(!StringUtils.isEmpty(sourceIpAddr.getText())) {
+        String text = sourceIpAddr.getText();
+        if (StringUtilities.isNotEmpty(text)) {
             config.set(httpSchema.getIpSourceType(), sourceIpType.getSelectedIndex());
         } else {
             config.removeProperty(httpSchema.getIpSourceType());

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/config/gui/UrlConfigGui.java
@@ -30,7 +30,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.gui.BindingGroup;
@@ -51,6 +50,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Basic URL / HTTP Request configuration:
@@ -490,7 +490,8 @@ public class UrlConfigGui extends JPanel implements ChangeListener {
         private boolean canSwitchToRawBodyPane() {
             Arguments arguments = argsPanel.createTestElement();
             for (int i = 0; i < arguments.getArgumentCount(); i++) {
-                if(!StringUtils.isEmpty(arguments.getArgument(i).getName())) {
+                String name = arguments.getArgument(i).getName();
+                if (StringUtilities.isNotEmpty(name)) {
                     return false;
                 }
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
@@ -51,7 +51,7 @@ import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -390,7 +390,7 @@ public class AuthManager extends ConfigTestElement implements TestStateListener,
             String line;
             while ((line = reader.readLine()) != null) {
                 try {
-                    if (line.startsWith("#") || JOrphanUtils.isBlank(line)) { //$NON-NLS-1$
+                    if (line.startsWith("#") || StringUtilities.isBlank(line)) { //$NON-NLS-1$
                         continue;
                     }
                     String[] tokens = line.split("\t"); //$NON-NLS-1$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CookieManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CookieManager.java
@@ -42,6 +42,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.reflect.ClassTools;
 import org.apache.jorphan.util.JMeterException;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -222,7 +223,7 @@ public class CookieManager extends ConfigTestElement implements TestStateListene
             final CollectionProperty cookies = getCookies();
             while ((line = reader.readLine()) != null) {
                 try {
-                    if (line.startsWith("#") || JOrphanUtils.isBlank(line)) {//$NON-NLS-1$
+                    if (line.startsWith("#") || StringUtilities.isBlank(line)) {//$NON-NLS-1$
                         continue;
                     }
                     String[] st = JOrphanUtils.split(line, TAB, false);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HeaderManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HeaderManager.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * This class provides an interface to headers file to pass HTTP headers along
@@ -155,7 +156,7 @@ public class HeaderManager extends ConfigTestElement implements Serializable, Re
             String line;
             while ((line = reader.readLine()) != null) {
                 try {
-                    if (line.startsWith("#") || JOrphanUtils.isBlank(line)) {// $NON-NLS-1$
+                    if (line.startsWith("#") || StringUtilities.isBlank(line)) {// $NON-NLS-1$
                         continue;
                     }
                     String[] st = JOrphanUtils.split(line, "\t", " ");// $NON-NLS-1$ $NON-NLS-2$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorServer.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HttpMirrorServer.java
@@ -29,10 +29,10 @@ import org.apache.commons.cli.avalon.CLArgsParser;
 import org.apache.commons.cli.avalon.CLOption;
 import org.apache.commons.cli.avalon.CLOptionDescriptor;
 import org.apache.commons.cli.avalon.CLUtil;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.Stoppable;
 import org.apache.jmeter.testelement.NonTestElement;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.slf4j.Logger;
@@ -256,7 +256,7 @@ public class HttpMirrorServer extends Thread implements Stoppable, NonTestElemen
         }
 
         String value = logLevelOption.getArgument(1);
-        if (StringUtils.isEmpty(value)) {
+        if (StringUtilities.isEmpty(value)) {
             // Set root level
             getLogger().info("Setting root log level to '{}'", name);// $NON-NLS-1$
             Configurator.setRootLevel(logLevel);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/gui/HttpTestSampleGui.java
@@ -30,7 +30,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
 import org.apache.jmeter.gui.JBooleanPropertyEditor;
 import org.apache.jmeter.gui.JTextComponentBinding;
@@ -48,6 +47,7 @@ import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JEditableCheckBox;
 import org.apache.jorphan.gui.JFactory;
+import org.apache.jorphan.util.StringUtilities;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -170,13 +170,15 @@ public class HttpTestSampleGui extends AbstractSamplerGui {
         HTTPSamplerBaseSchema httpSchema = samplerBase.getSchema();
         enableConcurrentDwn();
         if (!isAJP) {
-            if (!StringUtils.isEmpty(sourceIpAddr.getText())) {
+            String text = sourceIpAddr.getText();
+            if (StringUtilities.isNotEmpty(text)) {
                 samplerBase.set(httpSchema.getIpSourceType(), sourceIpType.getSelectedIndex());
             } else {
                 samplerBase.removeProperty(httpSchema.getIpSourceType());
             }
             String selectedImplementation = String.valueOf(httpImplementation.getSelectedItem());
-            samplerBase.set(httpSchema.getImplementation(), StringUtils.defaultIfBlank(selectedImplementation, null));
+            samplerBase.set(httpSchema.getImplementation(),
+                    StringUtilities.isBlank(selectedImplementation) ? null : selectedImplementation);
         }
     }
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/ArgumentHolder.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/ArgumentHolder.java
@@ -17,12 +17,12 @@
 
 package org.apache.jmeter.protocol.http.curl;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.lang3.tuple.Pair;
 
 public interface ArgumentHolder {
 
@@ -38,7 +38,7 @@ public interface ArgumentHolder {
         return getMetadata().containsKey("type");
     }
 
-    static Pair<String, Map<String, String>> parse(String name) {
+    static Map.Entry<String, Map<String, String>> parse(String name) {
         if (name.contains(";")) {
             String[] parts = name.split(";");
             String realName = parts[0];
@@ -47,9 +47,9 @@ public interface ArgumentHolder {
                 String[] typeParts = parts[i].split("\\s*=\\s*", 2);
                 metadata.put(typeParts[0].toLowerCase(Locale.US), typeParts[1]);
             }
-            return Pair.of(realName, metadata);
+            return new AbstractMap.SimpleEntry<>(realName, metadata);
         } else {
-            return Pair.of(name, Collections.emptyMap());
+            return new AbstractMap.SimpleEntry<>(name, Collections.emptyMap());
         }
     }
 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,11 +45,10 @@ import org.apache.commons.cli.avalon.CLArgsParser;
 import org.apache.commons.cli.avalon.CLOption;
 import org.apache.commons.cli.avalon.CLOptionDescriptor;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jmeter.protocol.http.control.AuthManager.Mechanism;
 import org.apache.jmeter.protocol.http.control.Authorization;
 import org.apache.jmeter.protocol.http.control.Cookie;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +126,7 @@ public class BasicCurlParser {
     public static final class Request {
         private boolean compressed;
         private String url;
-        private final List<Pair<String, String>> headers = new ArrayList<>();
+        private final List<Map.Entry<String, String>> headers = new ArrayList<>();
         private String method = "GET";
         private String postData;
         private String interfaceName;
@@ -136,8 +136,8 @@ public class BasicCurlParser {
         private String filepathCookie="";
         private final Authorization authorization = new Authorization();
         private String caCert = "";
-        private final List<Pair<String, ArgumentHolder>> formData = new ArrayList<>();
-        private final List<Pair<String, String>> formStringData = new ArrayList<>();
+        private final List<Map.Entry<String, ArgumentHolder>> formData = new ArrayList<>();
+        private final List<Map.Entry<String, String>> formStringData = new ArrayList<>();
         private final Set<String> dnsServers = new HashSet<>();
         private boolean isKeepAlive = true;
         private double maxTime = -1;
@@ -173,7 +173,7 @@ public class BasicCurlParser {
          * @param value the post data
          */
         public void setPostData(String value) {
-            if (StringUtils.isBlank(this.postData)) {
+            if (StringUtilities.isBlank(this.postData)) {
                 this.postData = value;
             } else {
                 this.postData = this.postData + "&" + value;
@@ -212,9 +212,9 @@ public class BasicCurlParser {
                 return;
             } else {
                 if (UNIQUE_HEADERS.contains(name.toLowerCase(Locale.US))) {
-                    headers.removeIf(p -> p.getLeft().equalsIgnoreCase(name));
+                    headers.removeIf(p -> p.getKey().equalsIgnoreCase(name));
                 }
-                headers.add(Pair.of(name, value));
+                headers.add(new AbstractMap.SimpleEntry<>(name, value));
             }
         }
 
@@ -252,7 +252,7 @@ public class BasicCurlParser {
         /**
          * @return the headers
          */
-        public List<Pair<String, String>> getHeaders() {
+        public List<Map.Entry<String, String>> getHeaders() {
             return Collections.unmodifiableList(this.headers);
         }
 
@@ -412,7 +412,7 @@ public class BasicCurlParser {
         /**
          * @return the map of form data
          */
-        public List<Pair<String,String>> getFormStringData() {
+        public List<Map.Entry<String,String>> getFormStringData() {
             return Collections.unmodifiableList(this.formStringData);
         }
 
@@ -421,13 +421,13 @@ public class BasicCurlParser {
          * @param value the value of form data
          */
         public void addFormStringData(String key, String value) {
-            formStringData.add(Pair.of(key, value));
+            formStringData.add(new AbstractMap.SimpleEntry<>(key, value));
         }
 
         /**
          * @return the map of form data
          */
-        public List<Pair<String,ArgumentHolder>> getFormData() {
+        public List<Map.Entry<String,ArgumentHolder>> getFormData() {
             return Collections.unmodifiableList(this.formData);
         }
 
@@ -436,7 +436,7 @@ public class BasicCurlParser {
          * @param value the value of form data
          */
         public void addFormData(String key, ArgumentHolder value) {
-            formData.add(Pair.of(key, value));
+            formData.add(new AbstractMap.SimpleEntry<>(key, value));
         }
 
         /**
@@ -828,7 +828,7 @@ public class BasicCurlParser {
      * An empty or null toProcess parameter results in a zero sized array.
      */
     public static String[] translateCommandline(String toProcess) {
-        if (toProcess == null || toProcess.isEmpty()) {
+        if (StringUtilities.isEmpty(toProcess)) {
             //no command? no string
             return new String[0];
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/FileArgumentHolder.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/FileArgumentHolder.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang3.tuple.Pair;
 
 public class FileArgumentHolder implements ArgumentHolder {
     private final String name;
@@ -36,8 +35,8 @@ public class FileArgumentHolder implements ArgumentHolder {
         if (name == null) {
             return new FileArgumentHolder("", Collections.emptyMap());
         }
-        Pair<String, Map<String, String>> parsed = ArgumentHolder.parse(name);
-        return new FileArgumentHolder(parsed.getLeft(), parsed.getRight());
+        Map.Entry<String, Map<String, String>> parsed = ArgumentHolder.parse(name);
+        return new FileArgumentHolder(parsed.getKey(), parsed.getValue());
     }
 
     @Override

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/StringArgumentHolder.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/StringArgumentHolder.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 public class StringArgumentHolder implements ArgumentHolder {
 
     @Override
@@ -54,8 +52,8 @@ public class StringArgumentHolder implements ArgumentHolder {
     }
 
     public static StringArgumentHolder of(String name) {
-        Pair<String, Map<String, String>> argdata = ArgumentHolder.parse(name);
-        return new StringArgumentHolder(argdata.getLeft(), argdata.getRight());
+        Map.Entry<String, Map<String, String>> argdata = ArgumentHolder.parse(name);
+        return new StringArgumentHolder(argdata.getKey(), argdata.getValue());
     }
 
     @Override

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPArgumentsPanel.java
@@ -23,8 +23,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -35,6 +33,8 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.apache.jorphan.util.BooleanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * A GUI panel allowing the user to enter HTTP Parameters.
@@ -148,7 +148,7 @@ public class HTTPArgumentsPanel extends ArgumentsPanel {
 
     protected boolean isMetaDataNormal(HTTPArgument arg) {
         return arg.getMetaData() == null || arg.getMetaData().equals("=")
-                || (arg.getValue() != null && arg.getValue().length() > 0);
+                || StringUtilities.isNotEmpty(arg.getValue());
     }
 
     @Override
@@ -198,7 +198,7 @@ public class HTTPArgumentsPanel extends ArgumentsPanel {
         int[] rowsSelected = getTable().getSelectedRows();
         for (int selectedRow : rowsSelected) {
             String name = (String) tableModel.getValueAt(selectedRow, 0);
-            if (StringUtils.isNotBlank(name)) {
+            if (StringUtilities.isNotBlank(name)) {
                 name = name.trim();
                 name = name.replaceAll("\\$", "_");
                 name = name.replaceAll("\\{", "_");

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPFileArgsPanel.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/HTTPFileArgsPanel.java
@@ -40,7 +40,6 @@ import javax.swing.JTable;
 import javax.swing.JViewport;
 import javax.swing.ListSelectionModel;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.gui.RowDetailDialog;
 import org.apache.jmeter.gui.util.FileDialoger;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
@@ -51,6 +50,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.apache.jorphan.util.StringUtilities;
 
 /*
  * Note: this class is currently only suitable for use with HTTSamplerBase.
@@ -283,7 +283,7 @@ public class HTTPFileArgsPanel extends JPanel implements ActionListener {
             tableModel.removeRow(rowSelected);
         } else if (BROWSE.equals(command)) {
             String path = browseAndGetFilePath();
-            if(StringUtils.isNotBlank(path)) {
+            if (StringUtilities.isNotBlank(path)) {
                 tableModel.setValueAt(path, rowSelected, 0);
             }
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/RegExUserParameters.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/RegExUserParameters.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.threads.JMeterVariables;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +66,7 @@ public class RegExUserParameters extends AbstractTestElement implements Serializ
         }
 
         Map<String, String> paramMap = buildParamsMap();
-        if(paramMap == null || paramMap.isEmpty()){
+        if (paramMap == null || paramMap.isEmpty()){
             log.info(
                     "RegExUserParameters element: {} => Referenced RegExp was not found, no parameter will be changed",
                     getName());

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/modifier/URLRewritingModifier.java
@@ -30,6 +30,7 @@ import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.property.BooleanProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.regex.MatchResult;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Compiler;
@@ -95,7 +96,7 @@ public class URLRewritingModifier extends AbstractTestElement implements Seriali
 
         // Bug 15025 - save session value across samplers
         if (shouldCache()) {
-            if (value == null || value.isEmpty()) {
+            if (StringUtilities.isEmpty(value)) {
                 value = savedValue;
             } else {
                 savedValue = value;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/CssParserCacheLoader.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/CssParserCacheLoader.java
@@ -21,9 +21,8 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,18 +41,18 @@ import com.helger.css.reader.errorhandler.DoNothingCSSInterpretErrorHandler;
 import com.helger.css.reader.errorhandler.LoggingCSSParseErrorHandler;
 
 public class CssParserCacheLoader implements
-        CacheLoader<Triple<String, URL, Charset>, URLCollection> {
+        CacheLoader<CssParser.CssCacheKey, URLCollection> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CssParserCacheLoader.class);
     private static final boolean IGNORE_ALL_CSS_ERRORS = JMeterUtils
             .getPropDefault("css.parser.ignore_all_css_errors", true);
 
     @Override
-    public URLCollection load(Triple<String, URL, Charset> triple)
+    public URLCollection load(CssParser.CssCacheKey triple)
             throws Exception {
-        final String cssContent = triple.getLeft();
-        final URL baseUrl = triple.getMiddle();
-        final Charset charset = triple.getRight();
+        final String cssContent = triple.cssContents();
+        final URL baseUrl = triple.baseUrl();
+        final Charset charset = triple.charset();
         final CSSReaderSettings readerSettings = new CSSReaderSettings()
                 .setBrowserCompliantMode(true)
                 .setFallbackCharset(charset)
@@ -80,7 +79,7 @@ public class CssParserCacheLoader implements
             @Override
             public void onImport(CSSImportRule rule) {
                 final String location = rule.getLocationString();
-                if (!StringUtils.isEmpty(location)) {
+                if (StringUtilities.isNotEmpty(location)) {
                     urls.addURL(location, baseUrl);
                 }
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HTMLParser.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -203,7 +203,7 @@ public abstract class HTMLParser extends BaseParser {
      * @return version null if not IE or the version after MSIE
      */
     protected Float extractIEVersion(String userAgent) {
-        if (StringUtils.isEmpty(userAgent)) {
+        if (StringUtilities.isEmpty(userAgent)) {
             log.info("userAgent is null");
             return null;
         }
@@ -229,7 +229,7 @@ public abstract class HTMLParser extends BaseParser {
      * @return normalized url
      */
     protected static String normalizeUrlValue(CharSequence url) {
-        if (!StringUtils.isEmpty(url)) {
+        if (StringUtilities.isNotEmpty(url)) {
             String trimmed = NORMALIZE_URL_PATTERN.matcher(url.toString().trim()).replaceAll("");
             if (!trimmed.isEmpty()) {
                 return trimmed;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/HtmlParsingUtils.java
@@ -34,6 +34,7 @@ import org.apache.jmeter.protocol.http.sampler.HTTPSamplerFactory;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.PatternCacheLRU;
 import org.apache.oro.text.regex.MatchResult;
 import org.apache.oro.text.regex.Pattern;
@@ -82,7 +83,7 @@ public final class HtmlParsingUtils {
             query = URLDecoder.decode(newLink.getQueryString(), StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // UTF-8 unsupported? You must be joking!
-            log.error("UTF-8 encoding not supported!");
+            log.error("UTF-8 charset not supported!");
             throw new Error("Should not happen: " + e.toString(), e);
         }
 
@@ -101,7 +102,7 @@ public final class HtmlParsingUtils {
         }
 
         final String domain = config.getDomain();
-        if (domain != null && !domain.isEmpty()) {
+        if (StringUtilities.isNotEmpty(domain)) {
             if (!isEqualOrMatchesWithJavaRegex(newLink.getDomain(), domain)) {
                 return false;
             }
@@ -136,7 +137,7 @@ public final class HtmlParsingUtils {
         }
 
         final String domain = config.getDomain();
-        if (domain != null && !domain.isEmpty()) {
+        if (StringUtilities.isNotEmpty(domain)) {
             if (!isEqualOrMatches(newLink.getDomain(), domain, matcher, patternCache)){
                 return false;
             }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JTidyHTMLParser.java
@@ -23,8 +23,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -113,10 +113,10 @@ class JTidyHTMLParser extends HTMLParser {
             if (name.equalsIgnoreCase(TAG_APPLET)) {
                 String codebase = getValue(attrs, ATT_CODEBASE);
                 String code = getValue(attrs, ATT_ARCHIVE);
-                if (StringUtils.isBlank(code)) {
+                if (StringUtilities.isBlank(code)) {
                     code = getValue(attrs, ATT_CODE);
                 }
-                if (StringUtils.isBlank(codebase)) {
+                if (StringUtilities.isBlank(codebase)) {
                     urls.addURL(code, baseUrl);
                 } else {
                     urls.addURL(codebase + "/" + code, baseUrl);
@@ -126,12 +126,12 @@ class JTidyHTMLParser extends HTMLParser {
 
             if (name.equalsIgnoreCase(TAG_OBJECT)) {
                 String data = getValue(attrs, "codebase");
-                if(!StringUtils.isEmpty(data)) {
+                if (StringUtilities.isNotEmpty(data)) {
                     urls.addURL(data, baseUrl);
                 }
 
                 data = getValue(attrs, "data");
-                if(!StringUtils.isEmpty(data)) {
+                if (StringUtilities.isNotEmpty(data)) {
                     urls.addURL(data, baseUrl);
                 }
                 break;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/JsoupBasedHtmlParser.java
@@ -22,8 +22,8 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.Locale;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -84,7 +84,7 @@ public class JsoupBasedHtmlParser extends HTMLParser {
             } else if (tagName.equals(TAG_BASE)) {
                 String baseref = tag.attr(ATT_HREF);
                 try {
-                    if (!StringUtils.isEmpty(baseref))// Bugzilla 30713
+                    if (StringUtilities.isNotEmpty(baseref))// Bugzilla 30713
                     {
                         baseUrl.url = ConversionUtils.makeRelativeURL(baseUrl.url, baseref);
                     }
@@ -97,12 +97,12 @@ public class JsoupBasedHtmlParser extends HTMLParser {
                 CharSequence codebase = tag.attr(ATT_CODEBASE);
                 CharSequence archive = tag.attr(ATT_ARCHIVE);
                 CharSequence code = tag.attr(ATT_CODE);
-                if (StringUtils.isNotBlank(codebase)) {
+                if (StringUtilities.isNotBlank(codebase)) {
                     String result;
-                    if (StringUtils.isNotBlank(archive)) {
-                        result = codebase.toString() + "/" + archive;
+                    if (StringUtilities.isNotBlank(archive)) {
+                        result = codebase + "/" + archive;
                     } else {
-                        result = codebase.toString() + "/" + code;
+                        result = codebase + "/" + code;
                     }
                     urls.addURL(normalizeUrlValue(result), baseUrl.url);
                 } else {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/LagartoBasedHtmlParser.java
@@ -24,8 +24,8 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 
 import jodd.lagarto.EmptyTagVisitor;
@@ -118,7 +118,7 @@ public class LagartoBasedHtmlParser extends HTMLParser {
                 } else if (tag.nameEquals(TAG_BASE)) {
                     CharSequence baseref = tag.getAttributeValue(ATT_HREF);
                     try {
-                        if (!StringUtils.isEmpty(baseref))// Bugzilla 30713
+                        if (StringUtilities.isNotEmpty(baseref))// Bugzilla 30713
                         {
                             baseUrl.url = ConversionUtils.makeRelativeURL(baseUrl.url, baseref.toString());
                         }
@@ -131,12 +131,12 @@ public class LagartoBasedHtmlParser extends HTMLParser {
                     CharSequence codebase = tag.getAttributeValue(ATT_CODEBASE);
                     CharSequence archive = tag.getAttributeValue(ATT_ARCHIVE);
                     CharSequence code = tag.getAttributeValue(ATT_CODE);
-                    if (StringUtils.isNotBlank(codebase)) {
+                    if (StringUtilities.isNotBlank(codebase)) {
                         String result;
-                        if (StringUtils.isNotBlank(archive)) {
-                            result = codebase.toString() + "/" + archive;
+                        if (StringUtilities.isNotBlank(archive)) {
+                            result = codebase + "/" + archive;
                         } else {
-                            result = codebase.toString() + "/" + code;
+                            result = codebase + "/" + code;
                         }
                         urls.addURL(normalizeUrlValue(result), baseUrl.url);
                     } else {
@@ -176,7 +176,7 @@ public class LagartoBasedHtmlParser extends HTMLParser {
                 }
                 // Now look for URLs in the STYLE attribute
                 CharSequence styleTagStr = tag.getAttributeValue(ATT_STYLE);
-                if(!StringUtils.isEmpty(styleTagStr)) {
+                if (StringUtilities.isNotEmpty(styleTagStr)) {
                     HtmlParsingUtils.extractStyleURLs(baseUrl.url, urls, styleTagStr.toString());
                 }
                 break;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/URLCollection.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/parser/URLCollection.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jmeter.protocol.http.util.ConversionUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +77,7 @@ public class URLCollection implements Iterable<URL> {
      *         collection
      */
     public boolean addURL(String url, URL baseUrl) {
-        if (url == null || url.length() == 0) {
+        if (StringUtilities.isEmpty(url)) {
             return false;
         }
         url=StringEscapeUtils.unescapeXml(url);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -36,7 +36,6 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.http.config.GraphQLRequestParams;
 import org.apache.jmeter.protocol.http.config.MultipartUrlConfig;
@@ -51,6 +50,7 @@ import org.apache.jmeter.protocol.http.util.GraphQLRequestParamUtils;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
@@ -462,7 +462,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
                 formEncodings, urlWithoutQuery);
 
         // Set the content encoding
-        if(!StringUtils.isEmpty(contentEncoding)) {
+        if (StringUtilities.isNotEmpty(contentEncoding)) {
             sampler.setContentEncoding(contentEncoding);
         }
     }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/FormCharSetFinder.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/FormCharSetFinder.java
@@ -19,9 +19,9 @@ package org.apache.jmeter.protocol.http.proxy;
 
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.http.parser.HTMLParseException;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -61,7 +61,7 @@ public class FormCharSetFinder {
         Elements forms = document.select("form");
         for (Element element : forms) {
             String action = element.attr("action");
-            if (!StringUtils.isEmpty(action)) {
+            if (StringUtilities.isNotEmpty(action)) {
                 // We use the page encoding where the form resides, as the
                 // default encoding for the form
                 String formCharSet = pageEncoding;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/HttpRequestHdr.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.apache.commons.lang3.CharUtils;
 import org.apache.jmeter.protocol.http.config.MultipartUrlConfig;
 import org.apache.jmeter.protocol.http.control.Header;
 import org.apache.jmeter.protocol.http.control.HeaderManager;
@@ -40,6 +39,7 @@ import org.apache.jmeter.protocol.http.util.ConversionUtils;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.CharUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,7 +157,7 @@ public class HttpRequestHdr {
         while ((inHeaders || readLength < dataLength) && ((x = in.read()) != -1)) {
             line.write(x);
             clientRequest.write(x);
-            if (firstLine && !CharUtils.isAscii((char) x)){// includes \n
+            if (firstLine && x >= 128){// includes \n
                 throw new IllegalArgumentException("Only ASCII supported in headers (perhaps SSL was used?)");
             }
             if (inHeaders && (byte) x == (byte) '\n') { // $NON-NLS-1$

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/Proxy.java
@@ -19,15 +19,14 @@ package org.apache.jmeter.protocol.http.proxy;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.net.Socket;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -52,6 +51,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.ExceptionUtils;
 import org.apache.jorphan.util.JMeterException;
 import org.apache.jorphan.util.JOrphanUtils;
 import org.slf4j.Logger;
@@ -486,9 +486,8 @@ public class Proxy extends Thread {
     private static SampleResult generateErrorResult(SampleResult result, HttpRequestHdr request, Exception e, String msg) {
         if (result == null) {
             result = new SampleResult();
-            ByteArrayOutputStream text = new ByteArrayOutputStream(200);
-            e.printStackTrace(new PrintStream(text)); // NOSONAR we store the Stacktrace in the result
-            result.setResponseData(text.toByteArray());
+            result.setResponseData(ExceptionUtils.getStackTraceAsBytes(e, StandardCharsets.UTF_8));
+            result.setDataEncoding(StandardCharsets.UTF_8.name());
             result.setSamplerData(request.getFirstLine());
             result.setSampleLabel(request.getUrl());
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/ProxyControl.java
@@ -44,13 +44,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.prefs.Preferences;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.apache.jmeter.assertions.Assertion;
 import org.apache.jmeter.assertions.ResponseAssertion;
 import org.apache.jmeter.assertions.gui.AssertionGui;
@@ -101,6 +101,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jmeter.visualizers.Visualizer;
 import org.apache.jorphan.exec.KeyToolUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Compiler;
@@ -807,7 +808,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
     // Package protected to allow test case access
     boolean filterUrl(HTTPSamplerBase sampler) {
         String domain = sampler.getDomain();
-        if (domain == null || domain.isEmpty()) {
+        if (StringUtilities.isEmpty(domain)) {
             return false;
         }
 
@@ -839,14 +840,14 @@ public class ProxyControl extends GenericController implements NonTestElement {
         String excludeExp = getContentTypeExclude();
 
         // If no expressions are specified, we let the sample pass
-        if ((includeExp == null || includeExp.isEmpty()) &&
-                (excludeExp == null || excludeExp.isEmpty())) {
+        if (StringUtilities.isEmpty(includeExp) &&
+                StringUtilities.isEmpty(excludeExp)) {
             return true;
         }
 
         // Check that we have a content type
         String sampleContentType = result.getContentType();
-        if (sampleContentType == null || sampleContentType.isEmpty()) {
+        if (StringUtilities.isEmpty(sampleContentType)) {
             if (log.isDebugEnabled()) {
                 log.debug("No Content-type found for : {}", result.getUrlAsString());
             }
@@ -881,7 +882,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
      * @return boolean true if Matching expression
      */
     private static boolean testPattern(String expression, String sampleContentType, boolean expectedToMatch) {
-        if (expression == null || expression.isEmpty()) {
+        if (StringUtilities.isEmpty(expression)) {
             return true;
         }
         if(log.isDebugEnabled()) {
@@ -1351,7 +1352,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
             for (ConfigTestElement config : configurations) {
                 String configValue = config.getPropertyAsString(name);
 
-                if (configValue != null && !configValue.isEmpty()) {
+                if (StringUtilities.isNotEmpty(configValue)) {
                     if (configValue.equals(value)) {
                         sampler.setProperty(name, ""); // $NON-NLS-1$
                     }
@@ -1556,7 +1557,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
                 log.error("Could not find key with alias {}", CERT_ALIAS);
                 keyStore = null;
             } else {
-                caCert.checkValidity(new Date(System.currentTimeMillis() + DateUtils.MILLIS_PER_DAY));
+                caCert.checkValidity(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1)));
             }
         } catch (Exception e) {
             keyStore = null;
@@ -1580,7 +1581,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
                         keyStore = null; // no CA key - probably the wrong store type.
                         break; // cannot continue
                     } else {
-                        caCert.checkValidity(new Date(System.currentTimeMillis()+DateUtils.MILLIS_PER_DAY));
+                        caCert.checkValidity(new Date(System.currentTimeMillis()+TimeUnit.DAYS.toMillis(1)));
                         log.info("Valid alias found for {}", alias);
                     }
                 }
@@ -1671,7 +1672,7 @@ public class ProxyControl extends GenericController implements NonTestElement {
             try {
                 keyStore = getKeyStore(storePassword.toCharArray());
                 X509Certificate caCert = (X509Certificate) keyStore.getCertificate(JMETER_SERVER_ALIAS);
-                caCert.checkValidity(new Date(System.currentTimeMillis() + DateUtils.MILLIS_PER_DAY));
+                caCert.checkValidity(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1)));
             } catch (Exception e) { // store is faulty, we need to recreate it
                 keyStore = null; // if cert is not valid, flag up to recreate it
                 log.warn(

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/gui/ProxyControlGui.java
@@ -62,8 +62,6 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.control.gui.LogicControllerGui;
 import org.apache.jmeter.control.gui.TreeNodeWrapper;
@@ -92,6 +90,8 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.exec.KeyToolUtils;
 import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
+import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -346,8 +346,9 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
             model.setContentTypeInclude(contentTypeInclude.getText());
             model.setContentTypeExclude(contentTypeExclude.getText());
             httpSampleNameFormat.setEnabled(httpSampleNamingMode.getSelectedIndex() == 3);
-            if (StringUtils.isNotBlank(httpSampleNameFormat.getText())) {
-                model.setHttpSampleNameFormat(httpSampleNameFormat.getText());
+            String httpSampleNameFormat = this.httpSampleNameFormat.getText();
+            if (StringUtilities.isNotBlank(httpSampleNameFormat)) {
+                model.setHttpSampleNameFormat(httpSampleNameFormat);
             }
             TreeNodeWrapper nw = (TreeNodeWrapper) targetNodes.getSelectedItem();
             if (nw == null) {
@@ -699,14 +700,17 @@ public class ProxyControlGui extends LogicControllerGui implements JMeterGUIComp
     }
 
     void setSetCounters() {
-        if ((counterValue.getText().length() > 0) && NumberUtils.isParsable(counterValue.getText())) {
-            Proxy.setCounter(Integer.parseInt(counterValue.getText()));
-        } else {
-            JOptionPane.showMessageDialog(this,
-                    JMeterUtils.getResString("proxy_settings_counter_error_digits"), // $NON-NLS-1$
-                    JMeterUtils.getResString("proxy_settings_counter_error_invalid_data"), // $NON-NLS-1$
-                    JOptionPane.WARNING_MESSAGE);
+        String counterValue = this.counterValue.getText();
+        try {
+            Proxy.setCounter(Integer.parseInt(counterValue));
+            return;
+        } catch (NumberFormatException ignore) {
+            // ignore
         }
+        JOptionPane.showMessageDialog(this,
+                JMeterUtils.getResString("proxy_settings_counter_error_digits"), // $NON-NLS-1$
+                JMeterUtils.getResString("proxy_settings_counter_error_invalid_data"), // $NON-NLS-1$
+                JOptionPane.WARNING_MESSAGE);
     }
     /** {@inheritDoc} */
     @Override

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/AccessLogSampler.java
@@ -17,7 +17,6 @@
 
 package org.apache.jmeter.protocol.http.sampler;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.protocol.http.control.CookieManager;
 import org.apache.jmeter.protocol.http.util.accesslog.Filter;
@@ -29,6 +28,7 @@ import org.apache.jmeter.testelement.TestCloneable;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jorphan.util.JMeterException;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,11 +197,13 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     public void instantiateParser() {
         if (parser == null) {
             try {
-                if (StringUtils.isNotBlank(this.getParserClassName())) {
-                    if (StringUtils.isNotBlank(this.getLogFile())) {
-                        parser = Class.forName(getParserClassName())
+                String parserClassName = this.getParserClassName();
+                if (StringUtilities.isNotBlank(parserClassName)) {
+                    String logFile = this.getLogFile();
+                    if (StringUtilities.isNotBlank(logFile)) {
+                        parser = Class.forName(parserClassName)
                                 .asSubclass(LogParser.class).getDeclaredConstructor().newInstance();
-                        parser.setSourceFile(this.getLogFile());
+                        parser.setSourceFile(logFile);
                         parser.setFilter(filter);
                     } else {
                         log.error("No log file specified");
@@ -302,7 +304,7 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     }
 
     protected void initFilter() {
-        if (filter == null && StringUtils.isNotBlank(filterClassName)) {
+        if (filter == null && StringUtilities.isNotBlank(filterClassName)) {
             try {
                 filter = Class.forName(filterClassName)
                     .asSubclass(Filter.class).getDeclaredConstructor().newInstance();
@@ -318,7 +320,7 @@ public class AccessLogSampler extends HTTPSampler implements TestBean,ThreadList
     @Override
     public Object clone() {
         AccessLogSampler s = (AccessLogSampler) super.clone();
-        if (started && StringUtils.isNotBlank(filterClassName)) {
+        if (started && StringUtilities.isNotBlank(filterClassName)) {
 
             try {
                 if (TestCloneable.class.isAssignableFrom(Class.forName(filterClassName))) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPAbstractImpl.java
@@ -232,7 +232,7 @@ public abstract class HTTPAbstractImpl implements Interruptible, HTTPConstantsIn
      */
     protected InetAddress getIpSourceAddress() throws UnknownHostException, SocketException {
         final String ipSource = getIpSource();
-        if (ipSource.trim().length() > 0) {
+        if (!ipSource.isBlank()) {
             Class<? extends InetAddress> ipClass = null;
             final SourceType sourceType = HTTPSamplerBase.SourceType.values()[testElement.getIpSourceType()];
             switch (sourceType) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHCAbstractImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHCAbstractImpl.java
@@ -25,10 +25,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.JMeter;
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +104,7 @@ public abstract class HTTPHCAbstractImpl extends HTTPAbstractImpl {
             ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     static {
-        if(!StringUtils.isEmpty(JMeterUtils.getProperty("httpclient.timeout"))) { //$NON-NLS-1$
+        if (!JMeterUtils.getPropDefault("httpclient.timeout", "").isEmpty()) { //$NON-NLS-1$
             log.warn("You're using property 'httpclient.timeout' that will soon be deprecated for HttpClient3.1, you should either set "
                     + "timeout in HTTP Request GUI, HTTP Request Defaults or set http.socket.timeout in httpclient.parameters");
         }
@@ -166,7 +165,7 @@ public abstract class HTTPHCAbstractImpl extends HTTPAbstractImpl {
      * @return {@code true} iff both ProxyPort and ProxyHost are defined.
      */
     protected boolean isDynamicProxy(String proxyHost, int proxyPort){
-        return !JOrphanUtils.isBlank(proxyHost) && proxyPort > 0;
+        return StringUtilities.isNotBlank(proxyHost) && proxyPort > 0;
     }
 
     /**
@@ -184,6 +183,6 @@ public abstract class HTTPHCAbstractImpl extends HTTPAbstractImpl {
      * @return true if value is null or empty trimmed
      */
     protected static boolean isNullOrEmptyTrimmed(String value) {
-        return JOrphanUtils.isBlank(value);
+        return StringUtilities.isBlank(value);
     }
 }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPJavaImpl.java
@@ -204,7 +204,7 @@ public class HTTPJavaImpl extends HTTPAbstractImpl {
 
         if (res != null) {
             res.setRequestHeaders(getAllHeadersExceptCookie(conn, securityHeaders));
-            if(cookies != null && !cookies.isEmpty()) {
+            if (StringUtilities.isNotEmpty(cookies)) {
                 res.setCookies(cookies);
             } else {
                 // During recording Cookie Manager doesn't handle cookies

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSampleResult.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSampleResult.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * This is a specialisation of the SampleResult class for the HTTP protocol.
@@ -227,7 +228,7 @@ public class HTTPSampleResult extends SampleResult {
     @Override
     public String getDataEncodingWithDefault(String defaultEncoding) {
         String dataEncodingNoDefault = getDataEncodingNoDefault();
-        if(dataEncodingNoDefault != null && dataEncodingNoDefault.length()> 0) {
+        if (StringUtilities.isNotEmpty(dataEncodingNoDefault)) {
             return dataEncodingNoDefault;
         }
         return defaultEncoding;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -17,17 +17,16 @@
 
 package org.apache.jmeter.protocol.http.sampler;
 
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -46,7 +45,6 @@ import java.util.function.Predicate;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.ConfigTestElement;
@@ -87,7 +85,9 @@ import org.apache.jmeter.testelement.schema.PropertyDescriptor;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.ExceptionUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.MalformedCachePatternException;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.Perl5Matcher;
@@ -240,7 +240,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         ));
         String userDefinedMethods = JMeterUtils.getPropDefault(
                 "httpsampler.user_defined_methods", "");
-        if (StringUtils.isNotBlank(userDefinedMethods)) {
+        if (StringUtilities.isNotBlank(userDefinedMethods)) {
             defaultMethods.addAll(Arrays.asList(userDefinedMethods.split("\\s*,\\s*")));
         }
         METHODLIST = Collections.unmodifiableList(defaultMethods);
@@ -449,7 +449,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
 
     private static boolean hasNoMissingFile(HTTPFileArg[] files) {
         for (HTTPFileArg httpFileArg : files) {
-            if(StringUtils.isEmpty(httpFileArg.getPath())) {
+            String path = httpFileArg.getPath();
+            if (StringUtilities.isEmpty(path)) {
                 log.warn("File {} is invalid as no path is defined", httpFileArg);
                 return false;
             }
@@ -468,7 +469,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      */
     public String getProtocol() {
         String protocol = getString(getSchema().getProtocol());
-        if (protocol == null || protocol.isEmpty()) {
+        if (StringUtilities.isEmpty(protocol)) {
             return HTTPConstants.PROTOCOL_HTTP;
         }
         return protocol;
@@ -672,7 +673,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 contentEncoding);
 
         HTTPArgument arg;
-        final boolean nonEmptyEncoding = !StringUtils.isEmpty(contentEncoding);
+        final boolean nonEmptyEncoding = StringUtilities.isNotEmpty(contentEncoding);
         if (nonEmptyEncoding) {
             arg = new HTTPArgument(name, value, metaData, true, contentEncoding);
         } else {
@@ -786,7 +787,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      */
     public int getPortIfSpecified() {
         String portAsString = getString(getSchema().getPort());
-        if(portAsString == null || portAsString.isEmpty()) {
+        if (StringUtilities.isEmpty(portAsString)) {
             return UNSPECIFIED_PORT;
         }
 
@@ -1069,9 +1070,8 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     protected HTTPSampleResult errorResult(Throwable e, HTTPSampleResult res) {
         res.setSampleLabel(res.getSampleLabel());
         res.setDataType(SampleResult.TEXT);
-        ByteArrayOutputStream text = new ByteArrayOutputStream(200);
-        e.printStackTrace(new PrintStream(text)); // NOSONAR Stacktrace will be used in the response
-        res.setResponseData(text.toByteArray());
+        res.setResponseData(ExceptionUtils.getStackTraceAsBytes(e, StandardCharsets.UTF_8));
+        res.setDataEncoding(StandardCharsets.UTF_8.name());
         res.setResponseCode(NON_HTTP_RESPONSE_CODE+": " + e.getClass().getName());
         res.setResponseMessage(NON_HTTP_RESPONSE_MESSAGE+": " + e.getMessage());
         res.setSuccessful(false);
@@ -1162,7 +1162,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         }
         String lContentEncoding = contentEncoding;
         // Check if the sampler has a specified content encoding
-        if (JOrphanUtils.isBlank(lContentEncoding)) {
+        if (StringUtilities.isBlank(lContentEncoding)) {
             // We use the encoding which should be used according to the HTTP spec, which is UTF-8
             lContentEncoding = EncoderCache.URL_ARGUMENT_ENCODING;
         }
@@ -1255,7 +1255,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
                 log.debug("Name: {} Value: {} Metadata: {}", name, value, metaData);
                 // If we know the encoding, we can decode the argument value,
                 // to make it easier to read for the user
-                if (!StringUtils.isEmpty(contentEncoding)) {
+                if (StringUtilities.isNotEmpty(contentEncoding)) {
                     addEncodedArgument(name, value, metaData, contentEncoding);
                 } else {
                     // If we do not know the encoding, we just use the encoded value
@@ -1487,7 +1487,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     }
 
     private static Predicate<URL> generateMatcherPredicate(String regex, String explanation, boolean defaultAnswer) {
-        if (StringUtils.isEmpty(regex)) {
+        if (StringUtilities.isEmpty(regex)) {
             return s -> defaultAnswer;
         }
         if (USE_JAVA_REGEX) {
@@ -1525,7 +1525,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             throws LinkExtractorParseException {
         String parserClassName =
                 PARSERS_FOR_CONTENT_TYPE.get(res.getMediaType());
-        if (!StringUtils.isEmpty(parserClassName)) {
+        if (StringUtilities.isNotEmpty(parserClassName)) {
             return BaseParser.getParser(parserClassName);
         }
         return null;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerFactory.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerFactory.java
@@ -18,7 +18,7 @@
 package org.apache.jmeter.protocol.http.sampler;
 
 import org.apache.jmeter.util.JMeterUtils;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Factory to return the appropriate HTTPSampler for use with classes that need
@@ -67,7 +67,7 @@ public final class HTTPSamplerFactory {
      * @throws UnsupportedOperationException if alias is not recognised
      */
     public static HTTPSamplerBase newInstance(String alias) {
-        if (alias ==null || alias.length() == 0) {
+        if (StringUtilities.isEmpty(alias)) {
             return new HTTPSamplerProxy();
         }
         if (alias.equals(HTTP_SAMPLER_JAVA) || alias.equals(IMPL_JAVA)) {
@@ -87,7 +87,7 @@ public final class HTTPSamplerFactory {
         if (HTTPSamplerBase.PROTOCOL_FILE.equals(base.getProtocol())) {
             return new HTTPFileImpl(base);
         }
-        if (JOrphanUtils.isBlank(impl)){
+        if (StringUtilities.isBlank(impl)){
             impl = DEFAULT_CLASSNAME;
         }
         if (IMPL_JAVA.equals(impl) || HTTP_SAMPLER_JAVA.equals(impl)) {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PostWriter.java
@@ -35,6 +35,7 @@ import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
 import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Class for setting the necessary headers for a POST request, and sending the
@@ -242,7 +243,7 @@ public class PostWriter {
             // Check if the header manager had a content type header
             // This allows the user to specify their own content-type for a POST request
             String contentTypeHeader = connection.getRequestProperty(HTTPConstants.HEADER_CONTENT_TYPE);
-            boolean hasContentTypeHeader = contentTypeHeader != null && contentTypeHeader.length() > 0;
+            boolean hasContentTypeHeader = StringUtilities.isNotEmpty(contentTypeHeader);
 
             // If there are no arguments, we can send a file as the body of the request
             if(sampler.getArguments() != null && sampler.getArguments().getArgumentCount() == 0 && sampler.getSendFileAsPostBody()) {
@@ -251,7 +252,7 @@ public class PostWriter {
                 HTTPFileArg file = files[0];
                 if(!hasContentTypeHeader) {
                     // Allow the mimetype of the file to control the content type
-                    if(file.getMimeType() != null && file.getMimeType().length() > 0) {
+                    if (StringUtilities.isNotEmpty(file.getMimeType())) {
                         connection.setRequestProperty(HTTPConstants.HEADER_CONTENT_TYPE, file.getMimeType());
                     }
                     else {
@@ -287,7 +288,7 @@ public class PostWriter {
                     // TODO: needs a multiple file upload scenario
                     if(!hasContentTypeHeader) {
                         HTTPFileArg file = files.length > 0? files[0] : null;
-                        if(file != null && file.getMimeType() != null && file.getMimeType().length() > 0) {
+                        if(file != null && StringUtilities.isNotEmpty(file.getMimeType())) {
                             connection.setRequestProperty(HTTPConstants.HEADER_CONTENT_TYPE, file.getMimeType());
                         }
                         else {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PutWriter.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/PutWriter.java
@@ -26,6 +26,7 @@ import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
 import org.apache.jmeter.testelement.property.JMeterProperty;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * Class for setting the necessary headers for a PUT request, and sending the
@@ -50,7 +51,7 @@ public class PutWriter extends PostWriter {
         // Check if the header manager had a content type header
         // This allows the user to specify their own content-type for a PUT request
         String contentTypeHeader = connection.getRequestProperty(HTTPConstants.HEADER_CONTENT_TYPE);
-        boolean hasContentTypeHeader = contentTypeHeader != null && contentTypeHeader.length() > 0;
+        boolean hasContentTypeHeader = StringUtilities.isNotEmpty(contentTypeHeader);
 
         HTTPFileArg[] files = sampler.getHTTPFiles();
 

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
@@ -36,7 +36,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apiguardian.api.API;
 
 // @see TestHTTPUtils for unit tests
@@ -78,9 +78,9 @@ public class ConversionUtils {
                 charSet = contentType.substring(charSetStartPos + CHARSET_EQ_LEN);
                 if (charSet != null) {
                     // Remove quotes from charset name, see bug 55852
-                    charSet = StringUtils.replaceChars(charSet, "\'\"", null);
+                    charSet = StringUtilities.replaceChars(charSet, "'\"", null);
                     charSet = charSet.trim();
-                    if (charSet.length() > 0) {
+                    if (!charSet.isEmpty()) {
                         // See Bug 44784
                         int semi = charSet.indexOf(';');
                         if (semi == 0){

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPArgument.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPArgument.java
@@ -27,6 +27,7 @@ import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public class HTTPArgument extends Argument implements Serializable {
 
     public boolean isUseEquals() {
         boolean eq = get(getSchema().getUseEquals());
-        if (getMetaData().equals("=") || (getValue() != null && getValue().length() > 0)) {
+        if (getMetaData().equals("=") || StringUtilities.isNotEmpty(getValue())) {
             setUseEquals(true);
             return true;
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/HTTPFileArg.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.property.JMeterProperty;
 import org.apache.jmeter.testelement.schema.PropertiesAccessor;
 import org.apache.jmeter.testelement.schema.PropertyDescriptor;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.tika.Tika;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.exception.TikaException;
@@ -97,11 +97,11 @@ public class HTTPFileArg extends AbstractTestElement implements Serializable {
     }
 
     private static String detectMimeType(String path, String mimetype) {
-        if (StringUtils.isNotBlank(mimetype)) {
+        if (StringUtilities.isNotBlank(mimetype)) {
             return mimetype;
         }
         mimetype = Objects.toString(mimetype, "");
-        if (StringUtils.isBlank(path)) {
+        if (StringUtilities.isBlank(path)) {
             return mimetype;
         }
         File file = new File(path);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTP.java
@@ -36,7 +36,6 @@ import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.gui.util.HeaderAsPropertyRenderer;
 import org.apache.jmeter.gui.util.TextBoxDialoger.TextBoxDoubleClick;
@@ -53,6 +52,7 @@ import org.apache.jorphan.gui.GuiUtils;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.gui.RendererUtils;
 import org.apache.jorphan.reflect.Functor;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -208,14 +208,14 @@ public class RequestViewHTTP implements RequestView {
 
                 // Concatenate query post if exists
                 String queryPost = sampleResult.getQueryString();
-                if (!isMultipart && StringUtils.isNotBlank(queryPost)) {
+                if (!isMultipart && StringUtilities.isNotBlank(queryPost)) {
                     if (queryGet.length() > 0) {
                         queryGet += PARAM_CONCATENATE;
                     }
                     queryGet += queryPost;
                 }
 
-                if (StringUtils.isNotBlank(queryGet)) {
+                if (StringUtilities.isNotBlank(queryGet)) {
                     Set<Map.Entry<String, String[]>> keys = RequestViewHTTP.getQueryMap(queryGet).entrySet();
                     for (Map.Entry<String, String[]> entry : keys) {
                         for (String value : entry.getValue()) {
@@ -224,7 +224,7 @@ public class RequestViewHTTP implements RequestView {
                     }
                 }
 
-                if(isMultipart && StringUtils.isNotBlank(queryPost)) {
+                if (isMultipart && StringUtilities.isNotBlank(queryPost)) {
                     String contentType = lhm.get(HTTPConstants.HEADER_CONTENT_TYPE);
                     String boundaryString = extractBoundary(contentType);
                     MultipartUrlConfig urlconfig = new MultipartUrlConfig(boundaryString);
@@ -239,7 +239,7 @@ public class RequestViewHTTP implements RequestView {
 
             // Display cookie in headers table (same location on http protocol)
             String cookie = sampleResult.getCookies();
-            if (cookie != null && cookie.length() > 0) {
+            if (StringUtilities.isNotEmpty(cookie)) {
                 headersModel.addRow(new RowResult(
                         JMeterUtils.getParsedLabel("view_results_table_request_http_cookie"), //$NON-NLS-1$
                         sampleResult.getCookies()));
@@ -336,7 +336,7 @@ public class RequestViewHTTP implements RequestView {
      *            query will be returned.
      */
     public static String decodeQuery(String query) {
-        if (query != null && query.length() > 0) {
+        if (StringUtilities.isNotEmpty(query)) {
             try {
                 return URLDecoder.decode(query, CHARSET_DECODE); // better  ISO-8859-1 than UTF-8
             } catch (IllegalArgumentException | UnsupportedEncodingException e) {

--- a/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/HttpClientState.kt
+++ b/src/protocol/http/src/main/kotlin/org/apache/jmeter/protocol/http/HttpClientState.kt
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http
+
+import org.apache.http.auth.AuthState
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+
+public class HttpClientState(
+    public val client: CloseableHttpClient,
+    public val connectionManager: PoolingHttpClientConnectionManager,
+) {
+    public var authState: AuthState? = null
+}

--- a/src/protocol/http/src/test/java/org/apache/jmeter/curl/BasicCurlParserTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/curl/BasicCurlParserTest.java
@@ -26,11 +26,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jmeter.protocol.http.control.Cookie;
 import org.apache.jmeter.protocol.http.curl.ArgumentHolder;
 import org.apache.jmeter.protocol.http.curl.BasicCurlParser;
@@ -94,10 +95,10 @@ public class BasicCurlParserTest {
         assertEquals(5, request.getHeaders().size());
         assertTrue(request.isCompressed());
         assertEquals("GET", request.getMethod());
-        String resParser = "Request [compressed=true, url=http://jmeter.apache.org/, method=GET, headers=[(User-Agent,Mozilla/5.0 "
-                +"(Macintosh; Intel Mac OS X 10.11; rv:63.0) Gecko/20100101 Firefox/63.0), (Accept,text/html,application/xhtml+xml,"
-                + "application/xml;q=0.9,*/*;q=0.8), (Accept-Language,en-US,en;q=0.5), (DNT,1), "
-                + "(Upgrade-Insecure-Requests,1)]]";
+        String resParser = "Request [compressed=true, url=http://jmeter.apache.org/, method=GET, headers=["
+                + "User-Agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:63.0) Gecko/20100101 Firefox/63.0"
+                + ", Accept=text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+                + ", Accept-Language=en-US,en;q=0.5, DNT=1, Upgrade-Insecure-Requests=1]]";
         assertEquals(resParser, request.toString(),
                 "The method 'toString' should get all parameters correctly");
     }
@@ -245,7 +246,7 @@ public class BasicCurlParserTest {
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
         assertEquals(5, request.getHeaders().size(),
                 "With method 'parser', the quantity of Headers should be 5'");
-        assertTrue(request.getHeaders().contains(Pair.of("User-Agent", "Mozilla/5.0")),
+        assertTrue(request.getHeaders().contains(new AbstractMap.SimpleEntry<>("User-Agent", "Mozilla/5.0")),
                 "With method 'parser', Headers need to add 'user-agent' with value 'Mozilla/5.0' ");
     }
 
@@ -463,8 +464,8 @@ public class BasicCurlParserTest {
                 + "-H 'cache-control: no-cache' -F 'test=name' -F 'test1=name1' ";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,ArgumentHolder>> res = request.getFormData();
-        assertTrue(res.contains(Pair.of("test1", StringArgumentHolder.of("name1"))),
+        List<Map.Entry<String,ArgumentHolder>> res = request.getFormData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("test1", StringArgumentHolder.of("name1"))),
                 "With method 'parser', we should post form data");
     }
 
@@ -473,8 +474,8 @@ public class BasicCurlParserTest {
         String cmdLine = "curl 'https://example.invalid' -F 'test=\"\"' ";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,ArgumentHolder>> res = request.getFormData();
-        assertTrue(res.contains(Pair.of("test", StringArgumentHolder.of(""))),
+        List<Map.Entry<String,ArgumentHolder>> res = request.getFormData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("test", StringArgumentHolder.of(""))),
                 "With method 'parser', we should post form data: " + request.getFormData());
     }
 
@@ -483,8 +484,8 @@ public class BasicCurlParserTest {
         String cmdLine = "curl 'https://example.invalid' -H 'X-Something;' ";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String, String>> res = request.getHeaders();
-        assertTrue(res.contains(Pair.of("X-Something", "")),
+        List<Map.Entry<String, String>> res = request.getHeaders();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("X-Something", "")),
                 "With method 'parser', we should post form data: " + request.getFormData());
     }
 
@@ -494,8 +495,8 @@ public class BasicCurlParserTest {
                 + "--form 'test=\"something quoted\"'";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,ArgumentHolder>> res = request.getFormData();
-        assertTrue(res.contains(Pair.of("test", StringArgumentHolder.of("something quoted"))),
+        List<Map.Entry<String,ArgumentHolder>> res = request.getFormData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("test", StringArgumentHolder.of("something quoted"))),
                 "With method 'form', we should post form data");
     }
 
@@ -505,8 +506,8 @@ public class BasicCurlParserTest {
                 + "--form 'test=\"something \\\"quoted\\\"\"'";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,ArgumentHolder>> res = request.getFormData();
-        assertTrue(res.contains(Pair.of("test", StringArgumentHolder.of("something \"quoted\""))),
+        List<Map.Entry<String,ArgumentHolder>> res = request.getFormData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("test", StringArgumentHolder.of("something \"quoted\""))),
                 "With method 'form', we should post form data");
     }
 
@@ -517,8 +518,8 @@ public class BasicCurlParserTest {
                 + "--form 'image=@\"/some/file.jpg\"'";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,ArgumentHolder>> res = request.getFormData();
-        assertTrue(res.contains(Pair.of("image", FileArgumentHolder.of("/some/file.jpg"))),
+        List<Map.Entry<String,ArgumentHolder>> res = request.getFormData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("image", FileArgumentHolder.of("/some/file.jpg"))),
                 "With method 'form', we should post form data: " + request.getFormData());
     }
 
@@ -529,8 +530,8 @@ public class BasicCurlParserTest {
                 + "--form 'image=\"@/some/file.jpg\"'";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,ArgumentHolder>> res = request.getFormData();
-        assertTrue(res.contains(Pair.of("image", StringArgumentHolder.of("@/some/file.jpg"))),
+        List<Map.Entry<String,ArgumentHolder>> res = request.getFormData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("image", StringArgumentHolder.of("@/some/file.jpg"))),
                 "With method 'form', we should post form data");
     }
 
@@ -540,8 +541,8 @@ public class BasicCurlParserTest {
                 + "-H 'cache-control: no-cache' --form-string 'image=@C:\\Test\\test.jpg' ";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        List<Pair<String,String>> res = request.getFormStringData();
-        assertTrue(res.contains(Pair.of("image", "@C:\\Test\\test.jpg")),
+        List<Map.Entry<String,String>> res = request.getFormStringData();
+        assertTrue(res.contains(new AbstractMap.SimpleEntry<>("image", "@C:\\Test\\test.jpg")),
                 "With method 'parser', we should post form data: " + request.getFormStringData());
     }
 
@@ -634,7 +635,7 @@ public class BasicCurlParserTest {
         String cmdLine = "curl 'http://jmeter.apache.org/' --referer 'www.baidu.com'";
         BasicCurlParser basicCurlParser = new BasicCurlParser();
         BasicCurlParser.Request request = basicCurlParser.parse(cmdLine);
-        assertTrue(request.getHeaders().contains(Pair.of("Referer", "www.baidu.com")));
+        assertTrue(request.getHeaders().contains(new AbstractMap.SimpleEntry<>("Referer", "www.baidu.com")));
     }
 
     @Test

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/NotReusableParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/NotReusableParser.java
@@ -20,8 +20,6 @@ package org.apache.jmeter.protocol.http.parser;
 import java.net.URL;
 import java.util.Iterator;
 
-import org.apache.commons.lang3.NotImplementedException;
-
 /**
  * Test class, that implements an dummy {@link LinkExtractorParser} that is not
  * reusable
@@ -32,7 +30,7 @@ public class NotReusableParser implements LinkExtractorParser {
     public Iterator<URL> getEmbeddedResourceURLs(String userAgent,
             byte[] responseData, URL baseUrl, String encoding)
             throws LinkExtractorParseException {
-        throw new NotImplementedException("Test class");
+        throw new UnsupportedOperationException("Test class");
     }
 
     @Override

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/ReusableParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/ReusableParser.java
@@ -20,8 +20,6 @@ package org.apache.jmeter.protocol.http.parser;
 import java.net.URL;
 import java.util.Iterator;
 
-import org.apache.commons.lang3.NotImplementedException;
-
 /**
  * Test class, that implements an dummy {@link LinkExtractorParser} that is
  * reusable
@@ -32,7 +30,7 @@ public class ReusableParser implements LinkExtractorParser {
     public Iterator<URL> getEmbeddedResourceURLs(String userAgent,
             byte[] responseData, URL baseUrl, String encoding)
             throws LinkExtractorParseException {
-        throw new NotImplementedException("Test class");
+        throw new UnsupportedOperationException("Test class");
     }
 
     @Override

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -43,6 +43,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -394,7 +395,7 @@ public class TestHTMLParser extends JMeterTestCase {
 
     // Get expected results as a List
     private static List<String> getFile(String file) throws Exception {
-        if (file == null || file.isEmpty()) {
+        if (StringUtilities.isEmpty(file)) {
             return Collections.emptyList();
         }
         try (InputStream is = getInputStream(file);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/proxy/TestHttpRequestHdr.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/proxy/TestHttpRequestHdr.java
@@ -37,6 +37,7 @@ import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
 import org.apache.jmeter.protocol.http.util.HTTPArgument;
 import org.apache.jmeter.protocol.http.util.HTTPConstants;
 import org.apache.jmeter.protocol.http.util.HTTPFileArg;
+import org.apache.jorphan.util.StringUtilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -686,7 +687,7 @@ public class TestHttpRequestHdr extends JMeterTestCase {
             boolean expectedEncoded) throws IOException {
         assertEquals(expectedName, arg.getName());
         assertEquals(expectedValue, arg.getValue());
-        if(contentEncoding != null && contentEncoding.length() > 0) {
+        if (StringUtilities.isNotEmpty(contentEncoding)) {
             assertEquals(expectedEncodedValue, arg.getEncodedValue(contentEncoding));
         }
         else {
@@ -697,7 +698,7 @@ public class TestHttpRequestHdr extends JMeterTestCase {
     }
 
     private int getBodyLength(String postBody, String contentEncoding) throws IOException {
-        if(contentEncoding != null && !contentEncoding.isEmpty()) {
+        if (StringUtilities.isNotEmpty(contentEncoding)) {
             return postBody.getBytes(contentEncoding).length;
         }
         else {

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -46,6 +46,7 @@ import org.apache.jmeter.testelement.TestPlan;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.apache.oro.text.regex.MatchResult;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.PatternMatcherInput;
@@ -821,7 +822,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             String descriptionField,
             String descriptionValue,
             boolean valuesAlreadyUrlEncoded) throws IOException {
-        if (contentEncoding == null || contentEncoding.isEmpty()) {
+        if (StringUtilities.isEmpty(contentEncoding)) {
             contentEncoding = samplerDefaultEncoding;
         }
         // Check URL
@@ -852,7 +853,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             String titleValue,
             String descriptionField,
             String descriptionValue) throws IOException {
-        if (contentEncoding == null || contentEncoding.isEmpty()) {
+        if (StringUtilities.isEmpty(contentEncoding)) {
             contentEncoding = DEFAULT_HTTP_CONTENT_ENCODING;
         }
         // Check URL
@@ -900,7 +901,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             File fileValue,
             String fileMimeType,
             byte[] fileContent) throws IOException {
-        if (contentEncoding == null || contentEncoding.isEmpty()) {
+        if (StringUtilities.isEmpty(contentEncoding)) {
             contentEncoding = DEFAULT_HTTP_CONTENT_ENCODING;
         }
         // Check URL
@@ -940,7 +941,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             String contentEncoding,
             String expectedPostBody,
             String expectedContentType) throws IOException {
-        if (contentEncoding == null || contentEncoding.isEmpty()) {
+        if (StringUtilities.isEmpty(contentEncoding)) {
             contentEncoding = samplerDefaultEncoding;
         }
         // Check URL
@@ -1021,7 +1022,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             String descriptionField,
             String descriptionValue,
             boolean valuesAlreadyUrlEncoded) throws IOException {
-        if (contentEncoding == null || contentEncoding.isEmpty()) {
+        if (StringUtilities.isEmpty(contentEncoding)) {
             contentEncoding = EncoderCache.URL_ARGUMENT_ENCODING;
         }
         // Check URL
@@ -1077,7 +1078,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
         assertEquals(expectedMethod, methodSent);
         String uriSent = headersSent.substring(indexFirstSpace + 1, indexSecondSpace);
         int indexQueryStart = uriSent.indexOf('?');
-        if (expectedQueryString != null && !expectedQueryString.isEmpty()) {
+        if (StringUtilities.isNotEmpty(expectedQueryString)) {
             // We should have a query string part
             if (indexQueryStart <= 0 || indexQueryStart == uriSent.length() - 1) {
                 fail("Could not find query string in URI");
@@ -1094,7 +1095,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
         String pathSent = uriSent.substring(0, indexQueryStart);
         assertEquals(expectedPath, pathSent);
         // Check query
-        if (expectedQueryString != null && !expectedQueryString.isEmpty()) {
+        if (StringUtilities.isNotEmpty(expectedQueryString)) {
             String queryStringSent = uriSent.substring(indexQueryStart + 1);
             // Is it only the parameter values which are encoded in the specified
             // content encoding, the rest of the query is encoded in UTF-8

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/TestGraphQLRequestParamUtils.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/util/TestGraphQLRequestParamUtils.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.http.config.GraphQLRequestParams;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,7 +73,7 @@ class TestGraphQLRequestParamUtils {
             "{"
             + "\"operationName\":null,"
             + "\"variables\":" + EXPECTED_VARIABLES_GET_PARAM_VALUE + ","
-            + "\"query\":\"" + StringUtils.replace(QUERY.trim(), "\n", "\\n") + "\""
+            + "\"query\":\"" + (QUERY.trim() == null ? null : QUERY.trim().replace("\n", "\\n")) + "\""
             + "}";
 
     private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTPTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/visualizers/RequestViewHTTPTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.jmeter.protocol.http.visualizers;
 
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.jorphan.util.StringUtilities;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -157,7 +157,7 @@ class RequestViewHTTPTest {
         Assertions.assertNotNull(param1);
         Assertions.assertEquals(1, param1.getValue().length);
         Assertions.assertEquals(query, param1.getValue()[0]);
-        Assertions.assertTrue(StringUtils.isBlank(param1.getKey()));
+        Assertions.assertTrue(StringUtilities.isBlank(param1.getKey()));
     }
 
     @Test
@@ -199,11 +199,11 @@ class RequestViewHTTPTest {
         Assertions.assertNotNull(param1);
         Assertions.assertEquals(1, param1.getValue().length);
         Assertions.assertEquals(query, param1.getValue()[0]);
-        Assertions.assertTrue(StringUtils.isBlank(param1.getKey()));
+        Assertions.assertTrue(StringUtilities.isBlank(param1.getKey()));
     }
 
     @SafeVarargs
-    private static Map<String, List<String>> mapOf(Pair<String, String>... args) {
+    private static Map<String, List<String>> mapOf(Map.Entry<String, String>... args) {
         Map<String, List<String>> results = new HashMap<>();
         Arrays.stream(args)
                 .forEach(arg -> results.put(arg.getKey(), Arrays.asList(arg.getValue().split(","))));
@@ -213,18 +213,18 @@ class RequestViewHTTPTest {
     private static Stream<Arguments> data() {
         return Stream.of(Arguments.of("k1=v1&=&k2=v2",
                 mapOf(
-                        Pair.of("k1", "v1"),
-                        Pair.of("k2", "v2"))),
+                        new AbstractMap.SimpleEntry<>("k1", "v1"),
+                        new AbstractMap.SimpleEntry<>("k2", "v2"))),
                 Arguments.of("=", mapOf()),
                 Arguments.of("k1=v1&=value&k2=v2",
                         mapOf(
-                                Pair.of("k1", "v1"),
-                                Pair.of("", "value"),
-                                Pair.of("k2", "v2"))),
+                                new AbstractMap.SimpleEntry<>("k1", "v1"),
+                                new AbstractMap.SimpleEntry<>("", "value"),
+                                new AbstractMap.SimpleEntry<>("k2", "v2"))),
                 Arguments.of("a=1&a=2&=abc&=def",
                         mapOf(
-                                Pair.of("a", "1,2"),
-                                Pair.of("", "abc,def"))));
+                                new AbstractMap.SimpleEntry<>("a", "1,2"),
+                                new AbstractMap.SimpleEntry<>("", "abc,def"))));
     }
 
     @ParameterizedTest

--- a/src/protocol/java/build.gradle.kts
+++ b/src/protocol/java/build.gradle.kts
@@ -22,9 +22,6 @@ plugins {
 dependencies {
     api(projects.src.core)
 
-    implementation("org.apache.commons:commons-lang3") {
-        because("ArrayUtils")
-    }
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/config/gui/JavaConfigGui.java
@@ -33,7 +33,6 @@ import javax.swing.SwingConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.AbstractConfigGui;
@@ -49,6 +48,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JFactory;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.reflect.LogAndIgnoreServiceLoadExceptionHandler;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +149,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
 
         classNameLabeledChoice = new JLabeledChoice(
                 JMeterUtils.getResString("protocol_java_classname"),
-                possibleClasses.toArray(ArrayUtils.EMPTY_STRING_ARRAY), true,
+                possibleClasses.toArray(new String[0]), true,
                 false);
         classNameLabeledChoice.addChangeListener(this);
 
@@ -213,7 +213,7 @@ public class JavaConfigGui extends AbstractConfigGui implements ChangeListener {
                     // values that they did in the original test.
                     if (currArgsMap.containsKey(name)) {
                         String newVal = currArgsMap.get(name);
-                        if (newVal != null && newVal.length() > 0) {
+                        if (StringUtilities.isNotEmpty(newVal)) {
                             value = newVal;
                         }
                     }

--- a/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/JavaTest.java
+++ b/src/protocol/java/src/main/java/org/apache/jmeter/protocol/java/test/JavaTest.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.Interruptible;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -279,13 +280,13 @@ public class JavaTest extends AbstractJavaSamplerClient implements Serializable,
         results.setResponseMessage(responseMessage);
         results.setSampleLabel(label);
 
-        if (samplerData != null && samplerData.length() > 0) {
+        if (StringUtilities.isNotEmpty(samplerData)) {
             results.setSamplerData(samplerData);
         }
         if(samplerData != null) {
             results.setSentBytes(samplerData.length());
         }
-        if (resultData != null && resultData.length() > 0) {
+        if (StringUtilities.isNotEmpty(resultData)) {
             results.setResponseData(resultData, null);
         }
         results.setDataType(SampleResult.TEXT); // It's always text type even if empty

--- a/src/protocol/jdbc/build.gradle.kts
+++ b/src/protocol/jdbc/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
     api(projects.src.core)
 
     implementation("org.apache.commons:commons-dbcp2")
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils, ObjectUtils")
-    }
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/AbstractJDBCTestElement.java
@@ -43,12 +43,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.save.CSVSaveService;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.threads.JMeterVariables;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -386,7 +386,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement {
     }
 
     private int[] setArguments(PreparedStatement pstmt) throws SQLException, IOException {
-        if (getQueryArguments().trim().length()==0) {
+        if (getQueryArguments().isBlank()) {
             return new int[]{};
         }
         String[] arguments = CSVSaveService.csvSplitString(getQueryArguments(), COMMA_CHAR);
@@ -659,7 +659,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement {
      */
     public int getIntegerQueryTimeout() {
         int timeout;
-        if(StringUtils.isEmpty(queryTimeout)) {
+        if (StringUtilities.isEmpty(queryTimeout)) {
             return 0;
         } else {
             try {
@@ -690,7 +690,7 @@ public abstract class AbstractJDBCTestElement extends AbstractTestElement {
      */
     public int getIntegerResultSetMaxRows() {
         int maxrows;
-        if(StringUtils.isEmpty(resultSetMaxRows)) {
+        if (StringUtilities.isEmpty(resultSetMaxRows)) {
             return -1;
         } else {
             try {

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElement.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElement.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigElement;
 import org.apache.jmeter.gui.TestElementMetadata;
 import org.apache.jmeter.testbeans.TestBean;
@@ -36,7 +35,7 @@ import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +114,7 @@ public class DataSourceElement extends AbstractTestElement
         TestBeanHelper.prepare(this);
         JMeterVariables variables = getThreadContext().getVariables();
         String poolName = getDataSource();
-        if (JOrphanUtils.isBlank(poolName)) {
+        if (StringUtilities.isBlank(poolName)) {
             throw new IllegalArgumentException("Name for DataSource must not be empty in " + getName());
         } else if (variables.getObject(poolName) != null) {
             log.error("JDBC data source already defined for: {}", poolName);
@@ -220,16 +219,16 @@ public class DataSourceElement extends AbstractTestElement
         dataSource.setMinIdle(0);
         dataSource.setInitialSize(poolSize);
         dataSource.setAutoCommitOnReturn(false);
-        if(StringUtils.isNotEmpty(initQuery)) {
+        if (StringUtilities.isNotEmpty(initQuery)) {
             String[] sqls = initQuery.split("\n");
             dataSource.setConnectionInitSqls(Arrays.asList(sqls));
         } else {
             dataSource.setConnectionInitSqls(Collections.emptyList());
         }
-        if(StringUtils.isNotEmpty(connectionProperties)) {
+        if (StringUtilities.isNotEmpty(connectionProperties)) {
             dataSource.setConnectionProperties(connectionProperties);
         }
-        if (StringUtils.isNotEmpty(poolPreparedStatements)) {
+        if (StringUtilities.isNotEmpty(poolPreparedStatements)) {
             int maxPreparedStatements = Integer.parseInt(poolPreparedStatements);
             if (maxPreparedStatements < 0) {
                 dataSource.setPoolPreparedStatements(false);
@@ -263,7 +262,7 @@ public class DataSourceElement extends AbstractTestElement
         if(isKeepAlive()) {
             dataSource.setTestWhileIdle(true);
             String validationQuery = getCheckQuery();
-            if (StringUtils.isBlank(validationQuery)) {
+            if (StringUtilities.isBlank(validationQuery)) {
                 dataSource.setValidationQuery(null);
             } else {
                 dataSource.setValidationQuery(validationQuery);

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/config/DataSourceElementBeanInfo.java
@@ -23,11 +23,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.testbeans.BeanInfoSupport;
 import org.apache.jmeter.testbeans.gui.TypeEditor;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,7 +131,7 @@ public class DataSourceElementBeanInfo extends BeanInfoSupport {
      * @return integer value of the given transaction isolation mode
      */
     public static int getTransactionIsolationMode(String tag) {
-        if (!StringUtils.isEmpty(tag)) {
+        if (StringUtilities.isNotEmpty(tag)) {
             Integer isolationMode = TRANSACTION_ISOLATION_MAP.get(tag);
             if (isolationMode == null) {
                 try {

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/AbstractJDBCProcessor.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/processor/AbstractJDBCProcessor.java
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 
 import org.apache.jmeter.protocol.jdbc.AbstractJDBCTestElement;
 import org.apache.jmeter.protocol.jdbc.config.DataSourceElement;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public abstract class AbstractJDBCProcessor extends AbstractJDBCTestElement {
      * Calls the JDBC code to be executed.
      */
     protected void process() {
-        if (JOrphanUtils.isBlank(getDataSource())) {
+        if (StringUtilities.isBlank(getDataSource())) {
             throw new IllegalArgumentException("Name for DataSource must not be empty in " + getName());
         }
         try (Connection conn = DataSourceElement.getConnection(getDataSource())){

--- a/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
+++ b/src/protocol/jdbc/src/main/java/org/apache/jmeter/protocol/jdbc/sampler/JDBCSampler.java
@@ -21,9 +21,9 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.engine.util.ConfigMergabilityIndicator;
 import org.apache.jmeter.gui.TestElementMetadata;
@@ -34,7 +34,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.samplers.Sampler;
 import org.apache.jmeter.testbeans.TestBean;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jorphan.util.JOrphanUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 /**
  * A sampler which understands JDBC database requests.
@@ -73,7 +73,7 @@ public class JDBCSampler extends AbstractJDBCTestElement implements Sampler, Tes
 
         try {
             String dataSource = getDataSource();
-            if (JOrphanUtils.isBlank(dataSource)) {
+            if (StringUtilities.isBlank(dataSource)) {
                 throw new IllegalArgumentException("Name for DataSource must not be empty in " + getName());
             }
 
@@ -94,7 +94,7 @@ public class JDBCSampler extends AbstractJDBCTestElement implements Sampler, Tes
             res.setResponseMessage(ex.toString());
             res.setResponseCode("000");
             res.setResponseData(
-                    ObjectUtils.defaultIfNull(ex.getMessage(), "NO MESSAGE"),
+                    Objects.requireNonNullElse(ex.getMessage(), "NO MESSAGE"),
                     res.getDataEncodingWithDefault());
             res.setSuccessful(false);
         } finally {

--- a/src/protocol/jms/build.gradle.kts
+++ b/src/protocol/jms/build.gradle.kts
@@ -28,9 +28,6 @@ dependencies {
     // TODO: technically speaking, jms_1.1_spec should be compileOnly
     // since we either include a JMS implementation or we can't use JMS at all
     implementation("org.apache.geronimo.specs:geronimo-jms_1.1_spec")
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/InitialContextFactory.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/InitialContextFactory.java
@@ -24,7 +24,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,11 +105,11 @@ public class InitialContextFactory {
        builder.append("#");
        builder.append(providerUrl);
        builder.append("#");
-       if(!StringUtils.isEmpty(securityPrincipal)) {
+       if (StringUtilities.isNotEmpty(securityPrincipal)) {
            builder.append(securityPrincipal);
            builder.append("#");
        }
-       if(!StringUtils.isEmpty(securityCredentials)) {
+       if (StringUtilities.isNotEmpty(securityCredentials)) {
            builder.append(securityCredentials);
        }
        return builder.toString();

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ReceiveSubscriber.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/ReceiveSubscriber.java
@@ -33,6 +33,7 @@ import javax.naming.Context;
 import javax.naming.NamingException;
 
 import org.apache.jmeter.protocol.jms.Utils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -230,7 +231,7 @@ public class ReceiveSubscriber implements Closeable, MessageListener {
             Context ctx = InitialContextFactory.getContext(useProps,
                     initialContextFactory, providerUrl, useAuth, securityPrincipal, securityCredentials);
             connection = Utils.getConnection(ctx, connfactory);
-            if(!isEmpty(clientId)) {
+            if (StringUtilities.isNotEmpty(clientId)) {
                 connection.setClientID(clientId);
             }
             session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -272,14 +273,14 @@ public class ReceiveSubscriber implements Closeable, MessageListener {
     private static MessageConsumer createSubscriber(Session session,
             Destination destination, String durableSubscriptionId,
             String jmsSelector) throws JMSException {
-        if (isEmpty(durableSubscriptionId)) {
-            if(isEmpty(jmsSelector)) {
+        if (StringUtilities.isEmpty(durableSubscriptionId)) {
+            if (StringUtilities.isEmpty(jmsSelector)) {
                 return session.createConsumer(destination);
             } else {
                 return session.createConsumer(destination, jmsSelector);
             }
         } else {
-            if(isEmpty(jmsSelector)) {
+            if (StringUtilities.isEmpty(jmsSelector)) {
                 return session.createDurableSubscriber((Topic) destination, durableSubscriptionId);
             } else {
                 return session.createDurableSubscriber((Topic) destination, durableSubscriptionId, jmsSelector, false);
@@ -368,16 +369,5 @@ public class ReceiveSubscriber implements Closeable, MessageListener {
         if (!queue.offer(message)){
             log.warn("Could not add message to queue");
         }
-    }
-
-
-    /**
-     * Checks whether string is empty
-     *
-     * @param s1
-     * @return True if input is null, an empty string, or a white space-only string
-     */
-    private static boolean isEmpty(String s1) {
-        return s1 == null || s1.trim().isEmpty();
     }
 }

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/BaseJMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/BaseJMSSampler.java
@@ -26,7 +26,6 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
@@ -406,7 +405,8 @@ public abstract class BaseJMSSampler extends AbstractSampler {
      *
      */
     protected void configureIsReconnectErrorCode() {
-        String regex = StringUtils.trimToEmpty(getReconnectionErrorCodes());
+        String codes = getReconnectionErrorCodes();
+        String regex = codes == null ? "" : codes.trim();
         if (regex.isEmpty()) {
             isReconnectErrorCode = e -> false;
         } else {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/JMSSampler.java
@@ -46,7 +46,6 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.jms.Utils;
 import org.apache.jmeter.samplers.AbstractSampler;
@@ -61,6 +60,7 @@ import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -699,11 +699,11 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
     private Context getInitialContext() throws NamingException {
         Hashtable<String, String> table = new Hashtable<>();
 
-        if (getInitialContextFactory() != null && getInitialContextFactory().trim().length() > 0) {
+        if (StringUtilities.isNotBlank(getInitialContextFactory())) {
             LOGGER.debug("Using InitialContext [{}]", getInitialContextFactory());
             table.put(Context.INITIAL_CONTEXT_FACTORY, getInitialContextFactory());
         }
-        if (getContextProvider() != null && getContextProvider().trim().length() > 0) {
+        if (StringUtilities.isNotBlank(getContextProvider())) {
             LOGGER.debug("Using Provider [{}]", getContextProvider());
             table.put(Context.PROVIDER_URL, getContextProvider());
         }
@@ -766,7 +766,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
 
     private int getTimeoutAsInt() {
         String propAsString = getPropertyAsString(TIMEOUT);
-        if(StringUtils.isEmpty(propAsString)){
+        if (StringUtilities.isEmpty(propAsString)){
             return DEFAULT_TIMEOUT;
         } else {
             return Integer.parseInt(propAsString);
@@ -827,7 +827,7 @@ public class JMSSampler extends AbstractSampler implements ThreadListener {
 
     private boolean useTemporyQueue() {
         String recvQueue = getReceiveQueue();
-        return recvQueue == null || recvQueue.trim().length() == 0;
+        return StringUtilities.isBlank(recvQueue);
     }
 
     public void setArguments(Arguments args) {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/PublisherSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/PublisherSampler.java
@@ -51,6 +51,7 @@ import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -291,10 +292,8 @@ public class PublisherSampler extends BaseJMSSampler implements TestStateListene
             result.setResponseCode(errorCode);
         }
 
-        StringWriter writer = new StringWriter();
-        e.printStackTrace(new PrintWriter(writer)); // NOSONAR We're getting it
-                                                    // to put it in ResponseData
-        result.setResponseData(writer.toString(), "UTF-8");
+        result.setResponseData(ExceptionUtils.getStackTraceAsBytes(e, StandardCharsets.UTF_8));
+        result.setDataEncoding(StandardCharsets.UTF_8.name());
     }
 
     protected static Cache<Object, Object> buildCache(String configChoice) {

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/Receiver.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/Receiver.java
@@ -25,8 +25,8 @@ import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.jms.Utils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public final class Receiver implements Runnable {
         }
         session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
         log.debug("Receiver - ctor. Creating consumer with JMS Selector:{}", jmsSelector);
-        if(StringUtils.isEmpty(jmsSelector)) {
+        if (StringUtilities.isEmpty(jmsSelector)) {
             consumer = session.createConsumer(receiveQueue);
         } else {
             consumer = session.createConsumer(receiveQueue, jmsSelector);

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/SubscriberSampler.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/sampler/SubscriberSampler.java
@@ -29,7 +29,6 @@ import javax.jms.TextMessage;
 import javax.naming.NamingException;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.protocol.jms.Utils;
 import org.apache.jmeter.protocol.jms.client.InitialContextFactory;
 import org.apache.jmeter.protocol.jms.client.ReceiveSubscriber;
@@ -39,6 +38,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestStateListener;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -307,7 +307,7 @@ public class SubscriberSampler extends BaseJMSSampler implements Interruptible, 
                     }
                 }
                 Utils.messageProperties(propBuffer, msg);
-                if(!isLast && !StringUtils.isEmpty(separator)) {
+                if(!isLast && StringUtilities.isNotEmpty(separator)) {
                     propBuffer.append(separator);
                     buffer.append(separator);
                 }

--- a/src/protocol/junit/build.gradle.kts
+++ b/src/protocol/junit/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
     api(projects.src.core)
 
     api("junit:junit")
-    implementation("org.apache.commons:commons-lang3") {
-        because("ArrayUtils")
-    }
     implementation("org.exparity:hamcrest-date") {
         because("hamcrest-date.jar was historically shipped with JMeter")
     }

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/ClassFilter.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/control/gui/ClassFilter.java
@@ -20,7 +20,6 @@ package org.apache.jmeter.protocol.java.control.gui;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.ArrayUtils;
 
 class ClassFilter {
 
@@ -52,9 +51,9 @@ class ClassFilter {
             }
         }
         if (!newList.isEmpty()) {
-            return newList.toArray(ArrayUtils.EMPTY_STRING_ARRAY);
+            return newList.toArray(new String[0]);
         } else {
-            return ArrayUtils.EMPTY_STRING_ARRAY;
+            return new String[0];
         }
     }
 

--- a/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
+++ b/src/protocol/junit/src/main/java/org/apache/jmeter/protocol/java/sampler/JUnitSampler.java
@@ -28,6 +28,7 @@ import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.ThreadListener;
+import org.apache.jorphan.util.StringUtilities;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -506,7 +507,7 @@ public class JUnitSampler extends AbstractSampler implements ThreadListener {
                     // we have to check and make sure the constructor is
                     // accessible. if we didn't it would throw an exception
                     // and cause a NPE.
-                    if (label == null || label.length() == 0) {
+                    if (StringUtilities.isEmpty(label)) {
                         label = className;
                     }
                     if (strCon.getModifiers() == Modifier.PUBLIC) {

--- a/src/protocol/ldap/build.gradle.kts
+++ b/src/protocol/ldap/build.gradle.kts
@@ -25,9 +25,6 @@ dependencies {
     implementation("org.apache.commons:commons-text") {
         because("StringEscapeUtils")
     }
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
 
     testImplementation(testFixtures(projects.src.core))
 }

--- a/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPExtSampler.java
+++ b/src/protocol/ldap/src/main/java/org/apache/jmeter/protocol/ldap/sampler/LDAPExtSampler.java
@@ -38,7 +38,6 @@ import javax.naming.directory.DirContext;
 import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchResult;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
@@ -945,7 +944,7 @@ public class LDAPExtSampler extends AbstractSampler implements TestStateListener
                         sortedVals.add(value.toString());
                     }
                     Collections.sort(sortedVals);
-                    sb.append(StringUtils.join(sortedVals, ", "));
+                    sb.append(String.join(", ", sortedVals));
                 }
                 xmlb.tag(attr.getID(),sb);
             }

--- a/src/protocol/mail/build.gradle.kts
+++ b/src/protocol/mail/build.gradle.kts
@@ -30,9 +30,6 @@ dependencies {
     // This is an API-only jar. javax.activation is present in Java 8,
     // however it is not there in Java 9
     compileOnly("javax.activation:javax.activation-api")
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/SmtpSampler.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/SmtpSampler.java
@@ -44,7 +44,6 @@ import javax.mail.internet.MimeUtility;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.protocol.smtp.sampler.gui.SecuritySettingsPanel;
 import org.apache.jmeter.protocol.smtp.sampler.protocol.SendMailCommand;
@@ -54,9 +53,9 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jorphan.util.CharUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Sampler-Class for JMeter - builds, starts and interprets the results of the
@@ -381,7 +380,7 @@ public class SmtpSampler extends AbstractSampler {
 
     private static String encodeAddress(String address) {
         String trimmedAddress = address.trim();
-        if (!StringUtils.isAsciiPrintable(trimmedAddress)) {
+        if (!isAsciiPrintable(trimmedAddress)) {
             try {
                 final int startOfRealAddress = trimmedAddress.indexOf('<');
                 if (startOfRealAddress >= 0) {
@@ -393,6 +392,25 @@ public class SmtpSampler extends AbstractSampler {
             }
         }
         return trimmedAddress;
+    }
+
+    /**
+     * Checks if the string contains only ASCII printable characters (32-126).
+     *
+     * @param str the string to check
+     * @return true if all characters are ASCII printable, false otherwise
+     */
+    private static boolean isAsciiPrintable(String str) {
+        if (str == null) {
+            return false;
+        }
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (!CharUtils.isAscii(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/protocol/SendMailCommand.java
+++ b/src/protocol/mail/src/main/java/org/apache/jmeter/protocol/smtp/sampler/protocol/SendMailCommand.java
@@ -44,11 +44,11 @@ import javax.mail.internet.MimeMultipart;
 import javax.net.ssl.SSLContext;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.util.TrustAllSSLSocketFactory;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -282,10 +282,9 @@ public class SendMailCommand {
     void configureTLSProtocols(Properties props, String protocol) {
         String tlsProtocolsToUse = getTlsProtocolsToUse();
         if (useStartTLS || useSSL) {
-            if (StringUtils.isEmpty(tlsProtocolsToUse)) {
+            if (StringUtilities.isEmpty(tlsProtocolsToUse)) {
                 try {
-                    tlsProtocolsToUse = StringUtils.join(
-                        SSLContext.getDefault().getSupportedSSLParameters().getProtocols(), " ");
+                    tlsProtocolsToUse = String.join(" ", SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
                 } catch (Exception e) {
                     logger.error("Problem setting ssl/tls protocols for mail", e);
                 }

--- a/src/protocol/mongodb/build.gradle.kts
+++ b/src/protocol/mongodb/build.gradle.kts
@@ -23,9 +23,6 @@ dependencies {
     api(projects.src.core)
 
     api("org.mongodb:mongo-java-driver")
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
 
     testImplementation(testFixtures(projects.src.core))
 }

--- a/src/protocol/mongodb/src/main/java/org/apache/jmeter/protocol/mongodb/mongo/MongoDB.java
+++ b/src/protocol/mongodb/src/main/java/org/apache/jmeter/protocol/mongodb/mongo/MongoDB.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.protocol.mongodb.mongo;
 
 import java.util.List;
 
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class MongoDB {
         boolean authenticated = db.isAuthenticated();
 
         if(!authenticated) {
-            if(username != null && password != null && username.length() > 0 && password.length() > 0) {
+            if (StringUtilities.isNotEmpty(username) && StringUtilities.isNotEmpty(password)) {
                 authenticated = db.authenticate(username, password.toCharArray());
             }
         }

--- a/src/protocol/mongodb/src/main/java/org/apache/jmeter/protocol/mongodb/mongo/MongoUtils.java
+++ b/src/protocol/mongodb/src/main/java/org/apache/jmeter/protocol/mongodb/mongo/MongoUtils.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.jorphan.util.StringUtilities;
 
 import com.mongodb.ServerAddress;
 
@@ -40,8 +40,11 @@ public class MongoUtils {
         for(String connection : Arrays.asList(connections.split(","))) {
             int port = DEFAULT_PORT;
             String[] hostPort = connection.split(":");
-            if(hostPort.length > 1 && !StringUtils.isEmpty(hostPort[1])) {
-                port = Integer.parseInt(hostPort[1].trim());
+            if(hostPort.length > 1) {
+                String portValue = hostPort[1];
+                if (StringUtilities.isNotEmpty(portValue)) {
+                    port = Integer.parseInt(portValue.trim());
+                }
             }
             addresses.add(new ServerAddress(hostPort[0], port));
         }

--- a/src/protocol/native/build.gradle.kts
+++ b/src/protocol/native/build.gradle.kts
@@ -22,9 +22,5 @@ plugins {
 dependencies {
     api(projects.src.core)
 
-    implementation("org.apache.commons:commons-lang3") {
-        because("StringUtils")
-    }
-
     testImplementation(testFixtures(projects.src.core))
 }

--- a/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/SystemSampler.java
+++ b/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/SystemSampler.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.ConfigTestElement;
@@ -39,6 +38,7 @@ import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jorphan.exec.SystemCommand;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,13 +125,14 @@ public class SystemSampler extends AbstractSampler {
         }
 
         File directory;
-        if(StringUtils.isEmpty(getDirectory())) {
+        String directoryName = getDirectory();
+        if (StringUtilities.isEmpty(directoryName)) {
             directory = new File(FileServer.getDefaultBase());
             if(log.isDebugEnabled()) {
                 log.debug("Using default directory:"+directory.getAbsolutePath());
             }
         } else {
-            directory = new File(getDirectory());
+            directory = new File(directoryName);
             if(log.isDebugEnabled()) {
                 log.debug("Using configured directory:"+directory.getAbsolutePath());
             }

--- a/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
+++ b/src/protocol/native/src/main/java/org/apache/jmeter/protocol/system/gui/SystemSamplerGui.java
@@ -27,7 +27,6 @@ import javax.swing.BoxLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.Argument;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.config.gui.ArgumentsPanel;
@@ -41,6 +40,7 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.apache.jorphan.gui.JLabeledTextField;
 import org.apache.jorphan.gui.ObjectTableModel;
 import org.apache.jorphan.reflect.Functor;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,8 +116,9 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
         SystemSampler systemSampler = (SystemSampler)sampler;
         systemSampler.setCheckReturnCode(checkReturnCode.isSelected());
         if(checkReturnCode.isSelected()) {
-            if(!StringUtils.isEmpty(desiredReturnCode.getText())) {
-                systemSampler.setExpectedReturnCode(Integer.parseInt(desiredReturnCode.getText()));
+            String desiredReturnCode = this.desiredReturnCode.getText();
+            if (StringUtilities.isNotEmpty(desiredReturnCode)) {
+                systemSampler.setExpectedReturnCode(Integer.parseInt(desiredReturnCode));
             } else {
                 systemSampler.setExpectedReturnCode(SystemSampler.DEFAULT_RETURN_CODE);
             }
@@ -131,11 +132,12 @@ public class SystemSamplerGui extends AbstractSamplerGui implements ItemListener
         systemSampler.setStdin(stdin.getFilename());
         systemSampler.setStdout(stdout.getFilename());
         systemSampler.setStderr(stderr.getFilename());
-        if(!StringUtils.isEmpty(timeout.getText())) {
+        String timeout = this.timeout.getText();
+        if (StringUtilities.isNotEmpty(timeout)) {
             try {
-                systemSampler.setTimout(Long.parseLong(timeout.getText()));
+                systemSampler.setTimout(Long.parseLong(timeout));
             } catch (NumberFormatException e) {
-                log.error("Error parsing timeout field value:"+timeout.getText(), e);
+                log.error("Error parsing timeout field value:"+ timeout, e);
             }
         }
     }

--- a/src/protocol/tcp/build.gradle.kts
+++ b/src/protocol/tcp/build.gradle.kts
@@ -22,9 +22,6 @@ plugins {
 dependencies {
     api(projects.src.core)
 
-    implementation("org.apache.commons:commons-lang3") {
-        because("ArrayUtils")
-    }
     implementation("commons-io:commons-io") {
         because("IOUtils")
     }

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPClientImpl.java
@@ -24,9 +24,9 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class TCPClientImpl extends AbstractTCPClient {
         }
         setCharset(CHARSET);
         String configuredCharset = JMeterUtils.getProperty("tcp.charset");
-        if(StringUtils.isEmpty(configuredCharset)) {
+        if (StringUtilities.isEmpty(configuredCharset)) {
             log.info("Using platform default charset:{}",CHARSET);
         } else {
             log.info("Using charset:{}", configuredCharset);

--- a/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
+++ b/src/protocol/tcp/src/main/java/org/apache/jmeter/protocol/tcp/sampler/TCPSampler.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jmeter.config.ConfigTestElement;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
@@ -45,6 +44,7 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jmeter.testelement.ThreadListener;
 import org.apache.jmeter.util.JMeterUtils;
+import org.apache.jorphan.util.StringUtilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -295,7 +295,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
 
     public String getClassname() {
         String clazz = getPropertyAsString(CLASSNAME,"");
-        if (clazz==null || clazz.length()==0){
+        if (StringUtilities.isEmpty(clazz)){
             clazz = JMeterUtils.getPropDefault("tcp.handler", "TCPClientImpl"); //$NON-NLS-1$ $NON-NLS-2$
         }
         return clazz;
@@ -445,7 +445,7 @@ public class TCPSampler extends AbstractSampler implements ThreadListener, Inter
         }
         boolean isSuccessful = exception == null;
         // Reset the status code if the message contains one
-        if (!StringUtils.isEmpty(readResponse) && STATUS_PREFIX.length() > 0) {
+        if (StringUtilities.isNotEmpty(readResponse) && STATUS_PREFIX.length() > 0) {
             int i = readResponse.indexOf(STATUS_PREFIX);
             int j = readResponse.indexOf(STATUS_SUFFIX, i + STATUS_PREFIX.length());
             if (i != -1 && j > i) {


### PR DESCRIPTION
commons-lang3 is a heavy, and it is not modular, so a CVE in one of its classes would affect JMeter even if we do not use that.

At the same time both modern Java and Kotlin are much better than 10 years ago.
