### PR TITLE
chore: add dependency submission workflow

### DIFF
--- a/.github/workflows/gradle-dependency-submit.yaml
+++ b/.github/workflows/gradle-dependency-submit.yaml
@@ -1,0 +1,31 @@
+name: Dependency Submission
+
+# See https://github.com/gradle/actions/blob/768a17f3488dc3fe0155ff431553e1f53d57e22e/dependency-submission/README.md#the-dependency-submission-action
+# The action allows GitHub to alert about reported vulnerabilities in the project
+on:
+  push:
+    branches:
+      - main
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+jobs:
+  dependency-submission:
+    name: Submit dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      with:
+        persist-credentials: false
+    - name: Set up JDK 21
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+      with:
+        distribution: zulu
+        java-version: 21
+        server-id: central
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4


### PR DESCRIPTION
This enables GitHub security scanning for all the transitive dependencies
