### PR TITLE
chore: disable Dependabot updates

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -8,6 +8,9 @@ github:
     - test
     - java
 
+  dependabot_alerts:  true
+  dependabot_updates: false
+
   enabled_merge_buttons:
     squash: true
     merge:  false


### PR DESCRIPTION
We use Renovate bot.
