### PR TITLE
test: add missing JMeter initialization to test classes

### DIFF
--- a/src/core/src/test/java/org/apache/jmeter/engine/DistributedRunnerTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/engine/DistributedRunnerTest.java
@@ -34,9 +34,11 @@ import org.apache.jorphan.collections.HashTree;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Isolated("modifies jmeter locale")
 @Execution(ExecutionMode.SAME_THREAD) // System.setOut must not be run concurrently with other tests
 public class DistributedRunnerTest {
 

--- a/src/functions/src/test/java/org/apache/jmeter/functions/StringFromFileFunctionTest.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/StringFromFileFunctionTest.java
@@ -25,12 +25,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jorphan.util.JMeterStopThreadException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class StringFromFileFunctionTest {
+public class StringFromFileFunctionTest extends JMeterTestCase {
     private static Path dir;
 
     @BeforeAll

--- a/src/functions/src/test/java/org/apache/jmeter/functions/XPathConcurrencyTest.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/XPathConcurrencyTest.java
@@ -26,12 +26,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jmeter.engine.util.CompoundVariable;
+import org.apache.jmeter.junit.JMeterTestCase;
 import org.apache.jmeter.testkit.ResourceLocator;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class XPathConcurrencyTest {
+public class XPathConcurrencyTest extends JMeterTestCase {
     enum ReferenceEquality {
         SAME_OBJECTS, DIFFERENT_OBJECTS
     }

--- a/src/functions/src/test/kotlin/org/apache/jmeter/functions/ChangeCaseTest.kt
+++ b/src/functions/src/test/kotlin/org/apache/jmeter/functions/ChangeCaseTest.kt
@@ -18,6 +18,7 @@
 package org.apache.jmeter.functions
 
 import org.apache.jmeter.engine.util.CompoundVariable
+import org.apache.jmeter.junit.JMeterTestCase
 import org.apache.jmeter.samplers.SampleResult
 import org.apache.jmeter.threads.JMeterContextService
 import org.apache.jmeter.threads.JMeterVariables
@@ -27,7 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.Locale
 
-class ChangeCaseTest {
+class ChangeCaseTest : JMeterTestCase() {
     data class ExecuteCase(val input: String, val mode: String, val output: String)
 
     companion object {

--- a/src/functions/src/test/kotlin/org/apache/jmeter/functions/FunctionServicesTest.kt
+++ b/src/functions/src/test/kotlin/org/apache/jmeter/functions/FunctionServicesTest.kt
@@ -17,12 +17,13 @@
 
 package org.apache.jmeter.functions
 
+import org.apache.jmeter.junit.JMeterTestCase
 import org.apache.jmeter.util.JMeterUtils
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.ServiceLoader
 
-class FunctionServicesTest {
+class FunctionServicesTest : JMeterTestCase() {
     @Test
     fun `__counter loads`() {
         val functions = JMeterUtils.loadServicesAndScanJars(

--- a/src/functions/src/test/kotlin/org/apache/jmeter/functions/IterationCounterTest.kt
+++ b/src/functions/src/test/kotlin/org/apache/jmeter/functions/IterationCounterTest.kt
@@ -18,6 +18,7 @@
 package org.apache.jmeter.functions
 
 import org.apache.jmeter.engine.util.CompoundVariable
+import org.apache.jmeter.junit.JMeterTestCase
 import org.apache.jmeter.threads.JMeterContextService
 import org.apache.jmeter.threads.JMeterVariables
 import org.junit.jupiter.api.Assertions
@@ -25,7 +26,7 @@ import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import kotlin.concurrent.thread
 
-class IterationCounterTest {
+class IterationCounterTest : JMeterTestCase() {
 
     @Test
     fun `Counter per thread counts for each thread`() {

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -64,6 +65,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * The samples are executed against the HttpMirrorServer, which is
  * started when the unit tests are executed.
  */
+@Isolated("modifies jmeter locale")
 public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
     private static final java.util.regex.Pattern EMPTY_LINE_PATTERN = java.util.regex.Pattern.compile("^$",
             java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.MULTILINE);

--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerPrintDslTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/sampler/HttpSamplerPrintDslTest.kt
@@ -29,10 +29,12 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
 import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.jupiter.api.parallel.Resources
 import java.util.Locale
 
+@Isolated("modifies jmeter locale")
 @ResourceLock(value = Resources.LOCALE)
 class HttpSamplerPrintDslTest : JMeterTestCase() {
     companion object {

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/PublisherSamplerTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/PublisherSamplerTest.java
@@ -27,9 +27,11 @@ import org.apache.jmeter.util.JMeterUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.github.benmanes.caffeine.cache.Cache;
 
+@Isolated("modifies jmeter locale")
 public class PublisherSamplerTest {
 
     @BeforeEach

--- a/src/protocol/mail/src/test/java/org/apache/jmeter/protocol/mail/sampler/TestMailReaderSampler.java
+++ b/src/protocol/mail/src/test/java/org/apache/jmeter/protocol/mail/sampler/TestMailReaderSampler.java
@@ -25,7 +25,9 @@ import java.util.Properties;
 import org.apache.jmeter.util.JMeterUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
+@Isolated("modifies jmeter locale")
 public class TestMailReaderSampler {
 
     @SuppressWarnings("CatchAndPrintStackTrace")


### PR DESCRIPTION
Previously, the tests might trigger initialization of jmeter function classes before JMeter itself was loaded.

For instance, StringToFile loads resources in its clint block, so if StringToFile initializes too early, the descriptions don't load from the resources.

We should probably avoid clinit for resource-loading in the long run (locale might change on the fly), however adding the initialization does not look that bad either.

