### PR TITLE
chore: remove core->commons-collections dependency

### DIFF
--- a/src/core/build.gradle.kts
+++ b/src/core/build.gradle.kts
@@ -94,9 +94,6 @@ dependencies {
     implementation("org.apache-extras.beanshell:bsh:2.0b6") {
         because("Direct dependency required from BeanShellInterpreter")
     }
-    runtimeOnly("commons-collections:commons-collections") {
-        because("Compatibility for old plugins")
-    }
     implementation("org.jetbrains.lets-plot:lets-plot-batik")
     implementation("org.jetbrains.lets-plot:lets-plot-kotlin-jvm")
     implementation("org.apache.commons:commons-math3") {

--- a/src/dist/build.gradle.kts
+++ b/src/dist/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
     runtimeOnly("commons-codec:commons-codec") {
         because("commons-codec was a dependency in previous JMeter versions, so we keep it for compatibility")
     }
+    runtimeOnly("commons-collections:commons-collections") {
+        because("commons-collections was a dependency in previous JMeter versions, so we keep it for compatibility")
+    }
     runtimeOnly("org.apache.commons:commons-collections4") {
         because("commons-collections4 was a dependency in previous JMeter versions, so we keep it for compatibility")
     }


### PR DESCRIPTION
We still ship the jar in the distribution, however, we no longer depend on it in core
