### PR TITLE
Improve wait for delays on shutdown

### DIFF
--- a/bin/jmeter.properties
+++ b/bin/jmeter.properties
@@ -1174,6 +1174,9 @@ cookies=cookies
 # How often to check for shutdown during ramp-up (milliseconds)
 #jmeterthread.rampup.granularity=1000
 
+# How often to check for shutdown during timer delay (milliseconds)
+#jmeterthread.timer.granularity=1000
+
 #Should JMeter expand the tree when loading a test plan?
 # default value is false since JMeter 2.7
 #onload.expandtree=false

--- a/xdocs/usermanual/properties_reference.xml
+++ b/xdocs/usermanual/properties_reference.xml
@@ -1484,6 +1484,10 @@ JMETER-SERVER</source>
     How often to check for shutdown during ramp-up (milliseconds).<br/>
     Defaults to: <code>1000</code>
 </property>
+<property name="jmeterthread.timer.granularity">
+    How often to check for shutdown during timer delay (milliseconds).<br/>
+    Defaults to: <code>1000</code>
+</property>
 <property name="onload.expandtree">
     Should JMeter expand the tree when loading a test plan?<br/>
     Default value is <code>false</code> since JMeter 2.7<br/>


### PR DESCRIPTION
## Description
Improve the time for a shutdown when there are significant delays. 

## Motivation and Context
Currently, when shutting down a test, it waits for all the timer/delays to finish. They can take a long time as it just waits for the sleep to complete. Now the sleep behaviour is the same as ramp up sleeps with checks on the test running in between. Now shutting down a test (gracefully) is a lot quicker when you have significant delays in your test.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
Added jmeterthread.timer.granularity to update the interval of checking if a test is stopped

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style][style-guide] of this project.
- [X] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
