### PR TITLE
Skip checking empty filenames for result collectors

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/gui/action/AbstractAction.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/AbstractAction.java
@@ -89,6 +89,10 @@ public abstract class AbstractAction implements Command {
         SearchByClass<ResultCollector> resultListeners = new SearchByClass<>(ResultCollector.class);
         tree.traverse(resultListeners);
         for (ResultCollector rc : resultListeners.getSearchResults()) {
+            if ("".equals(rc.getFilename())) {
+                log.debug("Skip result collector ({}) as it has empty filename", rc.getName());
+                continue;
+            }
             File f = new File(rc.getFilename());
             if (f.exists()) {
                 switch (actionOnFile) {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -58,6 +58,7 @@ Summary
 </p>
 <ul>
 <li><a href="#Changes">Changes</a></li>
+<li><a href="#Bug fixes">Bug fixes</a></li>
 </ul>
 
   <ch_section>Changes</ch_section>
@@ -76,6 +77,11 @@ Summary
     <li><pr>5891</pr>Skip Internet Explorer 6-9 conditional comment processing when fetching resource links</li>
   </ul>
 
+  <ch_section>Bug fixes</ch_section>
+  <h3>General</h3>
+  <ul>
+    <li><pr>6654</pr><issue>6611</issue>Support JDK 25 and above for result collectors with empty file names</li>
+  </ul>
  <!--  =================== Thanks =================== -->
 
 <ch_section>Thanks</ch_section>


### PR DESCRIPTION
## Description

On Java 25 the semantic of checking existance for empty filenames has been changed. See https://bugs.openjdk.org/browse/JDK-8024695
The old behaviour was used in JMeter to skip empty filenames in result collectors. This patch should resolve the bug while maintaining backwards compatibility.

This should fix #6611.

## How Has This Been Tested?

Ran a simple test plan with an aggregate report element with empty filename.

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
