### PR TITLE
fix: preserve HTTP method on 307 and 308 redirects

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSampleResult.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSampleResult.java
@@ -105,25 +105,17 @@ public class HTTPSampleResult extends SampleResult {
      * Determine whether this result is a redirect.
      *
      * <p>
-     * If status is {@code 307}, the request has to be a HTTP method of {@code GET} or
-     * {@code HEAD}, to be considered a redirect. For all other status codes, the
-     * HTTP method will not be checked.
+     * Returns true for status codes: 301, 302, 303, 307 and 308.
+     * 307 and 308 preserve the original request method when followed.
      * </p>
-     * Returns true for: 301, 302, 303, 307 (GET or HEAD) and 308
      *
      * @return true iff res is an HTTP redirect response
      */
     public boolean isRedirect() {
-        /*
-         * Don't redirect the following:
-         * 300 = Multiple choice
-         * 304 = Not Modified
-         * 305 = Use Proxy
-         * 306 = (Unused)
-         */
         final String[] redirectCodes = { HTTPConstants.SC_MOVED_PERMANENTLY,
                 HTTPConstants.SC_MOVED_TEMPORARILY,
                 HTTPConstants.SC_SEE_OTHER,
+                HTTPConstants.SC_TEMPORARY_REDIRECT,
                 HTTPConstants.SC_PERMANENT_REDIRECT };
         String code = getResponseCode();
         for (String redirectCode : redirectCodes) {
@@ -131,13 +123,7 @@ public class HTTPSampleResult extends SampleResult {
                 return true;
             }
         }
-        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-        // If the 307 status code is received in response to a request other than GET or HEAD,
-        // the user agent MUST NOT automatically redirect the request unless it can be confirmed by the user,
-        // since this might change the conditions under which the request was issued.
-        // See Bug 54119
-        return HTTPConstants.SC_TEMPORARY_REDIRECT.equals(code) &&
-                (HTTPConstants.GET.equals(getHTTPMethod()) || HTTPConstants.HEAD.equals(getHTTPMethod()));
+        return false;
     }
 
     /**

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1669,9 +1669,9 @@ public abstract class HTTPSamplerBase extends AbstractSampler
             // this behaviour.
             location = encodeSpaces(location);
             log.debug("Location after /. and space transforms: {}", location);
-            // Change all but HEAD into GET (Bug 55450)
+            // Compute method based on redirect status code (Bug 55450, RFC 9110)
             String method = lastRes.getHTTPMethod();
-            method = computeMethodForRedirect(method);
+            method = computeMethodForRedirect(method, lastRes.getResponseCode());
 
             try {
                 URL url = ConversionUtils.makeRelativeURL(lastRes.getURL(), location);
@@ -1735,13 +1735,25 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     }
 
     /**
-     * See <a href="http://tools.ietf.org/html/rfc2616#section-10.3">RFC2616#section-10.3</a>
-     * JMeter conforms currently to HttpClient 4.5.2 supported RFC
-     * TODO Update when migrating to HttpClient 5.X using response code
+     * Compute the HTTP method to use for a redirect response.
+     *
+     * <ul>
+     *   <li>307/308: preserve method</li>
+     *   <li>301/302/303: HEAD stays HEAD, others become GET</li>
+     * </ul>
+     *
      * @param initialMethod the initial HTTP Method
-     * @return the new HTTP Method as per RFC
+     * @param responseCode the current redirect response code
+     * @return the HTTP Method to use for the redirected request
      */
-    private static String computeMethodForRedirect(String initialMethod) {
+    private static String computeMethodForRedirect(String initialMethod, String responseCode) {
+        // 307: RFC 9110 §15.4.8, 308: RFC 7538 §3 / RFC 9110 Errata 7109
+        // 307/308: preserve original method
+        if (HTTPConstants.SC_TEMPORARY_REDIRECT.equals(responseCode)
+                || HTTPConstants.SC_PERMANENT_REDIRECT.equals(responseCode)) {
+            return initialMethod;
+        }
+        // 301/302/303: HEAD stays HEAD, others become GET (Bug 55450)
         if (!HTTPConstants.HEAD.equalsIgnoreCase(initialMethod)) {
             return HTTPConstants.GET;
         }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,7 +34,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 
 class TestRedirects {
 
@@ -44,7 +48,7 @@ class TestRedirects {
         Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
                 for (String method : httpMethods) {
-                    boolean shouldRedirect = statusCode != 307 || ("GET".equals(method) || "HEAD".equals(method));
+                    boolean shouldRedirect = true;
                     res.add(Arguments.of(httpImpl, statusCode, shouldRedirect, method));
                 }
             }
@@ -75,6 +79,101 @@ class TestRedirects {
                 Assertions.assertNull(res.getRedirectLocation());
             }
             Assertions.assertEquals("" + redirectCode, res.getResponseCode());
+        } finally {
+            server.stop();
+        }
+    }
+
+    public static List<Arguments> methodPreservationParams() {
+        List<Arguments> res = new ArrayList<>();
+        // Nested for depth is 2 (max allowed is 1). [NestedForDepth]
+        List<String> httpMethods = Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE");
+        Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
+            for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
+                for (String method : httpMethods) {
+                    String expectedMethod;
+                    if (statusCode == 307 || statusCode == 308) {
+                        expectedMethod = method;
+                    } else if ("HEAD".equals(method)) {
+                        expectedMethod = "HEAD";
+                    } else {
+                        expectedMethod = "GET";
+                    }
+                    res.add(Arguments.of(httpImpl, statusCode, method, expectedMethod));
+                }
+            }
+        });
+        return res;
+    }
+
+    @ParameterizedTest
+    @MethodSource("methodPreservationParams")
+    void testMethodPreservationOnRedirect(String httpImpl, int redirectCode,
+            String originalMethod, String expectedMethod) throws MalformedURLException {
+        WireMockServer server = createServer();
+        server.start();
+        try {
+            HTTPSamplerBase http = HTTPSamplerFactory.newInstance(httpImpl);
+            http.setAutoRedirects(false);
+            http.setFollowRedirects(true);
+
+            server.stubFor(any(urlPathEqualTo("/original")).willReturn(
+                    aResponse().withHeader("Location", server.url("/target"))
+                               .withStatus(redirectCode)));
+            server.stubFor(WireMock.request(expectedMethod, urlPathEqualTo("/target"))
+                    .atPriority(1)
+                    .willReturn(aResponse().withStatus(200)));
+            server.stubFor(any(urlPathEqualTo("/target"))
+                    .atPriority(10)
+                    .willReturn(aResponse().withStatus(405)));
+
+            HTTPSampleResult res = http.sample(new URL(server.url("/original")),
+                    originalMethod, false, 1);
+
+            Assertions.assertEquals("200", res.getResponseCode(),
+                    String.format("[%s] %s %d: expected final 200", httpImpl, originalMethod, redirectCode));
+            Assertions.assertEquals(expectedMethod, res.getHTTPMethod(),
+                    String.format("[%s] %s %d: expected method %s", httpImpl, originalMethod, redirectCode, expectedMethod));
+
+            server.verify(1, new RequestPatternBuilder(
+                    RequestMethod.fromString(expectedMethod), urlPathEqualTo("/target")));
+        } finally {
+            server.stop();
+        }
+    }
+
+    public static List<Arguments> redirectChainParams() {
+        return Arrays.stream(HTTPSamplerFactory.getImplementations())
+                .map(Arguments::of)
+                .collect(Collectors.toList());
+    }
+
+    @ParameterizedTest
+    @MethodSource("redirectChainParams")
+    void testRedirectChain307Then301(String httpImpl) throws MalformedURLException {
+        WireMockServer server = createServer();
+        server.start();
+        try {
+            HTTPSamplerBase http = HTTPSamplerFactory.newInstance(httpImpl);
+            http.setAutoRedirects(false);
+            http.setFollowRedirects(true);
+
+            // POST /a -> 307 -> POST /b -> 301 -> GET /c
+            server.stubFor(any(urlPathEqualTo("/a")).willReturn(
+                    aResponse().withHeader("Location", server.url("/b")).withStatus(307)));
+            server.stubFor(any(urlPathEqualTo("/b")).willReturn(
+                    aResponse().withHeader("Location", server.url("/c")).withStatus(301)));
+            server.stubFor(any(urlPathEqualTo("/c")).willReturn(
+                    aResponse().withStatus(200)));
+
+            HTTPSampleResult res = http.sample(new URL(server.url("/a")), "POST", false, 1);
+
+            Assertions.assertEquals("200", res.getResponseCode());
+            Assertions.assertEquals("GET", res.getHTTPMethod());
+
+            // /b should receive POST (307 preserves method), /c should receive GET (301 converts)
+            server.verify(1, new RequestPatternBuilder(RequestMethod.POST, urlPathEqualTo("/b")));
+            server.verify(1, new RequestPatternBuilder(RequestMethod.GET, urlPathEqualTo("/c")));
         } finally {
             server.stop();
         }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
@@ -48,8 +48,7 @@ class TestRedirects {
         Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
                 for (String method : httpMethods) {
-                    boolean shouldRedirect = true;
-                    res.add(Arguments.of(httpImpl, statusCode, shouldRedirect, method));
+                    res.add(Arguments.of(httpImpl, statusCode, true, method));
                 }
             }
             for (int statusCode : Arrays.asList(300, 304, 305, 306)) {
@@ -91,14 +90,10 @@ class TestRedirects {
         Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
                 for (String method : httpMethods) {
-                    String expectedMethod;
-                    if (statusCode == 307 || statusCode == 308) {
-                        expectedMethod = method;
-                    } else if ("HEAD".equals(method)) {
-                        expectedMethod = "HEAD";
-                    } else {
-                        expectedMethod = "GET";
-                    }
+                    String expectedMethod = switch (statusCode) {
+                        case 307, 308 -> method;
+                        default -> "HEAD".equals(method) ? "HEAD" : "GET";
+                    };
                     res.add(Arguments.of(httpImpl, statusCode, method, expectedMethod));
                 }
             }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
@@ -43,7 +43,6 @@ class TestRedirects {
 
     public static List<Arguments> redirectionParams() {
         List<Arguments> res = new ArrayList<>();
-        // Nested for depth is 2 (max allowed is 1). [NestedForDepth]
         List<String> httpMethods = Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE");
         Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
@@ -85,7 +84,6 @@ class TestRedirects {
 
     public static List<Arguments> methodPreservationParams() {
         List<Arguments> res = new ArrayList<>();
-        // Nested for depth is 2 (max allowed is 1). [NestedForDepth]
         List<String> httpMethods = Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE");
         Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {


### PR DESCRIPTION
## Summary

Fixes #6080

This change fixes redirect handling in JMeter's `Follow Redirects` path for HTTP 307 and 308 responses.

At the moment, JMeter only treats 307 as a redirect for `GET` and `HEAD`, so requests such as `POST 307` are not followed. In addition, redirected requests for 307/308 can still lose the original HTTP method.

This change updates `HTTPSampleResult.isRedirect()` so 307 is recognized as a redirect for all HTTP methods, and updates redirect method selection so 307/308 preserve the original method while keeping the existing 301/302/303 behavior unchanged.

It also uses `lastRes.getResponseCode()` in `followRedirects()`, so mixed redirect chains such as `307 -> 301` are handled correctly.

## Tests

- updated `testRedirect` for 307 redirect recognition
- added redirect method preservation coverage in `TestRedirects`
- added a mixed redirect chain test (`307 -> 301`)
- ran `./gradlew :src:protocol:http:check`