### PR TITLE
CI: some CI workers are slow, so use bigger margin for test duration

### DIFF
--- a/bin/testfiles/TestSchedulerWithTimer.jmx
+++ b/bin/testfiles/TestSchedulerWithTimer.jmx
@@ -2,7 +2,7 @@
 <jmeterTestPlan version="1.2" properties="3.2" jmeter="3.2-SNAPSHOT.20170410">
   <hashTree>
     <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
-      <stringProp name="TestPlan.comments">Each Thread Group should initially end after 20s but since scheduler is set to 5s, we check it ends within 6s. Tests for Bugs 60797 and 60049</stringProp>
+      <stringProp name="TestPlan.comments">Each Thread Group should initially end after 20s but since scheduler is set to 5s, we check it ends within 7s (some CI workers are slow). Tests for Bugs 60797 and 60049</stringProp>
       <boolProp name="TestPlan.functional_mode">false</boolProp>
       <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
@@ -170,7 +170,7 @@
           <stringProp name="cacheKey">7b043ed3-cbc5-4b9c-8427-8c70e6791c07</stringProp>
           <stringProp name="script">long start = Long.parseLong(props.get(&quot;TEST_START&quot;));
 long duration = System.currentTimeMillis() - start;
-long maxDurationPlusMargin = vars[&quot;MaxDuration&quot;].toInteger()*1000+1000;
+long maxDurationPlusMargin = vars[&quot;MaxDuration&quot;].toInteger()*1000+2000;
 if(duration&gt; maxDurationPlusMargin) {
 	SampleResult.setSuccessful(false);
 	SampleResult.setResponseData(&quot;Duration &quot;+duration+&quot; exceeded expected duration of &quot;+maxDurationPlusMargin);


### PR DESCRIPTION
## Description
Set a bigger margin for the scheduler to end in one flaky test

## Motivation and Context
Some CI workers seem to be slow and we get less value of a flaky test. We already gave one second margin. The slow workers often used 400 ms more, so use two seconds margin, to be on the safe(r) side. 

## How Has This Been Tested?
Let the CI builds decide :)

## Screenshots (if appropriate):

## Types of changes
- CI fix (hopefully)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
