### PR TITLE
CI: fix slow workers taking long time to start threads

### DIFF
--- a/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/HttpRequestInterruptTest.kt
+++ b/src/protocol/http/src/test/kotlin/org/apache/jmeter/protocol/http/HttpRequestInterruptTest.kt
@@ -65,7 +65,7 @@ class HttpRequestInterruptTest : JMeterTestCase() {
         }
 
         assertEquals(5, events.size) { "5 events expected, got $events" }
-        if (events.any { it.result.isSuccessful || it.result.isResponseCodeOK || it.result.time < 500 }) {
+        if (events.any { it.result.isSuccessful || it.result.isResponseCodeOK || (it.result.time + it.result.connectTime) < 500 }) {
             fail(
                 "All events should be failing, and they should take more than 500ms since the requests " +
                     "should have been cancelled after 1sec. Results are: $events"


### PR DESCRIPTION

## Description
Take connectTime into account, when calculating requests that are falsely "OK".

## Motivation and Context
The test breaks on slow workers with result.time almost 500ms. I think the long connectTime (more than 200ms) is responsible for the "early" interrupt. The tests that fail report the results and all five of them have an `elapsedTime` of almost 500 ms and a `connectTime` of more than 200ms.

So by adding those, we get over the limit of 500 ms and should be good, but without the elapsedTime, we fail.

## How Has This Been Tested?
Let's check the CI resuls.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- CI fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
