### PR TITLE
Remove NestedForDepth Checkstyle rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -118,7 +118,7 @@
     <module name="IllegalThrows"/>
     <module name="ModifiedControlVariable"/>
     <module name="MultipleVariableDeclarations"/>
-    <module name="NestedForDepth"/>
+
     <module name="NestedIfDepth">
       <!-- TODO: reduce this number -->
       <property name="max" value="4"/>

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -53,13 +52,13 @@ public class TestDecompression {
 
     public static List<Arguments> mockServerParams() {
         List<Arguments> res = new ArrayList<>();
-        Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
+        for (String httpImpl : HTTPSamplerFactory.getImplementations()) {
             for (ClientGzip clientGzip : ClientGzip.values()) {
                 for (ServerGzip serverGzip : ServerGzip.values()) {
                     res.add(Arguments.of(httpImpl, clientGzip, serverGzip));
                 }
             }
-        });
+        }
         return res;
     }
 

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
@@ -53,7 +53,6 @@ public class TestDecompression {
 
     public static List<Arguments> mockServerParams() {
         List<Arguments> res = new ArrayList<>();
-        // Nested for depth is 2 (max allowed is 1). [NestedForDepth]
         Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
             for (ClientGzip clientGzip : ClientGzip.values()) {
                 for (ServerGzip serverGzip : ServerGzip.values()) {

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
@@ -44,7 +44,7 @@ class TestRedirects {
     public static List<Arguments> redirectionParams() {
         List<Arguments> res = new ArrayList<>();
         List<String> httpMethods = Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE");
-        Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
+        for (String httpImpl : HTTPSamplerFactory.getImplementations()) {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
                 for (String method : httpMethods) {
                     res.add(Arguments.of(httpImpl, statusCode, true, method));
@@ -55,7 +55,7 @@ class TestRedirects {
                     res.add(Arguments.of(httpImpl, statusCode, false, method));
                 }
             }
-        });
+        }
         return res;
     }
 
@@ -85,7 +85,7 @@ class TestRedirects {
     public static List<Arguments> methodPreservationParams() {
         List<Arguments> res = new ArrayList<>();
         List<String> httpMethods = Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE");
-        Arrays.stream(HTTPSamplerFactory.getImplementations()).forEach(httpImpl -> {
+        for (String httpImpl : HTTPSamplerFactory.getImplementations()) {
             for (int statusCode : Arrays.asList(301, 302, 303, 307, 308)) {
                 for (String method : httpMethods) {
                     String expectedMethod = switch (statusCode) {
@@ -95,7 +95,7 @@ class TestRedirects {
                     res.add(Arguments.of(httpImpl, statusCode, method, expectedMethod));
                 }
             }
-        });
+        }
         return res;
     }
 


### PR DESCRIPTION
## Description

Remove `NestedForDepth` from `config/checkstyle/checkstyle.xml`, drop the stale `NestedForDepth` comment in `TestDecompression`, and replace the `Arrays.stream().forEach()` wrappers with plain `for` loops in `TestDecompression` and `TestRedirects`.

## Motivation and Context

In #6658, vlsi suggested relaxing this requirement. The current rule has led to patterns like `stream().forEach()` in test parameter generation, where plain nested loops are easier to read.

Closes #6665

## How Has This Been Tested?

- No functional code changes
- `./gradlew checkstyleAll`
- `./gradlew :src:protocol:http:test --tests "*TestRedirects*" --tests "*TestDecompression*"`

## Checklist:

- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines