### PR TITLE
chore: remove deprecated packages keyword from log4j configs

### DIFF
--- a/bin/testfiles/log4j2-batch.xml
+++ b/bin/testfiles/log4j2-batch.xml
@@ -15,7 +15,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<Configuration status="WARN" packages="org.apache.jmeter.gui.logging">
+<Configuration status="WARN">
 
   <Appenders>
 

--- a/src/core/src/testFixtures/resources/log4j2.xml
+++ b/src/core/src/testFixtures/resources/log4j2.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<Configuration status="WARN" packages="org.apache.jmeter.gui.logging">
+<Configuration status="WARN">
 
   <Appenders>
 


### PR DESCRIPTION
## Description
Remove `packages` attribute from some log4j2.xml files we use in the tests.

## Motivation and Context
The original packages keyword in our real config file was removed quite a while ago. We don't need or use these attributes anymore.

## How Has This Been Tested?
Ran a local test. Finished without error.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Chore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
