### PR TITLE
chore: print stacktrace on the console should the test timeout

### DIFF
--- a/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/build-logic.test-junit5.gradle.kts
@@ -42,5 +42,6 @@ tasks.configureEach<Test> {
         value?.let { systemProperty(name, it) }
     }
     passProperty("junit.jupiter.execution.parallel.enabled", "true")
+    passProperty("junit.jupiter.execution.timeout.threaddump.enabled", "true")
     passProperty("junit.jupiter.execution.timeout.default", "2 m")
 }


### PR DESCRIPTION
Let's try print thread dumps in case of test timeouts.

It might surface the reasons for timeouts like in https://github.com/apache/jmeter/issues/6681

See https://github.com/junit-team/junit-framework/issues/5552