### PR TITLE
[6411] Java 21: virtual threads for sampler execution + API migration

### DIFF
--- a/build-logic/build-parameters/build.gradle.kts
+++ b/build-logic/build-parameters/build.gradle.kts
@@ -38,7 +38,7 @@ buildParameters {
         description.set("Collect test coverage")
     }
     integer("targetJavaVersion") {
-        defaultValue.set(17)
+        defaultValue.set(21)
         mandatory.set(true)
         description.set("Java version for source and target compatibility")
     }

--- a/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
+++ b/src/components/src/main/java/org/apache/jmeter/visualizers/backend/influxdb/HttpMetricsSender.java
@@ -17,6 +17,7 @@
 
 package org.apache.jmeter.visualizers.backend.influxdb;
 
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -120,7 +121,7 @@ class HttpMetricsSender extends AbstractInfluxdbMetricsSender {
                 .disableCookieManagement()
                 .disableConnectionState()
                 .build();
-        url = new URL(influxdbUrl);
+        url = URI.create(influxdbUrl).toURL();
         token = influxDBToken;
         httpRequest = createRequest(url, token);
         httpClient.start();

--- a/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -55,7 +56,7 @@ public class ResponseAssertionTest {
         jmctx.setVariables(vars);
         jmctx.setPreviousResult(sample);
         sample.setResponseData("response Data\nline 2\n\nEOF", null);
-        sample.setURL(new URL("http://localhost/Sampler/Data/"));
+        sample.setURL(URI.create("http://localhost/Sampler/Data/").toURL());
         sample.setResponseCode("401");
         sample.setResponseHeaders("X-Header: abcd");
         sample.setRequestHeaders("X-reqHeader: cdef");

--- a/src/components/src/test/java/org/apache/jmeter/extractor/TestRegexExtractor.java
+++ b/src/components/src/test/java/org/apache/jmeter/extractor/TestRegexExtractor.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
 import java.net.URL;
 
 import org.apache.jmeter.samplers.SampleResult;
@@ -314,7 +315,7 @@ public class TestRegexExtractor {
         assertTrue(extractor.useUrl(), "useURL should be true");
         extractor.process();
         assertNull(vars.get("regVal"));
-        result.setURL(new URL("http://jakarta.apache.org/index.html?abcd"));
+        result.setURL(URI.create("http://jakarta.apache.org/index.html?abcd").toURL());
         extractor.process();
         assertEquals("index", vars.get("regVal"));
     }

--- a/src/core/src/main/java/org/apache/jmeter/JMeter.java
+++ b/src/core/src/main/java/org/apache/jmeter/JMeter.java
@@ -382,7 +382,7 @@ public class JMeter implements JMeterPlugin {
 
             Thread.setDefaultUncaughtExceptionHandler(
                     (Thread t, Throwable e) -> {
-                    if (!(e instanceof ThreadDeath)) {
+                    if (!(e instanceof VirtualMachineError)) {
                         log.error("Uncaught exception in thread {}", t, e);
                         System.err.println("Uncaught Exception " + e + " in thread " + t + ". See log file for details.");//NOSONAR
                     }

--- a/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
+++ b/src/core/src/main/java/org/apache/jmeter/engine/StandardJMeterEngine.java
@@ -30,11 +30,11 @@ import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.jmeter.JMeter;
 import org.apache.jmeter.samplers.SampleEvent;
@@ -92,19 +92,17 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
     /** Whether to call System.exit(0) unconditionally at end of non-GUI test */
     private static final boolean SYSTEM_EXIT_FORCED = JMeterUtils.getPropDefault("jmeterengine.force.system.exit", false);
 
-    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
-
     /**
      * Executor service to execute management tasks like "start test", "stop test".
-     * The use of {@link ExecutorService} allows propagating the exception from the threads.
-     * Thread keepalive time is set to 1 second, so threads are released early,
-     * so the application can shut down faster.
+     * Uses platform threads to keep the JVM alive while tests run
+     * (virtual threads are daemon threads and would allow premature JVM exit).
      */
     private static final ExecutorService EXECUTOR_SERVICE =
-            new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                    1L, TimeUnit.SECONDS,
-                    new java.util.concurrent.SynchronousQueue<>(),
-                    (runnable) -> new Thread(runnable, "StandardJMeterEngine-" + THREAD_COUNTER.incrementAndGet()));
+            Executors.newThreadPerTaskExecutor(
+                    Thread.ofPlatform().name("StandardJMeterEngine-", 1).factory());
+
+    private static final ReentrantLock REGISTER_LOCK = new ReentrantLock();
+    private final ReentrantLock stopTestLock = new ReentrantLock();
 
     private volatile Future<?> runningTest;
 
@@ -156,8 +154,13 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
         }
     }
 
-    public static synchronized void register(TestStateListener tl) {
-        testList.add(tl);
+    public static void register(TestStateListener tl) {
+        REGISTER_LOCK.lock();
+        try {
+            testList.add(tl);
+        } finally {
+            REGISTER_LOCK.unlock();
+        }
     }
 
     public static boolean stopThread(String threadName) {
@@ -296,14 +299,19 @@ public class StandardJMeterEngine implements JMeterEngine, Runnable {
      * Stop Test Now
      */
     @Override
-    public synchronized void stopTest() {
+    public void stopTest() {
         stopTest(true);
     }
 
     @Override
     @SuppressWarnings("FutureReturnValueIgnored")
-    public synchronized void stopTest(boolean now) {
-        EXECUTOR_SERVICE.submit(new StopTest(now));
+    public void stopTest(boolean now) {
+        stopTestLock.lock();
+        try {
+            EXECUTOR_SERVICE.submit(new StopTest(now));
+        } finally {
+            stopTestLock.unlock();
+        }
     }
 
     private class StopTest implements Runnable {

--- a/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/AbstractJMeterGuiComponent.java
@@ -388,7 +388,7 @@ public abstract class AbstractJMeterGuiComponent extends JPanel implements JMete
     @Override
     public String getDocAnchor() {
         // Ensure we use default bundle
-        String label =  JMeterUtils.getResString(getLabelResource(), new Locale("",""));
+        String label =  JMeterUtils.getResString(getLabelResource(), Locale.ROOT);
         return label.replace(' ', '_');
     }
 

--- a/src/core/src/main/java/org/apache/jmeter/gui/action/ChangeLanguage.java
+++ b/src/core/src/main/java/org/apache/jmeter/gui/action/ChangeLanguage.java
@@ -53,9 +53,9 @@ public class ChangeLanguage extends AbstractActionWithNoRunningTest {
 
         int sep = locale.indexOf('_');
         if (sep > 0) {
-            loc = new Locale(locale.substring(0, sep), locale.substring(sep + 1));
+            loc = Locale.of(locale.substring(0, sep), locale.substring(sep + 1));
         } else {
-            loc = new Locale(locale, "");
+            loc = Locale.of(locale);
         }
         log.debug("Changing locale to {}", loc);
         try {

--- a/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
+++ b/src/core/src/main/java/org/apache/jmeter/testbeans/gui/TestBeanGUI.java
@@ -490,7 +490,7 @@ public class TestBeanGUI extends AbstractJMeterGuiComponent implements JMeterGUI
     public String getDocAnchor() {
         ResourceBundle resourceBundle = ResourceBundle.getBundle(
                 testBeanClass.getName() + "Resources",  // $NON-NLS-1$
-                new Locale("",""));
+                Locale.ROOT);
 
         String name = resourceBundle.getString("displayName");
         return name.replace(' ', '_');

--- a/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/AbstractThreadGroup.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.IdentityHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.jmeter.control.Controller;
 import org.apache.jmeter.control.IteratingController;
@@ -50,6 +51,7 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
 
     // Only create the map if it is required
     private final transient IdentityHashMap<TestElement, Object> children = new IdentityHashMap<>();
+    private final transient ReentrantLock childrenLock = new ReentrantLock();
 
     private static final Object DUMMY = new Object();
 
@@ -166,11 +168,14 @@ public abstract class AbstractThreadGroup extends AbstractTestElement
      */
     @Override
     public final boolean addTestElementOnce(TestElement child){
-        synchronized (children) {
+        childrenLock.lock();
+        try {
             if (children.putIfAbsent(child, DUMMY) == null) {
                 addTestElement(child);
                 return true;
             }
+        } finally {
+            childrenLock.unlock();
         }
         return false;
     }

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterContextService.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterContextService.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.threads;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.jmeter.util.JMeterUtils;
 
@@ -39,6 +40,7 @@ public final class JMeterContextService {
 
     private static final AtomicInteger TOTAL_THREADS = new AtomicInteger();
 
+    private static final ReentrantLock TEST_LIFECYCLE_LOCK = new ReentrantLock();
     private static UnmodifiableJMeterVariables variables;
 
 
@@ -81,11 +83,16 @@ public final class JMeterContextService {
      * Zeroes numberOfActiveThreads.
      * Saves current time in a field and in the JMeter property "TESTSTART.MS"
      */
-    public static synchronized void startTest() {
-        if (testStart.get() == 0) {
-            NUMBER_OF_ACTIVE_THREADS.set(0);
-            testStart.set(System.currentTimeMillis());
-            JMeterUtils.setProperty("TESTSTART.MS", Long.toString(testStart.get()));// $NON-NLS-1$
+    public static void startTest() {
+        TEST_LIFECYCLE_LOCK.lock();
+        try {
+            if (testStart.get() == 0) {
+                NUMBER_OF_ACTIVE_THREADS.set(0);
+                testStart.set(System.currentTimeMillis());
+                JMeterUtils.setProperty("TESTSTART.MS", Long.toString(testStart.get()));// $NON-NLS-1$
+            }
+        } finally {
+            TEST_LIFECYCLE_LOCK.unlock();
         }
     }
 
@@ -122,9 +129,14 @@ public final class JMeterContextService {
      * Called by MainFrame#testEnded().
      * Clears start time field.
      */
-    public static synchronized void endTest() {
-        testStart.set(0);
-        resetClientSideVariables();
+    public static void endTest() {
+        TEST_LIFECYCLE_LOCK.lock();
+        try {
+            testStart.set(0);
+            resetClientSideVariables();
+        } finally {
+            TEST_LIFECYCLE_LOCK.unlock();
+        }
     }
 
     public static long getTestStartTime() {

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
@@ -326,8 +326,6 @@ public class JMeterThread implements Runnable, Interruptible {
             }
         } catch (Exception | JMeterError e) {
             log.error("Test failed!", e);
-        } catch (ThreadDeath e) {
-            throw e; // Must not ignore this one
         } finally {
             currentSamplerForInterruption = null; // prevent any further interrupts
             interruptLock.lock();  // make sure current interrupt is finished, prevent another starting yet

--- a/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/TestCompiler.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.jmeter.assertions.Assertion;
 import org.apache.jmeter.config.ConfigTestElement;
@@ -64,6 +65,7 @@ public class TestCompiler implements HashTreeTraverser {
      * Otherwise, the child is added to the parent and the pair is added to the Set.
      */
     private static final Set<ObjectPair> PAIRING = new HashSet<>();
+    private static final ReentrantLock PAIRING_LOCK = new ReentrantLock();
 
     // TODO: replace with ArrayDequeue
     private final LinkedList<TestElement> stack = new LinkedList<>();
@@ -84,9 +86,12 @@ public class TestCompiler implements HashTreeTraverser {
      * test run.
      */
     public static void initialize() {
-        // synch is probably not needed as only called before run starts
-        synchronized (PAIRING) {
+        // lock is probably not needed as only called before run starts
+        PAIRING_LOCK.lock();
+        try {
             PAIRING.clear();
+        } finally {
+            PAIRING_LOCK.unlock();
         }
     }
 
@@ -152,13 +157,16 @@ public class TestCompiler implements HashTreeTraverser {
                     duplicate = !te.addTestElementOnce(child);
                 } else { // this is only possible for 3rd party controllers by default
                     ObjectPair pair = new ObjectPair(child, parent);
-                    synchronized (PAIRING) {// Called from multiple threads
+                    PAIRING_LOCK.lock();
+                    try { // Called from multiple threads
                         if (!PAIRING.contains(pair)) {
                             parent.addTestElement(child);
                             PAIRING.add(pair);
                         } else {
                             duplicate = true;
                         }
+                    } finally {
+                        PAIRING_LOCK.unlock();
                     }
                 }
             }

--- a/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/ThreadGroup.java
@@ -22,6 +22,7 @@ import java.io.ObjectInputStream;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.jmeter.engine.StandardJMeterEngine;
 import org.apache.jmeter.gui.GUIMenuSortOrder;
@@ -77,7 +78,7 @@ public class ThreadGroup extends AbstractThreadGroup {
     // List of active threads
     private final ConcurrentHashMap<JMeterThread, Thread> allThreads = new ConcurrentHashMap<>();
 
-    private transient Object addThreadLock = new Object();
+    private transient ReentrantLock addThreadLock = new ReentrantLock();
 
     /** Is test (still) running? */
     private volatile boolean running = false;
@@ -230,9 +231,9 @@ public class ThreadGroup extends AbstractThreadGroup {
         log.info("Starting thread group... number={} threads={} ramp-up={} delayedStart={}", groupNumber,
                 numThreads, rampUpPeriodInSeconds, delayedStartup);
         if (delayedStartup) {
-            threadStarter = new Thread(new ThreadStarter(notifier, threadGroupTree, engine), getName()+"-ThreadStarter");
-            threadStarter.setDaemon(true);
-            threadStarter.start();
+            threadStarter = Thread.ofVirtual()
+                    .name(getName() + "-ThreadStarter")
+                    .start(new ThreadStarter(notifier, threadGroupTree, engine));
             // N.B. we don't wait for the thread to complete, as that would prevent parallel TGs
         } else {
             final JMeterVariables variables = JMeterContextService.getContext().getVariables();
@@ -248,7 +249,7 @@ public class ThreadGroup extends AbstractThreadGroup {
                             (perThreadDelayInMillis - timeElapsedToStartLastThread));
                 }
                 if (log.isDebugEnabled()) {
-                    log.debug("Computed delayForNextThreadInMillis:{} for thread:{}", delayForNextThreadInMillis, Thread.currentThread().getId());
+                    log.debug("Computed delayForNextThreadInMillis:{} for thread:{}", delayForNextThreadInMillis, Thread.currentThread().threadId());
                 }
                 lastThreadStartInMillis = nowInMillis;
                 startNewThread(notifier, threadGroupTree, engine, threadNum, variables, nowInMillis, Math.max(0, delayForNextThreadInMillis));
@@ -273,9 +274,10 @@ public class ThreadGroup extends AbstractThreadGroup {
         JMeterThread jmThread = makeThread(engine, this, notifier, groupNumber, threadNum, cloneTree(threadGroupTree), variables);
         scheduleThread(jmThread, now); // set start and end time
         jmThread.setInitialDelay(delay);
-        Thread newThread = new Thread(jmThread, jmThread.getThreadName());
+        Thread newThread = Thread.ofVirtual()
+                .name(jmThread.getThreadName())
+                .start(jmThread);
         registerStartedThread(jmThread, newThread);
-        newThread.start();
         return jmThread;
     }
 
@@ -284,7 +286,7 @@ public class ThreadGroup extends AbstractThreadGroup {
      */
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        addThreadLock = new Object();
+        addThreadLock = new ReentrantLock();
     }
 
     /**
@@ -297,15 +299,17 @@ public class ThreadGroup extends AbstractThreadGroup {
     }
 
     @Override
-    @SuppressWarnings("SynchronizeOnNonFinalField")
     public JMeterThread addNewThread(int delay, StandardJMeterEngine engine) {
         long now = System.currentTimeMillis();
         JMeterContext context = JMeterContextService.getContext();
         JMeterThread newJmThread;
         int numThreads;
-        synchronized (addThreadLock) {
+        addThreadLock.lock();
+        try {
             numThreads = getNumThreads();
             setNumThreads(numThreads + 1);
+        } finally {
+            addThreadLock.unlock();
         }
         newJmThread = startNewThread(notifier, threadGroupTree, engine, numThreads, context.getVariables(), now, delay);
         JMeterContextService.addTotalThreads( 1 );
@@ -587,10 +591,10 @@ public class ThreadGroup extends AbstractThreadGroup {
                         jmThread.setScheduled(true);
                         jmThread.setEndTime(endtime);
                     }
-                    Thread newThread = new Thread(jmThread, jmThread.getThreadName());
-                    newThread.setDaemon(false); // ThreadStarter is daemon, but we don't want sampler threads to be so too
+                    Thread newThread = Thread.ofVirtual()
+                            .name(jmThread.getThreadName())
+                            .start(jmThread);
                     registerStartedThread(jmThread, newThread);
-                    newThread.start();
                 }
             } catch (Exception ex) {
                 log.error("An error occurred scheduling delay start of threads for Thread Group: {}", getName(), ex);

--- a/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
+++ b/src/core/src/main/java/org/apache/jmeter/util/JMeterUtils.java
@@ -197,9 +197,9 @@ public class JMeterUtils implements UnitTestManager {
         if (loc != null) {
             String []parts = JOrphanUtils.split(loc,"_");// $NON-NLS-1$
             if (parts.length==2) {
-                setLocale(new Locale(parts[0], parts[1]));
+                setLocale(Locale.of(parts[0], parts[1]));
             } else {
-                setLocale(new Locale(loc, "")); // $NON-NLS-1$
+                setLocale(Locale.of(loc)); // $NON-NLS-1$
             }
         } else {
             setLocale(Locale.getDefault());
@@ -1302,7 +1302,6 @@ public class JMeterUtils implements UnitTestManager {
      */
     public static void helpGC() {
         System.gc(); // NOSONAR Intentional
-        System.runFinalization();
     }
 
     /**

--- a/src/core/src/test/java/org/apache/jmeter/engine/DistributedRunnerTest.java
+++ b/src/core/src/test/java/org/apache/jmeter/engine/DistributedRunnerTest.java
@@ -52,7 +52,7 @@ public class DistributedRunnerTest {
         } catch (IOException ex) {
             ex.printStackTrace(System.err);
         }
-        JMeterUtils.setLocale(new Locale("ignoreResources"));
+        JMeterUtils.setLocale(Locale.of("ignoreResources"));
     }
 
     @Test

--- a/src/core/src/test/java/org/apache/jmeter/save/TestCSVSaveService.java
+++ b/src/core/src/test/java/org/apache/jmeter/save/TestCSVSaveService.java
@@ -24,6 +24,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 
 import org.apache.jmeter.junit.JMeterTestCase;
@@ -172,7 +173,7 @@ public class TestCSVSaveService extends JMeterTestCase {
         result.setDataType("7");
         result.setSuccessful(true);
         result.setBytes(8L);
-        result.setURL(new URL("https://jmeter.apache.org"));
+        result.setURL(URI.create("https://jmeter.apache.org").toURL());
         result.setSentBytes(9);
         result.setGroupThreads(10);
         result.setAllThreads(11);

--- a/src/dist-check/src/test/java/org/apache/jmeter/testbeans/gui/PackageTest.java
+++ b/src/dist-check/src/test/java/org/apache/jmeter/testbeans/gui/PackageTest.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 public final class PackageTest extends JMeterTestCase {
     private static final Logger log = LoggerFactory.getLogger(PackageTest.class);
 
-    private static final Locale defaultLocale = new Locale("en","");
+    private static final Locale defaultLocale = Locale.of("en");
 
     private BeanInfo beanInfo;
 
@@ -177,13 +177,13 @@ public final class PackageTest extends JMeterTestCase {
             for (String lang : languages) {
                 final String[] language = lang.split("_");
                 if (language.length == 1) {
-                    Locale locale = new Locale(language[0]);
+                    Locale locale = Locale.of(language[0]);
                     if (locale.toString().equals(defaultLocaleId)) {
                         continue;
                     }
                     suite.add(arguments(testBeanClass, locale, defaultBundle));
                 } else if (language.length == 2) {
-                    Locale locale = new Locale(language[0], language[1]);
+                    Locale locale = Locale.of(language[0], language[1]);
                     if (locale.toString().equals(defaultLocaleId)) {
                         continue;
                     }

--- a/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/sampler/FTPSampler.java
+++ b/src/protocol/ftp/src/main/java/org/apache/jmeter/protocol/ftp/sampler/FTPSampler.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -178,7 +179,7 @@ public class FTPSampler extends AbstractSampler implements Interruptible {
         final String label = getLabel();
         res.setSamplerData(label);
         try {
-            res.setURL(new URL(label));
+            res.setURL(URI.create(label).toURL());
         } catch (MalformedURLException e1) {
             log.warn("Cannot set URL: "+e1.getLocalizedMessage());
         }

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/AuthManager.java
@@ -222,6 +222,7 @@ public class AuthManager extends ConfigTestElement implements TestStateListener,
         return auth.toBasicHeader();
     }
 
+    @SuppressWarnings("deprecation")
     public Authorization getAuthForURL(URL url) {
         if (!isSupportedProtocol(url)) {
             return null;

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/curl/BasicCurlParser.java
@@ -679,6 +679,7 @@ public class BasicCurlParser {
         super();
     }
 
+    @SuppressWarnings("deprecation")
     public Request parse(String commandLine) {
         String[] args = translateCommandline(commandLine);
         CLArgsParser parser = new CLArgsParser(args, OPTIONS);
@@ -1074,6 +1075,7 @@ public class BasicCurlParser {
      * @param url to extract domain and path for the cookie from
      * @return list of cookies
      */
+   @SuppressWarnings("deprecation")
    public static List<Cookie> stringToCookie(String cookieStr, String url) {
        List<Cookie> cookies = new ArrayList<>();
        final StringTokenizer tok = new StringTokenizer(cookieStr, "; ", true);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/gui/action/ParseCurlCommandAction.java
@@ -295,6 +295,7 @@ public class ParseCurlCommandAction extends AbstractAction implements MenuCreato
      * @return {@link HTTPSamplerProxy}
      * @throws MalformedURLException
      */
+    @SuppressWarnings("deprecation")
     private HTTPSamplerProxy createSampler(Request request, String commentText) throws MalformedURLException {
         HTTPSamplerProxy httpSampler = (HTTPSamplerProxy) HTTPSamplerFactory
                 .newInstance(HTTPSamplerFactory.DEFAULT_CLASSNAME);

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/proxy/DefaultSamplerCreator.java
@@ -433,6 +433,7 @@ public class DefaultSamplerCreator extends AbstractSamplerCreator {
      * @throws MalformedURLException when no {@link URL} could be built from
      *         <code>sampler</code> and <code>request</code>
      */
+    @SuppressWarnings("deprecation")
     protected void computeContentEncoding(HTTPSamplerBase sampler,
             HttpRequestHdr request, Map<String, String> pageEncodings,
             Map<String, String> formEncodings) throws MalformedURLException {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPHC4Impl.java
@@ -245,6 +245,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
          * @param authScope information which destination we want to get credentials for
          * @return matching authorization information entry from the AuthManager
          */
+        @SuppressWarnings("deprecation")
         private Authorization getAuthorizationForAuthScope(AuthScope authScope) {
             if (authScope == null) {
                 return null;
@@ -287,6 +288,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
 
     private static final class PreemptiveAuthRequestInterceptor implements HttpRequestInterceptor {
         @Override
+        @SuppressWarnings("deprecation")
         public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
             HttpClientContext localContext = HttpClientContext.adapt(context);
             AuthManager authManager = (AuthManager) localContext.getAttribute(CONTEXT_ATTRIBUTE_AUTH_MANAGER);
@@ -591,6 +593,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected HTTPSampleResult sample(URL url, String method,
             boolean areFollowingRedirect, int frameDepth) {
@@ -911,6 +914,7 @@ public class HTTPHC4Impl extends HTTPHCAbstractImpl {
      * @return the result of the execution of the httpRequest
      * @throws IOException
      */
+    @SuppressWarnings({"deprecation", "removal"})
     private CloseableHttpResponse executeRequest(final CloseableHttpClient httpClient,
             final HttpRequestBase httpRequest, final HttpContext localContext, final URL url)
             throws IOException {

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -1088,6 +1088,7 @@ public abstract class HTTPSamplerBase extends AbstractSampler
      * @return The URL to be requested by this sampler.
      * @throws MalformedURLException if url is malformed
      */
+    @SuppressWarnings("deprecation")
     public URL getUrl() throws MalformedURLException {
         String path = this.getPath();
         // Hack to allow entire URL to be provided in host field

--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/util/ConversionUtils.java
@@ -186,6 +186,7 @@ public class ConversionUtils {
      * @throws MalformedURLException when the given <code>URL</code> is malformed
      * @see <a href="https://bz.apache.org/bugzilla/show_bug.cgi?id=46690">Bug 46690 - handling of 302 redirects with invalid relative paths</a>
      */
+    @SuppressWarnings("deprecation")
     public static URL makeRelativeURL(URL baseURL, String location) throws MalformedURLException{
         URL initial = new URL(baseURL,location);
 
@@ -209,6 +210,7 @@ public class ConversionUtils {
      * @return String cleaned up url
      * @throws Exception when given <code>url</code> leads to a malformed URL or URI
      */
+    @SuppressWarnings("deprecation")
     public static String escapeIllegalURLCharacters(String url) throws Exception{
         String decodeUrl = URLDecoder.decode(url,StandardCharsets.UTF_8.name());
         URL urlString = new URL(decodeUrl);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/gui/action/ParseCurlCommandActionTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/gui/action/ParseCurlCommandActionTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -246,7 +247,7 @@ public class ParseCurlCommandActionTest {
         request = basicCurlParser.parse(
                 "curl -X PUT \"https://www.example.com:123/12345?param1=value1&param2=value2\" -H  \"accept: */*\" -H  \"X-XSRF-TOKEN: 1234\"");
         httpSampler = (HTTPSamplerProxy) method.invoke(p, request, "");
-        assertEquals(new URL("https://www.example.com:123/12345?param1=value1&param2=value2"), httpSampler.getUrl());
+        assertEquals(URI.create("https://www.example.com:123/12345?param1=value1&param2=value2").toURL(), httpSampler.getUrl());
         assertEquals(123, httpSampler.getPort());
         assertEquals("www.example.com", httpSampler.getDomain());
         assertEquals("/12345?param1=value1&param2=value2", httpSampler.getPath());

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestAuthManager.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestAuthManager.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -35,12 +36,16 @@ public class TestAuthManager extends JMeterTestCase {
 
     @Test
     public void testHttp() throws Exception {
-        Assertions.assertTrue(AuthManager.isSupportedProtocol(new URL("http:")));
+        @SuppressWarnings("deprecation")
+        URL httpUrl = new URL("http:");
+        Assertions.assertTrue(AuthManager.isSupportedProtocol(httpUrl));
     }
 
     @Test
     public void testHttps() throws Exception {
-        Assertions.assertTrue(AuthManager.isSupportedProtocol(new URL("https:")));
+        @SuppressWarnings("deprecation")
+        URL httpsUrl = new URL("https:");
+        Assertions.assertTrue(AuthManager.isSupportedProtocol(httpsUrl));
     }
 
     @Test
@@ -51,37 +56,37 @@ public class TestAuthManager extends JMeterTestCase {
         am.addFile(findTestPath("testfiles/TestAuth.txt"));
         assertEquals(9, ao.size());
         Authorization at;
-        at = am.getAuthForURL(new URL("http://a.b.c/"));
+        at = am.getAuthForURL(URI.create("http://a.b.c/").toURL());
         assertEquals("login", at.getUser());
         assertEquals("password", at.getPass());
-        at = am.getAuthForURL(new URL("http://a.b.c:80/")); // same as above
+        at = am.getAuthForURL(URI.create("http://a.b.c:80/").toURL()); // same as above
         assertEquals("login", at.getUser());
         assertEquals("password", at.getPass());
-        at = am.getAuthForURL(new URL("http://a.b.c:443/"));// not same
+        at = am.getAuthForURL(URI.create("http://a.b.c:443/").toURL());// not same
         assertNull(at);
-        at = am.getAuthForURL(new URL("http://a.b.c/1"));
+        at = am.getAuthForURL(URI.create("http://a.b.c/1").toURL());
         assertEquals("login1", at.getUser());
         assertEquals("password1", at.getPass());
         assertEquals("", at.getDomain());
         assertEquals("", at.getRealm());
-        at = am.getAuthForURL(new URL("http://d.e.f/"));
+        at = am.getAuthForURL(URI.create("http://d.e.f/").toURL());
         assertEquals("user", at.getUser());
         assertEquals("pass", at.getPass());
         assertEquals("domain", at.getDomain());
         assertEquals("realm", at.getRealm());
-        at = am.getAuthForURL(new URL("https://j.k.l/"));
+        at = am.getAuthForURL(URI.create("https://j.k.l/").toURL());
         assertEquals("jkl", at.getUser());
         assertEquals("pass", at.getPass());
-        at = am.getAuthForURL(new URL("https://j.k.l:443/"));
+        at = am.getAuthForURL(URI.create("https://j.k.l:443/").toURL());
         assertEquals("jkl", at.getUser());
         assertEquals("pass", at.getPass());
-        at = am.getAuthForURL(new URL("https://l.m.n/"));
+        at = am.getAuthForURL(URI.create("https://l.m.n/").toURL());
         assertEquals("lmn443", at.getUser());
         assertEquals("pass", at.getPass());
-        at = am.getAuthForURL(new URL("https://l.m.n:443/"));
+        at = am.getAuthForURL(URI.create("https://l.m.n:443/").toURL());
         assertEquals("lmn443", at.getUser());
         assertEquals("pass", at.getPass());
-        at = am.getAuthForURL(new URL("https://l.m.n:8443/"));
+        at = am.getAuthForURL(URI.create("https://l.m.n:8443/").toURL());
         assertEquals("lmn8443", at.getUser());
         assertEquals("pass", at.getPass());
     }
@@ -93,7 +98,7 @@ public class TestAuthManager extends JMeterTestCase {
                 "http://example.com\tuser\tpassword\t\t\tBASIC_DIGEST".getBytes(Charset.defaultCharset()));
         AuthManager manager = new AuthManager();
         manager.addFile(authFile.getAbsolutePath());
-        Authorization authForURL = manager.getAuthForURL(new URL("http://example.com"));
+        Authorization authForURL = manager.getAuthForURL(URI.create("http://example.com").toURL());
         assertEquals("password", authForURL.getPass());
     }
 
@@ -105,7 +110,7 @@ public class TestAuthManager extends JMeterTestCase {
                         .getBytes(Charset.defaultCharset()));
         AuthManager manager = new AuthManager();
         manager.addFile(authFile.getAbsolutePath());
-        Authorization authForURL = manager.getAuthForURL(new URL("http://example.com"));
+        Authorization authForURL = manager.getAuthForURL(URI.create("http://example.com").toURL());
         assertEquals("password", authForURL.getPass());
         assertEquals("domain", authForURL.getDomain());
     }
@@ -118,7 +123,7 @@ public class TestAuthManager extends JMeterTestCase {
                         .getBytes(Charset.defaultCharset()));
         AuthManager manager = new AuthManager();
         manager.addFile(authFile.getAbsolutePath());
-        Authorization authForURL = manager.getAuthForURL(new URL("http://example.com"));
+        Authorization authForURL = manager.getAuthForURL(URI.create("http://example.com").toURL());
         assertEquals("password", authForURL.getPass());
         assertEquals("domain", authForURL.getDomain());
         assertEquals(AuthManager.Mechanism.KERBEROS, authForURL.getMechanism());

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestCacheManagerBase.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestCacheManagerBase.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -61,7 +62,7 @@ public abstract class TestCacheManagerBase extends JMeterTestCase {
     public void setUp() throws Exception {
         this.cacheManager = new CacheManager();
         this.currentTimeInGMT = makeDate(Instant.now());
-        this.url = new URL(LOCAL_HOST);
+        this.url = URI.create(LOCAL_HOST).toURL();
 
         this.sampleResultOK = getSampleResultWithSpecifiedResponseCode("200");
     }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestCacheManagerThreadIteration.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestCacheManagerThreadIteration.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
@@ -221,7 +222,7 @@ public class TestCacheManagerThreadIteration {
     public void setUp() throws Exception {
         this.cacheManager = new CacheManager();
         this.currentTimeInGMT = makeDate(Instant.now());
-        this.url = new URL(LOCAL_HOST);
+        this.url = URI.create(LOCAL_HOST).toURL();
         this.sampleResultOK = getSampleResultWithSpecifiedResponseCode("200");
         this.httpMethod = new HttpPostStub();
         this.httpResponse = new HttpResponseStub();

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestHC4CookieManager.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestHC4CookieManager.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 
@@ -102,14 +103,14 @@ public class TestHC4CookieManager extends JMeterTestCase {
      */
     @Test
     public void testDomainHandling() throws Exception {
-        URL url = new URL("http://jakarta.apache.org/");
+        URL url = URI.create("http://jakarta.apache.org/").toURL();
         man.addCookieFromHeader("test=1;domain=.jakarta.apache.org", url);
         assertNotNull(man.getCookieHeaderForURL(url));
     }
 
     @Test
     public void testAddCookieFromHeaderWithWildcard() throws Exception {
-        URL url = new URL("https://subdomain.bt.com/page");
+        URL url = URI.create("https://subdomain.bt.com/page").toURL();
         String headerLine = "SMTRYNO=1; path=/; domain=.bt.com";
         man.addCookieFromHeader(headerLine, url);
         assertEquals(1, man.getCookieCount());
@@ -125,7 +126,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
         }
 
         // we check that CookieManager returns the cookies for the main domain
-        URL urlMainDomain = new URL("https://www.bt.com/page");
+        URL urlMainDomain = URI.create("https://www.bt.com/page").toURL();
         cookies =
                 cookieHandler.getCookiesForUrl(man.getCookies(), urlMainDomain,
                         CookieManager.ALLOW_VARIABLE_COOKIES);
@@ -139,7 +140,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testAddCookieFromHeaderWithNoWildcard() throws Exception {
-        URL url = new URL("https://subdomain.bt.com/page");
+        URL url = URI.create("https://subdomain.bt.com/page").toURL();
         String headerLine = "SMTRYNO=1; path=/";
         man.addCookieFromHeader(headerLine, url);
         assertEquals(1, man.getCookieCount());
@@ -155,7 +156,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
         }
 
         // we check that CookieManager returns the cookies for the main domain
-        URL urlMainDomain = new URL("https://www.bt.com/page");
+        URL urlMainDomain = URI.create("https://www.bt.com/page").toURL();
         cookies =
                 cookieHandler.getCookiesForUrl(man.getCookies(), urlMainDomain,
                         CookieManager.ALLOW_VARIABLE_COOKIES);
@@ -164,13 +165,13 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testAddCookieFromHeaderWithWildcard2() throws Exception {
-        URL url = new URL("https://www.bt.com/page");
+        URL url = URI.create("https://www.bt.com/page").toURL();
         String headerLine = "SMTRYNO=1; path=/; domain=.bt.com";
         man.addCookieFromHeader(headerLine, url);
 
         assertEquals(1, man.getCookieCount());
         HC4CookieHandler cookieHandler = (HC4CookieHandler) man.getCookieHandler();
-        URL urlSubDomain = new URL("https://subdomain.bt.com/page");
+        URL urlSubDomain = URI.create("https://subdomain.bt.com/page").toURL();
 
         List<org.apache.http.cookie.Cookie> cookies =
                 cookieHandler.getCookiesForUrl(man.getCookies(), urlSubDomain,
@@ -185,14 +186,14 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testBug56358() throws Exception {
-        URL url = new URL("http://remote.com:10008/get/cookie");
+        URL url = URI.create("http://remote.com:10008/get/cookie").toURL();
         String headerLine = "test=value;Max-age=120;path=/;Version=1";
         man.setCookiePolicy(CookieSpecs.STANDARD);
         man.addCookieFromHeader(headerLine, url);
 
         assertEquals(1, man.getCookieCount());
         HC4CookieHandler cookieHandler = (HC4CookieHandler) man.getCookieHandler();
-        URL urlSameDomainDifferentPort = new URL("http://remote.com:10001/test/me");
+        URL urlSameDomainDifferentPort = URI.create("http://remote.com:10001/test/me").toURL();
 
         List<org.apache.http.cookie.Cookie> cookies =
                 cookieHandler.getCookiesForUrl(man.getCookies(), urlSameDomainDifferentPort,
@@ -207,7 +208,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testCrossDomainHandling() throws Exception {
-        URL url = new URL("http://jakarta.apache.org/");
+        URL url = URI.create("http://jakarta.apache.org/").toURL();
         assertEquals(0, man.getCookieCount()); // starts empty
         man.addCookieFromHeader("test=2;domain=.hc.apache.org", url);
         assertEquals(0, man.getCookieCount()); // should not be stored
@@ -221,16 +222,16 @@ public class TestHC4CookieManager extends JMeterTestCase {
      */
     @Test
     public void testSimilarHostNames() throws Exception {
-        URL url = new URL("http://ache.org/");
+        URL url = URI.create("http://ache.org/").toURL();
         man.addCookieFromHeader("test=1", url);
-        url = new URL("http://jakarta.apache.org/");
+        url = URI.create("http://jakarta.apache.org/").toURL();
         assertNull(man.getCookieHeaderForURL(url));
     }
 
     // Test session cookie is returned
     @Test
     public void testSessionCookie() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader("test=1", url);
         String s = man.getCookieHeaderForURL(url);
         assertNotNull(s);
@@ -240,7 +241,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Bug 2063
     @Test
     public void testCookieWithEquals() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader("NSCP_USER_LOGIN1_NEW=SHA=xxxxx", url);
         String s = man.getCookieHeaderForURL(url);
         assertNotNull(s);
@@ -253,7 +254,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test Old cookie is not returned
     @Test
     public void testOldCookie() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader("test=1; expires=Mon, 01-Jan-1990 00:00:00 GMT", url);
         String s = man.getCookieHeaderForURL(url);
         assertNull(s);
@@ -262,7 +263,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test New cookie is returned
     @Test
     public void testNewCookie() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader("test=1; expires=Mon, 01-Jan-2990 00:00:00 GMT", url);
         assertEquals(1, man.getCookieCount());
         String s = man.getCookieHeaderForURL(url);
@@ -273,7 +274,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test HttpOnly cookie is parsed correctly
     @Test
     public void testHttpOnlyCookie() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader(
                 "mySASession=s%3AcafPSGf6UJguyhddGFFeLdHBy9CYbzIS.NhYyA26LGTAVoLxhCQUK%2F2Bs34MW5kGHmErKzG6r3XI; Path=/;"
                         + " Expires=Tue, 07 Feb 2990 09:13:14 GMT; HttpOnly",
@@ -287,7 +288,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test Secure cookie is parsed correctly and not transmitted for HTTP
     @Test
     public void testSecureCookieWithHttp() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader(
                 "mySASession=s%3AcafPSGf6UJguyhddGFFeLdHBy9CYbzIS.NhYyA26LGTAVoLxhCQUK%2F2Bs34MW5kGHmErKzG6r3XI; Path=/;"
                         + " Expires=Tue, 07 Feb 2990 09:13:14 GMT; HttpOnly; secure",
@@ -300,7 +301,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test Secure cookie is parsed correctly and transmitted for HTTPS
     @Test
     public void testSecureCookieWithHttps() throws Exception {
-        URL url = new URL("https://a.b.c/");
+        URL url = URI.create("https://a.b.c/").toURL();
         man.addCookieFromHeader(
                 "mySASession=s%3AcafPSGf6UJguyhddGFFeLdHBy9CYbzIS.NhYyA26LGTAVoLxhCQUK%2F2Bs34MW5kGHmErKzG6r3XI; Path=/;"
                         + " Expires=Tue, 07 Feb 2990 09:13:14 GMT; HttpOnly; secure",
@@ -316,7 +317,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     public void testCookies1() throws Exception {
         man.setCookiePolicy(CookieSpecs.DEFAULT);
         man.testStarted(); // ensure policy is picked up
-        URL url = new URL("http://a.b.c.d/testCookies1");
+        URL url = URI.create("http://a.b.c.d/testCookies1").toURL();
         man.addCookieFromHeader("test1=1; comment=\"how,now\", test2=2; version=1", url);
         assertEquals(2, man.getCookieCount());
         String s = man.getCookieHeaderForURL(url);
@@ -326,7 +327,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testCookies2() throws Exception {
-        URL url = new URL("https://a.b.c.d/testCookies2");
+        URL url = URI.create("https://a.b.c.d/testCookies2").toURL();
         //The cookie in question does not have a version attribute mandatory for
         //standard (RFC 2109 and RFC 2965) cookies. Therefore it is parsed as
         //Netscape style cookie in which case comma is not considered a valid
@@ -343,7 +344,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     public void testCookies3() throws Exception {
         man.setCookiePolicy(CookieSpecs.DEFAULT);
         man.testStarted(); // ensure policy is picked up
-        URL url = new URL("https://a.b.c.d/testCookies2");
+        URL url = URI.create("https://a.b.c.d/testCookies2").toURL();
         man.addCookieFromHeader("test1=1;secure, test2=2;secure; version=1", url);
         assertEquals(2, man.getCookieCount());
         String s = man.getCookieHeaderForURL(url);
@@ -354,7 +355,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test duplicate cookie handling
     @Test
     public void testDuplicateCookie() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader("test=1", url);
         String s = man.getCookieHeaderForURL(url);
         assertNotNull(s);
@@ -367,7 +368,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testDuplicateCookie2() throws Exception {
-        URL url = new URL("http://a.b.c/");
+        URL url = URI.create("http://a.b.c/").toURL();
         man.addCookieFromHeader("test=1", url);
         man.addCookieFromHeader("test2=a", url);
         String s = man.getCookieHeaderForURL(url);
@@ -388,9 +389,9 @@ public class TestHC4CookieManager extends JMeterTestCase {
      */
     @Test
     public void testMissingPath0() throws Exception {
-        URL url = new URL("http://d.e.f/goo.html");
+        URL url = URI.create("http://d.e.f/goo.html").toURL();
         man.addCookieFromHeader("test=moo", url);
-        String s = man.getCookieHeaderForURL(new URL("http://d.e.f/"));
+        String s = man.getCookieHeaderForURL(URI.create("http://d.e.f/").toURL());
         assertNotNull(s);
         assertEquals("test=moo", s);
     }
@@ -401,9 +402,9 @@ public class TestHC4CookieManager extends JMeterTestCase {
      */
     @Test
     public void testMissingPath1() throws Exception {
-        URL url = new URL("http://d.e.f/moo.html");
+        URL url = URI.create("http://d.e.f/moo.html").toURL();
         man.addCookieFromHeader("test=moo", url);
-        String s = man.getCookieHeaderForURL(new URL("http://d.e.f/goo.html"));
+        String s = man.getCookieHeaderForURL(URI.create("http://d.e.f/goo.html").toURL());
         assertNotNull(s);
         assertEquals("test=moo", s);
     }
@@ -413,9 +414,9 @@ public class TestHC4CookieManager extends JMeterTestCase {
      */
     @Test
     public void testRootPath0() throws Exception {
-        URL url = new URL("http://d.e.f/goo.html");
+        URL url = URI.create("http://d.e.f/goo.html").toURL();
         man.addCookieFromHeader("test=moo;path=/", url);
-        String s = man.getCookieHeaderForURL(new URL("http://d.e.f/"));
+        String s = man.getCookieHeaderForURL(URI.create("http://d.e.f/").toURL());
         assertNotNull(s);
         assertEquals("test=moo", s);
     }
@@ -425,9 +426,9 @@ public class TestHC4CookieManager extends JMeterTestCase {
      */
     @Test
     public void testRootPath1() throws Exception {
-        URL url = new URL("http://d.e.f/moo.html");
+        URL url = URI.create("http://d.e.f/moo.html").toURL();
         man.addCookieFromHeader("test=moo;path=/", url);
-        String s = man.getCookieHeaderForURL(new URL("http://d.e.f/goo.html"));
+        String s = man.getCookieHeaderForURL(URI.create("http://d.e.f/goo.html").toURL());
         assertNotNull(s);
         assertEquals("test=moo", s);
     }
@@ -435,32 +436,32 @@ public class TestHC4CookieManager extends JMeterTestCase {
     // Test cookie matching
     @Test
     public void testCookieMatching() throws Exception {
-        URL url = new URL("http://a.b.c:8080/TopDir/fred.jsp");
+        URL url = URI.create("http://a.b.c:8080/TopDir/fred.jsp").toURL();
         man.addCookieFromHeader("ID=abcd; Path=/TopDir", url);
         String s = man.getCookieHeaderForURL(url);
         assertNotNull(s);
         assertEquals("ID=abcd", s);
 
-        url = new URL("http://a.b.c:8080/other.jsp");
+        url = URI.create("http://a.b.c:8080/other.jsp").toURL();
         s = man.getCookieHeaderForURL(url);
         assertNull(s);
 
-        url = new URL("http://a.b.c:8080/TopDir/suub/another.jsp");
+        url = URI.create("http://a.b.c:8080/TopDir/suub/another.jsp").toURL();
         s = man.getCookieHeaderForURL(url);
         assertNotNull(s);
 
-        url = new URL("http://a.b.c:8080/TopDir");
+        url = URI.create("http://a.b.c:8080/TopDir").toURL();
         s = man.getCookieHeaderForURL(url);
         assertNotNull(s);
 
-        url = new URL("http://a.b.d/");
+        url = URI.create("http://a.b.d/").toURL();
         s = man.getCookieHeaderForURL(url);
         assertNull(s);
     }
 
     @Test
     public void testCookieOrdering1() throws Exception {
-        URL url = new URL("http://order.now/sub1/moo.html");
+        URL url = URI.create("http://order.now/sub1/moo.html").toURL();
         man.addCookieFromHeader("test1=moo1;path=/", url);
         // Waiting for https://issues.apache.org/jira/browse/HTTPCLIENT-1705
         man.addCookieFromHeader("test2=moo2;path=/sub1", url);
@@ -477,7 +478,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
 
     @Test
     public void testCookieOrdering2() throws Exception {
-        URL url = new URL("http://order.now/sub1/moo.html");
+        URL url = URI.create("http://order.now/sub1/moo.html").toURL();
         man.addCookieFromHeader("test1=moo1;", url);
         man.addCookieFromHeader("test2=moo2;path=/sub1", url);
         man.addCookieFromHeader("test2=moo3;path=/", url);
@@ -504,7 +505,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     public void testCookiePolicy2109() throws Exception {
         man.setCookiePolicy(org.apache.http.client.params.CookiePolicy.RFC_2109);
         man.testStarted(); // ensure policy is picked up
-        URL url = new URL("http://order.now/sub1/moo.html");
+        URL url = URI.create("http://order.now/sub1/moo.html").toURL();
         man.addCookieFromHeader("test1=moo1;", url);
         man.addCookieFromHeader("test2=moo2;path=/sub1", url);
         man.addCookieFromHeader("test2=moo3;path=/", url);
@@ -531,7 +532,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     public void testCookiePolicyNetscape() throws Exception {
         man.setCookiePolicy(CookieSpecs.NETSCAPE);
         man.testStarted(); // ensure policy is picked up
-        URL url = new URL("http://www.order.now/sub1/moo.html");
+        URL url = URI.create("http://www.order.now/sub1/moo.html").toURL();
         man.addCookieFromHeader("test1=moo1;", url);
         man.addCookieFromHeader("test2=moo2;path=/sub1", url);
         man.addCookieFromHeader("test2=moo3;path=/", url);
@@ -559,7 +560,7 @@ public class TestHC4CookieManager extends JMeterTestCase {
     public void testCookiePolicyIgnore() throws Exception {
         man.setCookiePolicy(CookieSpecs.IGNORE_COOKIES);
         man.testStarted(); // ensure policy is picked up
-        URL url = new URL("http://order.now/sub1/moo.html");
+        URL url = URI.create("http://order.now/sub1/moo.html").toURL();
         man.addCookieFromHeader("test1=moo1;", url);
         man.addCookieFromHeader("test2=moo2;path=/sub1", url);
         man.addCookieFromHeader("test2=moo3;path=/", url);

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/modifier/TestAnchorModifier.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/modifier/TestAnchorModifier.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -62,7 +63,7 @@ public class TestAnchorModifier extends JMeterTestCase {
         result.setResponseData(new TextFile(findTestFile(HTMLFileName)).getText(), null);
         result.setSampleLabel(context.toString());
         result.setSamplerData(context.toString());
-        result.setURL(new URL("http://bz.apache.org/fakepage.html"));
+        result.setURL(URI.create("http://bz.apache.org/fakepage.html").toURL());
         jmctx.setPreviousResult(result);
         AnchorModifier modifier = new AnchorModifier();
         modifier.setThreadContext(jmctx);
@@ -360,7 +361,7 @@ public class TestAnchorModifier extends JMeterTestCase {
 
 
     private static HTTPSamplerBase makeContext(String url) throws MalformedURLException {
-        URL u = new URL(url);
+        URL u = URI.create(url).toURL();
         HTTPSamplerBase context = new HTTPNullSampler();
         context.setDomain(u.getHost());
         context.setPath(u.getPath());

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestBug60842HtmlParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestBug60842HtmlParser.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.protocol.http.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -109,7 +110,7 @@ class TestBug60842HtmlParser {
         final ArrayList<URLString> c = new ArrayList<>();
         parser.getEmbeddedResourceURLs("Mozilla",
                 html.getBytes(StandardCharsets.UTF_8),
-                new URL("http://example.org"), new URLCollection(c),
+                URI.create("http://example.org").toURL(), new URLCollection(c),
                 StandardCharsets.UTF_8.name());
         List<String> urlNames = c.stream().map(u -> u.toString())
                 .collect(Collectors.toList());

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestCssParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestCssParser.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -74,8 +75,7 @@ public class TestCssParser extends JMeterTestCase {
             throws LinkExtractorParseException, MalformedURLException {
         List<URL> result = new ArrayList<>();
         Iterator<URL> urlIterator = parser.getEmbeddedResourceURLs(
-                "Mozilla", css.getBytes(StandardCharsets.UTF_8), new URL(
-                        "http://example.org/"), StandardCharsets.UTF_8
+                "Mozilla", css.getBytes(StandardCharsets.UTF_8), URI.create("http://example.org/").toURL(), StandardCharsets.UTF_8
                         .displayName());
         urlIterator.forEachRemaining(result::add);
         return result;

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/parser/TestHTMLParser.java
@@ -27,6 +27,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -318,7 +319,7 @@ public class TestHTMLParser extends JMeterTestCase {
     }
 
 
-    @SuppressWarnings("URLEqualsHashCode")
+    @SuppressWarnings({"URLEqualsHashCode", "deprecation"})
     private static void filetest(HTMLParser p, String file, String url, String resultFile, Collection<URLString> c,
             boolean orderMatters, // Does the order matter?
             String userAgent)
@@ -327,11 +328,12 @@ public class TestHTMLParser extends JMeterTestCase {
         String fname = file.substring(file.indexOf('/')+1);
         log.debug("file   {}", file);
         byte[] buffer = getInputStream(file).readAllBytes();
+        URL baseUrl = new URL(url);
         Iterator<URL> result;
         if (c == null) {
-            result = p.getEmbeddedResourceURLs(userAgent, buffer, new URL(url), System.getProperty("file.encoding"));
+            result = p.getEmbeddedResourceURLs(userAgent, buffer, baseUrl, System.getProperty("file.encoding"));
         } else {
-            result = p.getEmbeddedResourceURLs(userAgent, buffer, new URL(url), c,System.getProperty("file.encoding"));
+            result = p.getEmbeddedResourceURLs(userAgent, buffer, baseUrl, c,System.getProperty("file.encoding"));
         }
         List<String> actual = Lists.newArrayList(Iterators.transform(result, Object::toString));
         // TODO: Exact ordering is only required for some tests; change the

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/NullURLConnection.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/NullURLConnection.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.protocol.http.sampler;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Properties;
@@ -32,7 +33,7 @@ public final class NullURLConnection extends URLConnection {
     private final Properties data = new Properties();
 
     public NullURLConnection() throws MalformedURLException {
-        this(new URL("http://localhost"));
+        this(URI.create("http://localhost").toURL());
     }
 
     public NullURLConnection(URL url) {

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/PostWriterTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/PostWriterTest.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -905,7 +906,7 @@ public class PostWriterTest {
         private Map<String, String> properties = new HashMap<>();
 
         public StubURLConnection(String url) throws MalformedURLException {
-            super(new URL(url));
+            super(URI.create(url).toURL());
         }
 
         @Override

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestDecompression.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,7 @@ public class TestDecompression {
                             )
             );
 
-            HTTPSampleResult res = http.sample(new URL(server.url("/gzip")), "GET", false, 1);
+            HTTPSampleResult res = http.sample(URI.create(server.url("/gzip")).toURL(), "GET", false, 1);
 
             Assertions.assertAll(
                     () -> assertEquals(expectedResponse, res.getResponseDataAsString(), "response body"),

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestRedirects.java
@@ -22,6 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +71,7 @@ class TestRedirects {
             http.setAutoRedirects(false);
             server.stubFor(any(urlPathEqualTo("/some-location")).willReturn(
                     aResponse().withHeader("Location", server.url("/redirected")).withStatus(redirectCode)));
-            HTTPSampleResult res = http.sample(new URL(server.url("/some-location")), method, false, 1);
+            HTTPSampleResult res = http.sample(URI.create(server.url("/some-location")).toURL(), method, false, 1);
             if (shouldRedirect) {
                 Assertions.assertEquals(server.url("/redirected"), res.getRedirectLocation());
             } else {
@@ -120,7 +121,7 @@ class TestRedirects {
                     .atPriority(10)
                     .willReturn(aResponse().withStatus(405)));
 
-            HTTPSampleResult res = http.sample(new URL(server.url("/original")),
+            HTTPSampleResult res = http.sample(URI.create(server.url("/original")).toURL(),
                     originalMethod, false, 1);
 
             Assertions.assertEquals("200", res.getResponseCode(),
@@ -159,7 +160,7 @@ class TestRedirects {
             server.stubFor(any(urlPathEqualTo("/c")).willReturn(
                     aResponse().withStatus(200)));
 
-            HTTPSampleResult res = http.sample(new URL(server.url("/a")), "POST", false, 1);
+            HTTPSampleResult res = http.sample(URI.create(server.url("/a")).toURL(), "POST", false, 1);
 
             Assertions.assertEquals("200", res.getResponseCode());
             Assertions.assertEquals("GET", res.getHTTPMethod());

--- a/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/InitialContextFactory.java
+++ b/src/protocol/jms/src/main/java/org/apache/jmeter/protocol/jms/client/InitialContextFactory.java
@@ -50,7 +50,7 @@ public class InitialContextFactory {
      */
     public static Context lookupContext(String initialContextFactory,
             String providerUrl, boolean useAuth, String securityPrincipal, String securityCredentials) throws NamingException {
-        String cacheKey = createKey(Thread.currentThread().getId(),initialContextFactory ,providerUrl, securityPrincipal, securityCredentials);
+        String cacheKey = createKey(Thread.currentThread().threadId(),initialContextFactory ,providerUrl, securityPrincipal, securityCredentials);
         Context ctx = MAP.get(cacheKey);
         if (ctx == null) {
             Properties props = new Properties();

--- a/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/PublisherSamplerTest.java
+++ b/src/protocol/jms/src/test/java/org/apache/jmeter/protocol/jms/sampler/PublisherSamplerTest.java
@@ -36,7 +36,7 @@ public class PublisherSamplerTest {
 
     @BeforeEach
     public void initJMeter() {
-        JMeterUtils.setLocale(new Locale("ignoreResources"));
+        JMeterUtils.setLocale(Locale.of("ignoreResources"));
     }
 
     @AfterEach

--- a/src/protocol/mail/src/test/java/org/apache/jmeter/protocol/mail/sampler/TestMailReaderSampler.java
+++ b/src/protocol/mail/src/test/java/org/apache/jmeter/protocol/mail/sampler/TestMailReaderSampler.java
@@ -40,7 +40,7 @@ public class TestMailReaderSampler {
         } catch (IOException ex) {
             ex.printStackTrace(System.err);
         }
-        JMeterUtils.setLocale(new Locale("ignoreResources"));
+        JMeterUtils.setLocale(Locale.of("ignoreResources"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Virtual threads for sampler execution**: `ThreadGroup` now uses `Thread.ofVirtual()` for sampler threads and thread starters, reducing OS thread creation by ~3.5x (65 vs 226 thread creates for 200 concurrent users)
- **`synchronized` → `ReentrantLock`** conversions in `StandardJMeterEngine`, `ThreadGroup`, `JMeterContextService`, `TestCompiler`, `AbstractThreadGroup` to avoid virtual thread carrier pinning
- **Java 21 API migration**: deprecated `new URL()` → `URI.create().toURL()` in test code, `@SuppressWarnings` for production code where URI is too strict, `new Locale()` → `Locale.of()`, `Thread.getId()` → `threadId()`, removed deprecated `ThreadDeath` / `System.runFinalization()` usage
- **Build target**: Java 21

### Design decision
`StandardJMeterEngine.EXECUTOR_SERVICE` uses `Thread.ofPlatform()` (not virtual) — virtual threads are daemon threads and would cause immediate JVM exit in non-GUI mode. Sampler threads remain virtual, tracked via `waitThreadsStopped()`.

## A/B Test Results (200 threads, 180s, 30ms server delay)

| Metric | Virtual Threads | Platform Threads (master) |
|---|---|---|
| Throughput | ~2,450 req/s | ~2,390 req/s |
| Avg latency | 79ms | 81ms |
| Max latency | 6.5s | 7.6s |
| OS thread creates (JFR) | 65 | 226 |
| Thread alloc stats (JFR) | 146 | 470 |

## Test plan
- [x] `./gradlew check` — all tests pass (only pre-existing `batchFTP_TESTS` external dependency failure)
- [x] 180s load test with 200 threads: 440k+ requests, 0 JMeter errors
- [x] JFR comparison: virtual threads vs platform threads
- [ ] Distributed mode testing (engine executor + remote engines)