### PR TITLE
Fix: Make concurrent CSV Read function really thread safe

### DIFF
--- a/src/functions/src/main/java/org/apache/jmeter/functions/FileRowColContainer.java
+++ b/src/functions/src/main/java/org/apache/jmeter/functions/FileRowColContainer.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.jmeter.services.FileServer;
 import org.apache.jmeter.util.JMeterUtils;
@@ -50,7 +51,7 @@ public class FileRowColContainer {
                 ","); // $NON-NLS-1$
 
     /** Keeping track of which row is next to be read. */
-    private int nextRow;
+    private final AtomicInteger nextRow;
 
     /** Delimiter for this file */
     private final String delimiter;
@@ -59,7 +60,7 @@ public class FileRowColContainer {
         log.debug("FRCC({},{})", file, delim);
         fileName = file;
         delimiter = delim;
-        nextRow = 0;
+        nextRow = new AtomicInteger(0);
         fileData = new ArrayList<>();
         load();
     }
@@ -68,7 +69,7 @@ public class FileRowColContainer {
         log.debug("FRCC({})[{}]", file, DELIMITER);
         fileName = file;
         delimiter = DELIMITER;
-        nextRow = 0;
+        nextRow = new AtomicInteger(0);
         fileData = new ArrayList<>();
         load();
     }
@@ -119,13 +120,18 @@ public class FileRowColContainer {
      *
      */
     public int nextRow() {
-        int row = nextRow;
-        nextRow++;
-        if (nextRow >= fileData.size()) {// 0-based
-            nextRow = 0;
+        int size = fileData.size();
+        if (size == 0) {
+            throw new IllegalStateException("CSV file " + fileName + " has no data rows");
         }
-        log.debug("Row: {}", row);
-        return row;
+        while (true) {
+            int current = nextRow.get();
+            int next = (current + 1) % size;
+            if (nextRow.compareAndSet(current, next)) {
+                log.debug("Row: {}", current);
+                return current;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Current implementation could hand out the same row to more than one thread at the same time and could loose track when wrapping around.

To fix #6673 change to a AtomicInteger and a compareAndSet operation to allow thread safe wrap around. To guard against an endless loop in the case of an empty CSV file, we now throw an ISE in such a case.

This fixes #6673

## Description
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
