### PR TITLE
chore: group GitHub-maintained actions (actions/*, github/*) in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,17 @@
       ]
     },
     {
+      "groupName": "github official actions",
+      "description": "actions/* and github/* are maintained by GitHub/Microsoft and can be updated together",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "actions/**",
+        "github/**"
+      ]
+    },
+    {
       "groupName": "io.burt",
       "matchPackageNames": [
         "io.burt{/,}**"


### PR DESCRIPTION
## Summary

Adds a Renovate `packageRule` that groups updates to GitHub Actions maintained by GitHub/Microsoft (matching the `actions/*` and `github/*` namespaces). Third-party actions (e.g. `gradle/actions`, `release-drafter/release-drafter`, `burrunan/gradle-cache-action`, `oracle-actions/setup-java`) intentionally stay ungrouped, since their release cadence and review context are independent.

The new rule is placed alphabetically by `groupName` to keep future diffs minimal.

Example of PRs that would collapse into one under this rule, based on the current [Dependency Dashboard](https://github.com/apache/jmeter/issues/5823):

- `actions/github-script` v9
- (future) `actions/checkout`, `actions/setup-java` bumps

## Test plan

- [x] `renovate.json` is valid JSON
- [ ] Renovate dry-run (Mend portal) shows the next `actions/*` / `github/*` updates land as a single grouped PR