### PR TITLE
chore: group more dependencies in Renovate (commons, bouncycastle, hamcrest, kotlin, ...)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,13 @@
       "enabled": false
     },
     {
+      "groupName": "com.gradle",
+      "description": "Develocity and related Gradle Inc. plugins are released together",
+      "matchPackageNames": [
+        "com.gradle{/,}**"
+      ]
+    },
+    {
       "groupName": "com.helger",
       "matchPackageNames": [
         "com.helger{/,}**"
@@ -92,6 +99,18 @@
       ]
     },
     {
+      "groupName": "commons-* (classic)",
+      "description": "Classic Apache Commons artifacts where groupId == artifactId",
+      "matchPackageNames": [
+        "commons-codec{/,}**",
+        "commons-collections{/,}**",
+        "commons-io{/,}**",
+        "commons-lang{/,}**",
+        "commons-logging{/,}**",
+        "commons-net{/,}**"
+      ]
+    },
+    {
       "groupName": "org.ajoberstar.grgit",
       "matchPackageNames": [
         "org.ajoberstar.grgit{/,}**"
@@ -101,6 +120,12 @@
       "groupName": "org.apache.activemq",
       "matchPackageNames": [
         "org.apache.activemq{/,}**"
+      ]
+    },
+    {
+      "groupName": "org.apache.commons",
+      "matchPackageNames": [
+        "org.apache.commons{/,}**"
       ]
     },
     {
@@ -134,9 +159,28 @@
       ]
     },
     {
+      "groupName": "org.bouncycastle",
+      "matchPackageNames": [
+        "org.bouncycastle{/,}**"
+      ]
+    },
+    {
       "groupName": "org.eclipse.jetty",
       "matchPackageNames": [
         "org.eclipse.jetty{/,}**"
+      ]
+    },
+    {
+      "groupName": "org.hamcrest",
+      "matchPackageNames": [
+        "org.hamcrest{/,}**"
+      ]
+    },
+    {
+      "groupName": "org.jetbrains.kotlin",
+      "description": "Kotlin compiler plugins (jvm, kapt, serialization, ...) share a version",
+      "matchPackageNames": [
+        "org.jetbrains.kotlin{/,}**"
       ]
     },
     {
@@ -162,6 +206,14 @@
       "allowedVersions": "< 2.0.0",
       "matchPackageNames": [
         "org.slf4j{/,}**"
+      ]
+    },
+    {
+      "groupName": "xalan/xerces",
+      "description": "Legacy Apache XML stack, rarely updated and goes together",
+      "matchPackageNames": [
+        "xalan{/,}**",
+        "xerces{/,}**"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Follow-up to the GitHub Actions grouping. Adds seven more `packageRules` so Renovate creates one PR per family instead of many. All entries inserted alphabetically by `groupName` to keep future diffs minimal; nothing existing is modified.

| group | covers | typical PRs collapsed |
|---|---|---|
| `com.gradle` | `com.gradle.develocity`, `com.gradle.common-custom-user-data-gradle-plugin` | 2 → 1 |
| `commons-* (classic)` | `commons-codec`, `commons-collections`, `commons-io`, `commons-lang`, `commons-logging`, `commons-net` (groupId == artifactId) | up to 6 → 1 |
| `org.apache.commons` | `commons-lang3`, `commons-text`, `commons-jexl3`, `commons-pool2`, `commons-dbcp2`, `commons-collections4`, `commons-math3`, ... | up to 7 → 1 |
| `org.bouncycastle` | `bcmail-jdk18on`, `bcpkix-jdk18on`, `bcprov-jdk18on` (always share version) | 3 → 1 |
| `org.hamcrest` | `hamcrest`, `hamcrest-core`, `hamcrest-library` (always share version) | 3 → 1 |
| `org.jetbrains.kotlin` | `org.jetbrains.kotlin.jvm`, `org.jetbrains.kotlin.kapt`, ... (compiler plugins, always share version) | 2 → 1 |
| `xalan/xerces` | `xalan:xalan`, `xalan:serializer`, `xerces:xercesImpl` (legacy XML stack) | rarely-updated, but go together |

The new `org.jetbrains.kotlin` group intentionally does NOT capture `org.jetbrains.kotlinx:*` (coroutines monorepo) — that already groups via Renovate's `kotlinx-coroutines-monorepo` preset.

Independent monorepos (jackson, junit, spring, groovy, etc.) are already covered by Renovate presets and remain untouched.

## Test plan

- [x] `renovate.json` is valid JSON
- [ ] On next Renovate run, verify that the open rate-limited PRs for `bcmail-jdk18on`, `kotlin.jvm`+`kotlin.kapt`, and the `commons-*` entries collapse into single PRs