### PR TITLE
ci: add Renovate config lint workflow

### DIFF
--- a/.github/workflows/renovate-config-lint.yaml
+++ b/.github/workflows/renovate-config-lint.yaml
@@ -1,0 +1,27 @@
+name: Validate Renovate Config
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yaml
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/renovate-config-lint.yaml` to validate `renovate.json` via `renovate-config-validator` on PRs and pushes that touch the config (or the workflow itself).
- Catches typos and schema regressions before merge, similar to the workflow used in [Netcracker/qubership-profiler-agent](https://github.com/Netcracker/qubership-profiler-agent/blob/main/.github/workflows/renovate-config-lint.yaml).
- Follows the repo's existing CI conventions: pinned `actions/checkout@<sha> # v5`, `persist-credentials: false`, default `permissions: read-all`.

## Test plan
- [ ] CI green on this PR (workflow only runs on `renovate.json` / workflow path changes — touching the workflow file in this PR triggers it).
- [ ] Intentionally break `renovate.json` locally and re-run `docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json` to confirm the validator fails as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)