### PR TITLE
[New feature] Add a new Thread variable named "__jmv_THREAD_START_TIME_ITERATION

### DIFF
--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterThread.java
@@ -722,6 +722,7 @@ public class JMeterThread implements Runnable, Interruptible {
      */
     private IterationListener initRun(JMeterContext threadContext) {
         threadVars.putObject(JMeterVariables.VAR_IS_SAME_USER_KEY, isSameUserOnNextIteration);
+        threadVars.putObject(JMeterVariables.VAR_THREAD_START_TIME_ITERATION, threadVars.getStartThreadTimeIteration());
         threadContext.setVariables(threadVars);
         threadContext.setThreadNum(getThreadNum());
         setLastSampleOk(threadVars, true);
@@ -1019,6 +1020,8 @@ public class JMeterThread implements Runnable, Interruptible {
 
     void notifyTestListeners() {
         threadVars.incIteration();
+        threadVars.resetStartThreadTimeIteration();
+        threadVars.putObject(JMeterVariables.VAR_THREAD_START_TIME_ITERATION, threadVars.getStartThreadTimeIteration());
         for (TestIterationListener listener : testIterationStartListeners) {
             listener.testIterationStart(new LoopIterationEvent(threadGroupLoopController, threadVars.getIteration()));
             if (listener instanceof TestElement testElement) {

--- a/src/core/src/main/java/org/apache/jmeter/threads/JMeterVariables.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/JMeterVariables.java
@@ -33,6 +33,7 @@ public class JMeterVariables {
     private final Map<String, Object> variables = new HashMap<>();
 
     private int iteration = 0;
+    private long startTimeThreadIteration = System.currentTimeMillis();
 
     // Property names to preload into JMeter variables:
     private static final String [] PRE_LOAD = {
@@ -43,6 +44,7 @@ public class JMeterVariables {
     };
 
     static final String VAR_IS_SAME_USER_KEY = "__jmv_SAME_USER";
+    static final String VAR_THREAD_START_TIME_ITERATION ="__jmv_THREAD_START_TIME_ITERATION";
 
     /**
      * Constructor, that preloads the variables from the JMeter properties
@@ -177,5 +179,13 @@ public class JMeterVariables {
      */
     public boolean isSameUserOnNextIteration() {
         return Boolean.TRUE.equals(variables.get(VAR_IS_SAME_USER_KEY));
+    }
+
+    public void resetStartThreadTimeIteration() {
+        startTimeThreadIteration = System.currentTimeMillis();
+    }
+
+    public long getStartThreadTimeIteration() {
+        return startTimeThreadIteration;
     }
 }

--- a/src/core/src/main/java/org/apache/jmeter/threads/UnmodifiableJMeterVariables.java
+++ b/src/core/src/main/java/org/apache/jmeter/threads/UnmodifiableJMeterVariables.java
@@ -92,6 +92,16 @@ class UnmodifiableJMeterVariables extends JMeterVariables {
     }
 
     @Override
+    public long getStartThreadTimeIteration() {
+        return variables.getStartThreadTimeIteration();
+    }
+
+    @Override
+    public void resetStartThreadTimeIteration() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;

--- a/xdocs/usermanual/functions.xml
+++ b/xdocs/usermanual/functions.xml
@@ -1765,6 +1765,7 @@ However some variables are defined internally by JMeter. These are listed below.
 <li><code>JMeterThread.last_sample_ok</code> - whether or not the last sample was OK - <code>true</code>/<code>false</code>.
 Note: this is updated after PostProcessors and Assertions have been run.
 </li>
+<li><code>__jmv_THREAD_START_TIME_ITERATION</code> - contains the epoch unit milliseconds of the thread start iteration. Call function System.currentTimeMillis()</li>
 <li><code>START</code> variables (see next section)</li>
 </ul>
 </subsection>


### PR DESCRIPTION


## Description
Add a new unmodifiable JMeter Thread variable named "__jmv_THREAD_START_TIME_ITERATION"



## Motivation and Context
It is interesting to know the start timestamp of a thread iteration to calculate **cadences or pacing**.


## How Has This Been Tested?
Yes, add a groovy sampler first sampler of the thread group and compute the delta between the value in the variable __jmv_THREAD_START_TIME_ITERATION and the current time System.currentTimeMillis() in the groovy sampler.

Groovy code:
```groovy
long currentTime = System.currentTimeMillis();
long startThreadIter = Long.parseLong(vars.get("__jmv_THREAD_START_TIME_ITERATION"));
long delta = currentTime - startThreadIter;
return delta;
```
Results delta = 0 or 1 ms

## Screenshots (if appropriate):
Show the new thread variable in the "Debug Sampler"
<img width="827" height="562" alt="show __jmv_THREAD_START_TIME_ITERATION in debug sampler" src="https://github.com/user-attachments/assets/7ae64df9-4866-43df-af4e-3443e5192435" />

Show the Groovy code in the View Results Tree, delta is usually 0 or 1 ms (except for the first call which is a little longer) 
<img width="1151" height="570" alt="show grrovy code to compute delta between curret time and __jmv_THREAD_START_TIME_ITERATION" src="https://github.com/user-attachments/assets/d52eac64-ef50-4faa-b2f4-08083128fc5e" />

## Types of changes
- New feature (non-breaking change which adds functionality)

Update documentation: functions.xml
add __jmv_THREAD_START_TIME_ITERATION 

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
