### PR TITLE
chore(renovate): group Maven updates by groupId (incl. security)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,35 +9,22 @@
   "schedule": [
     "every 3 weeks on Monday"
   ],
+  "vulnerabilityAlerts": {
+    "description": "Security updates bypass the packageRules grouping below (Renovate resets their groupName), so apply the same groupId grouping to them here.",
+    "groupName": "{{{replace ':.*' '' depName}}} security"
+  },
   "packageRules": [
     {
-      "groupName": "com.fasterxml.jackson.core",
-      "matchPackageNames": [
-        "com.fasterxml.jackson.core{/,}**"
-      ]
-    },
-    {
-      "groupName": "com.github.ben-manes.caffeine",
-      "matchPackageNames": [
-        "com.github.ben-manes.caffeine{/,}**"
-      ]
+      "description": "Group every Maven update by its groupId by default. The more specific rules below run later and override this where a group must span several groupIds, pin a version, or stay disabled.",
+      "matchDatasources": [
+        "maven"
+      ],
+      "groupName": "{{{replace ':.*' '' depName}}}"
     },
     {
       "groupName": "com.github.vlsi",
       "matchPackageNames": [
         "com.github.vlsi{/,}**"
-      ]
-    },
-    {
-      "groupName": "com.github.weisj",
-      "matchPackageNames": [
-        "com.github.weisj{/,}**"
-      ]
-    },
-    {
-      "groupName": "com.google.auto.service",
-      "matchPackageNames": [
-        "com.google.auto.service{/,}**"
       ]
     },
     {
@@ -80,25 +67,6 @@
       ]
     },
     {
-      "groupName": "io.burt",
-      "matchPackageNames": [
-        "io.burt{/,}**"
-      ]
-    },
-    {
-      "groupName": "net.minidev json-smart",
-      "matchPackageNames": [
-        "net.minidev:accessors-smart{/,}**",
-        "net.minidev:json-smart{/,}**"
-      ]
-    },
-    {
-      "groupName": "com.miglayout",
-      "matchPackageNames": [
-        "com.miglayout{/,}**"
-      ]
-    },
-    {
       "groupName": "commons-* (classic)",
       "description": "Classic Apache Commons artifacts where groupId == artifactId",
       "matchPackageNames": [
@@ -111,94 +79,10 @@
       ]
     },
     {
-      "groupName": "org.ajoberstar.grgit",
-      "matchPackageNames": [
-        "org.ajoberstar.grgit{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.activemq",
-      "matchPackageNames": [
-        "org.apache.activemq{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.commons",
-      "matchPackageNames": [
-        "org.apache.commons{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.ftpserver",
-      "matchPackageNames": [
-        "org.apache.ftpserver{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.httpcomponents4",
-      "matchPackageNames": [
-        "org.apache.httpcomponents:{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.httpcomponents5",
-      "matchPackageNames": [
-        "org.apache.httpcomponents.client5:{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.logging.log4j",
-      "matchPackageNames": [
-        "org.apache.logging.log4j{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.apache.tika",
-      "matchPackageNames": [
-        "org.apache.tika{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.bouncycastle",
-      "matchPackageNames": [
-        "org.bouncycastle{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.eclipse.jetty",
-      "matchPackageNames": [
-        "org.eclipse.jetty{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.hamcrest",
-      "matchPackageNames": [
-        "org.hamcrest{/,}**"
-      ]
-    },
-    {
       "groupName": "org.jetbrains.kotlin",
       "description": "Kotlin compiler plugins (jvm, kapt, serialization, ...) share a version",
       "matchPackageNames": [
         "org.jetbrains.kotlin{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.jetbrains.lets-plot",
-      "matchPackageNames": [
-        "org.jetbrains.lets-plot{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.jodd",
-      "matchPackageNames": [
-        "org.jodd{/,}**"
-      ]
-    },
-    {
-      "groupName": "org.openjdk.jmh",
-      "matchPackageNames": [
-        "org.openjdk.jmh{/,}**"
       ]
     },
     {


### PR DESCRIPTION
## Why

Renovate opens a separate PR per groupId, and security updates are never grouped — Renovate resets their `groupName` to `null`. The recent Log4j advisory produced two separate security PRs, #6691 (`log4j-core`) and #6690 (`log4j-1.2-api`), even though both bump to the same `2.25.4`.

## What

- Add a catch-all `packageRule` (first, `matchDatasources: ["maven"]`) that sets `groupName` to the dependency's groupId through the `replace` template, so every Maven update groups by groupId by default.
- Add a `vulnerabilityAlerts` block with the same template, so security updates group by groupId too.
- Remove the per-groupId rules the catch-all now covers (log4j, bouncycastle, activemq, tika, `org.apache.commons`, jackson-core, caffeine, miglayout, lets-plot, jodd, jmh, hamcrest, jetty, ftpserver, grgit, httpcomponents 4 and 5, weisj, auto-service, io.burt, net.minidev).
- Keep the rules that do more than restate a single groupId: groups that span several groupIds (`com.google.errorprone`, classic `commons`, `xalan`/`xerces`, `com.github.vlsi`, `com.helger`, `com.gradle`, `org.jetbrains.kotlin`), version pins (`slf4j`, `xml-apis`), disabled entries (`guava`, internal `src:protocol`), and the GitHub Actions group.

## How to verify

- `renovate-config-validator renovate.json` passes.
- `renovate --platform=local --dry-run=full` on this branch keeps all four Log4j artifacts in `renovate/org.apache.logging.log4j`, and `org.bouncycastle`, `org.apache.activemq`, `org.apache.tika`, `org.apache.commons`, and `org.jetbrains.lets-plot` each stay grouped by groupId through the catch-all.

## Note

Grouping is by exact groupId, so a project split across several groupIds (for example Jackson's `core` and `dataformat`) forms one group per groupId. Where several groupIds should move together, keep an explicit rule after the catch-all, as `com.google.errorprone` already does. The same applies to a project that later adds a sub-groupId (for example `org.eclipse.jetty.http2`): add a rule if it should stay grouped with the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
