### PR TITLE
ci: build the whole test matrix in one generateRows call

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -5,6 +5,14 @@ import { appendFileSync } from 'fs';
 import { EOL } from 'os';
 import { createGitHubMatrixBuilder } from '@vlsi/github-actions-random-matrix/github';
 const { matrix, random } = createGitHubMatrixBuilder();
+
+// Some of the filter conditions might become unsatisfiable, and by default
+// the matrix would ignore that. That behaviour is useful for PR testing: if you
+// want only a subset, comment out the unwanted axis values and the matrix yields
+// the matching parameters. Un-comment the following line if you add new testing
+// parameters and want to notice accidentally unsatisfiable conditions.
+// matrix.failOnUnsatisfiableFilters(true);
+
 matrix.addAxis({
   name: 'java_distribution',
   values: [
@@ -88,19 +96,27 @@ matrix.imply({java_version: eaJava}, {java_distribution: {value: 'oracle'}})
 matrix.imply({java_distribution: {value: 'oracle'}}, {java_version: v => v === eaJava || v >= 21});
 // TODO: Semeru does not ship Java 21 builds yet
 matrix.exclude({java_distribution: {value: 'semeru'}, java_version: '21'});
-// Ensure at least one job with "same" hashcode exists
-matrix.generateRow({hash: {value: 'same'}});
-// Ensure at least one Windows and at least one Linux job is present (macOS is almost the same as Linux)
-matrix.generateRow({os: 'windows-latest'});
-// TODO: un-comment when xvfb will be possible
-// matrix.generateRow({os: 'ubuntu-latest'});
-// Ensure there will be at least one job with Java 17
-matrix.generateRow({java_version: "17"});
-// Ensure there will be at least one job with Java 25
-matrix.generateRow({java_version: "25"});
-// Ensure there will be at least one job with Java EA
-// matrix.generateRow({java_version: eaJava});
-const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
+
+// Drive the whole matrix from one batch of requirements. generateRows guarantees a row for
+// each entry, packs them into as few jobs as it can, and spends the rest of the MATRIX_JOBS
+// budget on pairwise coverage. Unlike a sequence of generateRow() calls, the job count is
+// exactly MATRIX_JOBS and the result no longer depends on the order of the list.
+const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 5), {
+  require: [
+    // Ensure at least one job with "same" hashcode exists
+    {hash: {value: 'same'}},
+    // Ensure at least one Windows job is present (macOS is almost the same as Linux)
+    {os: 'windows-latest'},
+    // TODO: un-comment when xvfb will be possible
+    // {os: 'ubuntu-latest'},
+    // Ensure there will be at least one job with Java 17
+    {java_version: '17'},
+    // Ensure there will be at least one job with Java 25
+    {java_version: '25'},
+    // Ensure there will be at least one job with Java EA
+    // {java_version: eaJava},
+  ],
+});
 if (include.length === 0) {
   throw new Error('Matrix list is empty');
 }
@@ -160,11 +176,15 @@ include.forEach(v => {
   delete v.hash;
 });
 
-console.log(include);
-
-let filePath = process.env['GITHUB_OUTPUT'] || '';
-if (filePath) {
+if (process.argv.includes('--coverage')) {
+  const coverage = matrix.pairCoverageReport();
+  console.log(`Pair coverage: ${coverage.covered}/${coverage.total} (${coverage.percentage}%), weight coverage ${coverage.weightPercentage}%`);
+} else {
+  console.log(include);
+  let filePath = process.env['GITHUB_OUTPUT'] || '';
+  if (filePath) {
     appendFileSync(filePath, `matrix<<MATRIX_BODY${EOL}${JSON.stringify({include})}${EOL}MATRIX_BODY${EOL}`, {
-        encoding: 'utf8'
+      encoding: 'utf8'
     });
+  }
 }

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@vlsi/github-actions-random-matrix": "2.0.0"
+        "@vlsi/github-actions-random-matrix": "2.1.0"
       }
     },
     "node_modules/@vlsi/github-actions-random-matrix": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.0.0.tgz",
-      "integrity": "sha512-8lEb4eadMBKs+Hnj9dCmcHtgHoWelT4RMXAQ/VcQ1r3vjR8P2hSMVGhkRXaXibCBf0lMttS934CGo2mlBMopPA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.1.0.tgz",
+      "integrity": "sha512-+KDQS/+AwEUBRrQR3WbBGva2Z2X5NAXDzWvaPAijSB0zNtUEAepw0YJWdsXDnSESeFpQ/rtna+SfEdKkTcIW8A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@vlsi/github-actions-random-matrix": "2.0.0"
+    "@vlsi/github-actions-random-matrix": "2.1.0"
   }
 }


### PR DESCRIPTION
## Why

`master` already generates the CI matrix with the `@vlsi/github-actions-random-matrix` npm package, but it still assembles the job set imperatively: a sequence of `generateRow()` calls followed by `generateRows(N)`. With that form the job count is an emergent function of call order rather than of `MATRIX_JOBS`, and each pinned requirement tends to cost its own job.

## What

- Replace the `generateRow()` sequence plus the trailing `generateRows(N)` with a single `generateRows(N, {require: […]})` batch. The required combinations (same hashcode, a Windows job, Java 17, Java 25) are packed into as few jobs as possible, the job count is exactly `MATRIX_JOBS`, and the result no longer depends on the order of the list.
- Bump `@vlsi/github-actions-random-matrix` from `2.0.0` to `2.1.0`; the `require` batch API lands in `2.1.0`.
- Add a `--coverage` flag that prints the pairwise-coverage summary for previewing the matrix locally.

The axes, constraints, and per-row JVM/Gradle arguments are unchanged.

## How to verify

```bash
npm ci --prefix .github/workflows
MATRIX_JOBS=4 RNG_SEED=demo node .github/workflows/matrix.mjs   # inspect the rows
node .github/workflows/matrix.mjs --coverage                    # pair-coverage summary
```

The same seed reproduces the same matrix; across seeds every run keeps a Windows job, a same-hashcode job, and Java 17 and 25, never emits the excluded Java EA or Semeru, and never pairs Oracle JDK with macOS.
