### PR TITLE
ci: pass the test JDK vendor to the Gradle toolchain

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -140,8 +140,9 @@ include.forEach(v => {
   // Gradle does not work in tr_TR locale, so pass locale to test only: https://github.com/gradle/gradle/issues/17361
   jvmArgs.push(`-Duser.country=${v.locale.country}`);
   jvmArgs.push(`-Duser.language=${v.locale.language}`);
-  v.java_distribution = v.java_distribution.value;
-  v.java_vendor = v.java_distribution.vendor;
+  const {value: javaDistribution, vendor: javaVendor} = v.java_distribution;
+  v.java_distribution = javaDistribution;
+  v.java_vendor = javaVendor;
   if (v.java_distribution === 'oracle') {
       v.oracle_java_website = v.java_version === eaJava ? 'jdk.java.net' : 'oracle.com';
   }


### PR DESCRIPTION
### Why

`matrix.mjs` builds the CI test matrix, and each row's `java_vendor` is meant to pin the JDK vendor for the test toolchain (`jdkTestVendor` → Gradle). The per-row post-processing read it from `v.java_distribution.vendor` *after* `v.java_distribution` had been reassigned to its string `value`. Reading `.vendor` off a string yields `undefined`, so `jdkTestVendor` reached Gradle empty and the test toolchain was never pinned to the matrix vendor — tests could run on any installed JDK of the matching version, which defeats varying the distribution across rows.

### What

Destructure the axis object before overwriting the field, so the read no longer depends on statement order:

```js
const {value: javaDistribution, vendor: javaVendor} = v.java_distribution;
v.java_distribution = javaDistribution;
v.java_vendor = javaVendor;
```

### How to verify

`npm ci --prefix .github/workflows && MATRIX_JOBS=8 node .github/workflows/matrix.mjs` — every row now carries a real `java_vendor` (`amazon`, `bellsoft`, `microsoft`, `oracle`, `eclipse`, `azul`) instead of `undefined`.

This makes the test toolchain actually request the matrix vendor. With `org.gradle.java.installations.auto-download=false`, the workflow already provisions a matching-vendor JDK for the test version via `actions/setup-java` (`distribution: ${{ matrix.java_distribution }}`), so the constraint is satisfiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
