### PR TITLE
ci: map JDK vendor tokens to JvmVendorSpec constants

### DIFF
--- a/build-logic/basics/src/main/kotlin/configureToolchain.kt
+++ b/build-logic/basics/src/main/kotlin/configureToolchain.kt
@@ -32,10 +32,27 @@ fun JavaToolchainSpec.configureToolchain(jdk: ToolchainProperties?) {
         return
     }
     languageVersion.set(JavaLanguageVersion.of(jdk.version))
-    jdk.vendor?.let {
-        vendor.set(JvmVendorSpec.matching(it))
+    jdk.vendor?.takeIf { it.isNotBlank() }?.let {
+        vendor.set(jvmVendorSpecFor(it))
     }
     if (jdk.implementation.equals("J9", ignoreCase = true)) {
         implementation.set(JvmImplementation.J9)
     }
 }
+
+// The CI matrix passes a short vendor token such as "eclipse". Map the known ones to Gradle's
+// built-in JvmVendorSpec constants, which recognise every alias a distribution reports across
+// versions; fall back to a substring match for anything unmapped. This matters for Temurin:
+// JDK 8 reports java.vendor="Temurin" while 11+ report "Eclipse Adoptium", so a plain
+// matching("eclipse") cannot resolve a Temurin 8 toolchain (JvmVendorSpec.matching probes the
+// runtime java.vendor, not the IMPLEMENTOR field of the release file).
+private fun jvmVendorSpecFor(vendor: String): JvmVendorSpec =
+    when (vendor.lowercase()) {
+        "eclipse", "adoptium", "temurin" -> JvmVendorSpec.ADOPTIUM
+        "amazon", "corretto" -> JvmVendorSpec.AMAZON
+        "azul", "zulu" -> JvmVendorSpec.AZUL
+        "bellsoft", "liberica" -> JvmVendorSpec.BELLSOFT
+        "microsoft" -> JvmVendorSpec.MICROSOFT
+        "oracle" -> JvmVendorSpec.ORACLE
+        else -> JvmVendorSpec.matching(vendor)
+    }


### PR DESCRIPTION
## Why

The CI matrix passes a short vendor token (such as `eclipse` for Temurin) for the test JDK toolchain, and the build mapped it with `JvmVendorSpec.matching(it)`. `matching` probes the runtime `java.vendor`, which Temurin reports inconsistently across versions: JDK 8 reports `java.vendor="Temurin"` while 11+ report `"Eclipse Adoptium"`. A plain `matching("eclipse")` therefore cannot resolve a Temurin 8 toolchain, and the same gap exists for any distribution whose vendor string differs from its matrix token.

The current matrix only tests JDK 17/21/25/EA, so this is latent rather than actively failing today — but the resolution logic is wrong for the general case, and re-adding an older JDK would surface it.

## What

- Map the known vendor tokens to Gradle's built-in `JvmVendorSpec` constants (`ADOPTIUM`, `AMAZON`, `AZUL`, `BELLSOFT`, `MICROSOFT`, `ORACLE`), which recognise every alias a distribution reports across versions; fall back to a substring match for anything unmapped.
- Guard against a blank vendor (`takeIf { it.isNotBlank() }`) so an empty token no longer narrows the toolchain query.

This mirrors [pgjdbc/pgjdbc#4257](https://github.com/pgjdbc/pgjdbc/pull/4257), which fixes the same issue in the shared `build-logic/basics/src/main/kotlin/configureToolchain.kt`. The new constants are a strict superset of the previous `matching(...)` behaviour for the distributions already in the matrix, so they change nothing for JDK 17+.

## How to verify

`./gradlew -Prelease :build-logic:basics:compileKotlin` compiles cleanly on Gradle 9.2.1, which provides all of the `JvmVendorSpec` constants used here.