### PR TITLE
Fix Assert order regarding the report from sonarQube

### DIFF
--- a/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
@@ -338,7 +338,7 @@ public class ResponseAssertionTest {
             thread.start();
         }
         latch.await();
-        assertEquals(failed.get(), 0);
+        assertEquals(0, failed.get());
     }
 
     class TestThread extends Thread {

--- a/src/components/src/test/java/org/apache/jmeter/control/TestIfController.java
+++ b/src/components/src/test/java/org/apache/jmeter/control/TestIfController.java
@@ -172,7 +172,7 @@ class TestIfController extends JMeterTestCase {
             assertEquals(order[counter], sampler.getName());
             counter++;
         }
-        assertEquals(counter, 6);
+        assertEquals(6, counter);
     }
 
     @Test
@@ -200,7 +200,7 @@ class TestIfController extends JMeterTestCase {
             assertEquals(order[counter], sampler.getName());
             counter++;
         }
-        assertEquals(counter, 6);
+        assertEquals(6, counter);
     }
 
 
@@ -237,7 +237,7 @@ class TestIfController extends JMeterTestCase {
             assertEquals(order[counter], sampler.getName());
             counter++;
         }
-        assertEquals(counter, 6);
+        assertEquals(6, counter);
     }
 
     /**
@@ -276,7 +276,7 @@ class TestIfController extends JMeterTestCase {
             assertEquals(order[counter], sampler.getName());
             counter++;
         }
-        assertEquals(counter, 6);
+        assertEquals(6, counter);
     }
 
     @Test

--- a/src/functions/src/test/java/org/apache/jmeter/functions/TestDateTimeConvertFunction.java
+++ b/src/functions/src/test/java/org/apache/jmeter/functions/TestDateTimeConvertFunction.java
@@ -123,7 +123,7 @@ class TestDateTimeConvertFunction extends JMeterTestCase implements JMeterSerial
         params.add(new CompoundVariable("yyyy-MM-dd"));
         params.add(new CompoundVariable("abcd"));
         dateConvert.setParameters(params);
-        Assertions.assertEquals(dateConvert.execute(result, null), "");
+        Assertions.assertEquals("", dateConvert.execute(result, null));
     }
 
     @Test
@@ -132,6 +132,6 @@ class TestDateTimeConvertFunction extends JMeterTestCase implements JMeterSerial
         params.add(new CompoundVariable("yyyy-MM-dd"));
         params.add(new CompoundVariable("dd-MM-yyyy HH:mm:ss"));
         dateConvert.setParameters(params);
-        Assertions.assertEquals(dateConvert.execute(result, null), "");
+        Assertions.assertEquals("", dateConvert.execute(result, null));
     }
 }

--- a/src/jorphan/src/test/java/org/apache/commons/cli/avalon/ClutilTestCase.java
+++ b/src/jorphan/src/test/java/org/apache/commons/cli/avalon/ClutilTestCase.java
@@ -127,11 +127,11 @@ public final class ClutilTestCase {
         assertNull(option0.getArgument(0), "Option Arg: " + option0.getArgument(0));
 
         final CLOption option1 = clOptions.get(1);
-        assertEquals(option1.getDescriptor().getId(), CLOption.TEXT_ARGUMENT);
-        assertEquals(option1.getArgument(0), "param");
+        assertEquals(CLOption.TEXT_ARGUMENT, option1.getDescriptor().getId());
+        assertEquals("param", option1.getArgument(0));
 
         final CLOption option2 = clOptions.get(2);
-        assertEquals(option2.getDescriptor().getId(), ALL_OPT);
+        assertEquals(ALL_OPT, option2.getDescriptor().getId());
         assertNull(option2.getArgument(0));
     }
 
@@ -160,7 +160,7 @@ public final class ClutilTestCase {
         assertEquals("param", option1.getArgument(0));
 
         final CLOption option2 = clOptions.get(2);
-        assertEquals(option2.getDescriptor().getId(), ALL_OPT);
+        assertEquals(ALL_OPT, option2.getDescriptor().getId());
         assertNull(option2.getArgument(0));
     }
 
@@ -185,7 +185,7 @@ public final class ClutilTestCase {
         assertEquals("param", option0.getArgument(0), "Option Arg: " + option0.getArgument(0));
 
         final CLOption option2 = clOptions.get(1);
-        assertEquals(option2.getDescriptor().getId(), ALL_OPT);
+        assertEquals(ALL_OPT, option2.getDescriptor().getId());
         assertNull(option2.getArgument(0));
     }
 
@@ -209,7 +209,7 @@ public final class ClutilTestCase {
         assertNull(option0.getArgument(0), "Option Arg: " + option0.getArgument(0));
 
         final CLOption option1 = clOptions.get(1);
-        assertEquals(option1.getDescriptor().getId(), ALL_OPT);
+        assertEquals(ALL_OPT, option1.getDescriptor().getId());
         assertNull(option1.getArgument(0));
     }
 
@@ -227,10 +227,10 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 2);
+        assertEquals(2, size);
         final CLOption option0 = clOptions.get(0);
-        assertEquals(option0.getDescriptor().getId(), TAINT_OPT);
-        assertEquals(option0.getArgument(0), "3");
+        assertEquals(TAINT_OPT, option0.getDescriptor().getId());
+        assertEquals("3", option0.getArgument(0));
 
         final CLOption option1 = clOptions.get(1);
         assertEquals(ALL_OPT, option1.getDescriptor().getId());
@@ -251,10 +251,10 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 2);
+        assertEquals(2, size);
         final CLOption option0 = clOptions.get(0);
-        assertEquals(option0.getDescriptor().getId(), TAINT_OPT);
-        assertEquals(option0.getArgument(0), "3");
+        assertEquals(TAINT_OPT, option0.getDescriptor().getId());
+        assertEquals("3", option0.getArgument(0));
 
         final CLOption option1 = clOptions.get(1);
         assertEquals(ALL_OPT, option1.getDescriptor().getId());
@@ -275,7 +275,7 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 2);
+        assertEquals(2, size);
         final CLOption option0 = clOptions.get(0);
         assertEquals(TAINT_OPT, option0.getDescriptor().getId());
         assertNull(option0.getArgument(0));
@@ -296,15 +296,15 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 8);
-        assertEquals(clOptions.get(0).getDescriptor().getId(), YOU_OPT);
-        assertEquals(clOptions.get(1).getDescriptor().getId(), 0);
-        assertEquals(clOptions.get(2).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions.get(3).getDescriptor().getId(), CLEAR1_OPT);
-        assertEquals(clOptions.get(4).getDescriptor().getId(), CLEAR2_OPT);
-        assertEquals(clOptions.get(5).getDescriptor().getId(), CLEAR3_OPT);
-        assertEquals(clOptions.get(6).getDescriptor().getId(), CLEAR5_OPT);
-        assertEquals(clOptions.get(7).getDescriptor().getId(), 0);
+        assertEquals(8, size);
+        assertEquals(YOU_OPT, clOptions.get(0).getDescriptor().getId());
+        assertEquals(0, clOptions.get(1).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions.get(2).getDescriptor().getId());
+        assertEquals(CLEAR1_OPT, clOptions.get(3).getDescriptor().getId());
+        assertEquals(CLEAR2_OPT, clOptions.get(4).getDescriptor().getId());
+        assertEquals(CLEAR3_OPT, clOptions.get(5).getDescriptor().getId());
+        assertEquals(CLEAR5_OPT, clOptions.get(6).getDescriptor().getId());
+        assertEquals(0, clOptions.get(7).getDescriptor().getId());
     }
 
     @Test
@@ -319,12 +319,12 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 5);
-        assertEquals(clOptions.get(0).getDescriptor().getId(), DEFINE_OPT);
-        assertEquals(clOptions.get(1).getDescriptor().getId(), 0);
-        assertEquals(clOptions.get(2).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions.get(3).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions.get(4).getDescriptor().getId(), 0);
+        assertEquals(5, size);
+        assertEquals(DEFINE_OPT, clOptions.get(0).getDescriptor().getId());
+        assertEquals(0, clOptions.get(1).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions.get(2).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions.get(3).getDescriptor().getId());
+        assertEquals(0, clOptions.get(4).getDescriptor().getId());
     }
 
     @Test
@@ -338,12 +338,12 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 5);
-        assertEquals(clOptions.get(0).getDescriptor().getId(), DEFINE_OPT);
-        assertEquals(clOptions.get(1).getDescriptor().getId(), 0);
-        assertEquals(clOptions.get(2).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions.get(3).getDescriptor().getId(), BLEE_OPT);
-        assertEquals(clOptions.get(4).getDescriptor().getId(), 0);
+        assertEquals(5, size);
+        assertEquals(DEFINE_OPT, clOptions.get(0).getDescriptor().getId());
+        assertEquals(0, clOptions.get(1).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions.get(2).getDescriptor().getId());
+        assertEquals(BLEE_OPT, clOptions.get(3).getDescriptor().getId());
+        assertEquals(0, clOptions.get(4).getDescriptor().getId());
     }
 
     @Test
@@ -357,9 +357,9 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 1);
-        assertEquals(clOptions.get(0).getDescriptor().getId(), FILE_OPT);
-        assertEquals(clOptions.get(0).getArgument(), "myfile.txt");
+        assertEquals(1, size);
+        assertEquals(FILE_OPT, clOptions.get(0).getDescriptor().getId());
+        assertEquals("myfile.txt", clOptions.get(0).getArgument());
     }
 
     @Test
@@ -560,12 +560,12 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 5);
-        assertEquals(clOptions.get(0).getDescriptor().getId(), DEFINE_OPT);
-        assertEquals(clOptions.get(1).getDescriptor().getId(), 0);
-        assertEquals(clOptions.get(2).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions.get(3).getDescriptor().getId(), 0);
-        assertEquals(clOptions.get(4).getDescriptor().getId(), CASE_CHECK_OPT);
+        assertEquals(5, size);
+        assertEquals(DEFINE_OPT, clOptions.get(0).getDescriptor().getId());
+        assertEquals(0, clOptions.get(1).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions.get(2).getDescriptor().getId());
+        assertEquals(0, clOptions.get(3).getDescriptor().getId());
+        assertEquals(CASE_CHECK_OPT, clOptions.get(4).getDescriptor().getId());
 
         final CLOption option = clOptions.get(0);
         assertEquals("stupid", option.getArgument(0));
@@ -664,8 +664,8 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 1);
-        assertEquals(clOptions.get(0).getDescriptor().getId(), YOU_OPT);
+        assertEquals(1, size);
+        assertEquals(YOU_OPT, clOptions.get(0).getDescriptor().getId());
     }
 
     @Test
@@ -688,8 +688,8 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions1 = parser1.getArguments();
         final int size1 = clOptions1.size();
 
-        assertEquals(size1, 1);
-        assertEquals(clOptions1.get(0).getDescriptor().getId(), YOU_OPT);
+        assertEquals(1, size1);
+        assertEquals(YOU_OPT, clOptions1.get(0).getDescriptor().getId());
 
         final CLArgsParser parser2 = new CLArgsParser(parser1.getUnparsedArgs(), options2);
 
@@ -698,14 +698,14 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions2 = parser2.getArguments();
         final int size2 = clOptions2.size();
 
-        assertEquals(size2, 7);
-        assertEquals(clOptions2.get(0).getDescriptor().getId(), 0);
-        assertEquals(clOptions2.get(1).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions2.get(2).getDescriptor().getId(), CLEAR1_OPT);
-        assertEquals(clOptions2.get(3).getDescriptor().getId(), CLEAR2_OPT);
-        assertEquals(clOptions2.get(4).getDescriptor().getId(), CLEAR3_OPT);
-        assertEquals(clOptions2.get(5).getDescriptor().getId(), CLEAR5_OPT);
-        assertEquals(clOptions2.get(6).getDescriptor().getId(), 0);
+        assertEquals(7, size2);
+        assertEquals(0, clOptions2.get(0).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions2.get(1).getDescriptor().getId());
+        assertEquals(CLEAR1_OPT, clOptions2.get(2).getDescriptor().getId());
+        assertEquals(CLEAR2_OPT, clOptions2.get(3).getDescriptor().getId());
+        assertEquals(CLEAR3_OPT, clOptions2.get(4).getDescriptor().getId());
+        assertEquals(CLEAR5_OPT, clOptions2.get(5).getDescriptor().getId());
+        assertEquals(0, clOptions2.get(6).getDescriptor().getId());
     }
 
     @Test
@@ -728,11 +728,11 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions1 = parser1.getArguments();
         final int size1 = clOptions1.size();
 
-        assertEquals(size1, 4);
-        assertEquals(clOptions1.get(0).getDescriptor().getId(), YOU_OPT);
-        assertEquals(clOptions1.get(1).getDescriptor().getId(), 0);
-        assertEquals(clOptions1.get(2).getDescriptor().getId(), ALL_OPT);
-        assertEquals(clOptions1.get(3).getDescriptor().getId(), CLEAR1_OPT);
+        assertEquals(4, size1);
+        assertEquals(YOU_OPT, clOptions1.get(0).getDescriptor().getId());
+        assertEquals(0, clOptions1.get(1).getDescriptor().getId());
+        assertEquals(ALL_OPT, clOptions1.get(2).getDescriptor().getId());
+        assertEquals(CLEAR1_OPT, clOptions1.get(3).getDescriptor().getId());
 
         assertEquals("ler", parser1.getUnparsedArgs()[0]);
 
@@ -743,9 +743,9 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions2 = parser2.getArguments();
         final int size2 = clOptions2.size();
 
-        assertEquals(size2, 2);
-        assertEquals(clOptions2.get(0).getDescriptor().getId(), 0);
-        assertEquals(clOptions2.get(1).getDescriptor().getId(), 0);
+        assertEquals(2, size2);
+        assertEquals(0, clOptions2.get(0).getDescriptor().getId());
+        assertEquals(0, clOptions2.get(1).getDescriptor().getId());
     }
 
     @Test
@@ -769,11 +769,11 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 1);
+        assertEquals(1, size);
         final CLOption option = clOptions.get(0);
-        assertEquals(option.getDescriptor().getId(), DEFINE_OPT);
-        assertEquals(option.getArgument(0), "stupid");
-        assertEquals(option.getArgument(1), "");
+        assertEquals(DEFINE_OPT, option.getDescriptor().getId());
+        assertEquals("stupid", option.getArgument(0));
+        assertEquals("", option.getArgument(1));
     }
 
     @Test
@@ -790,12 +790,12 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 2);
-        assertEquals(clOptions.get(1).getDescriptor().getId(), CLEAR1_OPT);
+        assertEquals(2, size);
+        assertEquals(CLEAR1_OPT, clOptions.get(1).getDescriptor().getId());
         final CLOption option = clOptions.get(0);
-        assertEquals(option.getDescriptor().getId(), DEFINE_OPT);
-        assertEquals(option.getArgument(0), "stupid");
-        assertEquals(option.getArgument(1), "");
+        assertEquals(DEFINE_OPT, option.getDescriptor().getId());
+        assertEquals("stupid", option.getArgument(0));
+        assertEquals("", option.getArgument(1));
     }
 
     @Test
@@ -812,12 +812,12 @@ public final class ClutilTestCase {
         final List<CLOption> clOptions = parser.getArguments();
         final int size = clOptions.size();
 
-        assertEquals(size, 2);
-        assertEquals(clOptions.get(1).getDescriptor().getId(), CLEAR1_OPT);
+        assertEquals(2, size);
+        assertEquals(CLEAR1_OPT, clOptions.get(1).getDescriptor().getId());
         final CLOption option = clOptions.get(0);
-        assertEquals(option.getDescriptor().getId(), DEFINE_OPT);
-        assertEquals(option.getArgument(0), "Stupid");
-        assertEquals(option.getArgument(1), "");
+        assertEquals(DEFINE_OPT, option.getDescriptor().getId());
+        assertEquals("Stupid", option.getArgument(0));
+        assertEquals("", option.getArgument(1));
     }
 
     /**

--- a/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
@@ -97,11 +97,11 @@ public class PackageTest {
         ListedHashTree tree = new ListedHashTree("key");
         ListedHashTree newTree = new ListedHashTree("value");
         tree.add("key", newTree);
-        assertEquals(tree.list().size(), 1);
+        assertEquals(1, tree.list().size());
         assertEquals("key", tree.getArray()[0]);
         assertEquals(1, tree.getTree("key").list().size());
         assertEquals(0, tree.getTree("key").getTree("value").size());
-        assertEquals(tree.getTree("key").getArray()[0], "value");
+        assertEquals("value", tree.getTree("key").getArray()[0]);
         assertNotNull(tree.getTree("key").get("value"));
     }
 

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/config/UrlConfigTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/config/UrlConfigTest.java
@@ -67,9 +67,9 @@ public class UrlConfigTest extends JMeterTestCase {
     public void testOverRide() {
         JMeterProperty jmp = partialConfig.getProperty(HTTPSamplerBase.DOMAIN);
         assertInstanceOf(NullProperty.class, jmp);
-        assertEquals(jmp, new NullProperty(HTTPSamplerBase.DOMAIN));
+        assertEquals(new NullProperty(HTTPSamplerBase.DOMAIN), jmp);
         partialConfig.addTestElement(defaultConfig);
-        assertEquals(partialConfig.getPropertyAsString(HTTPSamplerBase.DOMAIN), "www.xerox.com");
-        assertEquals(partialConfig.getPropertyAsString(HTTPSamplerBase.PATH), "main.jsp");
+        assertEquals("www.xerox.com", partialConfig.getPropertyAsString(HTTPSamplerBase.DOMAIN));
+        assertEquals("main.jsp", partialConfig.getPropertyAsString(HTTPSamplerBase.PATH));
     }
 }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/TestHTTPSamplersAgainstHttpMirrorServer.java
@@ -1009,7 +1009,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             fail("No header and body section found");
         }
         // No body should have been sent
-        assertEquals(bodySent.length(), 0);
+        assertEquals(0, bodySent.length());
         // Check method, path and query sent
         checkMethodPathQuery(headersSent, sampler.getMethod(), sampler.getPath(), (String) null, res);
     }
@@ -1056,7 +1056,7 @@ public class TestHTTPSamplersAgainstHttpMirrorServer extends JMeterTestCase {
             fail("No header and body section found in: [" + dataSentToMirrorServer + "]");
         }
         // No body should have been sent
-        assertEquals(bodySent.length(), 0);
+        assertEquals(0, bodySent.length());
         // Check method, path and query sent
         checkMethodPathQuery(headersSent, sampler.getMethod(), sampler.getPath(), expectedQueryString, res);
     }


### PR DESCRIPTION
## Description
I've found in SonarQube 90 issues regarding the [Swap these 2 arguments so they are in the correct order: expected value, actual value.](https://sonarcloud.io/project/issues?open=AWyHZEhF8nAqy55yUIVN&id=JMeter)

## Motivation and Context
I would like to fix it due to it was easy and fast thing

## How Has This Been Tested?
I've runned ./gradlew test and tests still pass

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
