### PR TITLE
docs: add build & test guidance for coding agents to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,17 @@
 Security model: [SECURITY.md](./SECURITY.md)
 
-## Building and testing (for coding agents)
+## Building and testing
 
-JMeter builds with Gradle. Use the wrapper `./gradlew` (or `gw` from
-[gdub](https://github.com/dougborg/gdub)). The full command list is in
-[`gradle.md`](gradle.md), and toolchain details are in the
-[Test builds](README.md#test-builds) section of `README.md`. The essentials:
+JMeter builds with Gradle. Use `./gradlew --quiet ...` to reduce output verbosity.
 
-- **Build everything (incl. tests + static checks):** `./gradlew build`
-- **Unit tests only:** `./gradlew test` — single module, e.g. `./gradlew :src:core:test`
-- **All checks (tests, checkstyle, spotless, …):** `./gradlew check`
-- **Run the GUI from source:** `./gradlew runGui`
-- **Assemble a runnable dist:** `./gradlew createDist && ./bin/jmeter`
-- **Format before committing:** `./gradlew style` (spotlessApply + checkstyleAll); check-only: `./gradlew spotlessCheck checkstyleAll`
-- **Skip tests:** append `-x test`
+After modifying Java code, before reporting the change as done (handing
+control back to the user), run `./gradlew --quiet classes style` and fix any
+reported issues.
 
-### Selecting the JDK for build and tests
+JMeter uses Gradle toolchains; JDKs are found locally or auto-provisioned. The
+code targets JDK 17. To test under a specific JDK pass build parameters:
 
-JMeter uses Gradle [toolchains](https://docs.gradle.org/current/userguide/toolchains.html),
-so JDKs are found locally or auto-provisioned. The default build JDK is 17
-(artifacts target Java 8). To build or test under a specific JDK — the way CI
-runs its matrix — pass build parameters:
-
-- `-PjdkBuildVersion=<n>` — JDK to build with (e.g. `21`)
 - `-PjdkTestVersion=<n>` — JDK to run **tests** with; `0` means "use the current Java"
-- `-PjdkTestVendor=<vendor>` / `-PjdkTestImplementation=<impl>` — pin the vendor / VM implementation
-
-Example — run the test suite on JDK 21 (Corretto):
-
-```sh
-./gradlew test -PjdkTestVersion=21 -PjdkTestVendor=corretto
-```
+- `-PjdkTestVendor=<vendor>` / `-PjdkTestImplementation=<impl>` — pin the vendor / VM implementation (jdkTestVersion is enough for most cases)
 
 List every available build parameter with `./gradlew parameters`.
-
-### Other useful tasks
-
-- After bumping a dependency version, refresh the expected checksums:
-  `./gradlew -PupdateExpectedJars check`
-- Coverage report: `./gradlew jacocoTestReport -Pcoverage`
-- Release Audit Tool (license-header check): `./gradlew rat`
-
-CI mirrors these across a JDK × vendor × OS × timezone × locale matrix (see
-[`.github/workflows/main.yml`](.github/workflows/main.yml)); the Error Prone
-static-analysis job runs on JDK 21.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,46 @@
 Security model: [SECURITY.md](./SECURITY.md)
+
+## Building and testing (for coding agents)
+
+JMeter builds with Gradle. Use the wrapper `./gradlew` (or `gw` from
+[gdub](https://github.com/dougborg/gdub)). The full command list is in
+[`gradle.md`](gradle.md), and toolchain details are in the
+[Test builds](README.md#test-builds) section of `README.md`. The essentials:
+
+- **Build everything (incl. tests + static checks):** `./gradlew build`
+- **Unit tests only:** `./gradlew test` — single module, e.g. `./gradlew :src:core:test`
+- **All checks (tests, checkstyle, spotless, …):** `./gradlew check`
+- **Run the GUI from source:** `./gradlew runGui`
+- **Assemble a runnable dist:** `./gradlew createDist && ./bin/jmeter`
+- **Format before committing:** `./gradlew style` (spotlessApply + checkstyleAll); check-only: `./gradlew spotlessCheck checkstyleAll`
+- **Skip tests:** append `-x test`
+
+### Selecting the JDK for build and tests
+
+JMeter uses Gradle [toolchains](https://docs.gradle.org/current/userguide/toolchains.html),
+so JDKs are found locally or auto-provisioned. The default build JDK is 17
+(artifacts target Java 8). To build or test under a specific JDK — the way CI
+runs its matrix — pass build parameters:
+
+- `-PjdkBuildVersion=<n>` — JDK to build with (e.g. `21`)
+- `-PjdkTestVersion=<n>` — JDK to run **tests** with; `0` means "use the current Java"
+- `-PjdkTestVendor=<vendor>` / `-PjdkTestImplementation=<impl>` — pin the vendor / VM implementation
+
+Example — run the test suite on JDK 21 (Corretto):
+
+```sh
+./gradlew test -PjdkTestVersion=21 -PjdkTestVendor=corretto
+```
+
+List every available build parameter with `./gradlew parameters`.
+
+### Other useful tasks
+
+- After bumping a dependency version, refresh the expected checksums:
+  `./gradlew -PupdateExpectedJars check`
+- Coverage report: `./gradlew jacocoTestReport -Pcoverage`
+- Release Audit Tool (license-header check): `./gradlew rat`
+
+CI mirrors these across a JDK × vendor × OS × timezone × locale matrix (see
+[`.github/workflows/main.yml`](.github/workflows/main.yml)); the Error Prone
+static-analysis job runs on JDK 21.


### PR DESCRIPTION
## Summary

Adds a short **"Building and testing"** section to `AGENTS.md` so any AI coding
agent has JMeter's build context up front — how to build and test, how to
format before handing a change back, and how to select a JDK for tests.

Kept deliberately minimal: only JMeter-specific, non-obvious guidance (agents
already know generic Gradle commands). It covers:

- use `./gradlew --quiet …` to reduce output; run `./gradlew --quiet classes style`
  and fix any issues before reporting a change as done;
- select the test JDK with `-PjdkTestVersion` / `-PjdkTestVendor`
  (`jdkTestVersion` is enough for most cases);
- list every build parameter with `./gradlew parameters`.

Pure documentation — no code or build changes; it points at the existing
`gradle.md` / `README.md` build docs rather than duplicating them.

Reviewed on a fork PR by Vladimir Sitnikov (`vlsi`), who trimmed the wording to
"only what an agent doesn't already know" and noted it looked mergeable for
`apache/jmeter`.
