### PR TITLE
Fix AassertTrue/assertFalse simplified regarding the report from sona…

### DIFF
--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
@@ -17,18 +17,14 @@
 
 package org.apache.jmeter.samplers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 // Extends JMeterTest case because it needs access to JMeter properties
 public class TestSampleSaveConfiguration extends JMeterTestCase {
@@ -50,21 +46,21 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
         SampleSaveConfiguration cloneA = (SampleSaveConfiguration) a.clone();
         assertNotSame(a, cloneA);
         assertEquals(a, cloneA);
-        assertTrue(a.equals(cloneA));
-        assertTrue(cloneA.equals(a));
+        assertEquals(a, cloneA);
+        assertEquals(cloneA, a);
         assertEquals(a.hashCode(), cloneA.hashCode());
 
         // Change the original
         a.setUrl(true);
-        assertFalse(a.equals(cloneA));
-        assertFalse(cloneA.equals(a));
-        assertFalse(a.hashCode() == cloneA.hashCode());
+        assertNotEquals(a, cloneA);
+        assertNotEquals(cloneA, a);
+        assertNotEquals(a.hashCode(), cloneA.hashCode());
 
         // Change the original back again
         a.setUrl(false);
         assertEquals(a, cloneA);
-        assertTrue(a.equals(cloneA));
-        assertTrue(cloneA.equals(a));
+        assertEquals(a, cloneA);
+        assertEquals(cloneA, a);
         assertEquals(a.hashCode(), cloneA.hashCode());
     }
 
@@ -85,8 +81,8 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
 
         // a and b should be equal
         assertEquals(a, b);
-        assertTrue(a.equals(b));
-        assertTrue(b.equals(a));
+        assertEquals(a, b);
+        assertEquals(b, a);
         assertEquals(a.hashCode(), b.hashCode());
         assertPrimitiveEquals(a.saveUrl(), b.saveUrl());
         assertPrimitiveEquals(a.saveAssertions(), b.saveAssertions());
@@ -95,10 +91,10 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
 
         a.setAssertions(false);
         // a and b should not be equal
-        assertFalse(a.equals(b));
-        assertFalse(b.equals(a));
-        assertFalse(a.hashCode() == b.hashCode());
-        assertFalse(a.saveAssertions() == b.saveAssertions());
+        assertNotEquals(a, b);
+        assertNotEquals(b, a);
+        assertNotEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a.saveAssertions(), b.saveAssertions());
     }
 
     @Test
@@ -106,8 +102,8 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
         SampleSaveConfiguration a = new SampleSaveConfiguration(false);
         SampleSaveConfiguration b = new SampleSaveConfiguration(false);
         assertEquals(a.hashCode(), b.hashCode(), "Hash codes should be equal");
-        assertTrue(a.equals(b), "Objects should be equal");
-        assertTrue(b.equals(a), "Objects should be equal");
+        assertEquals(a, b, "Objects should be equal");
+        assertEquals(b, a, "Objects should be equal");
     }
 
     @Test
@@ -115,16 +111,16 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
         SampleSaveConfiguration a = new SampleSaveConfiguration(true);
         SampleSaveConfiguration b = new SampleSaveConfiguration(true);
         assertEquals(a.hashCode(), b.hashCode(), "Hash codes should be equal");
-        assertTrue(a.equals(b), "Objects should be equal");
-        assertTrue(b.equals(a), "Objects should be equal");
+        assertEquals(a, b, "Objects should be equal");
+        assertEquals(b, a, "Objects should be equal");
     }
     @Test
     public void testFalseTrue() throws Exception {
         SampleSaveConfiguration a = new SampleSaveConfiguration(false);
         SampleSaveConfiguration b = new SampleSaveConfiguration(true);
-        assertFalse(a.hashCode() == b.hashCode(), "Hash codes should not be equal");
-        assertFalse(a.equals(b), "Objects should not be equal");
-        assertFalse(b.equals(a), "Objects should not be equal");
+        assertNotEquals(a.hashCode(), b.hashCode(), "Hash codes should not be equal");
+        assertNotEquals(a, b, "Objects should not be equal");
+        assertNotEquals(b, a, "Objects should not be equal");
     }
 
     @Test
@@ -132,27 +128,27 @@ public class TestSampleSaveConfiguration extends JMeterTestCase {
         SampleSaveConfiguration a = new SampleSaveConfiguration(false);
         SampleSaveConfiguration b = new SampleSaveConfiguration(false);
         assertEquals(a.hashCode(), b.hashCode(), "Hash codes should be equal");
-        assertTrue(a.equals(b), "Objects should be equal");
-        assertTrue(b.equals(a), "Objects should be equal");
-        assertTrue(a.strictDateFormatter() == null);
-        assertTrue(b.strictDateFormatter() == null);
-        assertTrue(a.threadSafeLenientFormatter() == null);
-        assertTrue(b.threadSafeLenientFormatter() == null);
+        assertEquals(a, b, "Objects should be equal");
+        assertEquals(b, a, "Objects should be equal");
+        assertNull(a.strictDateFormatter());
+        assertNull(b.strictDateFormatter());
+        assertNull(a.threadSafeLenientFormatter());
+        assertNull(b.threadSafeLenientFormatter());
         a.setDateFormat(null);
         b.setDateFormat(null);
         assertEquals(a.hashCode(), b.hashCode(), "Hash codes should be equal");
-        assertTrue(a.equals(b), "Objects should be equal");
-        assertTrue(b.equals(a), "Objects should be equal");
-        assertTrue(a.strictDateFormatter() == null);
-        assertTrue(b.strictDateFormatter() == null);
-        assertTrue(a.threadSafeLenientFormatter() == null);
-        assertTrue(b.threadSafeLenientFormatter() == null);
+        assertEquals(a, b, "Objects should be equal");
+        assertEquals(b, a, "Objects should be equal");
+        assertNull(a.strictDateFormatter());
+        assertNull(b.strictDateFormatter());
+        assertNull(a.threadSafeLenientFormatter());
+        assertNull(b.threadSafeLenientFormatter());
         a.setDateFormat("dd/MM/yyyy");
         b.setDateFormat("dd/MM/yyyy");
         assertEquals(a.hashCode(), b.hashCode(), "Hash codes should be equal");
-        assertTrue(a.equals(b), "Objects should be equal");
-        assertTrue(b.equals(a), "Objects should be equal");
-        assertTrue(a.strictDateFormatter().equals(b.strictDateFormatter()), "Objects should be equal");
+        assertEquals(a, b, "Objects should be equal");
+        assertEquals(b, a, "Objects should be equal");
+        assertEquals(a.strictDateFormatter(), b.strictDateFormatter(), "Objects should be equal");
     }
 
     @Test

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
@@ -19,11 +19,11 @@ package org.apache.jmeter.samplers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
@@ -17,14 +17,14 @@
 
 package org.apache.jmeter.samplers;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.jmeter.junit.JMeterTestCase;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 // Extends JMeterTest case because it needs access to JMeter properties
 public class TestSampleSaveConfiguration extends JMeterTestCase {

--- a/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
+++ b/src/core/src/test/java/org/apache/jmeter/samplers/TestSampleSaveConfiguration.java
@@ -17,7 +17,13 @@
 
 package org.apache.jmeter.samplers;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
@@ -18,9 +18,9 @@
 package org.apache.jorphan.collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
@@ -17,18 +17,14 @@
 
 package org.apache.jorphan.collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PackageTest {
 
@@ -52,16 +48,12 @@ public class PackageTest {
         HashTree tree3 = new HashTree("abcde");
         HashTree tree4 = new HashTree("abcde");
 
-        assertTrue(tree1.equals(tree1));
-        assertTrue(tree1.equals(tree2));
-        assertTrue(tree2.equals(tree1));
-        assertTrue(tree2.equals(tree2));
+        assertEquals(tree1, tree2);
+        assertEquals(tree2, tree1);
         assertEquals(tree1.hashCode(), tree2.hashCode());
 
-        assertTrue(tree3.equals(tree3));
-        assertTrue(tree3.equals(tree4));
-        assertTrue(tree4.equals(tree3));
-        assertTrue(tree4.equals(tree4));
+        assertEquals(tree3, tree4);
+        assertEquals(tree4, tree3);
         assertEquals(tree3.hashCode(), tree4.hashCode());
 
         assertNotSame(tree1, tree2);
@@ -70,24 +62,24 @@ public class PackageTest {
         assertNotSame(tree2, tree3);
         assertNotSame(tree2, tree4);
 
-        assertFalse(tree1.equals(tree3));
-        assertFalse(tree1.equals(tree4));
-        assertFalse(tree2.equals(tree3));
-        assertFalse(tree2.equals(tree4));
+        assertNotEquals(tree1, tree3);
+        assertNotEquals(tree1, tree4);
+        assertNotEquals(tree2, tree3);
+        assertNotEquals(tree2, tree4);
 
         assertNotNull(tree1);
         assertNotNull(tree2);
 
         tree1.add("abcd", tree3);
-        assertFalse(tree1.equals(tree2));
-        assertFalse(tree2.equals(tree1));// Check reflexive
+        assertNotEquals(tree1, tree2);
+        assertNotEquals(tree2, tree1);// Check reflexive
         if (tree1.hashCode() == tree2.hashCode()) {
             // This is not a requirement
             System.out.println("WARN: unequal HashTrees should not have equal hashCodes");
         }
         tree2.add("abcd", tree4);
-        assertTrue(tree1.equals(tree2));
-        assertTrue(tree2.equals(tree1));
+        assertEquals(tree1, tree2);
+        assertEquals(tree2, tree1);
         assertEquals(tree1.hashCode(), tree2.hashCode());
     }
 
@@ -112,37 +104,33 @@ public class PackageTest {
         ListedHashTree tree3 = new ListedHashTree("abcde");
         ListedHashTree tree4 = new ListedHashTree("abcde");
 
-        assertTrue(tree1.equals(tree1));
-        assertTrue(tree1.equals(tree2));
-        assertTrue(tree2.equals(tree1));
-        assertTrue(tree2.equals(tree2));
+        assertEquals(tree1, tree2);
+        assertEquals(tree2, tree1);
         assertEquals(tree1.hashCode(), tree2.hashCode());
 
-        assertTrue(tree3.equals(tree3));
-        assertTrue(tree3.equals(tree4));
-        assertTrue(tree4.equals(tree3));
-        assertTrue(tree4.equals(tree4));
+        assertEquals(tree3, tree4);
+        assertEquals(tree4, tree3);
         assertEquals(tree3.hashCode(), tree4.hashCode());
 
         assertNotSame(tree1, tree2);
         assertNotSame(tree1, tree3);
-        assertFalse(tree1.equals(tree3));
-        assertFalse(tree3.equals(tree1));
-        assertFalse(tree1.equals(tree4));
-        assertFalse(tree4.equals(tree1));
+        assertNotEquals(tree1, tree3);
+        assertNotEquals(tree3, tree1);
+        assertNotEquals(tree1, tree4);
+        assertNotEquals(tree4, tree1);
 
-        assertFalse(tree2.equals(tree3));
-        assertFalse(tree3.equals(tree2));
-        assertFalse(tree2.equals(tree4));
-        assertFalse(tree4.equals(tree2));
+        assertNotEquals(tree2, tree3);
+        assertNotEquals(tree3, tree2);
+        assertNotEquals(tree2, tree4);
+        assertNotEquals(tree4, tree2);
 
         tree1.add("abcd", tree3);
-        assertFalse(tree1.equals(tree2));
-        assertFalse(tree2.equals(tree1));
+        assertNotEquals(tree1, tree2);
+        assertNotEquals(tree2, tree1);
 
         tree2.add("abcd", tree4);
-        assertTrue(tree1.equals(tree2));
-        assertTrue(tree2.equals(tree1));
+        assertEquals(tree1, tree2);
+        assertEquals(tree2, tree1);
         assertEquals(tree1.hashCode(), tree2.hashCode());
 
         tree1.add("a1");
@@ -150,16 +138,16 @@ public class PackageTest {
         tree2.add("a2");
         tree2.add("a1");
 
-        assertFalse(tree1.equals(tree2));
-        assertFalse(tree2.equals(tree1));
+        assertNotEquals(tree1, tree2);
+        assertNotEquals(tree2, tree1);
         if (tree1.hashCode() == tree2.hashCode()) {
             // This is not a requirement
             System.out.println("WARN: unequal ListedHashTrees should not have equal hashcodes");
         }
 
         tree4.add("abcdef");
-        assertFalse(tree3.equals(tree4));
-        assertFalse(tree4.equals(tree3));
+        assertNotEquals(tree3, tree4);
+        assertNotEquals(tree4, tree3);
     }
 
     @Test

--- a/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.jorphan.collections;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class PackageTest {
 

--- a/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
+++ b/src/jorphan/src/test/java/org/apache/jorphan/collections/PackageTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.jorphan.collections;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Arrays;
 import java.util.Collection;


### PR DESCRIPTION
## Description
Fixes Sonar Qube issue (Java) JUnit assertTrue/assertFalse should be simplified to the corresponding dedicated assertion
https://sonarcloud.io/project/issues?rules=java%3AS5785&issueStatuses=OPEN%2CCONFIRMED&id=JMeter

Additionaly in PackageTest.java, I've removed self-assertions for example AssertEquals(a1,a1) which were useless.

## Motivation and Context
Remove issue from SonarQube

## How Has This Been Tested?
I've runned ./gradlew test and there is no issue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Delete as appropriate -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the [code style][style-guide] of this project.
- [ ] I have updated the documentation accordingly.

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines
