### PR TITLE
fix: CacheManager memory leak by reusing InheritableThreadLocal (#6730)

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CacheManager.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/CacheManager.java
@@ -80,7 +80,16 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
     public static final String MAX_SIZE = "maxSize";  // $NON-NLS-1$
     //-
 
-    private transient InheritableThreadLocal<Cache<String, CacheEntry>> threadCache;
+    @SuppressWarnings("ThreadLocalUsage") // intentionally using InheritableThreadLocal for per-thread cache
+    private final transient InheritableThreadLocal<Cache<String, CacheEntry>> threadCache =
+            new InheritableThreadLocal<Cache<String, CacheEntry>>(){
+                @Override
+                protected Cache<String, CacheEntry> initialValue() {
+                    return Caffeine.newBuilder()
+                            .maximumSize(getMaxSize())
+                            .build();
+                }
+            };
 
     private transient boolean useExpires; // Cached value
 
@@ -602,15 +611,7 @@ public class CacheManager extends ConfigTestElement implements TestStateListener
 
     private void clearCache() {
         log.debug("Clear cache");
-        // TODO: avoid re-creating the thread local every time, reset its contents instead
-        threadCache = new InheritableThreadLocal<Cache<String, CacheEntry>>(){
-            @Override
-            protected Cache<String, CacheEntry> initialValue() {
-                return Caffeine.newBuilder()
-                        .maximumSize(getMaxSize())
-                        .build();
-            }
-        };
+        threadCache.remove();
     }
 
     /**


### PR DESCRIPTION
## Summary

`CacheManager.clearCache()` creates a new `InheritableThreadLocal` instance on every call without calling `.remove()` on the previous one, causing a progressive memory leak that grows with `iteration_count × thread_count` when "Clear cache each iteration" is enabled.

The existing TODO in the code already acknowledged this:

```java
// TODO: avoid re-creating the thread local every time, reset its contents instead
```

## Fix

- Initialize `threadCache` once at field declaration
- Replace `clearCache()` body with `threadCache.remove()` instead of creating a new instance
- The next `.get()` call lazily creates a fresh cache via `initialValue()`
- Added `@SuppressWarnings("ThreadLocalUsage")` since `InheritableThreadLocal` is intentionally used for per-thread caching

## Testing

All 80 CacheManager tests pass (0 failed, 1 skipped):

```
TestCacheManagerThreadIteration:      5/5  ✅
TestCacheManagerHC4:                 50/50 ✅
TestCacheManagerUrlConnection:       25/25 ✅
```

Fixes #6730
