### PR TITLE
Fix #6457: Suppress spurious 'Existing CookieManager superseded by' warnings across iterations

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java
@@ -730,15 +730,20 @@ public abstract class HTTPSamplerBase extends AbstractSampler
     @Override
     public void addTestElement(TestElement el) {
         if (el instanceof CookieManager cookieManager) {
-            setCookieManager(cookieManager);
+            // Route through the private property setter to skip the "superseded by" warning:
+            // addTestElement is invoked on every thread-group iteration by TestCompiler,
+            // and the config element is the same instance as the one already attached,
+            // so the warning would always fire spuriously. Users still get the warning
+            // when they explicitly call setCookieManager with a different instance.
+            setCookieManagerProperty(cookieManager);
         } else if (el instanceof CacheManager cacheManager) {
-            setCacheManager(cacheManager);
+            setCacheManagerProperty(cacheManager);
         } else if (el instanceof HeaderManager headerManager) {
             setHeaderManager(headerManager);
         } else if (el instanceof AuthManager authManager) {
-            setAuthManager(authManager);
+            setAuthManagerProperty(authManager);
         } else if (el instanceof DNSCacheManager dnsCacheManager) {
-            setDNSResolver(dnsCacheManager);
+            setDNSResolverProperty(dnsCacheManager);
         } else if (el instanceof KeystoreConfig keystoreConfig) {
             setKeystoreConfigProperty(keystoreConfig);
         }  else {
@@ -923,13 +928,19 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         return get(getSchema().getPostBodyRaw());
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public void setAuthManager(AuthManager value) {
         AuthManager mgr = getAuthManager();
-        if (mgr != null) {
+        if (mgr != null && mgr != value) {
             if(log.isWarnEnabled()) {
                 log.warn("Existing AuthManager {} superseded by {}", mgr.getName(), value.getName());
             }
         }
+        setAuthManagerProperty(value);
+    }
+
+    // private method to allow AsyncSample and addTestElement to reset the value without performing checks
+    private void setAuthManagerProperty(AuthManager value) {
         set(getSchema().getAuthManager(), value);
     }
 
@@ -961,9 +972,10 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         set(getSchema().getCookieManager(), value);;
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public void setCookieManager(CookieManager value) {
         CookieManager mgr = getCookieManager();
-        if (mgr != null) {
+        if (mgr != null && mgr != value) {
             if(log.isWarnEnabled()) {
                 log.warn("Existing CookieManager {} superseded by {}", mgr.getName(), value.getName());
             }
@@ -983,9 +995,10 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         set(getSchema().getKeystoreConfig(), value);
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public void setKeystoreConfig(KeystoreConfig value) {
         KeystoreConfig mgr = getKeystoreConfig();
-        if (mgr != null && log.isWarnEnabled()) {
+        if (mgr != null && mgr != value && log.isWarnEnabled()) {
             log.warn("Existing KeystoreConfig {} superseded by {}", mgr.getName(), value.getName());
         }
         setKeystoreConfigProperty(value);
@@ -995,9 +1008,10 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         return getOrNull(getSchema().getKeystoreConfig());
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public void setCacheManager(CacheManager value) {
         CacheManager mgr = getCacheManager();
-        if (mgr != null) {
+        if (mgr != null && mgr != value) {
             if(log.isWarnEnabled()) {
                 log.warn("Existing CacheManager {} superseded by {}", mgr.getName(), value.getName());
             }
@@ -1013,13 +1027,19 @@ public abstract class HTTPSamplerBase extends AbstractSampler
         return getOrNull(getSchema().getDnsCacheManager());
     }
 
+    @SuppressWarnings("ReferenceEquality")
     public void setDNSResolver(DNSCacheManager cacheManager) {
         DNSCacheManager mgr = getDNSResolver();
-        if (mgr != null) {
+        if (mgr != null && mgr != cacheManager) {
             if(log.isWarnEnabled()) {
                 log.warn("Existing DNSCacheManager {} superseded by {}", mgr.getName(), cacheManager.getName());
             }
         }
+        setDNSResolverProperty(cacheManager);
+    }
+
+    // private method to allow addTestElement to reset the value without performing checks
+    private void setDNSResolverProperty(DNSCacheManager cacheManager) {
         set(getSchema().getDnsCacheManager(), cacheManager);
     }
 

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/HttpSamplerManagerWarningsTest.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/HttpSamplerManagerWarningsTest.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.http.sampler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.jmeter.config.KeystoreConfig;
+import org.apache.jmeter.protocol.http.control.AuthManager;
+import org.apache.jmeter.protocol.http.control.CacheManager;
+import org.apache.jmeter.protocol.http.control.CookieManager;
+import org.apache.jmeter.protocol.http.control.DNSCacheManager;
+import org.apache.jmeter.protocol.http.control.HeaderManager;
+import org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Regression tests for spurious "Existing XxxManager ... superseded by ..." warnings
+ * fired on every thread-group iteration after the first one.
+ *
+ * <p>Root cause: {@link HTTPSamplerBase#addTestElement(TestElement)} routed CookieManager,
+ * CacheManager, AuthManager and DNSCacheManager through their public {@code setXxxManager}
+ * methods, which log a warning whenever the existing manager is non-null. Since
+ * {@code clearTestElementChildren()} only clears the HeaderManager property, the manager
+ * reference survives across iterations and the warning fires N-1 times for N iterations.</p>
+ *
+ * <p>Fix:</p>
+ * <ul>
+ *   <li>{@code addTestElement} now routes replace-mode managers through their private
+ *       {@code setXxxManagerProperty} methods, mirroring the existing KeystoreConfig path.</li>
+ *   <li>The public {@code setXxxManager} methods now suppress the warning when the new
+ *       value is the same instance as the existing one (defensive guard for direct calls).</li>
+ * </ul>
+ *
+ * <p>These tests verify both the {@code addTestElement} path (used by TestCompiler on each
+ * iteration) and the public setter path. Warnings are captured by redirecting the log4j2
+ * "jmeter-log" file appender to a per-class temporary file via the {@code jmeter.logfile}
+ * system property (see {@code src/core/src/testFixtures/resources/log4j2.xml"}), so the
+ * tests do not depend on the working directory and can be re-run in isolation.</p>
+ */
+public class HttpSamplerManagerWarningsTest {
+
+    /** log4j2 system property used in src/core/src/testFixtures/resources/log4j2.xml. */
+    private static final String JMeter_LOGFILE_PROPERTY = "jmeter.logfile";
+
+    private static Path logFile;
+    private static String originalLogfileProperty;
+
+    private HTTPSamplerBase sampler;
+
+    @BeforeAll
+    public static void redirectLogFile(@TempDir Path tempDir) {
+        logFile = tempDir.resolve("HttpSamplerManagerWarningsTest.log");
+        originalLogfileProperty = System.getProperty(JMeter_LOGFILE_PROPERTY);
+        System.setProperty(JMeter_LOGFILE_PROPERTY, logFile.toAbsolutePath().toString());
+        // Force log4j2 to re-read the configuration so the ${sys:jmeter.logfile:-jmeter.log}
+        // lookup in src/core/src/testFixtures/resources/log4j2.xml picks up the new path.
+        ((LoggerContext) LogManager.getContext(false)).reconfigure();
+    }
+
+    @AfterAll
+    public static void restoreLogFile() {
+        if (originalLogfileProperty == null) {
+            System.clearProperty(JMeter_LOGFILE_PROPERTY);
+        } else {
+            System.setProperty(JMeter_LOGFILE_PROPERTY, originalLogfileProperty);
+        }
+        ((LoggerContext) LogManager.getContext(false)).reconfigure();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        sampler = (HTTPSamplerBase) new HttpTestSampleGui().createTestElement();
+    }
+
+    /**
+     * Provides the 5 replace-mode managers covered by the fix.
+     * Each argument is: (manager factory, display name).
+     */
+    static Stream<Arguments> replaceModeManagers() {
+        return Stream.of(
+                Arguments.of((ManagerFactory<CookieManager>) CookieManager::new, "CookieManager"),
+                Arguments.of((ManagerFactory<CacheManager>) CacheManager::new, "CacheManager"),
+                Arguments.of((ManagerFactory<AuthManager>) AuthManager::new, "AuthManager"),
+                Arguments.of((ManagerFactory<DNSCacheManager>) DNSCacheManager::new, "DNSCacheManager"),
+                Arguments.of((ManagerFactory<KeystoreConfig>) KeystoreConfig::new, "KeystoreConfig")
+        );
+    }
+
+    /**
+     * Scenario 1: simulate N thread-group iterations via {@code addTestElement}.
+     * Expected: zero "superseded by" warnings across all iterations.
+     */
+    @ParameterizedTest(name = "{1}: addTestElement x5 should produce no warning")
+    @MethodSource("replaceModeManagers")
+    public <T extends TestElement> void addTestElementAcrossIterationsShouldNotWarn(
+            ManagerFactory<T> factory, String displayName) throws IOException {
+        T manager = factory.create();
+        manager.setName(displayName + "-UnderTest");
+
+        long baseline = countSupersededWarningsInLog();
+        for (int i = 1; i <= 5; i++) {
+            sampler.addTestElement(manager);
+        }
+        long delta = countSupersededWarningsInLog() - baseline;
+        assertEquals(0L, delta,
+                "[" + displayName + "] 5 addTestElement iterations produced " + delta
+                        + " spurious 'superseded by' warnings (expected 0)");
+    }
+
+    /**
+     * Scenario 2: public setter called with the SAME instance should not warn (defensive guard).
+     * This protects against any caller that re-assigns the same manager instance.
+     */
+    @ParameterizedTest(name = "{1}: setXxx(sameInstance) should not warn")
+    @MethodSource("replaceModeManagers")
+    public <T extends TestElement> void setXxxManagerWithSameInstanceShouldNotWarn(
+            ManagerFactory<T> factory, String displayName) throws IOException {
+        T manager = factory.create();
+        manager.setName(displayName + "-Same");
+
+        // First call: sets the manager (no prior value, no warning expected)
+        long baseline = countSupersededWarningsInLog();
+        setManagerOnSampler(displayName, manager);
+        long deltaAfterFirst = countSupersededWarningsInLog() - baseline;
+        assertEquals(0L, deltaAfterFirst,
+                "[" + displayName + "] initial setXxxManager should not warn");
+
+        // Second call with the same instance: must not warn
+        setManagerOnSampler(displayName, manager);
+        long deltaAfterSecond = countSupersededWarningsInLog() - baseline;
+        assertEquals(0L, deltaAfterSecond,
+                "[" + displayName + "] setXxxManager with same instance should not warn");
+    }
+
+    /**
+     * Scenario 3: public setter called with a DIFFERENT instance must still warn, so that
+     * genuine misuses (user attaching multiple managers of the same type) are still detected.
+     */
+    @ParameterizedTest(name = "{1}: setXxx(differentInstance) should still warn")
+    @MethodSource("replaceModeManagers")
+    public <T extends TestElement> void setXxxManagerWithDifferentInstanceShouldStillWarn(
+            ManagerFactory<T> factory, String displayName) throws IOException {
+        T first = factory.create();
+        first.setName(displayName + "-First");
+        T second = factory.create();
+        second.setName(displayName + "-Second");
+        assertNotSame(first, second, "test fixture: two distinct instances expected");
+
+        setManagerOnSampler(displayName, first);
+        long baseline = countSupersededWarningsInLog();
+        setManagerOnSampler(displayName, second);
+        long delta = countSupersededWarningsInLog() - baseline;
+        assertTrue(delta >= 1,
+                "[" + displayName + "] setXxxManager with a different instance must still warn"
+                        + " (got " + delta + " warnings, expected >= 1)");
+    }
+
+    /**
+     * Scenario 4: HeaderManager uses merge (not replace) and is the original target of
+     * {@code clearTestElementChildren}. It must not produce "superseded by" warnings either,
+     * and the merge accumulation behaviour must keep working across iterations.
+     */
+    @Test
+    public void headerManagerAddTestElementShouldNotWarnAndShouldMerge() throws IOException {
+        HeaderManager hm = new HeaderManager();
+        hm.setName("HeaderManager-UnderTest");
+
+        long baseline = countSupersededWarningsInLog();
+        for (int i = 1; i <= 5; i++) {
+            sampler.addTestElement(hm);
+        }
+        long delta = countSupersededWarningsInLog() - baseline;
+        assertEquals(0L, delta,
+                "HeaderManager 5 addTestElement iterations produced " + delta
+                        + " 'superseded by' warnings (expected 0)");
+        // HeaderManager is cleared each iteration and re-merged, so it must remain attached.
+        assertNotNull(sampler.getHeaderManager(),
+                "HeaderManager should remain attached after iterations");
+    }
+
+    /**
+     * Scenario 5: end-to-end smoke test that combines all 6 managers in a single sampler
+     * across 10 iterations. This mirrors the real-world pattern where a Thread Group has
+     * multiple config elements as children.
+     */
+    @Test
+    public void allManagersTogetherAcrossIterationsShouldNotWarn() throws IOException {
+        CookieManager cookieManager = new CookieManager();
+        cookieManager.setName("HTTP Cookie Manager");
+        CacheManager cacheManager = new CacheManager();
+        cacheManager.setName("HTTP Cache Manager");
+        AuthManager authManager = new AuthManager();
+        authManager.setName("HTTP Authorization Manager");
+        DNSCacheManager dnsCacheManager = new DNSCacheManager();
+        dnsCacheManager.setName("DNS Cache Manager");
+        KeystoreConfig keystoreConfig = new KeystoreConfig();
+        keystoreConfig.setName("Keystore Config");
+        HeaderManager headerManager = new HeaderManager();
+        headerManager.setName("HTTP Header Manager");
+
+        long baseline = countSupersededWarningsInLog();
+        for (int i = 1; i <= 10; i++) {
+            sampler.addTestElement(cookieManager);
+            sampler.addTestElement(cacheManager);
+            sampler.addTestElement(authManager);
+            sampler.addTestElement(dnsCacheManager);
+            sampler.addTestElement(keystoreConfig);
+            sampler.addTestElement(headerManager);
+        }
+        long delta = countSupersededWarningsInLog() - baseline;
+        assertEquals(0L, delta,
+                "10 iterations with 6 managers produced " + delta
+                        + " 'superseded by' warnings (expected 0)");
+
+        // Sanity: managers are still attached
+        assertNotNull(sampler.getCookieManager());
+        assertNotNull(sampler.getCacheManager());
+        assertNotNull(sampler.getAuthManager());
+        assertNotNull(sampler.getDNSResolver());
+        assertNotNull(sampler.getKeystoreConfig());
+        assertNotNull(sampler.getHeaderManager());
+    }
+
+    // ---------------- helpers ----------------
+
+    /**
+     * Routes the given manager to the appropriate public setter on the sampler.
+     * Used by the parameterized tests so each manager type is exercised uniformly.
+     */
+    private void setManagerOnSampler(String displayName, TestElement manager) {
+        switch (displayName) {
+            case "CookieManager" -> sampler.setCookieManager((CookieManager) manager);
+            case "CacheManager" -> sampler.setCacheManager((CacheManager) manager);
+            case "AuthManager" -> sampler.setAuthManager((AuthManager) manager);
+            case "DNSCacheManager" -> sampler.setDNSResolver((DNSCacheManager) manager);
+            case "KeystoreConfig" -> sampler.setKeystoreConfig((KeystoreConfig) manager);
+            default -> throw new IllegalArgumentException("Unknown manager type: " + displayName);
+        }
+    }
+
+    private long countSupersededWarningsInLog() throws IOException {
+        return readSupersededLinesFromLog().size();
+    }
+
+    private List<String> readSupersededLinesFromLog() throws IOException {
+        if (!Files.exists(logFile)) {
+            return new ArrayList<>();
+        }
+        List<String> hits = new ArrayList<>();
+        for (String line : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (line.contains("superseded by")) {
+                hits.add(line);
+            }
+        }
+        return hits;
+    }
+
+    @FunctionalInterface
+    interface ManagerFactory<T extends TestElement> {
+        T create();
+    }
+}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -116,6 +116,10 @@ Summary
     <li><pr>6620</pr>Fix report generation paths so dashboard output files are created in the correct location after internal refactoring.</li>
     <li><bug>6456</bug>Handle malformed percent-encoded URLs gracefully when recording HTTP traffic, logging a warning instead of failing the recording.</li>
   </ul>
+  <h3>HTTP Samplers and Test Script Recorder</h3>
+  <ul>
+    <li><issue>6457</issue>Suppress spurious <code>Existing CookieManager &hellip; superseded by &hellip;</code> (and analogous <code>CacheManager</code>, <code>AuthManager</code>, <code>DNSCacheManager</code>, <code>KeystoreConfig</code>) warnings that fired on every thread-group iteration after the first one. <code>addTestElement</code> now routes replace-mode managers through their private property setters (mirroring the existing <code>KeystoreConfig</code> path), and the public setters no longer warn when the new value is the same instance as the existing one.</li>
+  </ul>
  <!--  =================== Thanks =================== -->
 
 <ch_section>Thanks</ch_section>


### PR DESCRIPTION
## Issue
Fixes #6457

Since 5.6, JMeter logs a flood of `Existing CookieManager ... superseded by ...` (and analogous `CacheManager`, `AuthManager`, `DNSCacheManager` warnings) on every thread-group iteration after the first one. In a long-running test plan with N iterations and M HTTP Samplers under a Thread Group, the log is filled with `(N-1) × M` redundant warning lines per manager type, hiding real issues and alarming users.

## Root cause
`HTTPSamplerBase#addTestElement(TestElement)` routed `CookieManager`, `CacheManager`, `AuthManager`, and `DNSCacheManager` through their **public** `setXxxManager` methods. Those public setters unconditionally log a warning whenever the existing manager is non-null.

`TestCompiler` calls `addTestElement` on every thread-group iteration after `clearTestElementChildren()`, but `clearTestElementChildren()` only clears the `HeaderManager` property — the replace-mode manager references survive across iterations. As a result, the warning fires `N-1` times for `N` iterations even though the user has attached exactly one manager.

`KeystoreConfig` was already exempted because its `addTestElement` branch already called the private `setKeystoreConfigProperty`, which does not warn.

## Fix
Two complementary changes in `HTTPSamplerBase`:

- `addTestElement` now routes replace-mode managers (`CookieManager`, `CacheManager`, `AuthManager`, `DNSCacheManager`) through their private `setXxxManagerProperty` / `setDNSResolverProperty` methods, mirroring the existing `KeystoreConfig` path. This is the path used by `TestCompiler` every iteration, so the warning no longer fires on legitimate re-application of the same config element.
- The public `setXxxManager` methods now suppress the warning when the new value is the same instance as the existing one (defensive guard for direct callers). The reference-equality check uses `==` deliberately and is annotated with `@SuppressWarnings("ReferenceEquality")`. Genuine misuse — attaching a *different* manager of the same type — still produces the warning, so the diagnostic value is preserved.

## Files changed
- `src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/sampler/HTTPSamplerBase.java` — reroute `addTestElement` for the 4 replace-mode managers, add same-instance guard to 5 public setters, extract 2 new private property setters (`setAuthManagerProperty`, `setDNSResolverProperty`) mirroring the existing pattern.
- `src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/sampler/HttpSamplerManagerWarningsTest.java` — new regression test (17 cases) covering: (1) `addTestElement` × 5 iterations for each of the 5 managers, (2) same-instance setter call, (3) different-instance setter call (must still warn), (4) `HeaderManager` merge path, (5) end-to-end smoke test with all 6 managers across 10 iterations.
- `xdocs/changes.xml` — bug-fix entry under a new `HTTP Samplers and Test Script Recorder` subsection.

## Verification
```
./gradlew --quiet :src:protocol:http:compileJava :src:protocol:http:compileTestJava \
                   :src:protocol:http:checkstyleMain :src:protocol:http:checkstyleTest
./gradlew --quiet :src:protocol:http:test --tests "org.apache.jmeter.protocol.http.sampler.HttpSamplerManagerWarningsTest"
```

## Before / After evidence

Both runs use the same `HttpSamplerManagerWarningsTest` (17 cases). The "before" run is on unpatched `master` with the test file checked out from this branch; the "after" run is on this branch.

### Before (without fix)
- Tests: 17 completed, **10 failed** (the 5 `addTestElement x5` cases for CookieManager/CacheManager/AuthManager/DNSCacheManager + the end-to-end case + the 5 same-instance setter cases all fail)
- `jmeter.log` `superseded by` lines: **62** total, broken down as:
  - **5 lines** from same-instance setter calls (the 5 `setXxx(sameInstance)` cases) — these should not warn
  - **5 lines** from different-instance setter calls — these are expected (genuine misuse detected)
  - **16 lines** from `addTestElement x5` iterations across 4 managers (4 spurious warnings × 4 managers; KeystoreConfig already exempted)
  - **36 lines** from the end-to-end test (9 iterations × 4 replace-mode managers)

Sample spurious warnings from the same-instance setter cases (lines 26, 29, 33-35 of `before-superseded-warnings.log`):
```
2026-07-26 15:27:20,424 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager CookieManager-Same superseded by CookieManager-Same
2026-07-26 15:27:20,490 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CacheManager CacheManager-Same superseded by CacheManager-Same
2026-07-26 15:27:20,536 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing AuthManager AuthManager-Same superseded by AuthManager-Same
2026-07-26 15:27:20,572 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing DNSCacheManager DNSCacheManager-Same superseded by DNSCacheManager-Same
2026-07-26 15:27:20,607 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing KeystoreConfig KeystoreConfig-Same superseded by KeystoreConfig-Same
```

Sample spurious warnings from `addTestElement x5` for CookieManager (lines 41-44, 4 spurious warnings for 5 iterations):
```
2026-07-26 15:27:20,870 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager CookieManager-UnderTest superseded by CookieManager-UnderTest
2026-07-26 15:27:20,870 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager CookieManager-UnderTest superseded by CookieManager-UnderTest
2026-07-26 15:27:20,870 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager CookieManager-UnderTest superseded by CookieManager-UnderTest
2026-07-26 15:27:20,870 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager CookieManager-UnderTest superseded by CookieManager-UnderTest
```

Sample spurious warnings from the end-to-end test (lines 57-92, 36 lines for 9 iterations × 4 managers):
```
2026-07-26 15:27:21,060 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager HTTP Cookie Manager superseded by HTTP Cookie Manager
2026-07-26 15:27:21,061 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CacheManager HTTP Cache Manager superseded by HTTP Cache Manager
2026-07-26 15:27:21,061 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing AuthManager HTTP Authorization Manager superseded by HTTP Authorization Manager
2026-07-26 15:27:21,061 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing DNSCacheManager DNS Cache Manager superseded by DNS Cache Manager
... (repeated 36 times across 9 iterations)
```

[before-superseded-warnings.log](https://github.com/user-attachments/files/30384310/before-superseded-warnings.log)


### After (with fix)
- Tests: 17 completed, **0 failed**
- `jmeter.log` `superseded by` lines: **5** total — **only** the expected warnings from the different-instance setter cases (lines 31-35 of `after-superseded-warnings.log`). Genuine misuse is still detected.

```
2026-07-26 15:26:03,348 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CookieManager CookieManager-First superseded by CookieManager-Second
2026-07-26 15:26:03,397 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing CacheManager CacheManager-First superseded by CacheManager-Second
2026-07-26 15:26:03,442 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing AuthManager AuthManager-First superseded by AuthManager-Second
2026-07-26 15:26:03,484 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing DNSCacheManager DNSCacheManager-First superseded by DNSCacheManager-Second
2026-07-26 15:26:03,511 WARN o.a.j.p.h.s.HTTPSamplerBase: Existing KeystoreConfig KeystoreConfig-First superseded by KeystoreConfig-Second
```
[after-superseded-warnings.log](https://github.com/user-attachments/files/30384311/after-superseded-warnings.log)



### Summary
| Metric | Before | After |
|---|---|---|
| Tests passing | 7/17 | 17/17 |
| `addTestElement x5` spurious warnings (4 managers × 4) | 16 | 0 |
| Same-instance setter spurious warnings (5 managers) | 5 | 0 |
| End-to-end spurious warnings (9 iterations × 4 managers) | 36 | 0 |
| Different-instance setter warnings (expected, kept) | 5 | 5 |
| **Total `superseded by` lines** | **62** | **5** |
