### PR TITLE
Don't send cookies after they reached their expiry time

### DIFF
--- a/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
+++ b/src/protocol/http/src/main/java/org/apache/jmeter/protocol/http/control/HC4CookieHandler.java
@@ -18,6 +18,7 @@
 package org.apache.jmeter.protocol.http.control;
 
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -228,7 +229,14 @@ public class HC4CookieHandler implements CookieHandler {
         CookieOrigin cookieOrigin = new CookieOrigin(host, port, path, secure);
 
         List<org.apache.http.cookie.Cookie> cookiesValid = new ArrayList<>();
+        // #6428 Cookies must not be sent after they reached their expiry time.
+        // The cookie specs used here do not check the expiry date in match(),
+        // so expired cookies have to be filtered out explicitly.
+        Date now = Date.from(Instant.now());
         for (org.apache.http.cookie.Cookie cookie : cookies) {
+            if (cookie.isExpired(now)) {
+                continue;
+            }
             if (cookieSpec.match(cookie, cookieOrigin)) {
                 cookiesValid.add(cookie);
             }

--- a/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestHC4CookieManager.java
+++ b/src/protocol/http/src/test/java/org/apache/jmeter/protocol/http/control/TestHC4CookieManager.java
@@ -259,6 +259,27 @@ public class TestHC4CookieManager extends JMeterTestCase {
         assertNull(s);
     }
 
+    // Test cookie that was valid when received is not sent anymore
+    // once its expiry time has passed (#6428)
+    @Test
+    public void testCookieExpiredAfterReceptionIsNotSent() throws Exception {
+        URL url = new URL("http://a.b.c/");
+        man.addCookieFromHeader("test=1; expires=Wed, 01-Jan-2099 00:00:00 GMT", url);
+        assertEquals(1, man.getCookieCount());
+        assertEquals("test=1", man.getCookieHeaderForURL(url));
+        // Simulate the passing of time: the cookie is expired by now
+        man.get(0).setExpires(System.currentTimeMillis() / 1000L - 3600L);
+        assertNull(man.getCookieHeaderForURL(url), "expired cookie must not be sent");
+    }
+
+    // Test session cookie (no expiry date) is still sent
+    @Test
+    public void testSessionCookieWithoutExpiryIsStillSent() throws Exception {
+        URL url = new URL("http://a.b.c/");
+        man.addCookieFromHeader("test=1", url);
+        assertEquals("test=1", man.getCookieHeaderForURL(url));
+    }
+
     // Test New cookie is returned
     @Test
     public void testNewCookie() throws Exception {

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -109,6 +109,7 @@ Summary
   <ch_section>Bug fixes</ch_section>
   <h3>General</h3>
   <ul>
+    <li><issue>6428</issue>HTTP Cookie Manager kept sending cookies after they reached their expiry time.</li>
     <li><pr>6654</pr><issue>6611</issue>Support JDK 25 and above for result collectors with empty file names</li>
     <li>Trim whitespace when parsing numeric JMeter properties so accidental spaces do not silently change configuration values.</li>
     <li><pr>6372</pr>Fix KeyManager logging when using CLI mode so keystore passwords are not incorrectly reported as missing. Contributed by Patrick Uiterwijk (patrick at puiterwijk.org)</li>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -58,7 +58,18 @@ Summary
 </p>
 <ul>
 <li><a href="#Changes">Changes</a></li>
+<li><a href="#Incompatible changes">Incompatible changes</a></li>
 <li><a href="#Bug fixes">Bug fixes</a></li>
+</ul>
+
+<!-- =================== Incompatible changes =================== -->
+
+<ch_section>Incompatible changes</ch_section>
+<ul>
+  <li><issue>6428</issue>HTTP Cookie Manager no longer sends cookies after they reached their expiry time.
+  Previously, expired cookies kept being sent indefinitely. Long-running tests that outlive a cookie's
+  expiry time may experience authentication or session failures and must handle re-authentication
+  or session refresh.</li>
 </ul>
 
   <ch_section>Changes</ch_section>
@@ -109,7 +120,6 @@ Summary
   <ch_section>Bug fixes</ch_section>
   <h3>General</h3>
   <ul>
-    <li><issue>6428</issue>HTTP Cookie Manager kept sending cookies after they reached their expiry time.</li>
     <li><pr>6654</pr><issue>6611</issue>Support JDK 25 and above for result collectors with empty file names</li>
     <li>Trim whitespace when parsing numeric JMeter properties so accidental spaces do not silently change configuration values.</li>
     <li><pr>6372</pr>Fix KeyManager logging when using CLI mode so keystore passwords are not incorrectly reported as missing. Contributed by Patrick Uiterwijk (patrick at puiterwijk.org)</li>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -57,8 +57,8 @@ JMeter 6.x requires Java 17 or later for execution (Java 21 is recommended).
 Summary
 </p>
 <ul>
-<li><a href="#Changes">Changes</a></li>
 <li><a href="#Incompatible changes">Incompatible changes</a></li>
+<li><a href="#Changes">Changes</a></li>
 <li><a href="#Bug fixes">Bug fixes</a></li>
 </ul>
 

--- a/xdocs/usermanual/component_reference.xml
+++ b/xdocs/usermanual/component_reference.xml
@@ -3847,6 +3847,12 @@ This means that cross-domain cookies are not stored.
 If you have bugged behaviour or want Cross-Domain cookies to be used, define the JMeter property "<code>CookieManager.check.cookies=false</code>".
 </p>
 <p>
+Cookies that reached their expiry time are no longer sent with requests.
+Be aware that long-running tests, such as endurance tests that outlive a cookie's expiry time,
+will no longer send the cookie once it has expired. This can lead to authentication or session
+errors, so such test plans must handle re-authentication or session refresh.
+</p>
+<p>
 Received Cookies can be stored as JMeter thread variables.
 To save cookies as variables, define the property "<code>CookieManager.save.cookies=true</code>".
 Also, cookies names are prefixed with "<code>COOKIE_</code>" before they are stored (this avoids accidental corruption of local variables)


### PR DESCRIPTION
## Description
Skip cookies that have reached their expiry time when the `HTTP Cookie Manager` builds the `Cookie` header for a request.

`HC4CookieHandler#getCookiesForUrl` now filters out expired cookies (via `cookie.isExpired(...)`) in addition to the existing domain/path/secure matching. Session cookies, which have no expiry date, are unaffected.

## Motivation and Context
Fixes #6428

Cookies that were valid when they were received kept being sent after their expiry time had passed:

1. Add an `HTTP Cookie Manager` (with "Clear cookies each iteration?" unchecked)
2. Receive a cookie with an `Expires`/`Max-Age` attribute in the past's future (e.g. `Set-Cookie: session_id=abc123; Expires=<now + 60s>; Path=/`)
3. Wait until the expiry time passes
4. Send another request to the same host → the expired cookie is still sent

**Root cause:** the expiry date is only checked once, when the `Set-Cookie` header is parsed (`addCookieFromHeader`). The send path (`getCookiesForUrl`) filters cookies with `cookieSpec.match(...)`, which matches on domain/path/secure only and never checks `isExpired`, so a cookie that was valid at reception time is sent forever.

## How Has This Been Tested?
- New regression tests in `TestHC4CookieManager`:
  - `testCookieExpiredAfterReceptionIsNotSent`: receives a valid cookie (future expiry), simulates the passing of time by moving the stored cookie's expiry into the past, and asserts `getCookieHeaderForURL` returns `null`
  - `testSessionCookieWithoutExpiryIsStillSent`: guards the session-cookie case (no expiry date → still sent)
- Full `:src:protocol:http:test` suite passes (854 tests, 0 failures)
- `./gradlew classes style` passes
- Verified the original repro end-to-end against a locally built distribution (expired cookie no longer sent)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly. (release notes entry added to `xdocs/changes.xml`)

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines