### PR TITLE
Encode non-ASCII SMTP attachment file names according to RFC 2231

### DIFF
--- a/src/bom-thirdparty/build.gradle.kts
+++ b/src/bom-thirdparty/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
         api("io.burt:jmespath-jackson:0.6.0")
         api("jakarta.jms:jakarta.jms-api:3.1.0")
         api("javax.activation:javax.activation-api:1.2.0")
-        api("javax.mail:mail:1.5.0-b01")
+        api("com.sun.mail:javax.mail:1.6.2")
         api("jcharts:jcharts:0.7.5")
         api("junit:junit:4.13.2") {
             because("ApacheJMeter_junit depends on junit4")

--- a/src/components/build.gradle.kts
+++ b/src/components/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
         )
     }
 
-    api("javax.mail:mail") {
+    api("com.sun.mail:javax.mail") {
         exclude("javax.activation", "activation")
     }
     // There's no javax.activation:activation:1.2.0, so we use com.sun...

--- a/src/protocol/mail/build.gradle.kts
+++ b/src/protocol/mail/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     api(projects.src.core)
 
-    api("javax.mail:mail") {
+    api("com.sun.mail:javax.mail") {
         exclude("javax.activation", "activation")
     }
     // There's no javax.activation:activation:1.2.0, so we use com.sun...

--- a/src/protocol/mail/src/test/java/org/apache/jmeter/protocol/smtp/sampler/protocol/SendMailCommandTest.java
+++ b/src/protocol/mail/src/test/java/org/apache/jmeter/protocol/smtp/sampler/protocol/SendMailCommandTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jmeter.protocol.smtp.sampler.protocol;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import javax.mail.Message;
+import javax.mail.internet.InternetAddress;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SendMailCommandTest {
+
+    private static final String NON_ASCII_FILE_NAME = "\u0442\u0435\u043a\u0441\u0442.txt"; // Russian for "text"
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void testNonAsciiAttachmentFileNameIsEncodedPerRfc2231() throws Exception {
+        SendMailCommand sendMailCommand = createSendMailCommandWithAttachment(NON_ASCII_FILE_NAME);
+        String rawMessage = writeMessageToString(sendMailCommand.prepareMessage());
+        // The file name must be encoded according to RFC 2231, so that the
+        // recipients see the original file name (see issue #6652)
+        assertTrue(
+                rawMessage.contains("filename*=UTF-8''%D1%82%D0%B5%D0%BA%D1%81%D1%82.txt"),
+                "filename* parameter with RFC 2231 encoded file name expected in:\n" + rawMessage);
+        // The mangled name must not appear anywhere
+        assertFalse(rawMessage.contains("B5:AB"), "mangled file name found in:\n" + rawMessage);
+    }
+
+    @Test
+    void testAsciiAttachmentFileNameIsNotEncoded() throws Exception {
+        SendMailCommand sendMailCommand = createSendMailCommandWithAttachment("attachment.txt");
+        String rawMessage = writeMessageToString(sendMailCommand.prepareMessage());
+        assertTrue(
+                rawMessage.contains("filename=attachment.txt"),
+                "plain ASCII file name expected in:\n" + rawMessage);
+        assertFalse(rawMessage.contains("filename*="), "unexpected RFC 2231 encoding in:\n" + rawMessage);
+    }
+
+    private SendMailCommand createSendMailCommandWithAttachment(String attachmentName) throws Exception {
+        File attachment = new File(tempDir, attachmentName);
+        Files.writeString(attachment.toPath(), "attachment content", StandardCharsets.UTF_8);
+
+        SendMailCommand sendMailCommand = new SendMailCommand();
+        sendMailCommand.setSmtpServer("localhost");
+        sendMailCommand.setSmtpPort("25");
+        sendMailCommand.setConnectionTimeOut("1000");
+        sendMailCommand.setTimeOut("1000");
+        sendMailCommand.setSender("from@example.com");
+        sendMailCommand.setReceiverTo(Collections.singletonList(new InternetAddress("to@example.com")));
+        sendMailCommand.setSubject("attachment file name test");
+        sendMailCommand.setMailBody("body");
+        sendMailCommand.addAttachment(attachment);
+        return sendMailCommand;
+    }
+
+    private static String writeMessageToString(Message message) throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (outputStream) {
+            message.writeTo(outputStream);
+        }
+        return outputStream.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -98,6 +98,7 @@ Summary
     <li>Update json-path to 2.10.0 for JSON query expressions.</li>
     <li>Update Neo4j Java driver to 6.x for Bolt-based database tests.</li>
     <li>Update Rhino JavaScript engine to 1.8.0 for JSR-223 JavaScript execution.</li>
+    <li>Update <code>javax.mail</code> to 1.6.2 from 1.5.0-b01, so mail attachments with non-ASCII file names are encoded correctly.</li>
   </ul>
 
   <h3>UI</h3>
@@ -109,6 +110,7 @@ Summary
   <ch_section>Bug fixes</ch_section>
   <h3>General</h3>
   <ul>
+    <li><issue>6652</issue>SMTP Sampler encoded non-ASCII attachment file names incorrectly. Attachment file names are now encoded according to RFC 2231 by upgrading <code>javax.mail</code> to 1.6.2.</li>
     <li><pr>6654</pr><issue>6611</issue>Support JDK 25 and above for result collectors with empty file names</li>
     <li>Trim whitespace when parsing numeric JMeter properties so accidental spaces do not silently change configuration values.</li>
     <li><pr>6372</pr>Fix KeyManager logging when using CLI mode so keystore passwords are not incorrectly reported as missing. Contributed by Patrick Uiterwijk (patrick at puiterwijk.org)</li>


### PR DESCRIPTION
## Description
Upgrade `javax.mail` from the 2013 beta `javax.mail:mail:1.5.0-b01` to `com.sun.mail:javax.mail:1.6.2`, so that attachment file names containing non-ASCII characters are encoded according to RFC 2231.

The `javax.mail.*` namespace is unchanged, so no code changes are required. The dependency verification metadata already trusts the `com.sun.mail` group (PGP key `4F7E32D440EF90A83011A8FC6425559C47CC79C4`), so no `verification-metadata.xml` changes were needed.

## Motivation and Context
Fixes #6652

The SMTP Sampler mangles attachment file names that contain non-ASCII characters. Sending an attachment named `текст.txt` produces:

```
Content-Type: text/plain; charset=us-ascii;
        name="B5:AB-attachment....txt"
Content-Disposition: attachment;
        filename="B5:AB-attachment....txt"
```

so recipients see garbage instead of the original file name.

**Root cause:** `SendMailCommand` builds attachments with `MimeBodyPart.setFileName(String)`. The old `javax.mail:mail:1.5.0-b01` does not encode non-ASCII file name parameters according to RFC 2231.

As suggested by @FSchumacher on the issue, upgrading to 1.6.2 fixes the encoding. With this change the same attachment is now sent as:

```
Content-Type: text/plain; charset=us-ascii;
        name*=UTF-8''%D1%82%D0%B5%D0%BA%D1%81%D1%82.txt
Content-Disposition: attachment;
        filename*=UTF-8''%D1%82%D0%B5%D0%BA%D1%81%D1%82.txt
```

## How Has This Been Tested?
- New `SendMailCommandTest`:
  - `testNonAsciiAttachmentFileNameIsEncodedPerRfc2231`: builds a message (via `prepareMessage()`, no SMTP server needed) with an attachment named `текст.txt` and asserts the raw message contains `filename*=UTF-8''%D1%82%D0%B5%D0%BA%D1%81%D1%82.txt` and no mangled name
  - `testAsciiAttachmentFileNameIsNotEncoded`: asserts pure ASCII names are still emitted as plain `filename=attachment.txt` (no RFC 2231 encoding)
- Full `:src:protocol:mail:test` (4 tests) and `:src:components:test` (549 tests, `MailReaderSampler` shares the dependency) suites pass
- `./gradlew classes style` passes
- Verified the original repro end-to-end against a locally built distribution

## Screenshots (if appropriate):
Not applicable (raw SMTP headers shown above).

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly. (release notes entry added to `xdocs/changes.xml`)

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines