### PR TITLE
Save Response Assertion patterns under correctly spelled property name

### DIFF
--- a/bin/examples/PerformanceTestPlanMemoryThread.jmx
+++ b/bin/examples/PerformanceTestPlanMemoryThread.jmx
@@ -155,7 +155,7 @@
               </RegexExtractor>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Code200" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="49586">200</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -164,7 +164,7 @@
               </ResponseAssertion>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="containsText" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="486644840">abcdefghijklmno</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -268,7 +268,7 @@
               </RegexExtractor>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Code200" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="49586">200</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -277,7 +277,7 @@
               </ResponseAssertion>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="containsText" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="486644840">abcdefghijklmno</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/templates/build-adv-web-test-plan.jmx
+++ b/bin/templates/build-adv-web-test-plan.jmx
@@ -143,7 +143,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="605898121">&lt;title&gt;Apache JMeter - Apache JMeter&amp;trade;&lt;/title&gt;</stringProp>
             </collectionProp>
             <stringProp name="TestPlan.comments">We check page contains some text</stringProp>
@@ -191,7 +191,7 @@
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-420601512">&lt;title&gt;Apache JMeter - Changes&lt;/title&gt;</stringProp>
             </collectionProp>
             <stringProp name="TestPlan.comments">We check page contains some text</stringProp>
@@ -250,7 +250,7 @@
           </GaussianRandomTimer>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1440480625">This is &lt;b&gt;ASF Bugzilla&lt;/b&gt;: the Apache Software Foundation bug system</stringProp>
             </collectionProp>
             <stringProp name="TestPlan.comments">We check page contains some text</stringProp>

--- a/bin/templates/build-ldap-test-plan.jmx
+++ b/bin/templates/build-ldap-test-plan.jmx
@@ -95,7 +95,7 @@
         </LDAPSampler>
         <hashTree/>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-          <collectionProp name="Asserion.test_strings">
+          <collectionProp name="Assertion.test_strings">
             <stringProp name="-733631846">successful</stringProp>
           </collectionProp>
           <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/templates/build-web-test-plan.jmx
+++ b/bin/templates/build-web-test-plan.jmx
@@ -94,7 +94,7 @@ Connect to 5s</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-868354929">&lt;h1&gt;Example Domain&lt;/h1&gt;</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -137,7 +137,7 @@ Connect to 5s</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion_404" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51512">404</stringProp>
             </collectionProp>
             <stringProp name="TestPlan.comments">The assertion is specia:

--- a/bin/templates/build-webservice-test-plan.jmx
+++ b/bin/templates/build-webservice-test-plan.jmx
@@ -98,7 +98,7 @@
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="130046656">&lt;/GetCityForecastByZIPResult&gt;</stringProp>
             </collectionProp>
             <stringProp name="TestPlan.comments">Verify content in response</stringProp>

--- a/bin/testfiles/AssertionTestPlan.jmx
+++ b/bin/testfiles/AssertionTestPlan.jmx
@@ -44,7 +44,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1139173792">&lt;/html&gt;</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/FTP_TESTS.jmx
+++ b/bin/testfiles/FTP_TESTS.jmx
@@ -158,7 +158,7 @@ props.put(&quot;FTP_SERVER&quot;, server);
         </FTPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-897552584">Apache JMeter Property file</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -181,7 +181,7 @@ props.put(&quot;FTP_SERVER&quot;, server);
         </FTPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-897552584">Apache JMeter Property file</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -217,7 +217,7 @@ props.put(&quot;FTP_SERVER&quot;, server);
         </FTPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-897552584">Apache JMeter Property file</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/GenTest210.expected.jmx
+++ b/bin/testfiles/GenTest210.expected.jmx
@@ -892,7 +892,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest210.jmx
+++ b/bin/testfiles/GenTest210.jmx
@@ -892,7 +892,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest22.jmx
+++ b/bin/testfiles/GenTest22.jmx
@@ -656,7 +656,7 @@
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
             <stringProp name="Assertion.assume_success">false</stringProp>
             <intProp name="Assertion.test_type">2</intProp>
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
           </ResponseAssertion>
           <hashTree/>

--- a/bin/testfiles/GenTest231.jmx
+++ b/bin/testfiles/GenTest231.jmx
@@ -698,7 +698,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertions" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <stringProp name="Assertion.assume_success">false</stringProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest24.jmx
+++ b/bin/testfiles/GenTest24.jmx
@@ -833,7 +833,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest25.expected.jmx
+++ b/bin/testfiles/GenTest25.expected.jmx
@@ -840,7 +840,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest25.jmx
+++ b/bin/testfiles/GenTest25.jmx
@@ -840,7 +840,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest251.expected.jmx
+++ b/bin/testfiles/GenTest251.expected.jmx
@@ -838,7 +838,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest251.jmx
+++ b/bin/testfiles/GenTest251.jmx
@@ -838,7 +838,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest26.expected.jmx
+++ b/bin/testfiles/GenTest26.expected.jmx
@@ -875,7 +875,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest26.jmx
+++ b/bin/testfiles/GenTest26.jmx
@@ -875,7 +875,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest27.expected.jmx
+++ b/bin/testfiles/GenTest27.expected.jmx
@@ -869,7 +869,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest27.jmx
+++ b/bin/testfiles/GenTest27.jmx
@@ -869,7 +869,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest27_original.expected.jmx
+++ b/bin/testfiles/GenTest27_original.expected.jmx
@@ -891,7 +891,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest27_original.jmx
+++ b/bin/testfiles/GenTest27_original.jmx
@@ -891,7 +891,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/GenTest2_13.expected.jmx
+++ b/bin/testfiles/GenTest2_13.expected.jmx
@@ -898,7 +898,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>

--- a/bin/testfiles/GenTest2_13.jmx
+++ b/bin/testfiles/GenTest2_13.jmx
@@ -898,7 +898,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>

--- a/bin/testfiles/GenTest3_0.expected.jmx
+++ b/bin/testfiles/GenTest3_0.expected.jmx
@@ -910,7 +910,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>

--- a/bin/testfiles/GenTest3_0.jmx
+++ b/bin/testfiles/GenTest3_0.jmx
@@ -910,7 +910,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>

--- a/bin/testfiles/GuiTest.expected.jmx
+++ b/bin/testfiles/GuiTest.expected.jmx
@@ -40,7 +40,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertions" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="0"/>
               <stringProp name="0"/>
               <stringProp name="0"/>

--- a/bin/testfiles/GuiTest.jmx
+++ b/bin/testfiles/GuiTest.jmx
@@ -40,7 +40,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertions" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>

--- a/bin/testfiles/GuiTest231.expected.jmx
+++ b/bin/testfiles/GuiTest231.expected.jmx
@@ -654,7 +654,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertion" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1513171730">must match</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/GuiTest231.jmx
+++ b/bin/testfiles/GuiTest231.jmx
@@ -654,7 +654,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertion" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1513171730">must match</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/GuiTest231_original.expected.jmx
+++ b/bin/testfiles/GuiTest231_original.expected.jmx
@@ -691,7 +691,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertion" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1513171730">must match</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/GuiTest231_original.jmx
+++ b/bin/testfiles/GuiTest231_original.jmx
@@ -691,7 +691,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertion" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1513171730">must match</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/GuiTest_original.jmx
+++ b/bin/testfiles/GuiTest_original.jmx
@@ -40,7 +40,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertions" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>

--- a/bin/testfiles/Http4ImplDigestAuth.jmx
+++ b/bin/testfiles/Http4ImplDigestAuth.jmx
@@ -91,7 +91,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2001128593">Digest Authentication test page</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -128,7 +128,7 @@
           </JSONPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="3569038">true</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -141,7 +141,7 @@
           <hashTree/>
         </hashTree>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-          <collectionProp name="Asserion.test_strings">
+          <collectionProp name="Assertion.test_strings">
             <stringProp name="915456995">Authorization: Digest</stringProp>
           </collectionProp>
           <stringProp name="Assertion.custom_message"></stringProp>

--- a/bin/testfiles/JDBC_TESTS.jmx
+++ b/bin/testfiles/JDBC_TESTS.jmx
@@ -97,7 +97,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1157542694">0 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -122,7 +122,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1157542694">0 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -147,7 +147,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1157542694">0 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -179,7 +179,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1157542694">0 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -209,7 +209,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1157542694">0 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -238,7 +238,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1157542694">0 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -279,7 +279,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1329970139">1 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -303,7 +303,7 @@ sql.close()
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -315,7 +315,7 @@ sql.close()
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2501">Mr</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -327,7 +327,7 @@ sql.close()
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1486782315">Fiodor Dostoievski</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -339,7 +339,7 @@ sql.close()
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -388,7 +388,7 @@ if (list.size()==1) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="48">0</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -400,7 +400,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2501">Mr</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -412,7 +412,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1324166668">Philip K. Dick</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -424,7 +424,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="50">2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -473,7 +473,7 @@ if (list.size()==2) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2501">Mr</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -485,7 +485,7 @@ if (list.size()==2) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1324166668">Philip K. Dick</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -497,7 +497,7 @@ if (list.size()==2) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-253830980">${__time(yyyy-MM-dd,)}</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -509,7 +509,7 @@ if (list.size()==2) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -558,7 +558,7 @@ if (list.size()==1) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2501">Mr</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -570,7 +570,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1324166668">Philip K. Dick</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -582,7 +582,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-253830980">${__time(yyyy-MM-dd,)}</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -594,7 +594,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -661,7 +661,7 @@ if (list.size()==1) {
           </JDBCSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1329970139">1 updates</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -773,7 +773,7 @@ if (list.size()==1) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1329970139">1 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -809,7 +809,7 @@ if (list.size()==1) {
           </JDBCPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_number_user_before_equal1" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="50">2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -821,7 +821,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_number_user_after_equal2" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51">3</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -833,7 +833,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_number_user_before_count" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -845,7 +845,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_number_user_after_count" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -871,7 +871,7 @@ if (list.size()==1) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="48">0</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -883,7 +883,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="48">0</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -926,7 +926,7 @@ if (list.size()==0 &amp;&amp; vars.get(&quot;ID_FURNITURE_1&quot;) == null &amp;
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -938,7 +938,7 @@ if (list.size()==0 &amp;&amp; vars.get(&quot;ID_FURNITURE_1&quot;) == null &amp;
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-59682870">conference table</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -950,7 +950,7 @@ if (list.size()==0 &amp;&amp; vars.get(&quot;ID_FURNITURE_1&quot;) == null &amp;
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -962,7 +962,7 @@ if (list.size()==0 &amp;&amp; vars.get(&quot;ID_FURNITURE_1&quot;) == null &amp;
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1011,7 +1011,7 @@ if (list.size()==1) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="53">5</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1023,7 +1023,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="154871418">coffee table</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1035,7 +1035,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="50">2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1047,7 +1047,7 @@ if (list.size()==1) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="50">2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1096,7 +1096,7 @@ if (list.size()==2) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1571">14</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1108,7 +1108,7 @@ if (list.size()==2) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="3535895">sofa</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1120,7 +1120,7 @@ if (list.size()==2) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51">3</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1132,7 +1132,7 @@ if (list.size()==2) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51">3</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1181,7 +1181,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1571">14</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1193,7 +1193,7 @@ if (list.size()==3) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="3535895">sofa</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1205,7 +1205,7 @@ if (list.size()==3) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51">3</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1217,7 +1217,7 @@ if (list.size()==3) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51">3</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1283,7 +1283,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1643270117">Name for DataSource must not be empty in JDBC_NoConfig</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -1307,7 +1307,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1180728046">java.sql.SQLSyntaxErrorException:</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -1332,7 +1332,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1329970139">1 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1355,7 +1355,7 @@ if (list.size()==3) {
           </JDBCPreProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_number_user_after_count" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -1381,7 +1381,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1329970139">1 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1404,7 +1404,7 @@ if (list.size()==3) {
           </JDBCPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_number_user_after_count" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49">1</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -1430,7 +1430,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1329970139">1 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1474,7 +1474,7 @@ if (list.size()==3) {
         </JDBCSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1329970139">1 updates</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/JMS_TESTS.jmx
+++ b/bin/testfiles/JMS_TESTS.jmx
@@ -100,7 +100,7 @@ try {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2603186">Test</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -178,7 +178,7 @@ class MyMessageListener implements MessageListener {
         </JSR223Sampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1700117006">Started Message Consumer</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -209,7 +209,7 @@ class MyMessageListener implements MessageListener {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1806444283">Reply to:Test</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -244,7 +244,7 @@ class MyMessageListener implements MessageListener {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="620675290">Test-with-customer-correlationId</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -285,7 +285,7 @@ class MyMessageListener implements MessageListener {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1882001775">No reply message received</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -326,7 +326,7 @@ class MyMessageListener implements MessageListener {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="451718395">Test-with-customer-correlationId-and-jms-properties-matching-selector</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -361,7 +361,7 @@ class MyMessageListener implements MessageListener {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1549895784">Oneway request has no response data</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -426,7 +426,7 @@ finally {
         </JSR223Sampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-487953317">Received : Test-send-only</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -462,7 +462,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1549895784">Oneway request has no response data</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -510,7 +510,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1029016402">requestQueue5 has 1 messages</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -540,7 +540,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1086280699">Test-send-only-for-count-and-read</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -576,7 +576,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1549895784">Oneway request has no response data</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -620,7 +620,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2008037952">requestQueue6: 1 message(s) removed</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -656,7 +656,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1343037074">requestQueue6 has 0 messages</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -687,7 +687,7 @@ finally {
         </JMSSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_noMessage" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1882001775">No reply message received</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -761,7 +761,7 @@ finally {
         </PublisherSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1719216023">1 messages published</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -786,7 +786,7 @@ finally {
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1506174364">1 message(s) received successfully of 1 expected</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -795,7 +795,7 @@ finally {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-2063475679">Test Topic</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -804,7 +804,7 @@ finally {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="812041149">Properties:
 prop1	value1
 propBoolean	true
@@ -884,7 +884,7 @@ propFloat	1.2</stringProp>
         </PublisherSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1719216023">1 messages published</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -924,7 +924,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51512">404</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -964,7 +964,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-2063475679">Test Topic</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1039,7 +1039,7 @@ propFloat	1.2</stringProp>
         </PublisherSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1719216023">1 messages published</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -1079,7 +1079,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51512">404</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -1119,7 +1119,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-2063475679">Test Topic</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1194,7 +1194,7 @@ propFloat	1.2</stringProp>
         </PublisherSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1719216023">1 messages published</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -1235,7 +1235,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1154304067">Test Durable Topic Message</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -1310,7 +1310,7 @@ propFloat	1.2</stringProp>
         </PublisherSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1719216023">1 messages published</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -1339,7 +1339,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51512">404</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -1367,7 +1367,7 @@ propFloat	1.2</stringProp>
         </SubscriberSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-2063475679">Test Topic</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/OS_TESTS.jmx
+++ b/bin/testfiles/OS_TESTS.jmx
@@ -61,7 +61,7 @@
           </SystemSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1685611991">README.md</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -70,7 +70,7 @@
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA2" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1349416313">MY_ENV_PROP=TEST</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -99,7 +99,7 @@
           </SystemSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1349416313">MY_ENV_PROP=TEST</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -135,7 +135,7 @@
           </SystemSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-57279347">Process timeout reached after 1000 milliseconds</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -144,7 +144,7 @@
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="52469">500</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -196,7 +196,7 @@
           </SystemSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1685611991">README.md</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -205,7 +205,7 @@
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA2" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1349416313">MY_ENV_PROP=TEST</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.request_data</stringProp>
@@ -245,7 +245,7 @@
           </SystemSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1349416313">MY_ENV_PROP=TEST</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -292,7 +292,7 @@
           </SystemSampler>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-57279347">Process timeout reached after 1000 milliseconds</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -301,7 +301,7 @@
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="52469">500</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>

--- a/bin/testfiles/ResponseDecompression.jmx
+++ b/bin/testfiles/ResponseDecompression.jmx
@@ -65,7 +65,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="SC_DEFLATE" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_deflate" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-770951746">Content-Encoding: deflate</stringProp>
               <stringProp name="1834063358">content-encoding: deflate</stringProp>
             </collectionProp>
@@ -104,7 +104,7 @@
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1909739726">Microsoft</stringProp>
                 <stringProp name="3023936">bing</stringProp>
               </collectionProp>
@@ -131,7 +131,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="SC_BROTLI" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_brotli" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-2024312099">Content-Encoding: br</stringProp>
               <stringProp name="1908861597">content-encoding: br</stringProp>
             </collectionProp>
@@ -170,7 +170,7 @@
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="497130182">facebook</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/SavedGenTest210.jmx
+++ b/bin/testfiles/SavedGenTest210.jmx
@@ -892,7 +892,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/SavedGenTest27.jmx
+++ b/bin/testfiles/SavedGenTest27.jmx
@@ -869,7 +869,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">2</intProp>

--- a/bin/testfiles/SavedGenTest2_13.jmx
+++ b/bin/testfiles/SavedGenTest2_13.jmx
@@ -898,7 +898,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>

--- a/bin/testfiles/SavedGenTest3_0.jmx
+++ b/bin/testfiles/SavedGenTest3_0.jmx
@@ -910,7 +910,7 @@
           </MD5HexAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings"/>
+            <collectionProp name="Assertion.test_strings"/>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
             <boolProp name="Assertion.assume_success">false</boolProp>
             <intProp name="Assertion.test_type">16</intProp>

--- a/bin/testfiles/SavedGuiTest.jmx
+++ b/bin/testfiles/SavedGuiTest.jmx
@@ -40,7 +40,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertions" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>

--- a/bin/testfiles/SavedGuiTest231.jmx
+++ b/bin/testfiles/SavedGuiTest231.jmx
@@ -654,7 +654,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertion" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1513171730">must match</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/SlowCharsFeature.jmx
+++ b/bin/testfiles/SlowCharsFeature.jmx
@@ -82,7 +82,7 @@ SampleResult.setBytes(0);</stringProp>
         </SizeAssertion>
         <hashTree/>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_206" enabled="true">
-          <collectionProp name="Asserion.test_strings">
+          <collectionProp name="Assertion.test_strings">
             <stringProp name="49592">206</stringProp>
           </collectionProp>
           <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -92,7 +92,7 @@ SampleResult.setBytes(0);</stringProp>
         </ResponseAssertion>
         <hashTree/>
         <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_PartialContent" enabled="true">
-          <collectionProp name="Asserion.test_strings">
+          <collectionProp name="Assertion.test_strings">
             <stringProp name="343054290">HTTP/1.1 206 Partial [Cc]ontent</stringProp>
           </collectionProp>
           <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -164,7 +164,7 @@ SampleResult.setBytes(0);</stringProp>
           </HTTPSamplerProxy>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="657066065">Apache JMeter</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -211,7 +211,7 @@ SampleResult.setBytes(0);</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_CHECK_SNI_OK" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1071695892">&lt;meta property=&quot;og:title&quot; content=&quot;analytics.usa.gov | The US government&apos;s web traffic.&quot; /&gt;</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -221,7 +221,7 @@ SampleResult.setBytes(0);</stringProp>
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NO_HANDSHAKE_ERROR" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="914337881">javax.net.ssl.SSLHandshakeException</stringProp>
                 <stringProp name="-1453429438">handshake_failure</stringProp>
               </collectionProp>
@@ -253,7 +253,7 @@ SampleResult.setBytes(0);</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_CHECK_SNI_OK" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1071695892">&lt;meta property=&quot;og:title&quot; content=&quot;analytics.usa.gov | The US government&apos;s web traffic.&quot; /&gt;</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -263,7 +263,7 @@ SampleResult.setBytes(0);</stringProp>
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NO_HANDSHAKE_ERROR" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="914337881">javax.net.ssl.SSLHandshakeException</stringProp>
                 <stringProp name="-1453429438">handshake_failure</stringProp>
               </collectionProp>

--- a/bin/testfiles/TCP_TESTS.jmx
+++ b/bin/testfiles/TCP_TESTS.jmx
@@ -182,7 +182,7 @@ vars.put(&quot;CR&quot;,URLDecoder.decode(&quot;%0A&quot;, &quot;ASCII&quot;)); 
         </TCPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_time" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1168273790">${__time(dd/MM/yyyy HH:mm,)}</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -207,7 +207,7 @@ vars.put(&quot;CR&quot;,URLDecoder.decode(&quot;%0A&quot;, &quot;ASCII&quot;)); 
         </TCPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RC_500" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="52469">500</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -216,7 +216,7 @@ vars.put(&quot;CR&quot;,URLDecoder.decode(&quot;%0A&quot;, &quot;ASCII&quot;)); 
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_ReadException" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1515665865">org.apache.jmeter.protocol.tcp.sampler.ReadException</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -277,7 +277,7 @@ vars.put(&quot;result_decoded&quot;, decoded);</stringProp>
           </JSR223PostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_time" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1168273790">${__time(dd/MM/yyyy HH:mm,)}</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -303,7 +303,7 @@ vars.put(&quot;result_decoded&quot;, decoded);</stringProp>
         </TCPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RC_500" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="52469">500</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -312,7 +312,7 @@ vars.put(&quot;result_decoded&quot;, decoded);</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_ReadException" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1515665865">org.apache.jmeter.protocol.tcp.sampler.ReadException</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -362,7 +362,7 @@ vars.put(&quot;result_decoded&quot;, decoded);</stringProp>
         </TCPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RC_500" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="52469">500</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -372,7 +372,7 @@ vars.put(&quot;result_decoded&quot;, decoded);</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_ConnectException" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2118305654">java.net.ConnectException: Connection refused</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -415,7 +415,7 @@ if (oldResponseMessage != null &amp;&amp; oldResponseMessage.contains(&quot;java
         </TCPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RC_500" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="52469">500</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -425,7 +425,7 @@ if (oldResponseMessage != null &amp;&amp; oldResponseMessage.contains(&quot;java
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_UnknownHostException" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1613728243">java.net.UnknownHostException: localhostXXXX</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -449,7 +449,7 @@ if (oldResponseMessage != null &amp;&amp; oldResponseMessage.contains(&quot;java
         </TCPSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RC_500" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="52469">500</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
@@ -459,7 +459,7 @@ if (oldResponseMessage != null &amp;&amp; oldResponseMessage.contains(&quot;java
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_no_protocol_handler" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-715322569">Protocol handler not found</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -508,7 +508,7 @@ vars.put(&quot;result_decoded&quot;, decoded);</stringProp>
           </JSR223PostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1168273790">${__time(dd/MM/yyyy HH:mm,)}</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/bin/testfiles/TEST_HTTP.jmx
+++ b/bin/testfiles/TEST_HTTP.jmx
@@ -76,7 +76,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1492901334">GET /test HTTP/1.1</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="2117109222">Host: localhost:8081</stringProp>
@@ -89,7 +89,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -129,7 +129,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -140,7 +140,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="70454">GET</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="2117109222">Host: localhost:8081</stringProp>
@@ -182,7 +182,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -193,7 +193,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="70454">GET</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="2117109222">Host: localhost:8081</stringProp>
@@ -240,7 +240,7 @@ mirrorServer.start();</stringProp>
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_ContentLength" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="224767426">Content-Length: 13</stringProp>
                 <stringProp name="-1752268452">Content-Type: text/plain</stringProp>
                 <stringProp name="-644619860">Content-Type:</stringProp>
@@ -252,7 +252,7 @@ mirrorServer.start();</stringProp>
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1492901334">GET /test HTTP/1.1</stringProp>
                 <stringProp name="894172713">Connection: keep-alive</stringProp>
                 <stringProp name="2117109222">Host: localhost:8081</stringProp>
@@ -340,7 +340,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Gzip" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
@@ -350,7 +350,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -361,7 +361,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2111395962">Example Domain</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -391,7 +391,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoGZIP_IN_RESPONSE" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="256417959">Content-Encoding: gzip</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -401,7 +401,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -412,7 +412,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoGzip_IN_REQUEST" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
@@ -422,7 +422,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="2111395962">Example Domain</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -499,7 +499,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Gzip" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
@@ -509,7 +509,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -571,7 +571,7 @@ mirrorServer.start();</stringProp>
             </HeaderManager>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Gzip" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
@@ -581,7 +581,7 @@ mirrorServer.start();</stringProp>
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-88801152">Content-Length:</stringProp>
                 <stringProp name="-644619860">Content-Type:</stringProp>
               </collectionProp>
@@ -637,7 +637,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1714160472">Exceeded maximum number of redirects</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -647,7 +647,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoContentLength" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-88801152">Content-Length:</stringProp>
               <stringProp name="-644619860">Content-Type:</stringProp>
             </collectionProp>
@@ -695,7 +695,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1075402381">Non HTTP response message</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_message</stringProp>
@@ -772,7 +772,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-530323176">POST /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
@@ -833,7 +833,7 @@ mirrorServer.start();</stringProp>
           </RegexExtractor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-530323176">POST /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
@@ -908,7 +908,7 @@ mirrorServer.start();</stringProp>
           </RegexExtractor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-530323176">POST /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
@@ -987,7 +987,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </RegexExtractor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-530323176">POST /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
@@ -1003,7 +1003,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1049865380">nv_contentType</stringProp>
               <stringProp name="1947100436">text/plain; charset=UTF-8</stringProp>
             </collectionProp>
@@ -1063,7 +1063,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </RegexExtractor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-530323176">POST /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
@@ -1121,7 +1121,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_not_present" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1722553038">Content-Type: multipart/form-data; boundary=</stringProp>
               <stringProp name="-1500123463">Content-Disposition: form-data; name=&quot;fileName&quot;; filename=&quot;user.properties&quot;</stringProp>
               <stringProp name="1533831720">Content-Transfer-Encoding: binary</stringProp>
@@ -1134,7 +1134,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_response_contains" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1439390532">Sample user.properties file</stringProp>
               <stringProp name="2117109222">Host: localhost:8081</stringProp>
               <stringProp name="-1351522793">User-Agent:</stringProp>
@@ -1146,7 +1146,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               <stringProp name="-1752268452">Content-Type: text/plain</stringProp>
@@ -1201,7 +1201,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_not_present" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1722553038">Content-Type: multipart/form-data; boundary=</stringProp>
               <stringProp name="-1500123463">Content-Disposition: form-data; name=&quot;fileName&quot;; filename=&quot;user.properties&quot;</stringProp>
               <stringProp name="1533831720">Content-Transfer-Encoding: binary</stringProp>
@@ -1215,7 +1215,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_response_contains" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1439390532">Sample user.properties file</stringProp>
               <stringProp name="-1351522793">User-Agent:</stringProp>
               <stringProp name="2117109222">Host: localhost:8081</stringProp>
@@ -1227,7 +1227,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               <stringProp name="-1752268452">Content-Type: text/plain</stringProp>
@@ -1282,7 +1282,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_not_present" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1722553038">Content-Type: multipart/form-data; boundary=</stringProp>
               <stringProp name="-1500123463">Content-Disposition: form-data; name=&quot;fileName&quot;; filename=&quot;user.properties&quot;</stringProp>
               <stringProp name="1533831720">Content-Transfer-Encoding: binary</stringProp>
@@ -1295,7 +1295,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_response_contains" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1439390532">Sample user.properties file</stringProp>
               <stringProp name="1737626343">PUT /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="2117109222">Host: localhost:8081</stringProp>
@@ -1308,7 +1308,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               <stringProp name="-1752268452">Content-Type: text/plain</stringProp>
@@ -1361,7 +1361,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_not_present" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1722553038">Content-Type: multipart/form-data; boundary=</stringProp>
               <stringProp name="-1500123463">Content-Disposition: form-data; name=&quot;fileName&quot;; filename=&quot;user.properties&quot;</stringProp>
               <stringProp name="1533831720">Content-Transfer-Encoding: binary</stringProp>
@@ -1374,7 +1374,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_response_contains" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1737626343">PUT /test?name0=value0 HTTP/1.1</stringProp>
               <stringProp name="-1294586556">Body of Put</stringProp>
               <stringProp name="-1351522793">User-Agent:</stringProp>
@@ -1386,7 +1386,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="894172713">Connection: keep-alive</stringProp>
               <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               <stringProp name="-1752268452">Content-Type: text/plain</stringProp>
@@ -1442,7 +1442,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
             </HeaderManager>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_not_present" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1722553038">Content-Type: multipart/form-data; boundary=</stringProp>
                 <stringProp name="-1500123463">Content-Disposition: form-data; name=&quot;fileName&quot;; filename=&quot;user.properties&quot;</stringProp>
                 <stringProp name="1533831720">Content-Transfer-Encoding: binary</stringProp>
@@ -1456,7 +1456,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_response_contains" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1737626343">PUT /test?name0=value0 HTTP/1.1</stringProp>
                 <stringProp name="2117109222">Host: localhost:8081</stringProp>
                 <stringProp name="-1351522793">User-Agent:</stringProp>
@@ -1468,7 +1468,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="894172713">Connection: keep-alive</stringProp>
                 <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               </collectionProp>
@@ -1523,7 +1523,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
             </HeaderManager>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_not_present" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="-1722553038">Content-Type: multipart/form-data; boundary=</stringProp>
                 <stringProp name="-1500123463">Content-Disposition: form-data; name=&quot;fileName&quot;; filename=&quot;user.properties&quot;</stringProp>
                 <stringProp name="1533831720">Content-Transfer-Encoding: binary</stringProp>
@@ -1537,7 +1537,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_response_contains" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="1737626343">PUT /test?name0=value0 HTTP/1.1</stringProp>
                 <stringProp name="2117109222">Host: localhost:8081</stringProp>
                 <stringProp name="-1351522793">User-Agent:</stringProp>
@@ -1550,7 +1550,7 @@ if(prev.getSamplerData().indexOf(textToCheck) &lt; 0) {
             </ResponseAssertion>
             <hashTree/>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="894172713">Connection: keep-alive</stringProp>
                 <stringProp name="-1680100360">Accept-Encoding: gzip</stringProp>
               </collectionProp>

--- a/bin/testfiles/TEST_HTTPS.jmx
+++ b/bin/testfiles/TEST_HTTPS.jmx
@@ -47,7 +47,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_CHECK_SNI_OK" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1071695892">Apache JMeter</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -56,7 +56,7 @@
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NO_HANDSHAKE_ERROR" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="914337881">javax.net.ssl.SSLHandshakeException</stringProp>
               <stringProp name="-1453429438">handshake_failure</stringProp>
             </collectionProp>

--- a/bin/testfiles/Test Plan_out.jmx
+++ b/bin/testfiles/Test Plan_out.jmx
@@ -36,7 +36,7 @@
         <GenericController guiclass="LogicControllerGui" testclass="GenericController" testname="Assertions" enabled="true"/>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>
               <stringProp name="0"></stringProp>

--- a/bin/testfiles/TestCookieManager.jmx
+++ b/bin/testfiles/TestCookieManager.jmx
@@ -121,7 +121,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="955707620">Cookie: myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -130,7 +130,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-230514610">myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
@@ -160,7 +160,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-1101339673">myCookie=value1; mySecureCookie=value3; myCookie2=value2</stringProp>
             </collectionProp>
@@ -252,7 +252,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="955707620">Cookie: myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -261,7 +261,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-230514610">myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
@@ -291,7 +291,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-1101339673">myCookie=value1; mySecureCookie=value3; myCookie2=value2</stringProp>
             </collectionProp>
@@ -344,7 +344,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-230514610">myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
@@ -354,7 +354,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="955707620">Cookie: myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -392,7 +392,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-1101339673">myCookie=value1; mySecureCookie=value3; myCookie2=value2</stringProp>
             </collectionProp>
@@ -460,7 +460,7 @@ mirrorServer.start();</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="955707620">Cookie: myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
@@ -469,7 +469,7 @@ mirrorServer.start();</stringProp>
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-230514610">myCookie=value1; myCookie2=value2</stringProp>
             </collectionProp>
@@ -508,7 +508,7 @@ mirrorServer.start();</stringProp>
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Request Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="735194388">Cookie Data:</stringProp>
               <stringProp name="-1101339673">myCookie=value1; mySecureCookie=value3; myCookie2=value2</stringProp>
             </collectionProp>

--- a/bin/testfiles/TestHeaderManager.jmx
+++ b/bin/testfiles/TestHeaderManager.jmx
@@ -103,7 +103,7 @@
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="483200697">Header1: val1_0\b
 </stringProp>
               <stringProp name="-1411296938">Header2: val2_0_overriden\b</stringProp>
@@ -155,7 +155,7 @@
           </HeaderManager>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-2062621902">Header1: val1_1\b</stringProp>
               <stringProp name="-1704699945">Header2: val2_1_overriden\b</stringProp>
               <stringProp name="1139229176">Header4: val4_1\b</stringProp>
@@ -169,7 +169,7 @@
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoOtherHeader" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1611083136">Header1: val1\b</stringProp>
               <stringProp name="876430658">Header2: val2\b</stringProp>
             </collectionProp>
@@ -216,7 +216,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1611083136">Header1: val1\b</stringProp>
               <stringProp name="876430658">Header2: val2\b</stringProp>
               <stringProp name="-931022844">Header3: val3\b</stringProp>
@@ -228,7 +228,7 @@
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_NoOtherHeader" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-1835006169">Header4</stringProp>
               <stringProp name="-1835006168">Header5</stringProp>
             </collectionProp>
@@ -241,7 +241,7 @@
         </hashTree>
       </hashTree>
       <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-        <collectionProp name="Asserion.test_strings">
+        <collectionProp name="Assertion.test_strings">
           <stringProp name="894172713">Connection: keep-alive</stringProp>
         </collectionProp>
         <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>

--- a/bin/testfiles/TestKeepAlive.jmx
+++ b/bin/testfiles/TestKeepAlive.jmx
@@ -107,7 +107,7 @@ JMeterUtils.setProperty(&quot;httpclient4.time_to_live&quot;, ttl.toString());</
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_ResHeaders_Close" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1984252372">Connection: close</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -117,7 +117,7 @@ JMeterUtils.setProperty(&quot;httpclient4.time_to_live&quot;, ttl.toString());</
           </ResponseAssertion>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_ReqHeaders_Close" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="1984252372">Connection: close</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>
@@ -149,7 +149,7 @@ JMeterUtils.setProperty(&quot;httpclient4.time_to_live&quot;, ttl.toString());</
           </HTTPSamplerProxy>
           <hashTree>
             <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Max100" enabled="true">
-              <collectionProp name="Asserion.test_strings">
+              <collectionProp name="Assertion.test_strings">
                 <stringProp name="803114368">Keep-Alive: timeout=30, max=100</stringProp>
               </collectionProp>
               <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -209,7 +209,7 @@ vars.put(&quot;thirdPause&quot;,thirdPause.toString());</stringProp>
             </HTTPSamplerProxy>
             <hashTree>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Max99" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="-1636660815">Keep-Alive: timeout=30, max=99</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -250,7 +250,7 @@ vars.put(&quot;thirdPause&quot;,thirdPause.toString());</stringProp>
             </HTTPSamplerProxy>
             <hashTree>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Max98" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="-1636660816">Keep-Alive: timeout=30, max=98</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -291,7 +291,7 @@ vars.put(&quot;thirdPause&quot;,thirdPause.toString());</stringProp>
             </HTTPSamplerProxy>
             <hashTree>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Max97" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="-1636660817">Keep-Alive: timeout=30, max=97</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.test_field">Assertion.response_headers</stringProp>
@@ -332,7 +332,7 @@ vars.put(&quot;thirdPause&quot;,thirdPause.toString());</stringProp>
             </HTTPSamplerProxy>
             <hashTree>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Max100" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="803114368">Keep-Alive: timeout=30, max=100</stringProp>
                 </collectionProp>
                 <stringProp name="TestPlan.comments">Connection has exceeded its TTL</stringProp>
@@ -374,7 +374,7 @@ vars.put(&quot;thirdPause&quot;,thirdPause.toString());</stringProp>
             </HTTPSamplerProxy>
             <hashTree>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Max100" enabled="true">
-                <collectionProp name="Asserion.test_strings">
+                <collectionProp name="Assertion.test_strings">
                   <stringProp name="803114368">Keep-Alive: timeout=30, max=100</stringProp>
                 </collectionProp>
                 <stringProp name="TestPlan.comments">Connection has exceeded its TTL</stringProp>
@@ -387,7 +387,7 @@ vars.put(&quot;thirdPause&quot;,thirdPause.toString());</stringProp>
             </hashTree>
           </hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_keepAlive" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="894172713">Connection: keep-alive</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.request_headers</stringProp>

--- a/bin/testfiles/TestRedirectionPolicies.jmx
+++ b/bin/testfiles/TestRedirectionPolicies.jmx
@@ -59,7 +59,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_200" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49586">200</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -84,7 +84,7 @@
           </JSONPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Redirected" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-557027443">https://httpbin.org/get</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -116,7 +116,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_302" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="50549">302</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -154,7 +154,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_200" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49586">200</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -179,7 +179,7 @@
           </JSONPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Redirected" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-557027443">https://httpbin.org/get</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -225,7 +225,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_302" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="50549">302</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -263,7 +263,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_200" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49586">200</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -288,7 +288,7 @@
           </JSONPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Redirected" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-557027443">https://httpbin.org/get</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -320,7 +320,7 @@
         </HTTPSamplerProxy>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_200" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="49586">200</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
@@ -345,7 +345,7 @@
           </JSONPostProcessor>
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="RA_Redirected" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="-557027443">https://httpbin.org/get</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>

--- a/extras/Test.jmx
+++ b/extras/Test.jmx
@@ -82,7 +82,7 @@
         </JavaSampler>
         <hashTree>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
-            <collectionProp name="Asserion.test_strings">
+            <collectionProp name="Assertion.test_strings">
               <stringProp name="51">3</stringProp>
             </collectionProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>

--- a/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
+++ b/src/components/src/main/java/org/apache/jmeter/assertions/ResponseAssertion.java
@@ -64,7 +64,12 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
     private static final String REQUEST_HEADERS = "Assertion.request_headers"; // $NON-NLS-1$
     private static final String REQUEST_DATA = "Assertion.request_data"; // $NON-NLS-1$
     private static final String ASSUME_SUCCESS = "Assertion.assume_success"; // $NON-NLS-1$
-    private static final String TEST_STRINGS = "Asserion.test_strings"; // $NON-NLS-1$
+    private static final String TEST_STRINGS = "Assertion.test_strings"; // $NON-NLS-1$
+    /**
+     * Misspelled historical name of {@link #TEST_STRINGS}, it was used by JMeter versions up to and including 5.6.3.
+     * It is still read to keep test plans saved by those versions working.
+     */
+    private static final String LEGACY_TEST_STRINGS = "Asserion.test_strings"; // $NON-NLS-1$
     private static final String TEST_TYPE = "Assertion.test_type"; // $NON-NLS-1$
     private static final String CUSTOM_MESSAGE = "Assertion.custom_message"; // $NON-NLS-1$
 
@@ -216,6 +221,17 @@ public class ResponseAssertion extends AbstractScopedAssertion implements Serial
             return CONTAINS;
         }
         return type.getIntValue();
+    }
+
+    @Override
+    public void setProperty(JMeterProperty property) {
+        if (LEGACY_TEST_STRINGS.equals(property.getName())) {
+            // Migrate the test patterns that were saved under the misspelled
+            // property name by JMeter versions up to and including 5.6.3, so that
+            // test plans saved by those versions keep working (see issue #6289)
+            property.setName(TEST_STRINGS);
+        }
+        super.setProperty(property);
     }
 
     public CollectionProperty getTestStrings() {

--- a/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
+++ b/src/components/src/test/java/org/apache/jmeter/assertions/ResponseAssertionTest.java
@@ -19,6 +19,7 @@ package org.apache.jmeter.assertions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,10 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jmeter.testelement.property.NullProperty;
+import org.apache.jmeter.testelement.property.StringProperty;
 import org.apache.jmeter.threads.JMeterContext;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.apache.jmeter.threads.JMeterVariables;
@@ -374,5 +379,54 @@ public class ResponseAssertionTest {
                 latch.countDown();
             }
         }
+    }
+
+    private static final String CORRECT_TEST_STRINGS_NAME = "Assertion.test_strings";
+    private static final String MISSPELLED_TEST_STRINGS_NAME = "Asserion.test_strings";
+
+    @Test
+    public void testPatternsAreStoredUnderCorrectPropertyName() {
+        ResponseAssertion responseAssertion = new ResponseAssertion();
+        responseAssertion.addTestString("pattern");
+        CollectionProperty testStrings = responseAssertion.getTestStrings();
+        assertEquals(1, testStrings.size());
+        assertEquals("pattern", testStrings.iterator().next().getStringValue());
+        // The patterns must be stored under the correctly spelled name
+        assertEquals(CORRECT_TEST_STRINGS_NAME, testStrings.getName());
+        // ... and not under the misspelled one
+        assertInstanceOf(NullProperty.class, responseAssertion.getProperty(MISSPELLED_TEST_STRINGS_NAME));
+    }
+
+    @Test
+    public void testPatternsSavedWithMisspelledPropertyNameAreMigrated() {
+        ResponseAssertion responseAssertion = new ResponseAssertion();
+        // Simulate a test plan saved by JMeter versions up to and including 5.6.3,
+        // which stored the patterns under the misspelled property name
+        CollectionProperty legacy = new CollectionProperty(MISSPELLED_TEST_STRINGS_NAME, new ArrayList<>());
+        legacy.addProperty(new StringProperty("legacy", "legacy pattern"));
+        responseAssertion.setProperty(legacy);
+
+        CollectionProperty testStrings = responseAssertion.getTestStrings();
+        assertEquals(1, testStrings.size());
+        assertEquals("legacy pattern", testStrings.iterator().next().getStringValue());
+        // The patterns must have been migrated to the correctly spelled name
+        assertEquals(CORRECT_TEST_STRINGS_NAME, testStrings.getName());
+        // ... and the legacy property must have been removed, so that re-saved
+        // test plans use the correct name only
+        assertInstanceOf(NullProperty.class, responseAssertion.getProperty(MISSPELLED_TEST_STRINGS_NAME));
+    }
+
+    @Test
+    public void testPatternsAreAddedToMigratedValues() {
+        ResponseAssertion responseAssertion = new ResponseAssertion();
+        CollectionProperty legacy = new CollectionProperty(MISSPELLED_TEST_STRINGS_NAME, new ArrayList<>());
+        legacy.addProperty(new StringProperty("legacy", "legacy pattern"));
+        responseAssertion.setProperty(legacy);
+
+        responseAssertion.addTestString("new pattern");
+
+        CollectionProperty testStrings = responseAssertion.getTestStrings();
+        assertEquals(2, testStrings.size());
+        assertEquals(CORRECT_TEST_STRINGS_NAME, testStrings.getName());
     }
 }

--- a/src/core/src/main/resources/org/apache/jmeter/gui/action/schematic.xsl
+++ b/src/core/src/main/resources/org/apache/jmeter/gui/action/schematic.xsl
@@ -282,7 +282,7 @@ ul.tree li:last-child {
     </xsl:choose>
     </b>
     [
-    <xsl:for-each select='collectionProp[@name="Asserion.test_strings"]/stringProp'>
+    <xsl:for-each select='collectionProp[@name="Assertion.test_strings" or @name="Asserion.test_strings"]/stringProp'>
       "<xsl:value-of select='.'/>"
       <xsl:if test="position() != last()">,</xsl:if>
    </xsl:for-each>

--- a/xdocs/changes.xml
+++ b/xdocs/changes.xml
@@ -109,6 +109,7 @@ Summary
   <ch_section>Bug fixes</ch_section>
   <h3>General</h3>
   <ul>
+    <li><issue>6289</issue>Response Assertion patterns were saved under a misspelled property name (<code>Asserion.test_strings</code>). The patterns are now saved under the correct name (<code>Assertion.test_strings</code>) while test plans saved by older versions keep loading correctly.</li>
     <li><pr>6654</pr><issue>6611</issue>Support JDK 25 and above for result collectors with empty file names</li>
     <li>Trim whitespace when parsing numeric JMeter properties so accidental spaces do not silently change configuration values.</li>
     <li><pr>6372</pr>Fix KeyManager logging when using CLI mode so keystore passwords are not incorrectly reported as missing. Contributed by Patrick Uiterwijk (patrick at puiterwijk.org)</li>


### PR DESCRIPTION
## Description
Save the patterns of the `Response Assertion` under the correctly spelled property name `Assertion.test_strings` instead of the misspelled `Asserion.test_strings`.

For backward compatibility, the misspelled name is still accepted when a test plan is loaded: `ResponseAssertion#setProperty` migrates a `Asserion.test_strings` collection on the fly by renaming it, so test plans saved by JMeter versions up to and including 5.6.3 (and by the current trunk) keep working, and their patterns are re-saved under the correct name.

The schematic view (`schematic.xsl`) matches both property names, so schematic rendering of old test plans is unchanged. The test plans shipped with JMeter (`bin/testfiles`, `bin/templates`, `bin/examples`, `extras`) are renamed to the correct property name.

## Motivation and Context
Fixes #6289

Every JMX file saved so far stores the assertion patterns under the misspelled property name:

```xml
<collectionProp name="Asserion.test_strings">
```

As noted on the issue, this also breaks interoperability with tooling that generates JMX files with the correct name (e.g. the OpenAPI generator): such assertions silently match nothing when loaded by JMeter, because JMeter looks up the misspelled property only.

## How Has This Been Tested?
- New tests in `ResponseAssertionTest`:
  - `testPatternsAreStoredUnderCorrectPropertyName`: patterns are stored under `Assertion.test_strings`
  - `testPatternsSavedWithMisspelledPropertyNameAreMigrated`: a `Asserion.test_strings` collection (as saved by JMeter ≤ 5.6.3) is migrated on `setProperty`, values preserved, legacy property gone
  - `testPatternsAreAddedToMigratedValues`: patterns added afterwards end up in the migrated collection
- All 28 `TestSaveService` load/save round-trip tests pass after renaming the property in the shipped test plans
- Full `:src:components:test` (552 tests) and `:src:core:test` (379 tests) suites pass
- `./gradlew classes style` passes
- Verified end-to-end against a locally built distribution: a legacy demo JMX (`xdocs/demos/AssertionTestPlan.jmx`, still using the misspelled name) loads with its patterns intact, and newly saved JMX files contain `Assertion.test_strings` only

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the [code style][style-guide] of this project.
- [x] I have updated the documentation accordingly. (release notes entry added to `xdocs/changes.xml`)

[style-guide]: https://wiki.apache.org/jmeter/CodeStyleGuidelines